### PR TITLE
Revert "Remove dependency on chrono"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ sigma = []
 webhook-endpoints = []
 
 # deserialize events from webhooks
-webhook-events = ["events", "hmac", "sha2"]
+webhook-events = ["events", "hmac", "sha2", "chrono"]
 events = []
 
 # runtimes
@@ -77,6 +77,7 @@ runtime-async-std-surf = ["async-std", "surf", "async"]
 
 [dependencies]
 async-std = { version = "1.9", optional = true }
+chrono = { version = "0.4", features = ["serde"], optional = true }
 http = "0.2"
 hyper = { version = "0.14", default-features = false, features = ["http1", "http2", "client", "tcp"], optional = true }
 hyper-tls = { version = "0.5", optional = true }

--- a/src/error.rs
+++ b/src/error.rs
@@ -289,7 +289,7 @@ pub enum WebhookError {
     /// The event signature could not be verified.
     BadSignature,
     /// The event signature's timestamp was too old.
-    BadTimestamp(u64),
+    BadTimestamp(i64),
     /// An error deserializing an event received from stripe.
     BadParse(serde_json::Error),
 }


### PR DESCRIPTION
Chrono is of course needed for Utc time. Don't code late at night!

This reverts commit e462ae4aef53a0f36d6fe6796820752490600335.