### PR TITLE
Clean up error handling code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,9 @@ tokio = { version = "1.2", optional = true }
 # webhook support
 hmac = { version = "0.10", optional = true }
 sha2 = { version = "0.9", optional = true }
+thiserror = "1.0.24"
 
 
 [dev-dependencies]
+anyhow = "1.0.38"
 lazy_static = "1.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,6 @@ runtime-async-std-surf = ["async-std", "surf", "async"]
 [dependencies]
 async-std = { version = "1.9", optional = true }
 chrono = { version = "0.4", features = ["serde"], optional = true }
-http = "0.2"
 hyper = { version = "0.14", default-features = false, features = ["http1", "http2", "client", "tcp"], optional = true }
 hyper-tls = { version = "0.5", optional = true }
 hyper-rustls = { version = "0.22", optional = true }

--- a/src/client/async_std.rs
+++ b/src/client/async_std.rs
@@ -35,27 +35,24 @@ pub struct Client {
 impl Client {
     /// Creates a new client pointed to `https://api.stripe.com/`
     pub fn new(secret_key: impl Into<String>) -> Client {
-        Client::from_url("https://api.stripe.com/", secret_key).expect("this url is valid")
+        Client::from_url("https://api.stripe.com/", secret_key)
     }
 
     /// Creates a new client posted to a custom `scheme://host/`
-    pub fn from_url<'a>(
-        scheme_host: impl Into<&'a str>,
-        secret_key: impl Into<String>,
-    ) -> Result<Client, ParseError> {
-        let host = Url::parse(scheme_host.into())?;
+    pub fn from_url<'a>(scheme_host: impl Into<&'a str>, secret_key: impl Into<String>) -> Client {
+        let host = Url::parse(scheme_host.into()).expect("invalid url");
         let client = surf::Client::new();
         let headers =
             Headers { stripe_version: Some(ApiVersion::V2020_08_27), ..Default::default() };
 
-        Ok(Client {
+        Client {
             host,
             api_root: "v1".to_string(),
             client,
             secret_key: secret_key.into(),
             headers,
             app_info: Some(AppInfo::default()),
-        })
+        }
     }
 
     /// Clones a new client with different headers.

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -2,9 +2,7 @@ use crate::client::tokio::Client as AsyncClient;
 use crate::error::StripeError;
 use crate::params::Headers;
 use serde::de::DeserializeOwned;
-use std::cell::RefCell;
-use std::sync::Arc;
-use std::time::Duration;
+use std::{cell::RefCell, sync::Arc, time::Duration};
 
 /// The delay after which the blocking `Client` will assume the request has failed.
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
@@ -43,7 +41,7 @@ impl Client {
             .enable_io()
             .enable_time() // use separate `io/time` instead of `all` to ensure `tokio/time` is enabled
             .build()
-            .unwrap();
+            .expect("should be able to get a runtime");
         Client { inner, runtime: Arc::new(RefCell::new(runtime)) }
     }
 

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -1,5 +1,5 @@
 use crate::client::tokio::Client as AsyncClient;
-use crate::error::Error;
+use crate::error::StripeError;
 use crate::params::Headers;
 use serde::de::DeserializeOwned;
 use std::cell::RefCell;
@@ -9,7 +9,7 @@ use std::time::Duration;
 /// The delay after which the blocking `Client` will assume the request has failed.
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
 
-pub type Response<T> = Result<T, Error>;
+pub type Response<T> = Result<T, StripeError>;
 
 #[inline(always)]
 pub(crate) fn ok<T>(ok: T) -> Response<T> {
@@ -17,7 +17,7 @@ pub(crate) fn ok<T>(ok: T) -> Response<T> {
 }
 
 #[inline(always)]
-pub(crate) fn err<T>(err: crate::Error) -> Response<T> {
+pub(crate) fn err<T>(err: crate::StripeError) -> Response<T> {
     Err(err)
 }
 
@@ -119,7 +119,7 @@ impl Client {
             tokio::time::timeout(DEFAULT_TIMEOUT, request).await
         }) {
             Ok(finished) => finished,
-            Err(_) => Err(Error::Timeout),
+            Err(_) => Err(StripeError::Timeout),
         }
     }
 }

--- a/src/client/tokio.rs
+++ b/src/client/tokio.rs
@@ -1,9 +1,11 @@
 use crate::error::{ErrorResponse, RequestError, StripeError};
 use crate::params::{AppInfo, Headers};
 use crate::resources::ApiVersion;
-use http::header::{HeaderMap, HeaderName, HeaderValue};
-use http::request::Builder as RequestBuilder;
-use hyper::{client::HttpConnector, Body};
+use hyper::{
+    client::HttpConnector,
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Body, Request,
+};
 use serde::de::DeserializeOwned;
 use std::future::{self, Future};
 use std::pin::Pin;

--- a/src/client/tokio.rs
+++ b/src/client/tokio.rs
@@ -1,4 +1,4 @@
-use crate::error::{Error, ErrorResponse, RequestError};
+use crate::error::{ErrorResponse, RequestError, StripeError};
 use crate::params::{AppInfo, Headers};
 use crate::resources::ApiVersion;
 use http::header::{HeaderMap, HeaderName, HeaderValue};
@@ -33,7 +33,7 @@ compile_error!("You must enable only one TLS implementation");
 
 type HttpClient = hyper::Client<connector::HttpsConnector<HttpConnector>, Body>;
 
-pub type Response<T> = Pin<Box<dyn Future<Output = Result<T, Error>> + Send>>;
+pub type Response<T> = Pin<Box<dyn Future<Output = Result<T, StripeError>> + Send>>;
 
 #[allow(dead_code)]
 #[inline(always)]
@@ -43,7 +43,7 @@ pub(crate) fn ok<T: Send + 'static>(ok: T) -> Response<T> {
 
 #[allow(dead_code)]
 #[inline(always)]
-pub(crate) fn err<T: Send + 'static>(err: Error) -> Response<T> {
+pub(crate) fn err<T: Send + 'static>(err: StripeError) -> Response<T> {
     Box::pin(future::ready(Err(err)))
 }
 
@@ -174,7 +174,9 @@ impl Client {
             .method("POST")
             .uri(url)
             .body(match serde_qs::to_string(&form) {
-                Err(err) => return Box::pin(future::ready(Err(Error::serialize(err)))),
+                Err(err) => {
+                    return Box::pin(future::ready(Err(StripeError::QueryStringSerialize(err))))
+                }
                 Ok(body) => hyper::Body::from(body),
             })
             .unwrap();
@@ -190,8 +192,12 @@ impl Client {
         format!("{}/{}", self.host, path.trim_start_matches('/'))
     }
 
-    fn url_with_params<P: serde::Serialize>(&self, path: &str, params: P) -> Result<String, Error> {
-        let params = serde_qs::to_string(&params).map_err(Error::serialize)?;
+    fn url_with_params<P: serde::Serialize>(
+        &self,
+        path: &str,
+        params: P,
+    ) -> Result<String, StripeError> {
+        let params = serde_qs::to_string(&params).map_err(StripeError::from)?;
         Ok(format!("{}/{}?{}", self.host, &path[1..], params))
     }
 
@@ -249,15 +255,15 @@ fn send<T: DeserializeOwned + Send + 'static>(
         let status = response.status();
         let bytes = hyper::body::to_bytes(response.into_body()).await?;
         if !status.is_success() {
-            let mut err = serde_json::from_slice(&bytes).unwrap_or_else(|err| {
-                let mut req = ErrorResponse { error: RequestError::default() };
-                req.error.message = Some(format!("failed to deserialize error: {}", err));
-                req
-            });
-            err.error.http_status = status.as_u16();
-            return Err(Error::from(err.error));
+            Err(serde_json::from_slice(&bytes)
+                .map(|mut e: ErrorResponse| {
+                    e.error.http_status = status.into();
+                    StripeError::from(e.error)
+                })
+                .unwrap_or_else(StripeError::from))
+        } else {
+            serde_json::from_slice(&bytes).map_err(StripeError::from)
         }
-        serde_json::from_slice(&bytes).map_err(Error::deserialize)
     })
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,105 +1,29 @@
 use crate::params::to_snakecase;
 use serde_derive::{Deserialize, Serialize};
 use std::num::ParseIntError;
+use thiserror::Error;
 
 /// An error encountered when communicating with the Stripe API.
-#[derive(Debug)]
-pub enum Error {
-    /// An error reported by Stripe in the response body.
-    Stripe(RequestError),
-    /// An error reading the response body.
-    Io(std::io::Error),
-    /// An error serializing a request before it is sent to stripe.
-    Serialize(Box<dyn std::error::Error + Send>),
-    /// An error deserializing a response received from stripe.
-    Deserialize(Box<dyn std::error::Error + Send>),
-    /// Indicates an operation not supported (yet?) by this library.
+#[derive(Debug, Error)]
+pub enum StripeError {
+    #[error("error reported by stripe")]
+    Stripe(#[from] RequestError),
+    #[error("error serializing or deserializing a querystring: {0}")]
+    QueryStringSerialize(#[from] serde_qs::Error),
+    #[error("error serializing or deserializing a request")]
+    JSONSerialize(#[from] serde_json::Error),
+    #[error("an unsupported operation was attempted")]
     Unsupported(&'static str),
-    /// An invariant has been violated. Either a bug in this library or Stripe
-    Unexpected(&'static str),
-    /// An http client error
+    #[error("error communicating with stripe")]
     ClientError,
-    /// The request timed out.
+    #[error("timeout communicating with stripe")]
     Timeout,
 }
 
-impl Error {
-    pub(crate) fn serialize<T>(err: T) -> Error
-    where
-        T: std::error::Error + Send + 'static,
-    {
-        Error::Serialize(Box::new(err))
-    }
-
-    pub(crate) fn deserialize<T>(err: T) -> Error
-    where
-        T: std::error::Error + Send + 'static,
-    {
-        Error::Deserialize(Box::new(err))
-    }
-}
-
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        #[allow(deprecated)]
-        f.write_str(std::error::Error::description(self))?;
-        match *self {
-            Error::Stripe(ref err) => write!(f, ": {}", err),
-            Error::Timeout => write!(f, ": timed out"),
-            Error::ClientError => write!(f, ": client error"),
-            Error::Io(ref err) => write!(f, ": {}", err),
-            Error::Serialize(ref err) => write!(f, ": {}", err),
-            Error::Deserialize(ref err) => write!(f, ": {}", err),
-            Error::Unsupported(msg) => write!(f, "{}", msg),
-            Error::Unexpected(msg) => write!(f, "{}", msg),
-        }
-    }
-}
-
-impl std::error::Error for Error {
-    fn description(&self) -> &str {
-        match *self {
-            Error::Stripe(_) => "error reported by stripe",
-            Error::ClientError => "error communicating with stripe",
-            Error::Timeout => "timeout communicating with stripe",
-            Error::Io(_) => "error reading response from stripe",
-            Error::Serialize(_) => "error serializing a request",
-            Error::Deserialize(_) => "error deserializing a response",
-            Error::Unsupported(_) => "an unsupported operation was attempted",
-            Error::Unexpected(_) => "an unexpected error has occurred",
-        }
-    }
-
-    fn cause(&self) -> Option<&dyn std::error::Error> {
-        match *self {
-            Error::Stripe(ref err) => Some(err),
-            Error::ClientError => None,
-            Error::Timeout => None,
-            Error::Io(ref err) => Some(err),
-            Error::Serialize(ref err) => Some(&**err),
-            Error::Deserialize(ref err) => Some(&**err),
-            Error::Unsupported(_) => None,
-            Error::Unexpected(_) => None,
-        }
-    }
-}
-
-impl From<RequestError> for Error {
-    fn from(err: RequestError) -> Error {
-        Error::Stripe(err)
-    }
-}
-
 #[cfg(feature = "hyper")]
-impl From<hyper::Error> for Error {
-    fn from(_err: hyper::Error) -> Error {
-        Error::ClientError
-    }
-}
-
-impl From<std::io::Error> for Error {
-    fn from(err: std::io::Error) -> Error {
-        Error::Io(err)
+impl From<hyper::Error> for StripeError {
+    fn from(_err: hyper::Error) -> StripeError {
+        StripeError::ClientError
     }
 }
 
@@ -108,7 +32,6 @@ impl From<std::io::Error> for Error {
 pub enum ErrorType {
     #[serde(skip_deserializing)]
     Unknown,
-
     #[serde(rename = "api_error")]
     Api,
     #[serde(rename = "api_connection_error")]
@@ -229,7 +152,8 @@ impl std::fmt::Display for ErrorCode {
 /// An error reported by stripe in a request's response.
 ///
 /// For more details see <https://stripe.com/docs/api#errors>.
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Default, Deserialize, Error)]
+#[error("{error_type} ({http_status}) with message: {message:?}")]
 pub struct RequestError {
     /// The HTTP status in the response.
     #[serde(skip_deserializing)]
@@ -255,22 +179,6 @@ pub struct RequestError {
     pub charge: Option<String>,
 }
 
-impl std::fmt::Display for RequestError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}({})", self.error_type, self.http_status)?;
-        if let Some(ref message) = self.message {
-            write!(f, ": {}", message)?;
-        }
-        Ok(())
-    }
-}
-
-impl std::error::Error for RequestError {
-    fn description(&self) -> &str {
-        self.message.as_deref().unwrap_or("request error")
-    }
-}
-
 /// The structure of the json body when an error is included in
 /// the response from Stripe.
 #[derive(Deserialize)]
@@ -279,53 +187,16 @@ pub struct ErrorResponse {
 }
 
 /// An error encountered when communicating with the Stripe API webhooks.
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum WebhookError {
-    /// The provided secret could not be parsed as a key
-    /// (e.g. it may not be the correct size).
+    #[error("invalid key length")]
     BadKey,
-    /// The event's headers are in an unexpected format.
-    BadHeader(ParseIntError),
-    /// The event signature could not be verified.
+    #[error("error parsing timestamp")]
+    BadHeader(#[from] ParseIntError),
+    #[error("error comparing signatures")]
     BadSignature,
-    /// The event signature's timestamp was too old.
+    #[error("error comparing timestamps - over tolerance")]
     BadTimestamp(i64),
-    /// An error deserializing an event received from stripe.
-    BadParse(serde_json::Error),
-}
-
-impl std::fmt::Display for WebhookError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        #[allow(deprecated)]
-        f.write_str(std::error::Error::description(self))?;
-        match *self {
-            WebhookError::BadKey => Ok(()),
-            WebhookError::BadHeader(ref err) => write!(f, ": {}", err),
-            WebhookError::BadSignature => Ok(()),
-            WebhookError::BadTimestamp(ref err) => write!(f, ": {}", err),
-            WebhookError::BadParse(ref err) => write!(f, ": {}", err),
-        }
-    }
-}
-
-impl std::error::Error for WebhookError {
-    fn description(&self) -> &str {
-        match *self {
-            WebhookError::BadKey => "invalid key length",
-            WebhookError::BadHeader(_) => "error parsing timestamp",
-            WebhookError::BadSignature => "error comparing signatures",
-            WebhookError::BadTimestamp(_) => "error comparing timestamps - over tolerance",
-            WebhookError::BadParse(_) => "error parsing event object",
-        }
-    }
-
-    fn cause(&self) -> Option<&dyn std::error::Error> {
-        match *self {
-            WebhookError::BadKey => None,
-            WebhookError::BadHeader(ref err) => Some(err),
-            WebhookError::BadSignature => None,
-            WebhookError::BadTimestamp(_) => None,
-            WebhookError::BadParse(ref err) => Some(err),
-        }
-    }
+    #[error("error parsing event object")]
+    BadParse(#[from] serde_json::Error),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,8 +12,8 @@ pub enum StripeError {
     QueryStringSerialize(#[from] serde_qs::Error),
     #[error("error serializing or deserializing a request")]
     JSONSerialize(#[from] serde_json::Error),
-    #[error("an unsupported operation was attempted")]
-    Unsupported(&'static str),
+    #[error("attempted to access an unsupported version of the api")]
+    UnsupportedVersion,
     #[error("error communicating with stripe")]
     ClientError,
     #[error("timeout communicating with stripe")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,6 +27,13 @@ impl From<hyper::Error> for StripeError {
     }
 }
 
+#[cfg(feature = "surf")]
+impl From<surf::Error> for StripeError {
+    fn from(_err: surf::Error) -> StripeError {
+        StripeError::ClientError
+    }
+}
+
 /// The list of possible values for a RequestError's type.
 #[derive(Debug, PartialEq, Deserialize)]
 pub enum ErrorType {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,7 @@ mod resources;
 //
 // See https://github.com/wyyerd/stripe-rs/issues/24#issuecomment-451514187
 // See https://github.com/rust-lang/rust/issues/44265
-pub use crate::error::{Error, ErrorCode, ErrorType, RequestError, WebhookError};
+pub use crate::error::{ErrorCode, ErrorType, RequestError, StripeError, WebhookError};
 pub use crate::ids::*;
 pub use crate::params::{
     Expandable, Headers, IdOrCreate, List, Metadata, Object, RangeBounds, RangeQuery, Timestamp,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,9 +57,8 @@
 //! ```
 
 #![allow(clippy::map_clone)]
-// N.B. not sure if this rule will break compatibility with older rust versions we might want to support
-#![allow(clippy::needless_pass_by_value)]
 #![allow(clippy::large_enum_variant)]
+#![warn(clippy::unwrap_used)]
 #![forbid(unsafe_code)]
 
 mod client {

--- a/src/params.rs
+++ b/src/params.rs
@@ -183,9 +183,7 @@ impl<T: DeserializeOwned + Send + 'static> List<T> {
             }
             client.get(&url)
         } else {
-            err(StripeError::Unsupported(
-                "URL for fetching additional data uses different API version",
-            ))
+            err(StripeError::UnsupportedVersion)
         }
     }
 }

--- a/src/params.rs
+++ b/src/params.rs
@@ -1,5 +1,5 @@
 use crate::config::{err, ok, Client, Response};
-use crate::error::Error;
+use crate::error::StripeError;
 use crate::resources::ApiVersion;
 use serde::de::DeserializeOwned;
 use serde_derive::{Deserialize, Serialize};
@@ -143,6 +143,8 @@ where
 }
 
 /// A single page of a cursor-paginated list of an object.
+///
+/// For more details, see <https://stripe.com/docs/api/pagination>
 #[derive(Debug, Deserialize, Serialize)]
 pub struct List<T> {
     pub data: Vec<T>,
@@ -181,7 +183,9 @@ impl<T: DeserializeOwned + Send + 'static> List<T> {
             }
             client.get(&url)
         } else {
-            err(Error::Unsupported("URL for fetching additional data uses different API version"))
+            err(StripeError::Unsupported(
+                "URL for fetching additional data uses different API version",
+            ))
         }
     }
 }

--- a/src/resources/setup_intent_ext.rs
+++ b/src/resources/setup_intent_ext.rs
@@ -1,0 +1,17 @@
+use crate::{resources::SetupIntent, Expandable, PaymentMethod};
+
+impl SetupIntent {
+    pub async fn confirm(&self, payment_method: Option<Expandable<PaymentMethod>>) -> SetupIntent {
+        unimplemented!()
+    }
+
+    pub async fn cancel(
+        &self,
+        cancellation_reason: Option<SetupIntentCancellationReason>,
+    ) -> SetupIntent {
+        unimplemented!()
+    }
+}
+
+#[cfg(test)]
+mod test {}


### PR DESCRIPTION
The goal of this PR is to clean up the error handling code.

- [x] Don't use boxed errors (directly)
- [x] Remove unused error cases
- [x] Use thiserror to reduce boilerplate
- [ ] Figure out the best way to propagate client errors

This also as a side-effect removes most of the unwraps so that they are explicitly handled in cases where an error could actually occur, or `expect`ed otherwise.