### PR TITLE
Add additional apis to setup intent ext

### DIFF
--- a/src/resources.rs
+++ b/src/resources.rs
@@ -20,6 +20,7 @@ mod core {
     pub mod payment_source;
     pub mod payout_ext;
     pub mod placeholders;
+    pub mod setup_intent_ext;
     pub mod token_ext;
 }
 
@@ -83,6 +84,7 @@ pub use {
         payment_source::*,
         placeholders::*,
         payout_ext::*,
+        setup_intent_ext::*,
         token_ext::*,
     },
     generated::core::{

--- a/src/resources/setup_intent_ext.rs
+++ b/src/resources/setup_intent_ext.rs
@@ -1,17 +1,82 @@
-use crate::{resources::SetupIntent, Expandable, PaymentMethod};
+use serde_derive::{Deserialize, Serialize};
+
+use crate::{
+    resources::SetupIntent, Client, Expandable, PaymentMethod, PaymentMethodId, Response,
+    SetupIntentCancellationReason,
+};
+
+#[derive(Clone, Debug, Deserialize, Serialize, Default)]
+pub struct SetupIntentConfirm {
+    payment_method: Option<PaymentMethodId>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, Default)]
+pub struct SetupIntentCancel {
+    cancellation_reason: Option<SetupIntentCancellationReason>,
+}
 
 impl SetupIntent {
-    pub async fn confirm(&self, payment_method: Option<Expandable<PaymentMethod>>) -> SetupIntent {
-        unimplemented!()
+    pub fn confirm(&self, client: &Client, params: SetupIntentConfirm) -> Response<SetupIntent> {
+        client.post_form(&format!("/setup_intents/{}/confirm", self.id), &params)
     }
 
-    pub async fn cancel(
-        &self,
-        cancellation_reason: Option<SetupIntentCancellationReason>,
-    ) -> SetupIntent {
-        unimplemented!()
+    pub fn cancel(&self, client: &Client, params: SetupIntentCancel) -> Response<SetupIntent> {
+        client.post_form(&format!("/setup_intents/{}/cancel", self.id), &params)
     }
 }
 
-#[cfg(test)]
-mod test {}
+#[cfg(all(test, feature = "blocking"))]
+mod test {
+    use anyhow::Result;
+
+    use super::SetupIntentConfirm;
+    use crate::{
+        Client, CreateCustomer, CreatePaymentMethod, CreateSetupIntent, Customer, PaymentMethod,
+        PaymentMethodTypeFilter, SetupIntent, SetupIntentStatus, UpdateSetupIntent,
+    };
+
+    fn create_intent() -> Result<(Client, SetupIntent, PaymentMethod)> {
+        let client = Client::from_url("http://localhost:12111", "sk_test_123");
+        let customer = Customer::create(&client, CreateCustomer { ..Default::default() })?;
+        let method = PaymentMethod::create(
+            &client,
+            CreatePaymentMethod {
+                type_: Some(PaymentMethodTypeFilter::Card),
+                customer: Some(customer.id),
+                ..Default::default()
+            },
+        )?;
+        println!("{:?}", method);
+        let intent = SetupIntent::create(
+            &client,
+            CreateSetupIntent { payment_method: Some(method.id.clone()), ..Default::default() },
+        )?;
+        let intent = SetupIntent::update(
+            &client,
+            &intent.id,
+            UpdateSetupIntent { payment_method: Some(method.id.clone()), ..Default::default() },
+        )?;
+        println!("{:?}", &intent);
+
+        Ok((client, intent, method))
+    }
+
+    #[test]
+    fn can_confirm() -> Result<()> {
+        let (client, intent, method) = create_intent()?;
+        let confirmed =
+            intent.confirm(&client, SetupIntentConfirm { payment_method: Some(method.id) })?;
+        println!("{:?}", confirmed);
+        assert_eq!(confirmed.status, SetupIntentStatus::Succeeded);
+        Ok(())
+    }
+
+    #[test]
+    fn can_cancel() -> Result<()> {
+        let (client, intent, _) = create_intent()?;
+        let cancelled = intent.cancel(&client, Default::default())?;
+        println!("{:?}", cancelled);
+        assert_eq!(cancelled.status, SetupIntentStatus::Canceled);
+        Ok(())
+    }
+}


### PR DESCRIPTION
This currently does not pass the tests, which I think may be due to the stripe api mocking service used in the tests.