### PR TITLE
Fix Clippy warnings should fail the build

### DIFF
--- a/.github/workflows/async-stripe.yml
+++ b/.github/workflows/async-stripe.yml
@@ -49,6 +49,7 @@ jobs:
           args: >
             --no-default-features
             --features runtime-${{ matrix.runtime }}
+            -- --deny warnings
   test:
     runs-on: ubuntu-20.04
     strategy:


### PR DESCRIPTION
Clippy warnings should fail the build. We have so many [warnings](https://github.com/arlyon/async-stripe/runs/2792250183#step:5:204), but the the build does not fail.

To make it wail, we need to add `-- --deny warnings` according the [doc](https://github.com/rust-lang/rust-clippy#travis-ci)