### PR TITLE
fix: use non-generic inner function for send

### DIFF
--- a/src/client/tokio.rs
+++ b/src/client/tokio.rs
@@ -271,20 +271,28 @@ fn send<T: DeserializeOwned + Send + 'static>(
 ) -> Response<T> {
     let client = client.clone(); // N.B. Client is send sync;  cloned clients share the same pool.
     Box::pin(async move {
-        let response = client.request(request).await?;
-        let status = response.status();
-        let bytes = hyper::body::to_bytes(response.into_body()).await?;
-        if !status.is_success() {
-            Err(serde_json::from_slice(&bytes)
-                .map(|mut e: ErrorResponse| {
-                    e.error.http_status = status.into();
-                    StripeError::from(e.error)
-                })
-                .unwrap_or_else(StripeError::from))
-        } else {
-            serde_json::from_slice(&bytes).map_err(StripeError::from)
-        }
+        let bytes = send_inner(&client, request).await?;
+        serde_json::from_slice(&bytes).map_err(StripeError::from)
     })
+}
+
+async fn send_inner(
+    client: &HttpClient,
+    request: hyper::Request<Body>,
+) -> Result<hyper::body::Bytes, StripeError> {
+    let response = client.request(request).await?;
+    let status = response.status();
+    let bytes = hyper::body::to_bytes(response.into_body()).await?;
+    if !status.is_success() {
+        Err(serde_json::from_slice(&bytes)
+            .map(|mut e: ErrorResponse| {
+                e.error.http_status = status.into();
+                StripeError::from(e.error)
+            })
+            .unwrap_or_else(StripeError::from))
+    } else {
+        Ok(bytes)
+    }
 }
 
 /// Formats a plugin's 'App Info' into a string that can be added to the end of an User-Agent string.


### PR DESCRIPTION
This should reduce the code size and compile time of the monomorphized `send` functions.

See [Non-Generic Inner Functions](https://www.possiblerust.com/pattern/non-generic-inner-functions) for more details on the tactic.