### PR TITLE
Introduce subtle and use it for constant time comparison

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ sigma = []
 webhook-endpoints = []
 
 # deserialize events from webhooks
-webhook-events = ["events", "hmac", "sha2", "chrono"]
+webhook-events = ["events", "hmac", "sha2", "chrono", "subtle"]
 events = []
 
 # runtimes
@@ -78,6 +78,7 @@ runtime-async-std-surf = ["async-std", "surf", "async"]
 [dependencies]
 async-std = { version = "1.9", optional = true }
 chrono = { version = "0.4", features = ["serde"], optional = true }
+thiserror = "1.0.24"
 hyper = { version = "0.14", default-features = false, features = ["http1", "http2", "client", "tcp"], optional = true }
 hyper-tls = { version = "0.5", optional = true }
 hyper-rustls = { version = "0.22", optional = true }
@@ -90,9 +91,9 @@ surf = { version = "2.1", optional = true }
 tokio = { version = "1.2", optional = true }
 
 # webhook support
-hmac = { version = "0.10", optional = true }
+hmac = { version = "0.11", optional = true }
 sha2 = { version = "0.9", optional = true }
-thiserror = "1.0.24"
+subtle = { version = "2.4", optional = true }
 
 
 [dev-dependencies]


### PR DESCRIPTION
This also bumps the `hmac` crate

Closes #87 