### PR TITLE
Api changes to resolve overlapping imports

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ to run a [`stripe-mock`](https://github.com/stripe/stripe-mock) server and selec
 
 ```sh
 docker run --rm -d -it -p 12111-12112:12111-12112 stripemock/stripe-mock:latest
-cargo test --features runtime-async-std-surf
+cargo test --features runtime-blocking
 ```
 
 ## Communication

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -152,10 +152,17 @@ pub use {
         invoiceitem::*,
         line_item::*,
         plan::*,
+        plan::PlanInterval,
         price::*,
         promotion_code::*,
-        subscription::*,
         subscription_item::*,
+        subscription_item::PlanInterval as SubscriptionItemInterval,
+        subscription_item::SubscriptionItemPriceDataRecurring as SubscriptionItemPriceDataRecurring,
+        // need to import this afterwards so that the SubscriptionItemPriceDataRecurring
+        // isn't silently ignored
+        subscription::*,
+        subscription::PlanInterval as SubscriptionInterval,
+        subscription::SubscriptionItemPriceDataRecurring as SubscriptionPriceDataRecurring,
         subscription_schedule::*,
         tax_id::*,
         tax_rate::*,

--- a/tests/plan_interval.rs
+++ b/tests/plan_interval.rs
@@ -1,0 +1,44 @@
+//! Basic tests to ensure that the plan interval types
+//! are exported properly. Mainly just needs to compile.
+
+mod mock;
+
+#[test]
+#[cfg(feature = "blocking")]
+fn can_create_plan() {
+    let id = "price_123".parse().unwrap();
+    mock::with_client(|client| {
+        let mut plan = stripe::Plan::retrieve(client, &id, &[]).unwrap();
+        plan.interval = Some(stripe::PlanInterval::Month);
+    });
+}
+
+#[test]
+#[cfg(feature = "blocking")]
+fn can_create_subscription_interval() {
+    let recurring = stripe::SubscriptionPriceDataRecurring {
+        interval: stripe::SubscriptionInterval::Month,
+        interval_count: Some(100),
+    };
+}
+
+#[test]
+#[cfg(feature = "blocking")]
+fn can_create_subscription_plan_interval() {
+    mock::with_client(|client| {
+        let id = "sub_123".parse().unwrap();
+        let mut create = stripe::CreateSubscriptionItem::new(id);
+        create.price_data = Some(stripe::SubscriptionItemPriceData {
+            currency: stripe::Currency::USD,
+            product: "My Product".to_string(),
+            recurring: stripe::SubscriptionItemPriceDataRecurring {
+                interval: stripe::SubscriptionItemInterval::Day,
+                interval_count: Some(6),
+            },
+            tax_behavior: None,
+            unit_amount: None,
+            unit_amount_decimal: None,
+        });
+        let result = stripe::SubscriptionItem::create(client, create).unwrap();
+    });
+}


### PR DESCRIPTION
This reexports the various overlapping APIs with different names and adds tests to ensure they continue to work.

Closes #67 and closes #66