### PR TITLE
Updating BTreeMap::from to Rust 1.56 syntax

### DIFF
--- a/openapi/src/mappings.rs
+++ b/openapi/src/mappings.rs
@@ -1,23 +1,20 @@
 use std::collections::BTreeMap;
 
 pub fn id_renames() -> BTreeMap<&'static str, &'static str> {
-    [
+    BTreeMap::from([
         ("fee_refund", "application_fee_refund"),
         ("invoiceitem", "invoice_item"),
         ("line_item", "invoice_line_item"),
         ("source_transaction", "charge"),
         ("item", "checkout_session_item"),
-    ]
-    .iter()
-    .copied()
-    .collect()
+    ])
 }
 
 pub type ObjectMap = BTreeMap<&'static str, &'static str>;
 
 #[rustfmt::skip]
 pub fn object_mappings() -> ObjectMap {
-    [
+    BTreeMap::from([
         // Config for object types
         ("account_business_profile", "business_profile"),
         ("account_capabilities_card_issuing", "capability_status"),
@@ -179,10 +176,7 @@ pub fn object_mappings() -> ObjectMap {
         ("webhook_endpoint_api_version", "api_version"),
         ("create_webhook_endpoint_enabled_events", "event_filter"),
         ("update_webhook_endpoint_enabled_events", "event_filter"),
-    ]
-    .iter()
-    .copied()
-    .collect()
+    ])
 }
 
 pub type FieldMap = BTreeMap<FieldSpec, ImportSpec>;
@@ -197,7 +191,7 @@ pub type ImportSpec = (
 
 #[rustfmt::skip]
 pub fn field_mappings() -> FieldMap {
-    [
+    BTreeMap::from([
         // Config for object types
         (("account", "type"), ("AccountType", "Option<AccountType>")),
         (("balance_transaction", "status"), ("BalanceTransactionStatus", "BalanceTransactionStatus")),
@@ -546,8 +540,5 @@ pub fn field_mappings() -> FieldMap {
         ),
         (("transfer_schedule_params", "delay_days"), ("DelayDays", "Option<DelayDays>")),
         (("create_webhook_endpoint", "api_version"), ("ApiVersion", "Option<ApiVersion>")),
-    ]
-    .iter()
-    .copied()
-    .collect()
+    ])
 }

--- a/openapi/src/metadata.rs
+++ b/openapi/src/metadata.rs
@@ -238,7 +238,7 @@ pub fn feature_groups() -> BTreeMap<&'static str, &'static str> {
 		("reserve_transaction", "core"),
 		("token", "core"),
 		// Payment Methods
-        ("alipay_account", "payment-methods"),
+                ("alipay_account", "payment-methods"),
 		("bank_account", "payment-methods"),
 		("payment_method", "payment-methods"),
 		("source", "payment-methods"),


### PR DESCRIPTION
This changes the old format for instantiating Maps from `.iter().cloned().collect()` to the new `BTreeMap::from` syntax introduced in Rust 1.56.

Please feel free to reject if this jump in MSRV (1.49 -> 1.56) is too large - just a QOL change I spotted digging around the codebase.