### PR TITLE
accept null as an InvoiceId

### DIFF
--- a/src/ids.rs
+++ b/src/ids.rs
@@ -581,11 +581,16 @@ impl<'de> serde::Deserialize<'de> for InvoiceId {
     where
         D: serde::de::Deserializer<'de>,
     {
-        let s: String = serde::Deserialize::deserialize(deserializer)?;
-        if s.is_empty() {
-            Ok(InvoiceId::none())
-        } else {
-            s.parse::<Self>().map_err(::serde::de::Error::custom)
+        let s: Option<String> = serde::Deserialize::deserialize(deserializer)?;
+        match s {
+            None => Ok(InvoiceId::none()),
+            Some(s) => {
+                if s.is_empty() {
+                    Ok(InvoiceId::none())
+                } else {
+                    s.parse::<Self>().map_err(::serde::de::Error::custom)
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
In some webhook requests from stripe, when an object has an `invoice_id`field but the entity isn't associated with an invoice, rather than the field being `""` or `null`, the whole field is simply absent.

This change accepts a missing `invoice_id` field and interprets that case into `none()`