### PR TITLE
Updates for Enums and Card Values

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ hyper = { version = "0.14", default-features = false, features = ["http1", "http
 hyper-tls = { version = "0.5", optional = true }
 hyper-rustls = { version = "0.22", optional = true }
 serde = ">=1.0.79" # we use `serde(other)` which was introduced in 1.0.79
+serde_path_to_error = "^0.1.5"
 serde_derive = ">=1.0.79"
 serde_json = "1.0"
 serde_qs = "0.8"

--- a/openapi/src/main.rs
+++ b/openapi/src/main.rs
@@ -1216,12 +1216,12 @@ fn gen_objects(out: &mut String, state: &mut Generated) {
         }
 
         let schema = value_obj.schema.clone();
+        out.push_str("\n");
         print_doc_from_schema(out, &schema, 0);
 
         if let Some(type_) = schema["type"].as_str() {
             match type_ {
                 "object" => {
-                    out.push_str("\n");
                     out.push_str("#[derive(Clone, Debug, Deserialize, Serialize)]\n");
                     out.push_str(&format!("pub struct {} {{\n", key_str));
                     if let Some(prop_map) = schema["properties"].as_object() {
@@ -1264,7 +1264,6 @@ fn gen_objects(out: &mut String, state: &mut Generated) {
                 other => assert!(false, "Expected an object here got: {}", other),
             }
         } else if let Some(array) = schema["anyOf"].as_array() {
-            out.push_str("\n");
             out.push_str("#[derive(Clone, Debug, Deserialize, Serialize)]\n");
             out.push_str(&format!("pub enum {} {{\n", key_str));
 

--- a/openapi/src/main.rs
+++ b/openapi/src/main.rs
@@ -1265,6 +1265,7 @@ fn gen_objects(out: &mut String, state: &mut Generated) {
             }
         } else if let Some(array) = schema["anyOf"].as_array() {
             out.push_str("#[derive(Clone, Debug, Deserialize, Serialize)]\n");
+            out.push_str("#[serde(rename_all = \"snake_case\")]\n");
             out.push_str(&format!("pub enum {} {{\n", key_str));
 
             let mut index = 0;

--- a/openapi/src/main.rs
+++ b/openapi/src/main.rs
@@ -1109,7 +1109,7 @@ fn gen_unions(out: &mut String, state: &mut Generated, meta: &Metadata) {
 
         out.push('\n');
         out.push_str("#[derive(Clone, Debug, Deserialize, Serialize)]\n");
-        out.push_str("#[serde(tag = \"object\", rename_all = \"snake_case\")]\n");
+        out.push_str("#[serde(untagged, rename_all = \"snake_case\")]\n");
         out.push_str("pub enum ");
         out.push_str(&union_name.to_camel_case());
         out.push_str(" {\n");

--- a/src/client/tokio.rs
+++ b/src/client/tokio.rs
@@ -272,7 +272,12 @@ fn send<T: DeserializeOwned + Send + 'static>(
     let client = client.clone(); // N.B. Client is send sync;  cloned clients share the same pool.
     Box::pin(async move {
         let bytes = send_inner(&client, request).await?;
-        println!("{:#?}", bytes);
+        let mut jd = serde_json::Deserializer::from_slice(&bytes);
+        let result : Result<T, _> = serde_path_to_error::deserialize(&mut jd);
+        if let Err(err) = result
+        {
+            println!("{:#?}", err);
+        }
         serde_json::from_slice(&bytes).map_err(StripeError::from)
     })
 }

--- a/src/client/tokio.rs
+++ b/src/client/tokio.rs
@@ -272,6 +272,7 @@ fn send<T: DeserializeOwned + Send + 'static>(
     let client = client.clone(); // N.B. Client is send sync;  cloned clients share the same pool.
     Box::pin(async move {
         let bytes = send_inner(&client, request).await?;
+        println!("{:#?}", bytes);
         serde_json::from_slice(&bytes).map_err(StripeError::from)
     })
 }

--- a/src/client/tokio.rs
+++ b/src/client/tokio.rs
@@ -273,9 +273,8 @@ fn send<T: DeserializeOwned + Send + 'static>(
     Box::pin(async move {
         let bytes = send_inner(&client, request).await?;
         let mut jd = serde_json::Deserializer::from_slice(&bytes);
-        let result : Result<T, _> = serde_path_to_error::deserialize(&mut jd);
-        if let Err(err) = result
-        {
+        let result: Result<T, _> = serde_path_to_error::deserialize(&mut jd);
+        if let Err(err) = result {
             println!("{:#?}", err);
         }
         serde_json::from_slice(&bytes).map_err(StripeError::from)

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -20,6 +20,7 @@ mod core {
     pub mod payment_source;
     pub mod payout_ext;
     pub mod placeholders;
+    pub mod setup_intent_ext;
     pub mod token_ext;
 }
 
@@ -90,6 +91,7 @@ pub use {
         placeholders::*,
         payout_ext::*,
         token_ext::*,
+        setup_intent_ext::*,
     },
     generated::core::{
         address::*,

--- a/src/resources/generated/account.rs
+++ b/src/resources/generated/account.rs
@@ -1853,7 +1853,7 @@ pub struct TransferScheduleParams {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "object", rename_all = "snake_case")]
+#[serde(untagged, rename_all = "snake_case")]
 pub enum ExternalAccount {
     BankAccount(BankAccount),
     Card(Card),

--- a/src/resources/generated/api_errors.rs
+++ b/src/resources/generated/api_errors.rs
@@ -64,7 +64,7 @@ pub struct ApiErrors {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "object", rename_all = "snake_case")]
+#[serde(untagged, rename_all = "snake_case")]
 pub enum ApiErrorsSourceUnion {
     BankAccount(BankAccount),
     Card(Card),

--- a/src/resources/generated/balance_transaction.rs
+++ b/src/resources/generated/balance_transaction.rs
@@ -211,7 +211,7 @@ impl<'a> ListBalanceTransactions<'a> {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "object", rename_all = "snake_case")]
+#[serde(untagged, rename_all = "snake_case")]
 pub enum BalanceTransactionSourceUnion {
     ApplicationFee(ApplicationFee),
     Charge(Charge),

--- a/src/resources/generated/charge.rs
+++ b/src/resources/generated/charge.rs
@@ -2042,8 +2042,8 @@ impl std::fmt::Display for PaymentMethodDetailsSofortPreferredLanguage {
         self.as_str().fmt(f)
     }
 }
-/// A token, like the ones returned by [Stripe.js](https://stripe.com/docs/js).
 
+/// A token, like the ones returned by [Stripe.js](https://stripe.com/docs/js).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum CreateChargeCardInfo {
     CustomerPaymentSourceCard(CustomerPaymentSourceCard),

--- a/src/resources/generated/charge.rs
+++ b/src/resources/generated/charge.rs
@@ -1202,8 +1202,13 @@ pub struct CreateCharge<'a> {
     pub capture: Option<bool>,
 
     /// A token, like the ones returned by [Stripe.js](https://stripe.com/docs/js).
+    #[serde(rename = "card")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub card: Option<CreateChargeCardInfo>,
+    pub card0: Option<CustomerPaymentSourceCard>,
+
+    #[serde(rename = "card")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub card1: Option<String>,
 
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     ///
@@ -1296,7 +1301,8 @@ impl<'a> CreateCharge<'a> {
             application_fee: Default::default(),
             application_fee_amount: Default::default(),
             capture: Default::default(),
-            card: Default::default(),
+            card0: Default::default(),
+            card1: Default::default(),
             currency: Default::default(),
             customer: Default::default(),
             description: Default::default(),
@@ -2041,14 +2047,6 @@ impl std::fmt::Display for PaymentMethodDetailsSofortPreferredLanguage {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         self.as_str().fmt(f)
     }
-}
-
-/// A token, like the ones returned by [Stripe.js](https://stripe.com/docs/js).
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum CreateChargeCardInfo {
-    CustomerPaymentSourceCard(CustomerPaymentSourceCard),
-    Alternate1(String),
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/src/resources/generated/charge.rs
+++ b/src/resources/generated/charge.rs
@@ -2045,6 +2045,7 @@ impl std::fmt::Display for PaymentMethodDetailsSofortPreferredLanguage {
 
 /// A token, like the ones returned by [Stripe.js](https://stripe.com/docs/js).
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum CreateChargeCardInfo {
     CustomerPaymentSourceCard(CustomerPaymentSourceCard),
     Alternate1(String),

--- a/src/resources/generated/charge.rs
+++ b/src/resources/generated/charge.rs
@@ -1201,6 +1201,10 @@ pub struct CreateCharge<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub capture: Option<bool>,
 
+    /// A token, like the ones returned by [Stripe.js](https://stripe.com/docs/js).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub card: Option<CreateChargeCardInfo>,
+
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     ///
     /// Must be a [supported currency](https://stripe.com/docs/currencies).
@@ -1292,6 +1296,7 @@ impl<'a> CreateCharge<'a> {
             application_fee: Default::default(),
             application_fee_amount: Default::default(),
             capture: Default::default(),
+            card: Default::default(),
             currency: Default::default(),
             customer: Default::default(),
             description: Default::default(),
@@ -2036,4 +2041,38 @@ impl std::fmt::Display for PaymentMethodDetailsSofortPreferredLanguage {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         self.as_str().fmt(f)
     }
+}
+/// A token, like the ones returned by [Stripe.js](https://stripe.com/docs/js).
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum CreateChargeCardInfo {
+    CustomerPaymentSourceCard(CustomerPaymentSourceCard),
+    Alternate1(String),
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct CustomerPaymentSourceCard {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address_city: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address_country: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address_line1: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address_line2: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address_state: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address_zip: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cvc: Option<String>,
+    pub exp_month: i32,
+    pub exp_year: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Metadata>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    pub number: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub object: Option<String>,
 }

--- a/src/resources/generated/customer.rs
+++ b/src/resources/generated/customer.rs
@@ -434,6 +434,10 @@ pub struct UpdateCustomer<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub balance: Option<i64>,
 
+    /// A token, like the ones returned by [Stripe.js](https://stripe.com/docs/js).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub card: Option<UpdateCustomerCardInfo>,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub coupon: Option<CouponId>,
 
@@ -551,6 +555,7 @@ impl<'a> UpdateCustomer<'a> {
         UpdateCustomer {
             address: Default::default(),
             balance: Default::default(),
+            card: Default::default(),
             coupon: Default::default(),
             default_alipay_account: Default::default(),
             default_bank_account: Default::default(),
@@ -910,4 +915,38 @@ impl std::fmt::Display for TaxIdType {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         self.as_str().fmt(f)
     }
+}
+/// A token, like the ones returned by [Stripe.js](https://stripe.com/docs/js).
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum UpdateCustomerCardInfo {
+    CustomerPaymentSourceCard(CustomerPaymentSourceCard),
+    Alternate1(String),
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct CustomerPaymentSourceCard {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address_city: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address_country: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address_line1: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address_line2: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address_state: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address_zip: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cvc: Option<String>,
+    pub exp_month: i32,
+    pub exp_year: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Metadata>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    pub number: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub object: Option<String>,
 }

--- a/src/resources/generated/customer.rs
+++ b/src/resources/generated/customer.rs
@@ -916,8 +916,8 @@ impl std::fmt::Display for TaxIdType {
         self.as_str().fmt(f)
     }
 }
-/// A token, like the ones returned by [Stripe.js](https://stripe.com/docs/js).
 
+/// A token, like the ones returned by [Stripe.js](https://stripe.com/docs/js).
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum UpdateCustomerCardInfo {
     CustomerPaymentSourceCard(CustomerPaymentSourceCard),

--- a/src/resources/generated/customer.rs
+++ b/src/resources/generated/customer.rs
@@ -919,6 +919,7 @@ impl std::fmt::Display for TaxIdType {
 
 /// A token, like the ones returned by [Stripe.js](https://stripe.com/docs/js).
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum UpdateCustomerCardInfo {
     CustomerPaymentSourceCard(CustomerPaymentSourceCard),
     Alternate1(String),

--- a/src/resources/generated/customer.rs
+++ b/src/resources/generated/customer.rs
@@ -435,8 +435,13 @@ pub struct UpdateCustomer<'a> {
     pub balance: Option<i64>,
 
     /// A token, like the ones returned by [Stripe.js](https://stripe.com/docs/js).
+    #[serde(rename = "card")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub card: Option<UpdateCustomerCardInfo>,
+    pub card0: Option<CustomerPaymentSourceCard>,
+
+    #[serde(rename = "card")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub card1: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub coupon: Option<CouponId>,
@@ -555,7 +560,8 @@ impl<'a> UpdateCustomer<'a> {
         UpdateCustomer {
             address: Default::default(),
             balance: Default::default(),
-            card: Default::default(),
+            card0: Default::default(),
+            card1: Default::default(),
             coupon: Default::default(),
             default_alipay_account: Default::default(),
             default_bank_account: Default::default(),
@@ -915,14 +921,6 @@ impl std::fmt::Display for TaxIdType {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         self.as_str().fmt(f)
     }
-}
-
-/// A token, like the ones returned by [Stripe.js](https://stripe.com/docs/js).
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum UpdateCustomerCardInfo {
-    CustomerPaymentSourceCard(CustomerPaymentSourceCard),
-    Alternate1(String),
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/src/resources/generated/invoice.rs
+++ b/src/resources/generated/invoice.rs
@@ -288,6 +288,10 @@ pub struct Invoice {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub paid: Option<Box<bool>>,
 
+    /// Returns true if the invoice was manually marked paid, returns false if the invoice hasn't been paid yet or was paid on Stripe.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub paid_out_of_band: Option<Box<bool>>,
+
     /// The PaymentIntent associated with this invoice.
     ///
     /// The PaymentIntent is generated when the invoice is finalized, and can then be used to pay the invoice.

--- a/src/resources/generated/payment_intent.rs
+++ b/src/resources/generated/payment_intent.rs
@@ -443,7 +443,13 @@ pub struct PaymentIntentPaymentMethodOptions {
     pub card_present: Option<Box<PaymentIntentPaymentMethodOptionsCardPresentUnion>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub fpx: Option<Box<PaymentIntentPaymentMethodOptionsFpxUnion>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub giropay: Option<Box<PaymentIntentPaymentMethodOptionsGiropayUnion>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub grabpay: Option<Box<PaymentIntentPaymentMethodOptionsGrabpayUnion>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ideal: Option<Box<PaymentIntentPaymentMethodOptionsIdealUnion>>,
@@ -612,7 +618,13 @@ pub struct PaymentMethodOptionsCardInstallments {
 pub struct PaymentMethodOptionsCardPresent {}
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct PaymentMethodOptionsFpx {}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct PaymentMethodOptionsGiropay {}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct PaymentMethodOptionsGrabpay {}
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct PaymentMethodOptionsIdeal {}
@@ -1176,7 +1188,13 @@ pub struct CreatePaymentIntentPaymentMethodOptions {
     pub card_present: Option<Box<CreatePaymentIntentPaymentMethodOptionsCardPresent>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub fpx: Option<Box<CreatePaymentIntentPaymentMethodOptionsFpx>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub giropay: Option<Box<CreatePaymentIntentPaymentMethodOptionsGiropay>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub grabpay: Option<Box<CreatePaymentIntentPaymentMethodOptionsGrabpay>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ideal: Option<Box<CreatePaymentIntentPaymentMethodOptionsIdeal>>,
@@ -1323,7 +1341,13 @@ pub struct UpdatePaymentIntentPaymentMethodOptions {
     pub card_present: Option<Box<UpdatePaymentIntentPaymentMethodOptionsCardPresent>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub fpx: Option<Box<UpdatePaymentIntentPaymentMethodOptionsFpx>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub giropay: Option<Box<UpdatePaymentIntentPaymentMethodOptionsGiropay>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub grabpay: Option<Box<UpdatePaymentIntentPaymentMethodOptionsGrabpay>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ideal: Option<Box<UpdatePaymentIntentPaymentMethodOptionsIdeal>>,
@@ -1555,7 +1579,13 @@ pub struct CreatePaymentIntentPaymentMethodOptionsCard {
 pub struct CreatePaymentIntentPaymentMethodOptionsCardPresent {}
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct CreatePaymentIntentPaymentMethodOptionsFpx {}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct CreatePaymentIntentPaymentMethodOptionsGiropay {}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct CreatePaymentIntentPaymentMethodOptionsGrabpay {}
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct CreatePaymentIntentPaymentMethodOptionsIdeal {}
@@ -1792,7 +1822,13 @@ pub struct UpdatePaymentIntentPaymentMethodOptionsCard {
 pub struct UpdatePaymentIntentPaymentMethodOptionsCardPresent {}
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct UpdatePaymentIntentPaymentMethodOptionsFpx {}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct UpdatePaymentIntentPaymentMethodOptionsGiropay {}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct UpdatePaymentIntentPaymentMethodOptionsGrabpay {}
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct UpdatePaymentIntentPaymentMethodOptionsIdeal {}
@@ -2091,8 +2127,28 @@ pub enum PaymentIntentPaymentMethodOptionsCardUnion {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(untagged, rename_all = "snake_case")]
+pub enum PaymentIntentPaymentMethodOptionsFpxUnion {
+    PaymentMethodOptionsFpx(PaymentMethodOptionsFpx),
+    #[serde(rename = "PaymentIntentTypeSpecificPaymentMethodOptionsClient")]
+    PaymentIntentTypeSpecificPaymentMethodOptionsClient(
+        PaymentIntentTypeSpecificPaymentMethodOptionsClient,
+    ),
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged, rename_all = "snake_case")]
 pub enum PaymentIntentPaymentMethodOptionsGiropayUnion {
     PaymentMethodOptionsGiropay(PaymentMethodOptionsGiropay),
+    #[serde(rename = "PaymentIntentTypeSpecificPaymentMethodOptionsClient")]
+    PaymentIntentTypeSpecificPaymentMethodOptionsClient(
+        PaymentIntentTypeSpecificPaymentMethodOptionsClient,
+    ),
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged, rename_all = "snake_case")]
+pub enum PaymentIntentPaymentMethodOptionsGrabpayUnion {
+    PaymentMethodOptionsGrabpay(PaymentMethodOptionsGrabpay),
     #[serde(rename = "PaymentIntentTypeSpecificPaymentMethodOptionsClient")]
     PaymentIntentTypeSpecificPaymentMethodOptionsClient(
         PaymentIntentTypeSpecificPaymentMethodOptionsClient,

--- a/src/resources/generated/payment_intent.rs
+++ b/src/resources/generated/payment_intent.rs
@@ -2010,7 +2010,7 @@ pub struct UpdatePaymentIntentPaymentMethodOptionsCardInstallmentsPlan {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "object", rename_all = "snake_case")]
+#[serde(untagged, rename_all = "snake_case")]
 pub enum PaymentIntentPaymentMethodOptionsAcssDebitUnion {
     PaymentIntentPaymentMethodOptionsAcssDebit(PaymentIntentPaymentMethodOptionsAcssDebit),
     #[serde(rename = "PaymentIntentTypeSpecificPaymentMethodOptionsClient")]
@@ -2020,7 +2020,7 @@ pub enum PaymentIntentPaymentMethodOptionsAcssDebitUnion {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "object", rename_all = "snake_case")]
+#[serde(untagged, rename_all = "snake_case")]
 pub enum PaymentIntentPaymentMethodOptionsAfterpayClearpayUnion {
     PaymentMethodOptionsAfterpayClearpay(PaymentMethodOptionsAfterpayClearpay),
     #[serde(rename = "PaymentIntentTypeSpecificPaymentMethodOptionsClient")]
@@ -2030,7 +2030,7 @@ pub enum PaymentIntentPaymentMethodOptionsAfterpayClearpayUnion {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "object", rename_all = "snake_case")]
+#[serde(untagged, rename_all = "snake_case")]
 pub enum PaymentIntentPaymentMethodOptionsAlipayUnion {
     PaymentMethodOptionsAlipay(PaymentMethodOptionsAlipay),
     #[serde(rename = "PaymentIntentTypeSpecificPaymentMethodOptionsClient")]
@@ -2040,7 +2040,7 @@ pub enum PaymentIntentPaymentMethodOptionsAlipayUnion {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "object", rename_all = "snake_case")]
+#[serde(untagged, rename_all = "snake_case")]
 pub enum PaymentIntentPaymentMethodOptionsAuBecsDebitUnion {
     PaymentIntentPaymentMethodOptionsAuBecsDebit(PaymentIntentPaymentMethodOptionsAuBecsDebit),
     #[serde(rename = "PaymentIntentTypeSpecificPaymentMethodOptionsClient")]
@@ -2050,7 +2050,7 @@ pub enum PaymentIntentPaymentMethodOptionsAuBecsDebitUnion {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "object", rename_all = "snake_case")]
+#[serde(untagged, rename_all = "snake_case")]
 pub enum PaymentIntentPaymentMethodOptionsBancontactUnion {
     PaymentMethodOptionsBancontact(PaymentMethodOptionsBancontact),
     #[serde(rename = "PaymentIntentTypeSpecificPaymentMethodOptionsClient")]
@@ -2060,7 +2060,7 @@ pub enum PaymentIntentPaymentMethodOptionsBancontactUnion {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "object", rename_all = "snake_case")]
+#[serde(untagged, rename_all = "snake_case")]
 pub enum PaymentIntentPaymentMethodOptionsBoletoUnion {
     PaymentMethodOptionsBoleto(PaymentMethodOptionsBoleto),
     #[serde(rename = "PaymentIntentTypeSpecificPaymentMethodOptionsClient")]
@@ -2070,7 +2070,7 @@ pub enum PaymentIntentPaymentMethodOptionsBoletoUnion {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "object", rename_all = "snake_case")]
+#[serde(untagged, rename_all = "snake_case")]
 pub enum PaymentIntentPaymentMethodOptionsCardPresentUnion {
     PaymentMethodOptionsCardPresent(PaymentMethodOptionsCardPresent),
     #[serde(rename = "PaymentIntentTypeSpecificPaymentMethodOptionsClient")]
@@ -2080,7 +2080,7 @@ pub enum PaymentIntentPaymentMethodOptionsCardPresentUnion {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "object", rename_all = "snake_case")]
+#[serde(untagged, rename_all = "snake_case")]
 pub enum PaymentIntentPaymentMethodOptionsCardUnion {
     PaymentIntentPaymentMethodOptionsCard(PaymentIntentPaymentMethodOptionsCard),
     #[serde(rename = "PaymentIntentTypeSpecificPaymentMethodOptionsClient")]
@@ -2090,7 +2090,7 @@ pub enum PaymentIntentPaymentMethodOptionsCardUnion {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "object", rename_all = "snake_case")]
+#[serde(untagged, rename_all = "snake_case")]
 pub enum PaymentIntentPaymentMethodOptionsGiropayUnion {
     PaymentMethodOptionsGiropay(PaymentMethodOptionsGiropay),
     #[serde(rename = "PaymentIntentTypeSpecificPaymentMethodOptionsClient")]
@@ -2100,7 +2100,7 @@ pub enum PaymentIntentPaymentMethodOptionsGiropayUnion {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "object", rename_all = "snake_case")]
+#[serde(untagged, rename_all = "snake_case")]
 pub enum PaymentIntentPaymentMethodOptionsIdealUnion {
     PaymentMethodOptionsIdeal(PaymentMethodOptionsIdeal),
     #[serde(rename = "PaymentIntentTypeSpecificPaymentMethodOptionsClient")]
@@ -2110,7 +2110,7 @@ pub enum PaymentIntentPaymentMethodOptionsIdealUnion {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "object", rename_all = "snake_case")]
+#[serde(untagged, rename_all = "snake_case")]
 pub enum PaymentIntentPaymentMethodOptionsInteracPresentUnion {
     PaymentMethodOptionsInteracPresent(PaymentMethodOptionsInteracPresent),
     #[serde(rename = "PaymentIntentTypeSpecificPaymentMethodOptionsClient")]
@@ -2120,7 +2120,7 @@ pub enum PaymentIntentPaymentMethodOptionsInteracPresentUnion {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "object", rename_all = "snake_case")]
+#[serde(untagged, rename_all = "snake_case")]
 pub enum PaymentIntentPaymentMethodOptionsKlarnaUnion {
     PaymentMethodOptionsKlarna(PaymentMethodOptionsKlarna),
     #[serde(rename = "PaymentIntentTypeSpecificPaymentMethodOptionsClient")]
@@ -2130,7 +2130,7 @@ pub enum PaymentIntentPaymentMethodOptionsKlarnaUnion {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "object", rename_all = "snake_case")]
+#[serde(untagged, rename_all = "snake_case")]
 pub enum PaymentIntentPaymentMethodOptionsOxxoUnion {
     PaymentMethodOptionsOxxo(PaymentMethodOptionsOxxo),
     #[serde(rename = "PaymentIntentTypeSpecificPaymentMethodOptionsClient")]
@@ -2140,7 +2140,7 @@ pub enum PaymentIntentPaymentMethodOptionsOxxoUnion {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "object", rename_all = "snake_case")]
+#[serde(untagged, rename_all = "snake_case")]
 pub enum PaymentIntentPaymentMethodOptionsP24Union {
     PaymentMethodOptionsP24(PaymentMethodOptionsP24),
     #[serde(rename = "PaymentIntentTypeSpecificPaymentMethodOptionsClient")]
@@ -2150,7 +2150,7 @@ pub enum PaymentIntentPaymentMethodOptionsP24Union {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "object", rename_all = "snake_case")]
+#[serde(untagged, rename_all = "snake_case")]
 pub enum PaymentIntentPaymentMethodOptionsSepaDebitUnion {
     PaymentIntentPaymentMethodOptionsSepaDebit(PaymentIntentPaymentMethodOptionsSepaDebit),
     #[serde(rename = "PaymentIntentTypeSpecificPaymentMethodOptionsClient")]
@@ -2160,7 +2160,7 @@ pub enum PaymentIntentPaymentMethodOptionsSepaDebitUnion {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "object", rename_all = "snake_case")]
+#[serde(untagged, rename_all = "snake_case")]
 pub enum PaymentIntentPaymentMethodOptionsSofortUnion {
     PaymentMethodOptionsSofort(PaymentMethodOptionsSofort),
     #[serde(rename = "PaymentIntentTypeSpecificPaymentMethodOptionsClient")]
@@ -2170,7 +2170,7 @@ pub enum PaymentIntentPaymentMethodOptionsSofortUnion {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "object", rename_all = "snake_case")]
+#[serde(untagged, rename_all = "snake_case")]
 pub enum PaymentIntentPaymentMethodOptionsWechatPayUnion {
     PaymentMethodOptionsWechatPay(PaymentMethodOptionsWechatPay),
     #[serde(rename = "PaymentIntentTypeSpecificPaymentMethodOptionsClient")]

--- a/src/resources/generated/payment_method.rs
+++ b/src/resources/generated/payment_method.rs
@@ -612,6 +612,14 @@ pub struct CreatePaymentMethod<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub boleto: Option<Box<CreatePaymentMethodBoleto>>,
 
+    /// If this is a `card` PaymentMethod, this hash contains the user's card details.
+    ///
+    /// For backwards compatibility, you can alternatively provide a Stripe token (e.g., for Apple Pay, Amex Express Checkout, or legacy Checkout) into the card hash with format `card: {token: "tok_visa"}`.
+    /// When providing a card number, you must meet the requirements for [PCI compliance](https://stripe.com/docs/security#validating-pci-compliance).
+    /// We strongly recommend using Stripe.js instead of interacting with this API directly.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub card: Option<CreatePaymentMethodCardInfo>,
+
     /// The `Customer` to whom the original PaymentMethod is attached.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub customer: Option<CustomerId>,
@@ -700,6 +708,7 @@ impl<'a> CreatePaymentMethod<'a> {
             bancontact: Default::default(),
             billing_details: Default::default(),
             boleto: Default::default(),
+            card: Default::default(),
             customer: Default::default(),
             eps: Default::default(),
             expand: Default::default(),
@@ -777,6 +786,10 @@ pub struct UpdatePaymentMethod<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub billing_details: Option<BillingDetails>,
 
+    /// If this is a `card` PaymentMethod, this hash contains the user's card details.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub card: Option<UpdatePaymentMethodCardInfo>,
+
     /// Specifies which fields in the response should be expanded.
     #[serde(skip_serializing_if = "Expand::is_empty")]
     pub expand: &'a [&'a str],
@@ -794,6 +807,7 @@ impl<'a> UpdatePaymentMethod<'a> {
     pub fn new() -> Self {
         UpdatePaymentMethod {
             billing_details: Default::default(),
+            card: Default::default(),
             expand: Default::default(),
             metadata: Default::default(),
         }
@@ -1742,4 +1756,38 @@ impl std::fmt::Display for WalletDetailsType {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         self.as_str().fmt(f)
     }
+}
+/// If this is a `card` PaymentMethod, this hash contains the user's card details.
+///
+/// For backwards compatibility, you can alternatively provide a Stripe token (e.g., for Apple Pay, Amex Express Checkout, or legacy Checkout) into the card hash with format `card: {token: "tok_visa"}`.
+/// When providing a card number, you must meet the requirements for [PCI compliance](https://stripe.com/docs/security#validating-pci-compliance).
+/// We strongly recommend using Stripe.js instead of interacting with this API directly.
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum CreatePaymentMethodCardInfo {
+    CardDetailsParams(CardDetailsParams),
+    TokenParams(TokenParams),
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct CardDetailsParams {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cvc: Option<String>,
+    pub exp_month: i32,
+    pub exp_year: i32,
+    pub number: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct TokenParams {
+    pub token: String,
+}
+/// If this is a `card` PaymentMethod, this hash contains the user's card details.
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct UpdatePaymentMethodCardInfo {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exp_month: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exp_year: Option<i32>,
 }

--- a/src/resources/generated/payment_method.rs
+++ b/src/resources/generated/payment_method.rs
@@ -617,8 +617,13 @@ pub struct CreatePaymentMethod<'a> {
     /// For backwards compatibility, you can alternatively provide a Stripe token (e.g., for Apple Pay, Amex Express Checkout, or legacy Checkout) into the card hash with format `card: {token: "tok_visa"}`.
     /// When providing a card number, you must meet the requirements for [PCI compliance](https://stripe.com/docs/security#validating-pci-compliance).
     /// We strongly recommend using Stripe.js instead of interacting with this API directly.
+    #[serde(rename = "card")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub card: Option<CreatePaymentMethodCardInfo>,
+    pub card0: Option<CardDetailsParams>,
+
+    #[serde(rename = "card")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub card1: Option<TokenParams>,
 
     /// The `Customer` to whom the original PaymentMethod is attached.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -708,7 +713,8 @@ impl<'a> CreatePaymentMethod<'a> {
             bancontact: Default::default(),
             billing_details: Default::default(),
             boleto: Default::default(),
-            card: Default::default(),
+            card0: Default::default(),
+            card1: Default::default(),
             customer: Default::default(),
             eps: Default::default(),
             expand: Default::default(),
@@ -788,7 +794,7 @@ pub struct UpdatePaymentMethod<'a> {
 
     /// If this is a `card` PaymentMethod, this hash contains the user's card details.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub card: Option<UpdatePaymentMethodCardInfo>,
+    pub card: Option<UpdateApiParam>,
 
     /// Specifies which fields in the response should be expanded.
     #[serde(skip_serializing_if = "Expand::is_empty")]
@@ -1758,18 +1764,6 @@ impl std::fmt::Display for WalletDetailsType {
     }
 }
 
-/// If this is a `card` PaymentMethod, this hash contains the user's card details.
-///
-/// For backwards compatibility, you can alternatively provide a Stripe token (e.g., for Apple Pay, Amex Express Checkout, or legacy Checkout) into the card hash with format `card: {token: "tok_visa"}`.
-/// When providing a card number, you must meet the requirements for [PCI compliance](https://stripe.com/docs/security#validating-pci-compliance).
-/// We strongly recommend using Stripe.js instead of interacting with this API directly.
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum CreatePaymentMethodCardInfo {
-    CardDetailsParams(CardDetailsParams),
-    TokenParams(TokenParams),
-}
-
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct CardDetailsParams {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1786,7 +1780,7 @@ pub struct TokenParams {
 
 /// If this is a `card` PaymentMethod, this hash contains the user's card details.
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct UpdatePaymentMethodCardInfo {
+pub struct UpdateApiParam {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub exp_month: Option<i32>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/resources/generated/payment_method.rs
+++ b/src/resources/generated/payment_method.rs
@@ -1757,12 +1757,12 @@ impl std::fmt::Display for WalletDetailsType {
         self.as_str().fmt(f)
     }
 }
+
 /// If this is a `card` PaymentMethod, this hash contains the user's card details.
 ///
 /// For backwards compatibility, you can alternatively provide a Stripe token (e.g., for Apple Pay, Amex Express Checkout, or legacy Checkout) into the card hash with format `card: {token: "tok_visa"}`.
 /// When providing a card number, you must meet the requirements for [PCI compliance](https://stripe.com/docs/security#validating-pci-compliance).
 /// We strongly recommend using Stripe.js instead of interacting with this API directly.
-
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum CreatePaymentMethodCardInfo {
     CardDetailsParams(CardDetailsParams),
@@ -1782,8 +1782,8 @@ pub struct CardDetailsParams {
 pub struct TokenParams {
     pub token: String,
 }
-/// If this is a `card` PaymentMethod, this hash contains the user's card details.
 
+/// If this is a `card` PaymentMethod, this hash contains the user's card details.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct UpdatePaymentMethodCardInfo {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/resources/generated/payment_method.rs
+++ b/src/resources/generated/payment_method.rs
@@ -1764,6 +1764,7 @@ impl std::fmt::Display for WalletDetailsType {
 /// When providing a card number, you must meet the requirements for [PCI compliance](https://stripe.com/docs/security#validating-pci-compliance).
 /// We strongly recommend using Stripe.js instead of interacting with this API directly.
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum CreatePaymentMethodCardInfo {
     CardDetailsParams(CardDetailsParams),
     TokenParams(TokenParams),

--- a/src/resources/generated/payment_method.rs
+++ b/src/resources/generated/payment_method.rs
@@ -740,6 +740,8 @@ impl<'a> CreatePaymentMethod<'a> {
 #[derive(Clone, Debug, Serialize)]
 pub struct ListPaymentMethods<'a> {
     /// The ID of the customer whose PaymentMethods will be retrieved.
+    ///
+    /// If not provided, the response list will be empty.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub customer: Option<CustomerId>,
 

--- a/src/resources/generated/payout.rs
+++ b/src/resources/generated/payout.rs
@@ -296,7 +296,7 @@ impl<'a> UpdatePayout<'a> {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "object", rename_all = "snake_case")]
+#[serde(untagged, rename_all = "snake_case")]
 pub enum PayoutDestinationUnion {
     BankAccount(BankAccount),
     Card(Card),

--- a/src/resources/generated/recipient.rs
+++ b/src/resources/generated/recipient.rs
@@ -129,6 +129,15 @@ impl Object for Recipient {
 /// The parameters for `Recipient::create`.
 #[derive(Clone, Debug, Serialize)]
 pub struct CreateRecipient<'a> {
+    /// A U.S.
+    ///
+    /// Visa or MasterCard debit card (_not_ prepaid) to attach to the recipient.
+    /// If the debit card is not valid, recipient creation will fail.
+    /// You can provide either a token, like the ones returned by [Stripe.js](https://stripe.com/docs/js), or a dictionary containing a user's debit card details, with the options described below.
+    /// Although not all information is required, the extra info helps prevent fraud.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub card: Option<String>,
+
     /// An arbitrary string which you can attach to a `Recipient` object.
     ///
     /// It is displayed alongside the recipient in the web interface.
@@ -173,6 +182,7 @@ pub struct CreateRecipient<'a> {
 impl<'a> CreateRecipient<'a> {
     pub fn new(name: &'a str, type_: RecipientType) -> Self {
         CreateRecipient {
+            card: Default::default(),
             description: Default::default(),
             email: Default::default(),
             expand: Default::default(),
@@ -240,6 +250,16 @@ impl<'a> ListRecipients<'a> {
 /// The parameters for `Recipient::update`.
 #[derive(Clone, Debug, Serialize, Default)]
 pub struct UpdateRecipient<'a> {
+    /// A U.S.
+    ///
+    /// Visa or MasterCard debit card (not prepaid) to attach to the recipient.
+    /// You can provide either a token, like the ones returned by [Stripe.js](https://stripe.com/docs/js), or a dictionary containing a user's debit card details, with the options described below.
+    /// Passing `card` will create a new card, make it the new recipient default card, and delete the old recipient default (if one exists).
+    /// If you want to add additional debit cards instead of replacing the existing default, use the [card creation API](https://stripe.com/docs/api#create_card).
+    /// Whenever you attach a card to a recipient, Stripe will automatically validate the debit card.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub card: Option<String>,
+
     /// ID of the card to set as the recipient's new default for payouts.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_card: Option<&'a str>,
@@ -285,6 +305,7 @@ pub struct UpdateRecipient<'a> {
 impl<'a> UpdateRecipient<'a> {
     pub fn new() -> Self {
         UpdateRecipient {
+            card: Default::default(),
             default_card: Default::default(),
             description: Default::default(),
             email: Default::default(),

--- a/src/resources/generated/token.rs
+++ b/src/resources/generated/token.rs
@@ -326,6 +326,7 @@ impl std::fmt::Display for CreateTokenAccountBusinessType {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
 pub enum CreateTokenCardInfo {
     CreditCardSpecs(CreditCardSpecs),
     Alternate1(String),

--- a/src/resources/generated/token.rs
+++ b/src/resources/generated/token.rs
@@ -75,6 +75,9 @@ pub struct CreateToken<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub account: Option<Box<CreateTokenAccount>>,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub card: Option<CreateTokenCardInfo>,
+
     /// The customer (owned by the application's account) for which to create a token.
     ///
     /// This can be used only with an [OAuth access token](https://stripe.com/docs/connect/standard-accounts) or [Stripe-Account header](https://stripe.com/docs/connect/authentication).
@@ -103,6 +106,7 @@ impl<'a> CreateToken<'a> {
     pub fn new() -> Self {
         CreateToken {
             account: Default::default(),
+            card: Default::default(),
             customer: Default::default(),
             cvc_update: Default::default(),
             expand: Default::default(),
@@ -319,4 +323,35 @@ impl std::fmt::Display for CreateTokenAccountBusinessType {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         self.as_str().fmt(f)
     }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum CreateTokenCardInfo {
+    CreditCardSpecs(CreditCardSpecs),
+    Alternate1(String),
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct CreditCardSpecs {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address_city: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address_country: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address_line1: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address_line2: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address_state: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub address_zip: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub currency: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cvc: Option<String>,
+    pub exp_month: String,
+    pub exp_year: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    pub number: String,
 }

--- a/src/resources/generated/token.rs
+++ b/src/resources/generated/token.rs
@@ -75,8 +75,13 @@ pub struct CreateToken<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub account: Option<Box<CreateTokenAccount>>,
 
+    #[serde(rename = "card")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub card: Option<CreateTokenCardInfo>,
+    pub card0: Option<CreditCardSpecs>,
+
+    #[serde(rename = "card")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub card1: Option<String>,
 
     /// The customer (owned by the application's account) for which to create a token.
     ///
@@ -106,7 +111,8 @@ impl<'a> CreateToken<'a> {
     pub fn new() -> Self {
         CreateToken {
             account: Default::default(),
-            card: Default::default(),
+            card0: Default::default(),
+            card1: Default::default(),
             customer: Default::default(),
             cvc_update: Default::default(),
             expand: Default::default(),
@@ -323,13 +329,6 @@ impl std::fmt::Display for CreateTokenAccountBusinessType {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         self.as_str().fmt(f)
     }
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum CreateTokenCardInfo {
-    CreditCardSpecs(CreditCardSpecs),
-    Alternate1(String),
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/src/resources/setup_intent_ext.rs
+++ b/src/resources/setup_intent_ext.rs
@@ -1,14 +1,57 @@
-use crate::{resources::SetupIntent, Expandable, PaymentMethod};
+use serde_derive::Serialize;
 
-impl SetupIntent {
-    pub async fn confirm(&self, payment_method: Option<Expandable<PaymentMethod>>) -> SetupIntent {
-        unimplemented!()
+use crate::config::{Client, Response};
+use crate::resources::SetupIntent;
+use crate::SetupIntentId;
+
+#[derive(Clone, Debug, Serialize)]
+pub struct ConfirmSetupIntent {
+    /// Specifies which payment method
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payment_method: Option<String>,
+
+    //Mandate data and payment method options not implemented.  If you want
+    //something better, create an issue and lets fix
+    /// Where to redirect the user after they log out of their dashboard.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub redirect_url: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct CancelSetupIntent {}
+
+pub trait SetupIntentExt {
+    fn confirm(
+        client: &Client,
+        setup_id: &SetupIntentId,
+        params: ConfirmSetupIntent,
+    ) -> Response<Self>
+    where
+        Self: Sized;
+
+    fn cancel(
+        client: &Client,
+        setup_id: &SetupIntentId,
+        params: CancelSetupIntent,
+    ) -> Response<Self>
+    where
+        Self: Sized;
+}
+
+impl SetupIntentExt for SetupIntent {
+    fn confirm(
+        client: &Client,
+        setup_id: &SetupIntentId,
+        params: ConfirmSetupIntent,
+    ) -> Response<SetupIntent> {
+        client.post_form(&format!("/setup_intents/{}/confirm", setup_id), &params)
     }
 
-    pub async fn cancel(
-        &self,
-        cancellation_reason: Option<SetupIntentCancellationReason>,
-    ) -> SetupIntent {
+    fn cancel(
+        _client: &Client,
+        _setup_id: &SetupIntentId,
+        _params: CancelSetupIntent,
+    ) -> Response<SetupIntent> {
         unimplemented!()
     }
 }

--- a/src/resources/setup_intent_ext.rs
+++ b/src/resources/setup_intent_ext.rs
@@ -65,7 +65,8 @@ impl SetupIntentExt for SetupIntent {
     }
 
     fn retrieve_ext(client: &Client, setup_intent_secret: &String) -> Response<SetupIntent> {
-        client.get(&format!("/setup_intents/{}", setup_intent_secret))
+        unimplemented!()
+        //client.get(&format!("/setup_intents/{}", setup_intent_secret))
     }
 }
 

--- a/src/resources/setup_intent_ext.rs
+++ b/src/resources/setup_intent_ext.rs
@@ -37,7 +37,7 @@ pub trait SetupIntentExt {
     where
         Self: Sized;
 
-    fn retreive_ext(
+    fn retrieve_ext(
         client: &Client,
         setup_intent_secret: &String
     ) -> Response<Self>
@@ -62,7 +62,7 @@ impl SetupIntentExt for SetupIntent {
         unimplemented!()
     }
 
-    fn retreive_ext(
+    fn retrieve_ext(
         client: &Client,
         setup_intent_secret: &String
     ) -> Response<SetupIntent> {

--- a/src/resources/setup_intent_ext.rs
+++ b/src/resources/setup_intent_ext.rs
@@ -6,6 +6,11 @@ use crate::SetupIntentId;
 
 #[derive(Clone, Debug, Serialize)]
 pub struct ConfirmSetupIntent {
+
+    /// The client secret if on the client side
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_secret: Option<String>,
+
     /// Specifies which payment method
     #[serde(skip_serializing_if = "Option::is_none")]
     pub payment_method: Option<String>,

--- a/src/resources/setup_intent_ext.rs
+++ b/src/resources/setup_intent_ext.rs
@@ -37,12 +37,9 @@ pub trait SetupIntentExt {
     where
         Self: Sized;
 
-    fn retrieve_ext(
-        client: &Client,
-        setup_intent_secret: &String
-    ) -> Response<Self>
-        where 
-            Self: Sized;
+    fn retrieve_ext(client: &Client, setup_intent_secret: &String) -> Response<Self>
+    where
+        Self: Sized;
 }
 
 impl SetupIntentExt for SetupIntent {
@@ -62,10 +59,7 @@ impl SetupIntentExt for SetupIntent {
         unimplemented!()
     }
 
-    fn retrieve_ext(
-        client: &Client,
-        setup_intent_secret: &String
-    ) -> Response<SetupIntent> {
+    fn retrieve_ext(client: &Client, setup_intent_secret: &String) -> Response<SetupIntent> {
         client.get(&format!("/setup_intents/{}", setup_intent_secret))
     }
 }

--- a/src/resources/setup_intent_ext.rs
+++ b/src/resources/setup_intent_ext.rs
@@ -64,7 +64,7 @@ impl SetupIntentExt for SetupIntent {
         unimplemented!()
     }
 
-    fn retrieve_ext(client: &Client, setup_intent_secret: &String) -> Response<SetupIntent> {
+    fn retrieve_ext(_client: &Client, _setup_intent_secret: &String) -> Response<SetupIntent> {
         unimplemented!()
         //client.get(&format!("/setup_intents/{}", setup_intent_secret))
     }

--- a/src/resources/setup_intent_ext.rs
+++ b/src/resources/setup_intent_ext.rs
@@ -36,6 +36,13 @@ pub trait SetupIntentExt {
     ) -> Response<Self>
     where
         Self: Sized;
+
+    fn retreive_ext(
+        client: &Client,
+        setup_intent_secret: &String
+    ) -> Response<Self>
+        where 
+            Self: Sized;
 }
 
 impl SetupIntentExt for SetupIntent {
@@ -53,6 +60,13 @@ impl SetupIntentExt for SetupIntent {
         _params: CancelSetupIntent,
     ) -> Response<SetupIntent> {
         unimplemented!()
+    }
+
+    fn retreive_ext(
+        client: &Client,
+        setup_intent_secret: &String
+    ) -> Response<SetupIntent> {
+        client.get(&format!("/setup_intents/{}", setup_intent_secret))
     }
 }
 

--- a/src/resources/setup_intent_ext.rs
+++ b/src/resources/setup_intent_ext.rs
@@ -6,7 +6,6 @@ use crate::SetupIntentId;
 
 #[derive(Clone, Debug, Serialize)]
 pub struct ConfirmSetupIntent {
-
     /// The client secret if on the client side
     #[serde(skip_serializing_if = "Option::is_none")]
     pub client_secret: Option<String>,


### PR DESCRIPTION
Hey Arlyon,  I've made changes to enums so that they work under more circumstances.  In particular, I make the enums be untagged and not tagged with object.  This is what the OpenAPI expects, but it hasn't come up yet for others I guess.

I've also added code that properly handles credit cards.  I've tested this API myself, so I know it works.  I built the beginnings of a new paradigm for the code generation and made it so it only gets called by the code that handles the "card" keyword.  This way it can coexist in the baseline while we find and work out any bugs, but makes a clear path for stuff in the future.

I wasn't sure what to call this update, but I can make changes if you want them.  Let me know.  Also, your container seemed to break on the last build, not sure what that's about, but everything is building and testing fine on my machine.