### PR TITLE
Idempotency Feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,9 @@ full = [
   "orders",
   "sigma",
   "webhook-endpoints",
+  "idempotency",
 ]
+idempotency = []
 
 # stripe feature groups
 checkout = ["billing"]

--- a/openapi/src/main.rs
+++ b/openapi/src/main.rs
@@ -1931,8 +1931,20 @@ fn gen_impl_requests(
                 out.push_str("> {\n");
                 out.push_str("        client.post_form(\"/");
                 out.push_str(&segments.join("/"));
-                out.push_str("\", &params)\n");
+                out.push_str("\", &params, None)\n");
+                out.push_str("    }\n\n");
+
+                out.push_str("    #[cfg(feature = \"idempotency\")]\n");
+                out.push_str("    pub fn create_with_idempotency(client: &Client, params: ");
+                out.push_str(&params_name);
+                out.push_str("<'_>, idempotency_key: &str) -> Response<");
+                out.push_str(&return_type);
+                out.push_str("> {\n");
+                out.push_str("        client.post_form(\"/");
+                out.push_str(&segments.join("/"));
+                out.push_str("\", &params, Some(idempotency_key))\n");
                 out.push_str("    }");
+
                 methods.insert(MethodTypes::Create, out);
             } else if !methods.contains_key(&MethodTypes::Update)
                 && parameter_count == 1
@@ -1987,8 +1999,22 @@ fn gen_impl_requests(
                     out.push_str("> {\n");
                     out.push_str("        client.post_form(");
                     out.push_str(&format!("&format!(\"/{}/{{}}\", id)", segments[0]));
-                    out.push_str(", &params)\n");
+                    out.push_str(", &params, None)\n");
+                    out.push_str("    }\n\n");
+
+                    out.push_str("    #[cfg(feature = \"idempotency\")]\n");
+                    out.push_str("    pub fn update_with_idempotency(client: &Client, id: &");
+                    out.push_str(&id_type);
+                    out.push_str(", params: ");
+                    out.push_str(&params_name);
+                    out.push_str("<'_>, idempotency_key: &str) -> Response<");
+                    out.push_str(&return_type);
+                    out.push_str("> {\n");
+                    out.push_str("        client.post_form(");
+                    out.push_str(&format!("&format!(\"/{}/{{}}\", id)", segments[0]));
+                    out.push_str(", &params, Some(idempotency_key))\n");
                     out.push_str("    }");
+
                     methods.insert(MethodTypes::Update, out);
                 }
             }

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -96,8 +96,12 @@ impl Client {
     }
 
     /// Make a `POST` http request with just a path
-    pub fn post<T: DeserializeOwned + Send + 'static>(&self, path: &str) -> Response<T> {
-        self.send_blocking(self.inner.post(path))
+    pub fn post<T: DeserializeOwned + Send + 'static>(
+        &self,
+        path: &str,
+        idem_key: Option<&str>,
+    ) -> Response<T> {
+        self.send_blocking(self.inner.post(path, idem_key))
     }
 
     /// Make a `POST` http request with urlencoded body
@@ -105,8 +109,9 @@ impl Client {
         &self,
         path: &str,
         form: F,
+        idem_key: Option<&str>,
     ) -> Response<T> {
-        self.send_blocking(self.inner.post_form(path, form))
+        self.send_blocking(self.inner.post_form(path, form, idem_key))
     }
 
     fn send_blocking<T: DeserializeOwned + Send + 'static>(

--- a/src/ids.rs
+++ b/src/ids.rs
@@ -501,7 +501,7 @@ def_id!(OrderId, "or_");
 def_id!(OrderReturnId, "orret_");
 def_id!(MandateId: String); // TODO: Figure out what prefix this id has
 def_id!(PaymentIntentId, "pi_");
-def_id!(PaymentLinkId: String);
+def_id!(PaymentLinkId, "plink_");
 def_id!(PaymentMethodId, "pm_" | "card_" | "src_" | "ba_");
 def_id!(
     enum PaymentSourceId {

--- a/src/resources/charge_ext.rs
+++ b/src/resources/charge_ext.rs
@@ -41,8 +41,9 @@ impl Charge {
         client: &Client,
         charge_id: &ChargeId,
         params: CaptureCharge<'_>,
+        idem_key: Option<&str>,
     ) -> Response<Charge> {
-        client.post_form(&format!("/charges/{}/capture", charge_id), params)
+        client.post_form(&format!("/charges/{}/capture", charge_id), params, idem_key)
     }
 }
 

--- a/src/resources/customer_ext.rs
+++ b/src/resources/customer_ext.rs
@@ -13,13 +13,14 @@ impl Customer {
         client: &Client,
         customer_id: &CustomerId,
         source: PaymentSourceParams,
+        idem_key: Option<&str>,
     ) -> Response<PaymentSource> {
         #[derive(Serialize)]
         struct AttachSource {
             source: PaymentSourceParams,
         }
         let params = AttachSource { source };
-        client.post_form(&format!("/customers/{}/sources", customer_id), params)
+        client.post_form(&format!("/customers/{}/sources", customer_id), params, idem_key)
     }
 
     /// Detaches a source from a customer
@@ -50,10 +51,12 @@ impl Customer {
         customer_id: &CustomerId,
         bank_account_id: &BankAccountId,
         params: VerifyBankAccount<'_>,
+        idem_key: Option<&str>,
     ) -> Response<BankAccount> {
         client.post_form(
             &format!("/customers/{}/sources/{}/verify", customer_id, bank_account_id),
             params,
+            idem_key,
         )
     }
 }

--- a/src/resources/generated/account.rs
+++ b/src/resources/generated/account.rs
@@ -122,7 +122,16 @@ impl Account {
     /// With [Connect](https://stripe.com/docs/connect), you can create Stripe accounts for your users.
     /// To do this, you’ll first need to [register your platform](https://dashboard.stripe.com/account/applications/settings).
     pub fn create(client: &Client, params: CreateAccount<'_>) -> Response<Account> {
-        client.post_form("/accounts", &params)
+        client.post_form("/accounts", &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn create_with_idempotency(
+        client: &Client,
+        params: CreateAccount<'_>,
+        idempotency_key: &str,
+    ) -> Response<Account> {
+        client.post_form("/accounts", &params, Some(idempotency_key))
     }
 
     /// Retrieves the details of an account.
@@ -137,7 +146,17 @@ impl Account {
     /// (These are marked **Custom Only** below.) Parameters marked **Custom and Express** are not supported for Standard accounts.  To update your own account, use the [Dashboard](https://dashboard.stripe.com/account).
     /// Refer to our [Connect](https://stripe.com/docs/connect/updating-accounts) documentation to learn more about updating accounts.
     pub fn update(client: &Client, id: &AccountId, params: UpdateAccount<'_>) -> Response<Account> {
-        client.post_form(&format!("/accounts/{}", id), &params)
+        client.post_form(&format!("/accounts/{}", id), &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn update_with_idempotency(
+        client: &Client,
+        id: &AccountId,
+        params: UpdateAccount<'_>,
+        idempotency_key: &str,
+    ) -> Response<Account> {
+        client.post_form(&format!("/accounts/{}", id), &params, Some(idempotency_key))
     }
 
     /// With [Connect](https://stripe.com/docs/connect), you can delete accounts you manage.

--- a/src/resources/generated/account_link.rs
+++ b/src/resources/generated/account_link.rs
@@ -28,7 +28,16 @@ pub struct AccountLink {
 impl AccountLink {
     /// Creates an AccountLink object that includes a single-use Stripe URL that the platform can redirect their user to in order to take them through the Connect Onboarding flow.
     pub fn create(client: &Client, params: CreateAccountLink<'_>) -> Response<AccountLink> {
-        client.post_form("/account_links", &params)
+        client.post_form("/account_links", &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn create_with_idempotency(
+        client: &Client,
+        params: CreateAccountLink<'_>,
+        idempotency_key: &str,
+    ) -> Response<AccountLink> {
+        client.post_form("/account_links", &params, Some(idempotency_key))
     }
 }
 

--- a/src/resources/generated/billing_portal_session.rs
+++ b/src/resources/generated/billing_portal_session.rs
@@ -56,7 +56,16 @@ impl BillingPortalSession {
         client: &Client,
         params: CreateBillingPortalSession<'_>,
     ) -> Response<BillingPortalSession> {
-        client.post_form("/billing_portal/sessions", &params)
+        client.post_form("/billing_portal/sessions", &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn create_with_idempotency(
+        client: &Client,
+        params: CreateBillingPortalSession<'_>,
+        idempotency_key: &str,
+    ) -> Response<BillingPortalSession> {
+        client.post_form("/billing_portal/sessions", &params, Some(idempotency_key))
     }
 }
 

--- a/src/resources/generated/charge.rs
+++ b/src/resources/generated/charge.rs
@@ -231,7 +231,16 @@ impl Charge {
     /// If your API key is in test mode, the supplied payment source (e.g., card) won’t actually be charged, although everything else will occur as if in live mode.
     /// (Stripe assumes that the charge would have completed successfully).
     pub fn create(client: &Client, params: CreateCharge<'_>) -> Response<Charge> {
-        client.post_form("/charges", &params)
+        client.post_form("/charges", &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn create_with_idempotency(
+        client: &Client,
+        params: CreateCharge<'_>,
+        idempotency_key: &str,
+    ) -> Response<Charge> {
+        client.post_form("/charges", &params, Some(idempotency_key))
     }
 
     /// Retrieves the details of a charge that has previously been created.
@@ -246,7 +255,17 @@ impl Charge {
     ///
     /// Any parameters not provided will be left unchanged.
     pub fn update(client: &Client, id: &ChargeId, params: UpdateCharge<'_>) -> Response<Charge> {
-        client.post_form(&format!("/charges/{}", id), &params)
+        client.post_form(&format!("/charges/{}", id), &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn update_with_idempotency(
+        client: &Client,
+        id: &ChargeId,
+        params: UpdateCharge<'_>,
+        idempotency_key: &str,
+    ) -> Response<Charge> {
+        client.post_form(&format!("/charges/{}", id), &params, Some(idempotency_key))
     }
 }
 
@@ -2118,13 +2137,6 @@ pub struct CustomerPaymentSourceCard {
     pub number: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub object: Option<String>,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(untagged, rename_all = "snake_case")]
-pub enum DestinationUnion {
-    DestinationSpecs(DestinationSpecs),
-    Alternate1(String),
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/src/resources/generated/charge.rs
+++ b/src/resources/generated/charge.rs
@@ -2121,6 +2121,13 @@ pub struct CustomerPaymentSourceCard {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(untagged, rename_all = "snake_case")]
+pub enum DestinationUnion {
+    DestinationSpecs(DestinationSpecs),
+    Alternate1(String),
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct DestinationSpecs {
     pub account: String,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/resources/generated/checkout_session.rs
+++ b/src/resources/generated/checkout_session.rs
@@ -207,7 +207,16 @@ impl CheckoutSession {
 
     /// Creates a Session object.
     pub fn create(client: &Client, params: CreateCheckoutSession<'_>) -> Response<CheckoutSession> {
-        client.post_form("/checkout/sessions", &params)
+        client.post_form("/checkout/sessions", &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn create_with_idempotency(
+        client: &Client,
+        params: CreateCheckoutSession<'_>,
+        idempotency_key: &str,
+    ) -> Response<CheckoutSession> {
+        client.post_form("/checkout/sessions", &params, Some(idempotency_key))
     }
 }
 

--- a/src/resources/generated/coupon.rs
+++ b/src/resources/generated/coupon.rs
@@ -99,7 +99,16 @@ impl Coupon {
     /// If you set an `amount_off`, that amount will be subtracted from any invoice’s subtotal.
     /// For example, an invoice with a subtotal of $100 will have a final total of $0 if a coupon with an `amount_off` of 20000 is applied to it and an invoice with a subtotal of $300 will have a final total of $100 if a coupon with an `amount_off` of 20000 is applied to it.
     pub fn create(client: &Client, params: CreateCoupon<'_>) -> Response<Coupon> {
-        client.post_form("/coupons", &params)
+        client.post_form("/coupons", &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn create_with_idempotency(
+        client: &Client,
+        params: CreateCoupon<'_>,
+        idempotency_key: &str,
+    ) -> Response<Coupon> {
+        client.post_form("/coupons", &params, Some(idempotency_key))
     }
 
     /// Retrieves the coupon with the given ID.
@@ -111,7 +120,17 @@ impl Coupon {
     ///
     /// Other coupon details (currency, duration, amount_off) are, by design, not editable.
     pub fn update(client: &Client, id: &CouponId, params: UpdateCoupon<'_>) -> Response<Coupon> {
-        client.post_form(&format!("/coupons/{}", id), &params)
+        client.post_form(&format!("/coupons/{}", id), &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn update_with_idempotency(
+        client: &Client,
+        id: &CouponId,
+        params: UpdateCoupon<'_>,
+        idempotency_key: &str,
+    ) -> Response<Coupon> {
+        client.post_form(&format!("/coupons/{}", id), &params, Some(idempotency_key))
     }
 
     /// You can delete coupons via the [coupon management](https://dashboard.stripe.com/coupons) page of the Stripe dashboard.

--- a/src/resources/generated/credit_note.rs
+++ b/src/resources/generated/credit_note.rs
@@ -122,7 +122,16 @@ impl CreditNote {
     /// Instead, it can result in any combination of the following:  <ul> <li>Refund: create a new refund (using `refund_amount`) or link an existing refund (using `refund`).</li> <li>Customer balance credit: credit the customer’s balance (using `credit_amount`) which will be automatically applied to their next invoice when it’s finalized.</li> <li>Outside of Stripe credit: record the amount that is or will be credited outside of Stripe (using `out_of_band_amount`).</li> </ul>  For post-payment credit notes the sum of the refund, credit and outside of Stripe amounts must equal the credit note total.  You may issue multiple credit notes for an invoice.
     /// Each credit note will increment the invoice’s `pre_payment_credit_notes_amount` or `post_payment_credit_notes_amount` depending on its `status` at the time of credit note creation.
     pub fn create(client: &Client, params: CreateCreditNote<'_>) -> Response<CreditNote> {
-        client.post_form("/credit_notes", &params)
+        client.post_form("/credit_notes", &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn create_with_idempotency(
+        client: &Client,
+        params: CreateCreditNote<'_>,
+        idempotency_key: &str,
+    ) -> Response<CreditNote> {
+        client.post_form("/credit_notes", &params, Some(idempotency_key))
     }
 
     /// Retrieves the credit note object with the given identifier.
@@ -136,7 +145,17 @@ impl CreditNote {
         id: &CreditNoteId,
         params: UpdateCreditNote<'_>,
     ) -> Response<CreditNote> {
-        client.post_form(&format!("/credit_notes/{}", id), &params)
+        client.post_form(&format!("/credit_notes/{}", id), &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn update_with_idempotency(
+        client: &Client,
+        id: &CreditNoteId,
+        params: UpdateCreditNote<'_>,
+        idempotency_key: &str,
+    ) -> Response<CreditNote> {
+        client.post_form(&format!("/credit_notes/{}", id), &params, Some(idempotency_key))
     }
 }
 

--- a/src/resources/generated/customer.rs
+++ b/src/resources/generated/customer.rs
@@ -148,7 +148,16 @@ impl Customer {
 
     /// Creates a new customer object.
     pub fn create(client: &Client, params: CreateCustomer<'_>) -> Response<Customer> {
-        client.post_form("/customers", &params)
+        client.post_form("/customers", &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn create_with_idempotency(
+        client: &Client,
+        params: CreateCustomer<'_>,
+        idempotency_key: &str,
+    ) -> Response<Customer> {
+        client.post_form("/customers", &params, Some(idempotency_key))
     }
 
     /// Retrieves a Customer object.
@@ -168,7 +177,17 @@ impl Customer {
         id: &CustomerId,
         params: UpdateCustomer<'_>,
     ) -> Response<Customer> {
-        client.post_form(&format!("/customers/{}", id), &params)
+        client.post_form(&format!("/customers/{}", id), &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn update_with_idempotency(
+        client: &Client,
+        id: &CustomerId,
+        params: UpdateCustomer<'_>,
+        idempotency_key: &str,
+    ) -> Response<Customer> {
+        client.post_form(&format!("/customers/{}", id), &params, Some(idempotency_key))
     }
 
     /// Permanently deletes a customer.

--- a/src/resources/generated/ephemeral_key.rs
+++ b/src/resources/generated/ephemeral_key.rs
@@ -37,7 +37,16 @@ pub struct EphemeralKey {
 impl EphemeralKey {
     /// Creates a short-lived API key for a given resource.
     pub fn create(client: &Client, params: CreateEphemeralKey<'_>) -> Response<EphemeralKey> {
-        client.post_form("/ephemeral_keys", &params)
+        client.post_form("/ephemeral_keys", &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn create_with_idempotency(
+        client: &Client,
+        params: CreateEphemeralKey<'_>,
+        idempotency_key: &str,
+    ) -> Response<EphemeralKey> {
+        client.post_form("/ephemeral_keys", &params, Some(idempotency_key))
     }
 
     /// Invalidates a short-lived API key for a given resource.

--- a/src/resources/generated/file_link.rs
+++ b/src/resources/generated/file_link.rs
@@ -53,7 +53,16 @@ impl FileLink {
 
     /// Creates a new file link object.
     pub fn create(client: &Client, params: CreateFileLink<'_>) -> Response<FileLink> {
-        client.post_form("/file_links", &params)
+        client.post_form("/file_links", &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn create_with_idempotency(
+        client: &Client,
+        params: CreateFileLink<'_>,
+        idempotency_key: &str,
+    ) -> Response<FileLink> {
+        client.post_form("/file_links", &params, Some(idempotency_key))
     }
 
     /// Retrieves the file link with the given ID.
@@ -69,7 +78,17 @@ impl FileLink {
         id: &FileLinkId,
         params: UpdateFileLink<'_>,
     ) -> Response<FileLink> {
-        client.post_form(&format!("/file_links/{}", id), &params)
+        client.post_form(&format!("/file_links/{}", id), &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn update_with_idempotency(
+        client: &Client,
+        id: &FileLinkId,
+        params: UpdateFileLink<'_>,
+        idempotency_key: &str,
+    ) -> Response<FileLink> {
+        client.post_form(&format!("/file_links/{}", id), &params, Some(idempotency_key))
     }
 }
 

--- a/src/resources/generated/invoice.rs
+++ b/src/resources/generated/invoice.rs
@@ -407,7 +407,16 @@ impl Invoice {
     /// The draft invoice created pulls in all pending invoice items on that customer, including prorations.
     /// The invoice remains a draft until you [finalize](https://stripe.com/docs/api#finalize_invoice) the invoice, which allows you to [pay](https://stripe.com/docs/api#pay_invoice) or [send](https://stripe.com/docs/api#send_invoice) the invoice to your customers.
     pub fn create(client: &Client, params: CreateInvoice<'_>) -> Response<Invoice> {
-        client.post_form("/invoices", &params)
+        client.post_form("/invoices", &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn create_with_idempotency(
+        client: &Client,
+        params: CreateInvoice<'_>,
+        idempotency_key: &str,
+    ) -> Response<Invoice> {
+        client.post_form("/invoices", &params, Some(idempotency_key))
     }
 
     /// Retrieves the invoice with the given ID.

--- a/src/resources/generated/invoiceitem.rs
+++ b/src/resources/generated/invoiceitem.rs
@@ -130,7 +130,16 @@ impl InvoiceItem {
     ///
     /// If no invoice is specified, the item will be on the next invoice created for the customer specified.
     pub fn create(client: &Client, params: CreateInvoiceItem<'_>) -> Response<InvoiceItem> {
-        client.post_form("/invoiceitems", &params)
+        client.post_form("/invoiceitems", &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn create_with_idempotency(
+        client: &Client,
+        params: CreateInvoiceItem<'_>,
+        idempotency_key: &str,
+    ) -> Response<InvoiceItem> {
+        client.post_form("/invoiceitems", &params, Some(idempotency_key))
     }
 
     /// Retrieves the invoice item with the given ID.
@@ -146,7 +155,17 @@ impl InvoiceItem {
         id: &InvoiceItemId,
         params: UpdateInvoiceItem<'_>,
     ) -> Response<InvoiceItem> {
-        client.post_form(&format!("/invoiceitems/{}", id), &params)
+        client.post_form(&format!("/invoiceitems/{}", id), &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn update_with_idempotency(
+        client: &Client,
+        id: &InvoiceItemId,
+        params: UpdateInvoiceItem<'_>,
+        idempotency_key: &str,
+    ) -> Response<InvoiceItem> {
+        client.post_form(&format!("/invoiceitems/{}", id), &params, Some(idempotency_key))
     }
 
     /// Deletes an invoice item, removing it from an invoice.

--- a/src/resources/generated/order.rs
+++ b/src/resources/generated/order.rs
@@ -131,7 +131,16 @@ impl Order {
 
     /// Creates a new order object.
     pub fn create(client: &Client, params: CreateOrder<'_>) -> Response<Order> {
-        client.post_form("/orders", &params)
+        client.post_form("/orders", &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn create_with_idempotency(
+        client: &Client,
+        params: CreateOrder<'_>,
+        idempotency_key: &str,
+    ) -> Response<Order> {
+        client.post_form("/orders", &params, Some(idempotency_key))
     }
 
     /// Retrieves the details of an existing order.
@@ -145,7 +154,17 @@ impl Order {
     ///
     /// Any parameters not provided will be left unchanged.
     pub fn update(client: &Client, id: &OrderId, params: UpdateOrder<'_>) -> Response<Order> {
-        client.post_form(&format!("/orders/{}", id), &params)
+        client.post_form(&format!("/orders/{}", id), &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn update_with_idempotency(
+        client: &Client,
+        id: &OrderId,
+        params: UpdateOrder<'_>,
+        idempotency_key: &str,
+    ) -> Response<Order> {
+        client.post_form(&format!("/orders/{}", id), &params, Some(idempotency_key))
     }
 }
 

--- a/src/resources/generated/payment_intent.rs
+++ b/src/resources/generated/payment_intent.rs
@@ -216,7 +216,16 @@ impl PaymentIntent {
     /// You can read more about the different payment flows available via the Payment Intents API [here](https://stripe.com/docs/payments/payment-intents).  When `confirm=true` is used during creation, it is equivalent to creating and confirming the PaymentIntent in the same call.
     /// You may use any parameters available in the [confirm API](https://stripe.com/docs/api/payment_intents/confirm) when `confirm=true` is supplied.
     pub fn create(client: &Client, params: CreatePaymentIntent<'_>) -> Response<PaymentIntent> {
-        client.post_form("/payment_intents", &params)
+        client.post_form("/payment_intents", &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn create_with_idempotency(
+        client: &Client,
+        params: CreatePaymentIntent<'_>,
+        idempotency_key: &str,
+    ) -> Response<PaymentIntent> {
+        client.post_form("/payment_intents", &params, Some(idempotency_key))
     }
 
     /// Retrieves the details of a PaymentIntent that has previously been created.
@@ -244,7 +253,17 @@ impl PaymentIntent {
         id: &PaymentIntentId,
         params: UpdatePaymentIntent<'_>,
     ) -> Response<PaymentIntent> {
-        client.post_form(&format!("/payment_intents/{}", id), &params)
+        client.post_form(&format!("/payment_intents/{}", id), &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn update_with_idempotency(
+        client: &Client,
+        id: &PaymentIntentId,
+        params: UpdatePaymentIntent<'_>,
+        idempotency_key: &str,
+    ) -> Response<PaymentIntent> {
+        client.post_form(&format!("/payment_intents/{}", id), &params, Some(idempotency_key))
     }
 }
 

--- a/src/resources/generated/payment_link.rs
+++ b/src/resources/generated/payment_link.rs
@@ -92,7 +92,16 @@ impl PaymentLink {
 
     /// Creates a payment link.
     pub fn create(client: &Client, params: CreatePaymentLink<'_>) -> Response<PaymentLink> {
-        client.post_form("/payment_links", &params)
+        client.post_form("/payment_links", &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn create_with_idempotency(
+        client: &Client,
+        params: CreatePaymentLink<'_>,
+        idempotency_key: &str,
+    ) -> Response<PaymentLink> {
+        client.post_form("/payment_links", &params, Some(idempotency_key))
     }
 
     /// Retrieve a payment link.
@@ -106,7 +115,17 @@ impl PaymentLink {
         id: &PaymentLinkId,
         params: UpdatePaymentLink<'_>,
     ) -> Response<PaymentLink> {
-        client.post_form(&format!("/payment_links/{}", id), &params)
+        client.post_form(&format!("/payment_links/{}", id), &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn update_with_idempotency(
+        client: &Client,
+        id: &PaymentLinkId,
+        params: UpdatePaymentLink<'_>,
+        idempotency_key: &str,
+    ) -> Response<PaymentLink> {
+        client.post_form(&format!("/payment_links/{}", id), &params, Some(idempotency_key))
     }
 }
 

--- a/src/resources/generated/payment_method.rs
+++ b/src/resources/generated/payment_method.rs
@@ -124,7 +124,16 @@ impl PaymentMethod {
     ///
     /// Read the [Stripe.js reference](https://stripe.com/docs/stripe-js/reference#stripe-create-payment-method) to learn how to create PaymentMethods via Stripe.js.  Instead of creating a PaymentMethod directly, we recommend using the [PaymentIntents](https://stripe.com/docs/payments/accept-a-payment) API to accept a payment immediately or the [SetupIntent](https://stripe.com/docs/payments/save-and-reuse) API to collect payment method details ahead of a future payment.
     pub fn create(client: &Client, params: CreatePaymentMethod<'_>) -> Response<PaymentMethod> {
-        client.post_form("/payment_methods", &params)
+        client.post_form("/payment_methods", &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn create_with_idempotency(
+        client: &Client,
+        params: CreatePaymentMethod<'_>,
+        idempotency_key: &str,
+    ) -> Response<PaymentMethod> {
+        client.post_form("/payment_methods", &params, Some(idempotency_key))
     }
 
     /// Retrieves a PaymentMethod object.
@@ -144,7 +153,17 @@ impl PaymentMethod {
         id: &PaymentMethodId,
         params: UpdatePaymentMethod<'_>,
     ) -> Response<PaymentMethod> {
-        client.post_form(&format!("/payment_methods/{}", id), &params)
+        client.post_form(&format!("/payment_methods/{}", id), &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn update_with_idempotency(
+        client: &Client,
+        id: &PaymentMethodId,
+        params: UpdatePaymentMethod<'_>,
+        idempotency_key: &str,
+    ) -> Response<PaymentMethod> {
+        client.post_form(&format!("/payment_methods/{}", id), &params, Some(idempotency_key))
     }
 }
 

--- a/src/resources/generated/payout.rs
+++ b/src/resources/generated/payout.rs
@@ -123,7 +123,16 @@ impl Payout {
     /// Your [Stripe balance](https://stripe.com/docs/api#balance) must be able to cover the payout amount, or you’ll receive an “Insufficient Funds” error.  If your API key is in test mode, money won’t actually be sent, though everything else will occur as if in live mode.  If you are creating a manual payout on a Stripe account that uses multiple payment source types, you’ll need to specify the source type balance that the payout should draw from.
     /// The [balance object](https://stripe.com/docs/api#balance_object) details available and pending amounts by source type.
     pub fn create(client: &Client, params: CreatePayout<'_>) -> Response<Payout> {
-        client.post_form("/payouts", &params)
+        client.post_form("/payouts", &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn create_with_idempotency(
+        client: &Client,
+        params: CreatePayout<'_>,
+        idempotency_key: &str,
+    ) -> Response<Payout> {
+        client.post_form("/payouts", &params, Some(idempotency_key))
     }
 
     /// Retrieves the details of an existing payout.
@@ -138,7 +147,17 @@ impl Payout {
     /// Any parameters not provided will be left unchanged.
     /// This request accepts only the metadata as arguments.
     pub fn update(client: &Client, id: &PayoutId, params: UpdatePayout<'_>) -> Response<Payout> {
-        client.post_form(&format!("/payouts/{}", id), &params)
+        client.post_form(&format!("/payouts/{}", id), &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn update_with_idempotency(
+        client: &Client,
+        id: &PayoutId,
+        params: UpdatePayout<'_>,
+        idempotency_key: &str,
+    ) -> Response<Payout> {
+        client.post_form(&format!("/payouts/{}", id), &params, Some(idempotency_key))
     }
 }
 

--- a/src/resources/generated/plan.rs
+++ b/src/resources/generated/plan.rs
@@ -146,7 +146,17 @@ impl Plan {
     /// Any parameters not provided are left unchanged.
     /// By design, you cannot change a plan’s ID, amount, currency, or billing cycle.
     pub fn update(client: &Client, id: &PlanId, params: UpdatePlan<'_>) -> Response<Plan> {
-        client.post_form(&format!("/plans/{}", id), &params)
+        client.post_form(&format!("/plans/{}", id), &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn update_with_idempotency(
+        client: &Client,
+        id: &PlanId,
+        params: UpdatePlan<'_>,
+        idempotency_key: &str,
+    ) -> Response<Plan> {
+        client.post_form(&format!("/plans/{}", id), &params, Some(idempotency_key))
     }
 
     /// Deleting plans means new subscribers can’t be added.

--- a/src/resources/generated/price.rs
+++ b/src/resources/generated/price.rs
@@ -130,7 +130,16 @@ impl Price {
     ///
     /// The price can be recurring or one-time.
     pub fn create(client: &Client, params: CreatePrice<'_>) -> Response<Price> {
-        client.post_form("/prices", &params)
+        client.post_form("/prices", &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn create_with_idempotency(
+        client: &Client,
+        params: CreatePrice<'_>,
+        idempotency_key: &str,
+    ) -> Response<Price> {
+        client.post_form("/prices", &params, Some(idempotency_key))
     }
 
     /// Retrieves the price with the given ID.
@@ -142,7 +151,17 @@ impl Price {
     ///
     /// Any parameters not provided are left unchanged.
     pub fn update(client: &Client, id: &PriceId, params: UpdatePrice<'_>) -> Response<Price> {
-        client.post_form(&format!("/prices/{}", id), &params)
+        client.post_form(&format!("/prices/{}", id), &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn update_with_idempotency(
+        client: &Client,
+        id: &PriceId,
+        params: UpdatePrice<'_>,
+        idempotency_key: &str,
+    ) -> Response<Price> {
+        client.post_form(&format!("/prices/{}", id), &params, Some(idempotency_key))
     }
 }
 

--- a/src/resources/generated/product.rs
+++ b/src/resources/generated/product.rs
@@ -102,7 +102,16 @@ impl Product {
 
     /// Creates a new product object.
     pub fn create(client: &Client, params: CreateProduct<'_>) -> Response<Product> {
-        client.post_form("/products", &params)
+        client.post_form("/products", &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn create_with_idempotency(
+        client: &Client,
+        params: CreateProduct<'_>,
+        idempotency_key: &str,
+    ) -> Response<Product> {
+        client.post_form("/products", &params, Some(idempotency_key))
     }
 
     /// Retrieves the details of an existing product.
@@ -116,7 +125,17 @@ impl Product {
     ///
     /// Any parameters not provided will be left unchanged.
     pub fn update(client: &Client, id: &ProductId, params: UpdateProduct<'_>) -> Response<Product> {
-        client.post_form(&format!("/products/{}", id), &params)
+        client.post_form(&format!("/products/{}", id), &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn update_with_idempotency(
+        client: &Client,
+        id: &ProductId,
+        params: UpdateProduct<'_>,
+        idempotency_key: &str,
+    ) -> Response<Product> {
+        client.post_form(&format!("/products/{}", id), &params, Some(idempotency_key))
     }
 
     /// Delete a product.

--- a/src/resources/generated/promotion_code.rs
+++ b/src/resources/generated/promotion_code.rs
@@ -86,7 +86,17 @@ impl PromotionCode {
         id: &PromotionCodeId,
         params: UpdatePromotionCode<'_>,
     ) -> Response<PromotionCode> {
-        client.post_form(&format!("/promotion_codes/{}", id), &params)
+        client.post_form(&format!("/promotion_codes/{}", id), &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn update_with_idempotency(
+        client: &Client,
+        id: &PromotionCodeId,
+        params: UpdatePromotionCode<'_>,
+        idempotency_key: &str,
+    ) -> Response<PromotionCode> {
+        client.post_form(&format!("/promotion_codes/{}", id), &params, Some(idempotency_key))
     }
 }
 

--- a/src/resources/generated/recipient.rs
+++ b/src/resources/generated/recipient.rs
@@ -85,7 +85,16 @@ impl Recipient {
     /// Creates a new `Recipient` object and verifies the recipient’s identity.
     /// Also verifies the recipient’s bank account information or debit card, if either is provided.
     pub fn create(client: &Client, params: CreateRecipient<'_>) -> Response<Recipient> {
-        client.post_form("/recipients", &params)
+        client.post_form("/recipients", &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn create_with_idempotency(
+        client: &Client,
+        params: CreateRecipient<'_>,
+        idempotency_key: &str,
+    ) -> Response<Recipient> {
+        client.post_form("/recipients", &params, Some(idempotency_key))
     }
 
     /// Retrieves the details of an existing recipient.
@@ -105,7 +114,17 @@ impl Recipient {
         id: &RecipientId,
         params: UpdateRecipient<'_>,
     ) -> Response<Recipient> {
-        client.post_form(&format!("/recipients/{}", id), &params)
+        client.post_form(&format!("/recipients/{}", id), &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn update_with_idempotency(
+        client: &Client,
+        id: &RecipientId,
+        params: UpdateRecipient<'_>,
+        idempotency_key: &str,
+    ) -> Response<Recipient> {
+        client.post_form(&format!("/recipients/{}", id), &params, Some(idempotency_key))
     }
 
     /// Permanently deletes a recipient.

--- a/src/resources/generated/refund.rs
+++ b/src/resources/generated/refund.rs
@@ -106,7 +106,16 @@ impl Refund {
 
     /// Create a refund.
     pub fn create(client: &Client, params: CreateRefund<'_>) -> Response<Refund> {
-        client.post_form("/refunds", &params)
+        client.post_form("/refunds", &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn create_with_idempotency(
+        client: &Client,
+        params: CreateRefund<'_>,
+        idempotency_key: &str,
+    ) -> Response<Refund> {
+        client.post_form("/refunds", &params, Some(idempotency_key))
     }
 
     /// Retrieves the details of an existing refund.
@@ -118,7 +127,17 @@ impl Refund {
     ///
     /// Any parameters not provided will be left unchanged.  This request only accepts `metadata` as an argument.
     pub fn update(client: &Client, id: &RefundId, params: UpdateRefund<'_>) -> Response<Refund> {
-        client.post_form(&format!("/refunds/{}", id), &params)
+        client.post_form(&format!("/refunds/{}", id), &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn update_with_idempotency(
+        client: &Client,
+        id: &RefundId,
+        params: UpdateRefund<'_>,
+        idempotency_key: &str,
+    ) -> Response<Refund> {
+        client.post_form(&format!("/refunds/{}", id), &params, Some(idempotency_key))
     }
 }
 

--- a/src/resources/generated/setup_intent.rs
+++ b/src/resources/generated/setup_intent.rs
@@ -123,7 +123,16 @@ impl SetupIntent {
     /// After the SetupIntent is created, attach a payment method and [confirm](https://stripe.com/docs/api/setup_intents/confirm)
     /// to collect any required permissions to charge the payment method later.
     pub fn create(client: &Client, params: CreateSetupIntent<'_>) -> Response<SetupIntent> {
-        client.post_form("/setup_intents", &params)
+        client.post_form("/setup_intents", &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn create_with_idempotency(
+        client: &Client,
+        params: CreateSetupIntent<'_>,
+        idempotency_key: &str,
+    ) -> Response<SetupIntent> {
+        client.post_form("/setup_intents", &params, Some(idempotency_key))
     }
 
     /// Retrieves the details of a SetupIntent that has previously been created.
@@ -141,7 +150,17 @@ impl SetupIntent {
         id: &SetupIntentId,
         params: UpdateSetupIntent<'_>,
     ) -> Response<SetupIntent> {
-        client.post_form(&format!("/setup_intents/{}", id), &params)
+        client.post_form(&format!("/setup_intents/{}", id), &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn update_with_idempotency(
+        client: &Client,
+        id: &SetupIntentId,
+        params: UpdateSetupIntent<'_>,
+        idempotency_key: &str,
+    ) -> Response<SetupIntent> {
+        client.post_form(&format!("/setup_intents/{}", id), &params, Some(idempotency_key))
     }
 }
 

--- a/src/resources/generated/shipping_rate.rs
+++ b/src/resources/generated/shipping_rate.rs
@@ -77,7 +77,16 @@ impl ShippingRate {
 
     /// Creates a new shipping rate object.
     pub fn create(client: &Client, params: CreateShippingRate<'_>) -> Response<ShippingRate> {
-        client.post_form("/shipping_rates", &params)
+        client.post_form("/shipping_rates", &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn create_with_idempotency(
+        client: &Client,
+        params: CreateShippingRate<'_>,
+        idempotency_key: &str,
+    ) -> Response<ShippingRate> {
+        client.post_form("/shipping_rates", &params, Some(idempotency_key))
     }
 
     /// Returns the shipping rate object with the given ID.
@@ -95,7 +104,17 @@ impl ShippingRate {
         id: &ShippingRateId,
         params: UpdateShippingRate<'_>,
     ) -> Response<ShippingRate> {
-        client.post_form(&format!("/shipping_rates/{}", id), &params)
+        client.post_form(&format!("/shipping_rates/{}", id), &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn update_with_idempotency(
+        client: &Client,
+        id: &ShippingRateId,
+        params: UpdateShippingRate<'_>,
+        idempotency_key: &str,
+    ) -> Response<ShippingRate> {
+        client.post_form(&format!("/shipping_rates/{}", id), &params, Some(idempotency_key))
     }
 }
 

--- a/src/resources/generated/sku.rs
+++ b/src/resources/generated/sku.rs
@@ -91,7 +91,16 @@ impl Sku {
 
     /// Creates a new SKU associated with a product.
     pub fn create(client: &Client, params: CreateSku<'_>) -> Response<Sku> {
-        client.post_form("/skus", &params)
+        client.post_form("/skus", &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn create_with_idempotency(
+        client: &Client,
+        params: CreateSku<'_>,
+        idempotency_key: &str,
+    ) -> Response<Sku> {
+        client.post_form("/skus", &params, Some(idempotency_key))
     }
 
     /// Retrieves the details of an existing SKU.
@@ -106,7 +115,17 @@ impl Sku {
     /// Any parameters not provided will be left unchanged.  Note that a SKU’s `attributes` are not editable.
     /// Instead, you would need to deactivate the existing SKU and create a new one with the new attribute values.
     pub fn update(client: &Client, id: &SkuId, params: UpdateSku<'_>) -> Response<Sku> {
-        client.post_form(&format!("/skus/{}", id), &params)
+        client.post_form(&format!("/skus/{}", id), &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn update_with_idempotency(
+        client: &Client,
+        id: &SkuId,
+        params: UpdateSku<'_>,
+        idempotency_key: &str,
+    ) -> Response<Sku> {
+        client.post_form(&format!("/skus/{}", id), &params, Some(idempotency_key))
     }
 
     /// Delete a SKU.

--- a/src/resources/generated/source.rs
+++ b/src/resources/generated/source.rs
@@ -170,7 +170,16 @@ impl Source {
 
     /// Creates a new source object.
     pub fn create(client: &Client, params: CreateSource<'_>) -> Response<Source> {
-        client.post_form("/sources", &params)
+        client.post_form("/sources", &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn create_with_idempotency(
+        client: &Client,
+        params: CreateSource<'_>,
+        idempotency_key: &str,
+    ) -> Response<Source> {
+        client.post_form("/sources", &params, Some(idempotency_key))
     }
 
     /// Retrieves an existing source object.
@@ -186,7 +195,17 @@ impl Source {
     /// It is also possible to update type specific information for selected payment methods.
     /// Please refer to our [payment method guides](https://stripe.com/docs/sources) for more detail.
     pub fn update(client: &Client, id: &SourceId, params: UpdateSource<'_>) -> Response<Source> {
-        client.post_form(&format!("/sources/{}", id), &params)
+        client.post_form(&format!("/sources/{}", id), &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn update_with_idempotency(
+        client: &Client,
+        id: &SourceId,
+        params: UpdateSource<'_>,
+        idempotency_key: &str,
+    ) -> Response<Source> {
+        client.post_form(&format!("/sources/{}", id), &params, Some(idempotency_key))
     }
 }
 

--- a/src/resources/generated/subscription.rs
+++ b/src/resources/generated/subscription.rs
@@ -203,7 +203,16 @@ impl Subscription {
     ///
     /// Each customer can have up to 500 active or scheduled subscriptions.
     pub fn create(client: &Client, params: CreateSubscription<'_>) -> Response<Subscription> {
-        client.post_form("/subscriptions", &params)
+        client.post_form("/subscriptions", &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn create_with_idempotency(
+        client: &Client,
+        params: CreateSubscription<'_>,
+        idempotency_key: &str,
+    ) -> Response<Subscription> {
+        client.post_form("/subscriptions", &params, Some(idempotency_key))
     }
 
     /// Retrieves the subscription with the given ID.
@@ -224,7 +233,17 @@ impl Subscription {
         id: &SubscriptionId,
         params: UpdateSubscription<'_>,
     ) -> Response<Subscription> {
-        client.post_form(&format!("/subscriptions/{}", id), &params)
+        client.post_form(&format!("/subscriptions/{}", id), &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn update_with_idempotency(
+        client: &Client,
+        id: &SubscriptionId,
+        params: UpdateSubscription<'_>,
+        idempotency_key: &str,
+    ) -> Response<Subscription> {
+        client.post_form(&format!("/subscriptions/{}", id), &params, Some(idempotency_key))
     }
 
     /// Cancels a customer’s subscription immediately.

--- a/src/resources/generated/subscription_item.rs
+++ b/src/resources/generated/subscription_item.rs
@@ -71,7 +71,16 @@ impl SubscriptionItem {
         client: &Client,
         params: CreateSubscriptionItem<'_>,
     ) -> Response<SubscriptionItem> {
-        client.post_form("/subscription_items", &params)
+        client.post_form("/subscription_items", &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn create_with_idempotency(
+        client: &Client,
+        params: CreateSubscriptionItem<'_>,
+        idempotency_key: &str,
+    ) -> Response<SubscriptionItem> {
+        client.post_form("/subscription_items", &params, Some(idempotency_key))
     }
 
     /// Retrieves the subscription item with the given ID.
@@ -89,7 +98,17 @@ impl SubscriptionItem {
         id: &SubscriptionItemId,
         params: UpdateSubscriptionItem<'_>,
     ) -> Response<SubscriptionItem> {
-        client.post_form(&format!("/subscription_items/{}", id), &params)
+        client.post_form(&format!("/subscription_items/{}", id), &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn update_with_idempotency(
+        client: &Client,
+        id: &SubscriptionItemId,
+        params: UpdateSubscriptionItem<'_>,
+        idempotency_key: &str,
+    ) -> Response<SubscriptionItem> {
+        client.post_form(&format!("/subscription_items/{}", id), &params, Some(idempotency_key))
     }
 
     /// Deletes an item from the subscription.

--- a/src/resources/generated/subscription_schedule.rs
+++ b/src/resources/generated/subscription_schedule.rs
@@ -101,7 +101,16 @@ impl SubscriptionSchedule {
         client: &Client,
         params: CreateSubscriptionSchedule<'_>,
     ) -> Response<SubscriptionSchedule> {
-        client.post_form("/subscription_schedules", &params)
+        client.post_form("/subscription_schedules", &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn create_with_idempotency(
+        client: &Client,
+        params: CreateSubscriptionSchedule<'_>,
+        idempotency_key: &str,
+    ) -> Response<SubscriptionSchedule> {
+        client.post_form("/subscription_schedules", &params, Some(idempotency_key))
     }
 
     /// Retrieves the details of an existing subscription schedule.
@@ -121,7 +130,17 @@ impl SubscriptionSchedule {
         id: &SubscriptionScheduleId,
         params: UpdateSubscriptionSchedule<'_>,
     ) -> Response<SubscriptionSchedule> {
-        client.post_form(&format!("/subscription_schedules/{}", id), &params)
+        client.post_form(&format!("/subscription_schedules/{}", id), &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn update_with_idempotency(
+        client: &Client,
+        id: &SubscriptionScheduleId,
+        params: UpdateSubscriptionSchedule<'_>,
+        idempotency_key: &str,
+    ) -> Response<SubscriptionSchedule> {
+        client.post_form(&format!("/subscription_schedules/{}", id), &params, Some(idempotency_key))
     }
 }
 

--- a/src/resources/generated/tax_rate.rs
+++ b/src/resources/generated/tax_rate.rs
@@ -82,7 +82,16 @@ impl TaxRate {
 
     /// Creates a new tax rate.
     pub fn create(client: &Client, params: CreateTaxRate<'_>) -> Response<TaxRate> {
-        client.post_form("/tax_rates", &params)
+        client.post_form("/tax_rates", &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn create_with_idempotency(
+        client: &Client,
+        params: CreateTaxRate<'_>,
+        idempotency_key: &str,
+    ) -> Response<TaxRate> {
+        client.post_form("/tax_rates", &params, Some(idempotency_key))
     }
 
     /// Retrieves a tax rate with the given ID.
@@ -92,7 +101,17 @@ impl TaxRate {
 
     /// Updates an existing tax rate.
     pub fn update(client: &Client, id: &TaxRateId, params: UpdateTaxRate<'_>) -> Response<TaxRate> {
-        client.post_form(&format!("/tax_rates/{}", id), &params)
+        client.post_form(&format!("/tax_rates/{}", id), &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn update_with_idempotency(
+        client: &Client,
+        id: &TaxRateId,
+        params: UpdateTaxRate<'_>,
+        idempotency_key: &str,
+    ) -> Response<TaxRate> {
+        client.post_form(&format!("/tax_rates/{}", id), &params, Some(idempotency_key))
     }
 }
 

--- a/src/resources/generated/token.rs
+++ b/src/resources/generated/token.rs
@@ -49,7 +49,16 @@ impl Token {
     ///
     /// This token can be used only once, by attaching it to a [Custom account](https://stripe.com/docs/api#accounts).
     pub fn create(client: &Client, params: CreateToken<'_>) -> Response<Token> {
-        client.post_form("/tokens", &params)
+        client.post_form("/tokens", &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn create_with_idempotency(
+        client: &Client,
+        params: CreateToken<'_>,
+        idempotency_key: &str,
+    ) -> Response<Token> {
+        client.post_form("/tokens", &params, Some(idempotency_key))
     }
 
     /// Retrieves the token with the given ID.

--- a/src/resources/generated/topup.rs
+++ b/src/resources/generated/topup.rs
@@ -99,7 +99,17 @@ impl Topup {
     ///
     /// Other top-up details are not editable by design.
     pub fn update(client: &Client, id: &TopupId, params: UpdateTopup<'_>) -> Response<Topup> {
-        client.post_form(&format!("/topups/{}", id), &params)
+        client.post_form(&format!("/topups/{}", id), &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn update_with_idempotency(
+        client: &Client,
+        id: &TopupId,
+        params: UpdateTopup<'_>,
+        idempotency_key: &str,
+    ) -> Response<Topup> {
+        client.post_form(&format!("/topups/{}", id), &params, Some(idempotency_key))
     }
 }
 

--- a/src/resources/generated/transfer.rs
+++ b/src/resources/generated/transfer.rs
@@ -96,7 +96,16 @@ impl Transfer {
     ///
     /// Your [Stripe balance](https://stripe.com/docs/api#balance) must be able to cover the transfer amount, or you’ll receive an “Insufficient Funds” error.
     pub fn create(client: &Client, params: CreateTransfer<'_>) -> Response<Transfer> {
-        client.post_form("/transfers", &params)
+        client.post_form("/transfers", &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn create_with_idempotency(
+        client: &Client,
+        params: CreateTransfer<'_>,
+        idempotency_key: &str,
+    ) -> Response<Transfer> {
+        client.post_form("/transfers", &params, Some(idempotency_key))
     }
 
     /// Retrieves the details of an existing transfer.
@@ -114,7 +123,17 @@ impl Transfer {
         id: &TransferId,
         params: UpdateTransfer<'_>,
     ) -> Response<Transfer> {
-        client.post_form(&format!("/transfers/{}", id), &params)
+        client.post_form(&format!("/transfers/{}", id), &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn update_with_idempotency(
+        client: &Client,
+        id: &TransferId,
+        params: UpdateTransfer<'_>,
+        idempotency_key: &str,
+    ) -> Response<Transfer> {
+        client.post_form(&format!("/transfers/{}", id), &params, Some(idempotency_key))
     }
 }
 

--- a/src/resources/generated/webhook_endpoint.rs
+++ b/src/resources/generated/webhook_endpoint.rs
@@ -87,7 +87,16 @@ impl WebhookEndpoint {
     /// If set to true, then a Connect webhook endpoint that notifies the specified `url` about events from all connected accounts is created; otherwise an account webhook endpoint that notifies the specified `url` only about events from your account is created.
     /// You can also create webhook endpoints in the [webhooks settings](https://dashboard.stripe.com/account/webhooks) section of the Dashboard.
     pub fn create(client: &Client, params: CreateWebhookEndpoint<'_>) -> Response<WebhookEndpoint> {
-        client.post_form("/webhook_endpoints", &params)
+        client.post_form("/webhook_endpoints", &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn create_with_idempotency(
+        client: &Client,
+        params: CreateWebhookEndpoint<'_>,
+        idempotency_key: &str,
+    ) -> Response<WebhookEndpoint> {
+        client.post_form("/webhook_endpoints", &params, Some(idempotency_key))
     }
 
     /// Retrieves the webhook endpoint with the given ID.
@@ -107,7 +116,17 @@ impl WebhookEndpoint {
         id: &WebhookEndpointId,
         params: UpdateWebhookEndpoint<'_>,
     ) -> Response<WebhookEndpoint> {
-        client.post_form(&format!("/webhook_endpoints/{}", id), &params)
+        client.post_form(&format!("/webhook_endpoints/{}", id), &params, None)
+    }
+
+    #[cfg(feature = "idempotency")]
+    pub fn update_with_idempotency(
+        client: &Client,
+        id: &WebhookEndpointId,
+        params: UpdateWebhookEndpoint<'_>,
+        idempotency_key: &str,
+    ) -> Response<WebhookEndpoint> {
+        client.post_form(&format!("/webhook_endpoints/{}", id), &params, Some(idempotency_key))
     }
 
     /// You can also delete webhook endpoints via the [webhook endpoint management](https://dashboard.stripe.com/account/webhooks) page of the Stripe dashboard.

--- a/src/resources/invoice_ext.rs
+++ b/src/resources/invoice_ext.rs
@@ -19,8 +19,12 @@ impl Invoice {
     /// Pays an invoice.
     ///
     /// For more details see <https://stripe.com/docs/api#pay_invoice.>.
-    pub fn pay(client: &Client, invoice_id: &InvoiceId) -> Response<Invoice> {
-        client.post(&format!("/invoices/{}/pay", invoice_id))
+    pub fn pay(
+        client: &Client,
+        invoice_id: &InvoiceId,
+        idem_key: Option<&str>,
+    ) -> Response<Invoice> {
+        client.post(&format!("/invoices/{}/pay", invoice_id), idem_key)
     }
 }
 

--- a/src/resources/line_item_ext.rs
+++ b/src/resources/line_item_ext.rs
@@ -8,8 +8,12 @@ impl InvoiceLineItem {
     /// Creates an invoice line item.
     ///
     /// For more details see <https://stripe.com/docs/api#invoice_line_item_object>.
-    pub fn create(client: &Client, params: CreateInvoiceLineItem<'_>) -> Response<InvoiceLineItem> {
-        client.post_form("/invoiceitems", &params)
+    pub fn create(
+        client: &Client,
+        params: CreateInvoiceLineItem<'_>,
+        idem_key: Option<&str>,
+    ) -> Response<InvoiceLineItem> {
+        client.post_form("/invoiceitems", &params, idem_key)
     }
 }
 

--- a/src/resources/login_links_ext.rs
+++ b/src/resources/login_links_ext.rs
@@ -6,11 +6,7 @@ use crate::resources::LoginLink;
 use crate::AccountId;
 
 pub trait CreateLoginLinkExt {
-    fn create(
-        client: &Client,
-        id: &AccountId,
-        redirect_url: &str
-    ) -> Response<Self>
+    fn create(client: &Client, id: &AccountId, redirect_url: &str) -> Response<Self>
     where
         Self: Sized;
 
@@ -23,7 +19,6 @@ pub trait CreateLoginLinkExt {
     ) -> Response<Self>
     where
         Self: Sized;
-
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -38,11 +33,7 @@ pub struct CreateLoginLink<'a> {
 }
 
 impl CreateLoginLinkExt for LoginLink {
-    fn create(
-        client: &Client,
-        id: &AccountId,
-        redirect_url: &str,
-    ) -> Response<Self> {
+    fn create(client: &Client, id: &AccountId, redirect_url: &str) -> Response<Self> {
         let create_login_link =
             CreateLoginLink { expand: &[], redirect_url: Some(redirect_url.to_string()) };
 
@@ -59,7 +50,10 @@ impl CreateLoginLinkExt for LoginLink {
         let create_login_link =
             CreateLoginLink { expand: &[], redirect_url: Some(redirect_url.to_string()) };
 
-        client.post_form(&format!("/accounts/{}/login_links", id), &create_login_link, Some(idem_key))
+        client.post_form(
+            &format!("/accounts/{}/login_links", id),
+            &create_login_link,
+            Some(idem_key),
+        )
     }
-
 }

--- a/src/resources/login_links_ext.rs
+++ b/src/resources/login_links_ext.rs
@@ -6,9 +6,24 @@ use crate::resources::LoginLink;
 use crate::AccountId;
 
 pub trait CreateLoginLinkExt {
-    fn create(client: &Client, id: &AccountId, redirect_url: &str) -> Response<Self>
+    fn create(
+        client: &Client,
+        id: &AccountId,
+        redirect_url: &str
+    ) -> Response<Self>
     where
         Self: Sized;
+
+    #[cfg(features = "idempotency")]
+    fn create_with_idempotency(
+        client: &Client,
+        id: &AccountId,
+        redirect_url: &str,
+        idem_key: &str,
+    ) -> Response<Self>
+    where
+        Self: Sized;
+
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -23,10 +38,28 @@ pub struct CreateLoginLink<'a> {
 }
 
 impl CreateLoginLinkExt for LoginLink {
-    fn create(client: &Client, id: &AccountId, redirect_url: &str) -> Response<Self> {
+    fn create(
+        client: &Client,
+        id: &AccountId,
+        redirect_url: &str,
+    ) -> Response<Self> {
         let create_login_link =
             CreateLoginLink { expand: &[], redirect_url: Some(redirect_url.to_string()) };
 
-        client.post_form(&format!("/accounts/{}/login_links", id), &create_login_link)
+        client.post_form(&format!("/accounts/{}/login_links", id), &create_login_link, None)
     }
+
+    #[cfg(features = "idempotency")]
+    fn create_with_idempotency(
+        client: &Client,
+        id: &AccountId,
+        redirect_url: &str,
+        idem_key: &str,
+    ) -> Response<Self> {
+        let create_login_link =
+            CreateLoginLink { expand: &[], redirect_url: Some(redirect_url.to_string()) };
+
+        client.post_form(&format!("/accounts/{}/login_links", id), &create_login_link, Some(idem_key))
+    }
+
 }

--- a/src/resources/payment_intent_ext.rs
+++ b/src/resources/payment_intent_ext.rs
@@ -15,8 +15,13 @@ impl PaymentIntent {
         client: &Client,
         payment_intent_id: &str,
         params: PaymentIntentConfirmParams<'_>,
+        idem_key: Option<&str>,
     ) -> Response<PaymentIntent> {
-        client.post_form(&format!("/payment_intents/{}/confirm", payment_intent_id), params)
+        client.post_form(
+            &format!("/payment_intents/{}/confirm", payment_intent_id),
+            params,
+            idem_key,
+        )
     }
 
     /// Capture the funds of an existing uncaptured PaymentIntent where required_action="requires_capture".
@@ -26,8 +31,13 @@ impl PaymentIntent {
         client: &Client,
         payment_intent_id: &str,
         params: CapturePaymentIntent,
+        idem_key: Option<&str>,
     ) -> Response<PaymentIntent> {
-        client.post_form(&format!("/payment_intents/{}/capture", payment_intent_id), params)
+        client.post_form(
+            &format!("/payment_intents/{}/capture", payment_intent_id),
+            params,
+            idem_key,
+        )
     }
 
     /// A PaymentIntent object can be canceled when it is in one of these statuses: requires_source, requires_capture, requires_confirmation, requires_source_action.
@@ -37,8 +47,13 @@ impl PaymentIntent {
         client: &Client,
         payment_intent_id: &str,
         params: CancelPaymentIntent,
+        idem_key: Option<&str>,
     ) -> Response<PaymentIntent> {
-        client.post_form(&format!("/payment_intents/{}/cancel", payment_intent_id), params)
+        client.post_form(
+            &format!("/payment_intents/{}/cancel", payment_intent_id),
+            params,
+            idem_key,
+        )
     }
 }
 /// The resource representing a Stripe PaymentError object.

--- a/src/resources/payment_method_ext.rs
+++ b/src/resources/payment_method_ext.rs
@@ -13,6 +13,20 @@ pub struct AttachPaymentMethod {
 }
 
 impl PaymentMethod {
+    #[cfg(features = "idempotency")]
+    pub fn attach_with_idempotency(
+        client: &Client,
+        payment_method_id: &PaymentMethodId,
+        params: AttachPaymentMethod,
+        idem_key: &str,
+    ) -> Response<PaymentMethod> {
+        client.post_form(
+            &format!("/payment_methods/{}/attach", payment_method_id),
+            params,
+            Some(idem_key),
+        )
+    }
+
     /// Attach a payment method to a customer
     ///
     /// For more details see <https://stripe.com/docs/api/payment_methods/attach>.
@@ -20,13 +34,22 @@ impl PaymentMethod {
         client: &Client,
         payment_method_id: &PaymentMethodId,
         params: AttachPaymentMethod,
-        idem_key: Option<&str>,
     ) -> Response<PaymentMethod> {
         client.post_form(
             &format!("/payment_methods/{}/attach", payment_method_id),
             params,
-            idem_key,
+            None,
         )
+    }
+
+
+    #[cfg(features = "idempotency")]
+    pub fn detach_with_idempotency(
+        client: &Client,
+        payment_method_id: &PaymentMethodId,
+        idem_key: &str,
+    ) -> Response<PaymentMethod> {
+        client.post(&format!("/payment_methods/{}/detach", payment_method_id), Some(idem_key))
     }
 
     /// Detach a PaymentMethod from a Customer
@@ -35,8 +58,8 @@ impl PaymentMethod {
     pub fn detach(
         client: &Client,
         payment_method_id: &PaymentMethodId,
-        idem_key: Option<&str>,
     ) -> Response<PaymentMethod> {
-        client.post(&format!("/payment_methods/{}/detach", payment_method_id), idem_key)
+        client.post(&format!("/payment_methods/{}/detach", payment_method_id), None)
     }
+
 }

--- a/src/resources/payment_method_ext.rs
+++ b/src/resources/payment_method_ext.rs
@@ -35,13 +35,8 @@ impl PaymentMethod {
         payment_method_id: &PaymentMethodId,
         params: AttachPaymentMethod,
     ) -> Response<PaymentMethod> {
-        client.post_form(
-            &format!("/payment_methods/{}/attach", payment_method_id),
-            params,
-            None,
-        )
+        client.post_form(&format!("/payment_methods/{}/attach", payment_method_id), params, None)
     }
-
 
     #[cfg(features = "idempotency")]
     pub fn detach_with_idempotency(
@@ -55,11 +50,7 @@ impl PaymentMethod {
     /// Detach a PaymentMethod from a Customer
     ///
     /// For more details see <https://stripe.com/docs/api/payment_methods/detach>.
-    pub fn detach(
-        client: &Client,
-        payment_method_id: &PaymentMethodId,
-    ) -> Response<PaymentMethod> {
+    pub fn detach(client: &Client, payment_method_id: &PaymentMethodId) -> Response<PaymentMethod> {
         client.post(&format!("/payment_methods/{}/detach", payment_method_id), None)
     }
-
 }

--- a/src/resources/payment_method_ext.rs
+++ b/src/resources/payment_method_ext.rs
@@ -20,14 +20,23 @@ impl PaymentMethod {
         client: &Client,
         payment_method_id: &PaymentMethodId,
         params: AttachPaymentMethod,
+        idem_key: Option<&str>,
     ) -> Response<PaymentMethod> {
-        client.post_form(&format!("/payment_methods/{}/attach", payment_method_id), params)
+        client.post_form(
+            &format!("/payment_methods/{}/attach", payment_method_id),
+            params,
+            idem_key,
+        )
     }
 
     /// Detach a PaymentMethod from a Customer
     ///
     /// For more details see <https://stripe.com/docs/api/payment_methods/detach>.
-    pub fn detach(client: &Client, payment_method_id: &PaymentMethodId) -> Response<PaymentMethod> {
-        client.post(&format!("/payment_methods/{}/detach", payment_method_id))
+    pub fn detach(
+        client: &Client,
+        payment_method_id: &PaymentMethodId,
+        idem_key: Option<&str>,
+    ) -> Response<PaymentMethod> {
+        client.post(&format!("/payment_methods/{}/detach", payment_method_id), idem_key)
     }
 }

--- a/src/resources/payout_ext.rs
+++ b/src/resources/payout_ext.rs
@@ -7,8 +7,8 @@ impl Payout {
     /// Cancels the payout.
     ///
     /// For more details see <https://stripe.com/docs/api/payouts/cancel>.
-    pub fn cancel(client: &Client, id: &PayoutId) -> Response<Payout> {
-        client.post(&format!("/payouts/{}/cancel", id))
+    pub fn cancel(client: &Client, id: &PayoutId, idem_key: Option<&str>) -> Response<Payout> {
+        client.post(&format!("/payouts/{}/cancel", id), idem_key)
     }
 }
 

--- a/src/resources/setup_intent_ext.rs
+++ b/src/resources/setup_intent_ext.rs
@@ -43,7 +43,6 @@ pub trait SetupIntentExt {
     where
         Self: Sized;
 
-
     fn cancel(
         client: &Client,
         setup_id: &SetupIntentId,
@@ -75,7 +74,6 @@ impl SetupIntentExt for SetupIntent {
     ) -> Response<SetupIntent> {
         client.post_form(&format!("/setup_intents/{}/confirm", setup_id), &params, Some(idem_key))
     }
-
 
     fn cancel(
         _client: &Client,

--- a/src/resources/setup_intent_ext.rs
+++ b/src/resources/setup_intent_ext.rs
@@ -33,6 +33,17 @@ pub trait SetupIntentExt {
     where
         Self: Sized;
 
+    #[cfg(features = "idempotency")]
+    fn confirm_with_idempotency(
+        client: &Client,
+        setup_id: &SetupIntentId,
+        params: ConfirmSetupIntent,
+        idem_key: &str,
+    ) -> Response<Self>
+    where
+        Self: Sized;
+
+
     fn cancel(
         client: &Client,
         setup_id: &SetupIntentId,
@@ -52,8 +63,19 @@ impl SetupIntentExt for SetupIntent {
         setup_id: &SetupIntentId,
         params: ConfirmSetupIntent,
     ) -> Response<SetupIntent> {
-        client.post_form(&format!("/setup_intents/{}/confirm", setup_id), &params)
+        client.post_form(&format!("/setup_intents/{}/confirm", setup_id), &params, None)
     }
+
+    #[cfg(features = "idempotency")]
+    fn confirm_with_idempotency(
+        client: &Client,
+        setup_id: &SetupIntentId,
+        params: ConfirmSetupIntent,
+        idem_key: &str,
+    ) -> Response<SetupIntent> {
+        client.post_form(&format!("/setup_intents/{}/confirm", setup_id), &params, Some(idem_key))
+    }
+
 
     fn cancel(
         _client: &Client,


### PR DESCRIPTION
The idempotency feature is a new configuration parameter that when it is set to true, allows additional create and update functions that support idempotency strings.  

A user of this feature does the following:

1. Turn on the feature named "idempotency"
2. Any message that you want to send an idempotency post with, you must use create_with_idempotency or update_with_idempotency.
3. Adhere to Stripe's standards for idempotency keys for correct use.

This is an optional feature.