### PR TITLE
Add CheckoutSessionAsyncPaymentFailed/Succeded to Webhooks Events

### DIFF
--- a/src/resources/webhook_events.rs
+++ b/src/resources/webhook_events.rs
@@ -53,6 +53,10 @@ pub enum EventType {
     ChargeDisputeUpdated,
     #[serde(rename = "charge.refund.updated")]
     ChargeRefundUpdated,
+    #[serde(rename = "checkout.session.async_payment_failed")]
+    CheckoutSessionAsyncPaymentFailed,
+    #[serde(rename = "checkout.session.async_payment_succeeded")]
+    CheckoutSessionAsyncPaymentSucceeded,
     #[serde(rename = "checkout.session.completed")]
     CheckoutSessionCompleted,
     #[serde(rename = "coupon.created")]


### PR DESCRIPTION
Should be pretty simple and straightforward.
Types are listed here: https://stripe.com/docs/api/events/types