### PR TITLE
Development idempotency header

### DIFF
--- a/src/client/async_std.rs
+++ b/src/client/async_std.rs
@@ -61,10 +61,17 @@ impl Client {
     ///
     /// This is the recommended way to send requests for many different Stripe accounts
     /// or with different Meta, Extra, and Expand headers while using the same secret key.
-    pub fn with_headers(&self, headers: Headers) -> Client {
-        let mut client = self.clone();
-        client.headers = headers;
-        client
+    pub fn with_headers(mut self, headers: Headers) -> Client {
+        self.headers = headers;
+        self
+    }
+
+    /// Clones a new client with idempotency key headers.
+    ///
+    /// For short living idempotency keys, they only matter on push requests
+    pub fn with_idempotency_key(mut self, idempotency_key: String) -> Client {
+        self.headers.idempotency_key = Some(idempotency_key);
+        self
     }
 
     pub fn set_app_info(&mut self, name: String, version: Option<String>, url: Option<String>) {

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -51,8 +51,16 @@ impl Client {
     ///
     /// This is the recommended way to send requests for many different Stripe accounts
     /// or with different Meta, Extra, and Expand headers while using the same secret key.
-    pub fn with_headers(&self, headers: Headers) -> Client {
-        Client { inner: self.inner.with_headers(headers), runtime: self.runtime.clone() }
+    pub fn with_headers(self, headers: Headers) -> Client {
+        Client { inner: self.inner.with_headers(headers), runtime: self.runtime }
+    }
+
+    /// Clones a new client with idempotency key headers.
+    ///
+    /// For short living idempotency keys, they only matter on push requests
+    pub fn with_idempotency_key(mut self, idempotency_key: String) -> Client {
+        self.inner = self.inner.with_idempotency_key(idempotency_key);
+        self
     }
 
     pub fn set_app_info(&mut self, name: String, version: Option<String>, url: Option<String>) {

--- a/src/client/tokio.rs
+++ b/src/client/tokio.rs
@@ -92,10 +92,17 @@ impl Client {
     ///
     /// This is the recommended way to send requests for many different Stripe accounts
     /// or with different Meta, Extra, and Expand headers while using the same secret key.
-    pub fn with_headers(&self, headers: Headers) -> Client {
-        let mut client = self.clone();
-        client.headers = headers;
-        client
+    pub fn with_headers(mut self, headers: Headers) -> Client {
+        self.headers = headers;
+        self
+    }
+
+    /// Clones a new client with idempotency key headers.
+    ///
+    /// For short living idempotency keys, they only matter on push requests
+    pub fn with_idempotency_key(mut self, idempotency_key: String) -> Client {
+        self.headers.idempotency_key = Some(idempotency_key);
+        self
     }
 
     pub fn set_app_info(&mut self, name: String, version: Option<String>, url: Option<String>) {

--- a/src/error.rs
+++ b/src/error.rs
@@ -97,6 +97,7 @@ pub enum ErrorCode {
     CustomerMaxSubscriptions,
     EmailInvalid,
     ExpiredCard,
+    IdempotencyKeyInUse,
     IncorrectAddress,
     IncorrectCvc,
     IncorrectNumber,

--- a/src/ids.rs
+++ b/src/ids.rs
@@ -459,6 +459,8 @@ def_id!(ApplicationFeeId, "fee_");
 def_id!(ApplicationFeeRefundId, "fr_");
 def_id!(BalanceTransactionId, "txn_");
 def_id!(BankAccountId, "ba_");
+def_id!(BillingPortalSessionId, "bps_");
+def_id!(BillingPortalConfigurationId, "bpc_");
 def_id!(BankTokenId, "btok_");
 def_id!(
     #[optional]

--- a/src/ids.rs
+++ b/src/ids.rs
@@ -555,6 +555,7 @@ def_id!(SubscriptionScheduleId, "sub_sched_");
 def_id!(TaxIdId, "txi_");
 def_id!(TaxCodeId, "txcd_");
 def_id!(TaxRateId, "txr_");
+def_id!(TestHelpersTestClockId, "clock_");
 def_id!(
     enum TokenId {
         #[default]

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -118,6 +118,7 @@ pub use {
         shipping_rate::*,
         tax_code::*,
         tax_deducted_at_source::*,
+        test_helpers_test_clock::*,
         token::*,
         api_errors::*,
     },

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -165,6 +165,8 @@ pub use {
         subscription_ext::*
     },
     generated::billing::{
+        billing_portal_session::*,
+        billing_portal_configuration::*,
         coupon::*,
         discount::*,
         invoice::*,

--- a/src/resources/generated.rs
+++ b/src/resources/generated.rs
@@ -36,6 +36,7 @@ pub mod core {
     pub mod shipping_rate;
     pub mod tax_code;
     pub mod tax_deducted_at_source;
+    pub mod test_helpers_test_clock;
     pub mod token;
 }
 

--- a/src/resources/generated.rs
+++ b/src/resources/generated.rs
@@ -61,6 +61,8 @@ pub mod checkout {
 #[path = "generated"]
 #[cfg(feature = "billing")]
 pub mod billing {
+    pub mod billing_portal_configuration;
+    pub mod billing_portal_session;
     pub mod coupon;
     pub mod discount;
     pub mod invoice;

--- a/src/resources/generated/customer.rs
+++ b/src/resources/generated/customer.rs
@@ -12,7 +12,7 @@ use crate::ids::{
 use crate::params::{Deleted, Expand, Expandable, List, Metadata, Object, RangeQuery, Timestamp};
 use crate::resources::{
     Address, Currency, Discount, PaymentMethod, PaymentSource, PaymentSourceParams, Scheduled,
-    Shipping, Subscription, TaxId,
+    Shipping, Subscription, TaxId, TestHelpersTestClock,
 };
 
 /// The resource representing a Stripe "Customer".
@@ -136,6 +136,10 @@ pub struct Customer {
     /// The customer's tax IDs.
     #[serde(default)]
     pub tax_ids: List<TaxId>,
+
+    /// ID of the test clock this customer belongs to.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub test_clock: Option<Expandable<TestHelpersTestClock>>,
 }
 
 impl Customer {
@@ -342,6 +346,10 @@ pub struct CreateCustomer<'a> {
     /// The customer's tax IDs.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tax_id_data: Option<Vec<TaxIdData>>,
+
+    /// ID of the test clock to attach to the customer.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub test_clock: Option<&'a str>,
 }
 
 impl<'a> CreateCustomer<'a> {
@@ -367,6 +375,7 @@ impl<'a> CreateCustomer<'a> {
             tax: Default::default(),
             tax_exempt: Default::default(),
             tax_id_data: Default::default(),
+            test_clock: Default::default(),
         }
     }
 }

--- a/src/resources/generated/invoiceitem.rs
+++ b/src/resources/generated/invoiceitem.rs
@@ -9,6 +9,7 @@ use crate::ids::{CustomerId, InvoiceId, InvoiceItemId, PriceId, SubscriptionId};
 use crate::params::{Deleted, Expand, Expandable, List, Metadata, Object, RangeQuery, Timestamp};
 use crate::resources::{
     Currency, Customer, Discount, Invoice, Period, Price, Subscription, TaxRate,
+    TestHelpersTestClock,
 };
 
 /// The resource representing a Stripe "InvoiceItem".
@@ -108,6 +109,10 @@ pub struct InvoiceItem {
     /// When set, the `default_tax_rates` on the invoice do not apply to this invoice item.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tax_rates: Option<Vec<TaxRate>>,
+
+    /// ID of the test clock this invoice item belongs to.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub test_clock: Option<Expandable<TestHelpersTestClock>>,
 
     /// Unit amount (in the `currency` specified) of the invoice item.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/resources/generated/line_item.rs
+++ b/src/resources/generated/line_item.rs
@@ -66,6 +66,10 @@ pub struct InvoiceLineItem {
     /// Whether this is a proration.
     pub proration: bool,
 
+    /// Additional details for proration line items.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub proration_details: Option<InvoicesLineItemsProrationDetails>,
+
     /// The quantity of the subscription, if the line item is a subscription or a proration.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub quantity: Option<u64>,
@@ -122,6 +126,22 @@ pub struct TaxAmount {
 
     /// The tax rate that was applied to get this tax amount.
     pub tax_rate: Expandable<TaxRate>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct InvoicesLineItemsProrationDetails {
+    /// For a credit proration `line_item`, the original debit line_items to which the credit proration applies.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub credited_items: Option<InvoicesLineItemsCreditedItems>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct InvoicesLineItemsCreditedItems {
+    /// Invoice containing the credited invoice line items.
+    pub invoice: String,
+
+    /// Credited invoice line items.
+    pub invoice_line_items: Vec<String>,
 }
 
 /// An enum representing the possible values of an `InvoiceLineItem`'s `type` field.

--- a/src/resources/generated/payment_intent.rs
+++ b/src/resources/generated/payment_intent.rs
@@ -374,23 +374,53 @@ pub struct PaymentIntentNextActionKonbini {
 pub struct PaymentIntentNextActionKonbiniStores {
     /// FamilyMart instruction details.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub familymart: Option<PaymentIntentNextActionKonbiniStoresStore>,
+    pub familymart: Option<PaymentIntentNextActionKonbiniFamilymart>,
 
     /// Lawson instruction details.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub lawson: Option<PaymentIntentNextActionKonbiniStoresStore>,
+    pub lawson: Option<PaymentIntentNextActionKonbiniLawson>,
 
     /// Ministop instruction details.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ministop: Option<PaymentIntentNextActionKonbiniStoresStore>,
+    pub ministop: Option<PaymentIntentNextActionKonbiniMinistop>,
 
     /// Seicomart instruction details.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub seicomart: Option<PaymentIntentNextActionKonbiniStoresStore>,
+    pub seicomart: Option<PaymentIntentNextActionKonbiniSeicomart>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-pub struct PaymentIntentNextActionKonbiniStoresStore {
+pub struct PaymentIntentNextActionKonbiniFamilymart {
+    /// The confirmation number.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub confirmation_number: Option<String>,
+
+    /// The payment code.
+    pub payment_code: String,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct PaymentIntentNextActionKonbiniLawson {
+    /// The confirmation number.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub confirmation_number: Option<String>,
+
+    /// The payment code.
+    pub payment_code: String,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct PaymentIntentNextActionKonbiniMinistop {
+    /// The confirmation number.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub confirmation_number: Option<String>,
+
+    /// The payment code.
+    pub payment_code: String,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct PaymentIntentNextActionKonbiniSeicomart {
     /// The confirmation number.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub confirmation_number: Option<String>,

--- a/src/resources/generated/payment_method_options_boleto.rs
+++ b/src/resources/generated/payment_method_options_boleto.rs
@@ -5,7 +5,7 @@
 use serde_derive::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "payment_method_options_boleto".
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct PaymentMethodOptionsBoleto {
     /// The number of calendar days before a Boleto voucher expires.
     ///

--- a/src/resources/generated/payment_method_options_oxxo.rs
+++ b/src/resources/generated/payment_method_options_oxxo.rs
@@ -5,7 +5,7 @@
 use serde_derive::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "payment_method_options_oxxo".
-#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct PaymentMethodOptionsOxxo {
     /// The number of calendar days before an OXXO invoice expires.
     ///

--- a/src/resources/generated/product.rs
+++ b/src/resources/generated/product.rs
@@ -360,7 +360,7 @@ pub struct UpdateProduct<'a> {
 
     /// A URL of a publicly-accessible webpage for this product.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub url: Option<&'a str>,
+    pub url: Option<String>,
 }
 
 impl<'a> UpdateProduct<'a> {

--- a/src/resources/generated/quote.rs
+++ b/src/resources/generated/quote.rs
@@ -9,7 +9,7 @@ use crate::ids::{CustomerId, QuoteId};
 use crate::params::{Expand, Expandable, List, Metadata, Object, Timestamp};
 use crate::resources::{
     Account, CheckoutSessionItem, Currency, Customer, Discount, Invoice,
-    QuotesResourceTotalDetails, Subscription, SubscriptionSchedule, TaxRate,
+    QuotesResourceTotalDetails, Subscription, SubscriptionSchedule, TaxRate, TestHelpersTestClock,
 };
 
 /// The resource representing a Stripe "Quote".
@@ -144,6 +144,10 @@ pub struct Quote {
     /// The subscription schedule that was created or updated from this quote.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub subscription_schedule: Option<Expandable<SubscriptionSchedule>>,
+
+    /// ID of the test clock this quote belongs to.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub test_clock: Option<Expandable<TestHelpersTestClock>>,
 
     pub total_details: QuotesResourceTotalDetails,
 

--- a/src/resources/generated/refund.rs
+++ b/src/resources/generated/refund.rs
@@ -61,6 +61,9 @@ pub struct Refund {
     #[serde(default)]
     pub metadata: Metadata,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_action: Option<RefundNextAction>,
+
     /// ID of the PaymentIntent that was refunded.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub payment_intent: Option<Expandable<PaymentIntent>>,
@@ -130,6 +133,34 @@ impl Object for Refund {
     fn object(&self) -> &'static str {
         "refund"
     }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct RefundNextAction {
+    /// Contains the refund details.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display_details: Option<RefundNextActionDisplayDetails>,
+
+    /// Type of the next action to perform.
+    #[serde(rename = "type")]
+    pub type_: String,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct RefundNextActionDisplayDetails {
+    pub email_sent: EmailSent,
+
+    /// The expiry timestamp.
+    pub expires_at: Timestamp,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct EmailSent {
+    /// The timestamp when the email was sent.
+    pub email_sent_at: Timestamp,
+
+    /// The recipient's email address.
+    pub email_sent_to: String,
 }
 
 /// The parameters for `Refund::create`.

--- a/src/resources/generated/subscription.rs
+++ b/src/resources/generated/subscription.rs
@@ -12,6 +12,7 @@ use crate::resources::{
     InvoicePaymentMethodOptionsBancontact, InvoicePaymentMethodOptionsKonbini, PaymentMethod,
     PaymentSource, Scheduled, SetupIntent, SubscriptionBillingThresholds, SubscriptionItem,
     SubscriptionItemBillingThresholds, SubscriptionSchedule, SubscriptionTransferData, TaxRate,
+    TestHelpersTestClock,
 };
 
 /// The resource representing a Stripe "Subscription".
@@ -177,6 +178,10 @@ pub struct Subscription {
     /// Note that when a subscription has a status of `unpaid`, no subsequent invoices will be attempted (invoices will be created, but then immediately automatically closed).
     /// After receiving updated payment information from a customer, you may choose to reopen and pay their closed invoices.
     pub status: SubscriptionStatus,
+
+    /// ID of the test clock this subscription belongs to.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub test_clock: Option<Expandable<TestHelpersTestClock>>,
 
     /// The account (if any) the subscription's payments will be attributed to for tax reporting, and where funds from each payment will be transferred to for each of the subscription's invoices.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/resources/generated/subscription_schedule.rs
+++ b/src/resources/generated/subscription_schedule.rs
@@ -10,7 +10,7 @@ use crate::params::{Expand, Expandable, List, Metadata, Object, RangeQuery, Time
 use crate::resources::{
     CollectionMethod, Coupon, Currency, Customer, PaymentMethod, Price, Scheduled, Subscription,
     SubscriptionBillingThresholds, SubscriptionItemBillingThresholds, SubscriptionTransferData,
-    TaxRate,
+    TaxRate, TestHelpersTestClock,
 };
 
 /// The resource representing a Stripe "SubscriptionSchedule".
@@ -83,6 +83,10 @@ pub struct SubscriptionSchedule {
     /// ID of the subscription managed by the subscription schedule.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub subscription: Option<Expandable<Subscription>>,
+
+    /// ID of the test clock this subscription schedule belongs to.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub test_clock: Option<Expandable<TestHelpersTestClock>>,
 }
 
 impl SubscriptionSchedule {

--- a/src/resources/generated/test_helpers_test_clock.rs
+++ b/src/resources/generated/test_helpers_test_clock.rs
@@ -2,9 +2,10 @@
 // This file was automatically generated.
 // ======================================
 
-use crate::ids::{TestHelpersTestClockId};
-use crate::params::{Object, Timestamp};
 use serde_derive::{Deserialize, Serialize};
+
+use crate::ids::TestHelpersTestClockId;
+use crate::params::{Object, Timestamp};
 
 /// The resource representing a Stripe "TestClock".
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]

--- a/src/resources/generated/test_helpers_test_clock.rs
+++ b/src/resources/generated/test_helpers_test_clock.rs
@@ -1,0 +1,90 @@
+// ======================================
+// This file was automatically generated.
+// ======================================
+
+use crate::ids::{TestHelpersTestClockId};
+use crate::params::{Object, Timestamp};
+use serde_derive::{Deserialize, Serialize};
+
+/// The resource representing a Stripe "TestClock".
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct TestHelpersTestClock {
+    /// Unique identifier for the object.
+    pub id: TestHelpersTestClockId,
+
+    /// Time at which the object was created.
+    ///
+    /// Measured in seconds since the Unix epoch.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created: Option<Timestamp>,
+
+    // Always true for a deleted object
+    #[serde(default)]
+    pub deleted: bool,
+
+    /// Time at which this clock is scheduled to auto delete.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deletes_after: Option<Timestamp>,
+
+    /// Time at which all objects belonging to this clock are frozen.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub frozen_time: Option<Timestamp>,
+
+    /// Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub livemode: Option<bool>,
+
+    /// The custom name supplied at creation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+
+    /// The status of the Test Clock.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<TestHelpersTestClockStatus>,
+}
+
+impl Object for TestHelpersTestClock {
+    type Id = TestHelpersTestClockId;
+    fn id(&self) -> Self::Id {
+        self.id.clone()
+    }
+    fn object(&self) -> &'static str {
+        "test_helpers.test_clock"
+    }
+}
+
+/// An enum representing the possible values of an `TestHelpersTestClock`'s `status` field.
+#[derive(Copy, Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum TestHelpersTestClockStatus {
+    Advancing,
+    InternalFailure,
+    Ready,
+}
+
+impl TestHelpersTestClockStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            TestHelpersTestClockStatus::Advancing => "advancing",
+            TestHelpersTestClockStatus::InternalFailure => "internal_failure",
+            TestHelpersTestClockStatus::Ready => "ready",
+        }
+    }
+}
+
+impl AsRef<str> for TestHelpersTestClockStatus {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl std::fmt::Display for TestHelpersTestClockStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        self.as_str().fmt(f)
+    }
+}
+impl std::default::Default for TestHelpersTestClockStatus {
+    fn default() -> Self {
+        Self::Advancing
+    }
+}

--- a/tests/customer.rs
+++ b/tests/customer.rs
@@ -23,7 +23,7 @@ fn customer_create_and_delete_without_account() {
 #[cfg(feature = "blocking")]
 fn customer_create_and_delete_with_account() {
     mock::with_client(|client| {
-        let client = client.with_headers(stripe::Headers {
+        let client = client.clone().with_headers(stripe::Headers {
             stripe_account: Some("TEST".into()),
             client_id: Some("ca_123".into()),
             stripe_version: Some(stripe::ApiVersion::V2019_03_14),


### PR DESCRIPTION
Closes #145

Okay, Arlyon

Here is the simplified idempotency API.  It's much simpler and I can tell you that it works, I've tested myself.

It's so small, I didn't bother making it a feature and it doesn't break backward compatibility, so I think that's good.