### PR TITLE
Simplify the id heuristic to include non-root types

### DIFF
--- a/openapi/src/metadata.rs
+++ b/openapi/src/metadata.rs
@@ -57,17 +57,17 @@ impl<'a> Metadata<'a> {
             if fields.contains_key("object") {
                 objects.insert(schema_name);
                 if !schema["properties"]["id"].is_null() {
-                    if let Some(id_src) = schema["x-resourceId"].as_str() {
-                        let id_type = if let Some(rename) = id_renames.get(&id_src) {
-                            rename.to_camel_case() + "Id"
-                        } else {
-                            id_src.replace('.', "_").to_camel_case() + "Id"
-                        };
-                        id_mappings.insert(
-                            schema_name.replace('.', "_").to_owned(),
-                            (id_type, CopyOrClone::Clone),
-                        );
-                    }
+                    let id_type = id_renames
+                        .get(&schema_name)
+                        .unwrap_or_else(|| &schema_name)
+                        .replace('.', "_")
+                        .to_camel_case()
+                        + "Id";
+
+                    id_mappings.insert(
+                        schema_name.replace('.', "_").to_owned(),
+                        (id_type, CopyOrClone::Clone),
+                    );
                 }
             }
             for (_, field) in fields {

--- a/openapi/src/metadata.rs
+++ b/openapi/src/metadata.rs
@@ -59,7 +59,7 @@ impl<'a> Metadata<'a> {
                 if !schema["properties"]["id"].is_null() {
                     let id_type = id_renames
                         .get(&schema_name)
-                        .unwrap_or_else(|| &schema_name)
+                        .unwrap_or(&schema_name)
                         .replace('.', "_")
                         .to_camel_case()
                         + "Id";

--- a/src/ids.rs
+++ b/src/ids.rs
@@ -456,6 +456,7 @@ impl std::error::Error for ParseIdError {
 def_id!(AccountId, "acct_");
 def_id!(AlipayAccountId, "aliacc_");
 def_id!(ApplicationFeeId, "fee_");
+def_id!(ApplicationId, "ca_");
 def_id!(ApplicationFeeRefundId, "fr_");
 def_id!(BalanceTransactionId, "txn_");
 def_id!(BankAccountId, "ba_");
@@ -484,6 +485,7 @@ def_id!(CardTokenId, "tok_");
 def_id!(ChargeId, "ch_" | "py_"); // TODO: Understand (and then document) why "py_" is a valid charge id
 def_id!(CheckoutSessionId, "cs_");
 def_id!(CheckoutSessionItemId: String); // TODO: Figure out what prefix this id has
+def_id!(ConnectCollectionTransferId: String);
 def_id!(CouponId: String); // N.B. A coupon id can be user-provided so can be any arbitrary string
 def_id!(CustomerId, "cus_");
 def_id!(DiscountId, "di_");
@@ -535,12 +537,14 @@ def_id!(
 );
 def_id!(PersonId, "person_");
 def_id!(PlanId: String); // N.B. A plan id can be user-provided so can be any arbitrary string
+def_id!(PlatformTaxFeeId: String);
 def_id!(PriceId: String); // TODO: Figure out what prefix this id has
 def_id!(ProductId: String); // N.B. A product id can be user-provided so can be any arbitrary string
 def_id!(PromotionCodeId, "promo_"); // N.B. A product id can be user-provided so can be any arbitrary string
 def_id!(QuoteId, "qt_");
 def_id!(RecipientId: String); // FIXME: This doesn't seem to be documented yet
 def_id!(RefundId, "re_");
+def_id!(ReserveTransactionId: String);
 def_id!(ReviewId, "prv_");
 def_id!(ScheduledQueryRunId, "sqr_");
 def_id!(SetupAttemptId, "setatt_");
@@ -554,6 +558,7 @@ def_id!(SubscriptionLineId, "sli_");
 def_id!(SubscriptionScheduleId, "sub_sched_");
 def_id!(TaxIdId, "txi_");
 def_id!(TaxCodeId, "txcd_");
+def_id!(TaxDeductedAtSourceId: String);
 def_id!(TaxRateId, "txr_");
 def_id!(TestHelpersTestClockId, "clock_");
 def_id!(

--- a/src/ids.rs
+++ b/src/ids.rs
@@ -195,9 +195,8 @@ macro_rules! def_id {
                 if !s.starts_with($prefix) $(
                     && !s.starts_with($alt_prefix)
                 )* {
-
                     // N.B. For debugging
-                    eprintln!("bad id is: {} (expected: {:?})", s, $prefix);
+                    eprintln!("bad id \"{}\" (expected: {:?})", s, $prefix);
 
                     Err(ParseIdError {
                         typename: stringify!($struct_name),

--- a/src/resources/generated/application.rs
+++ b/src/resources/generated/application.rs
@@ -4,19 +4,25 @@
 
 use serde_derive::{Deserialize, Serialize};
 
+use crate::ids::ApplicationId;
 use crate::params::Object;
 
 /// The resource representing a Stripe "Application".
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Application {
+    /// Unique identifier for the object.
+    pub id: ApplicationId,
+
     /// The name of the application.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 }
 
 impl Object for Application {
-    type Id = ();
-    fn id(&self) -> Self::Id {}
+    type Id = ApplicationId;
+    fn id(&self) -> Self::Id {
+        self.id.clone()
+    }
     fn object(&self) -> &'static str {
         "application"
     }

--- a/src/resources/generated/card.rs
+++ b/src/resources/generated/card.rs
@@ -146,6 +146,12 @@ pub struct Card {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub recipient: Option<Expandable<Recipient>>,
 
+    /// For external accounts, possible values are `new` and `errored`.
+    ///
+    /// If a transfer fails, the status is set to `errored` and transfers are stopped until account details are updated.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+
     /// If the card number is tokenized, this is the method that was used.
     ///
     /// Can be `android_pay` (includes Google Pay), `apple_pay`, `masterpass`, `visa_checkout`, or null.

--- a/src/resources/generated/connect_collection_transfer.rs
+++ b/src/resources/generated/connect_collection_transfer.rs
@@ -4,12 +4,16 @@
 
 use serde_derive::{Deserialize, Serialize};
 
+use crate::ids::ConnectCollectionTransferId;
 use crate::params::{Expandable, Object};
 use crate::resources::{Account, Currency};
 
 /// The resource representing a Stripe "ConnectCollectionTransfer".
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct ConnectCollectionTransfer {
+    /// Unique identifier for the object.
+    pub id: ConnectCollectionTransferId,
+
     /// Amount transferred, in %s.
     pub amount: i64,
 
@@ -26,8 +30,10 @@ pub struct ConnectCollectionTransfer {
 }
 
 impl Object for ConnectCollectionTransfer {
-    type Id = ();
-    fn id(&self) -> Self::Id {}
+    type Id = ConnectCollectionTransferId;
+    fn id(&self) -> Self::Id {
+        self.id.clone()
+    }
     fn object(&self) -> &'static str {
         "connect_collection_transfer"
     }

--- a/src/resources/generated/payment_intent.rs
+++ b/src/resources/generated/payment_intent.rs
@@ -741,7 +741,7 @@ pub struct PaymentIntentTypeSpecificPaymentMethodOptionsClient {
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct PaymentMethodOptionsAfterpayClearpay {
-    /// Order identifier shown to the merchant in Afterpay’s online portal.
+    /// Order identifier shown to the customer in Afterpay’s online portal.
     ///
     /// We recommend using a value that helps you answer any questions a customer might have about the payment.
     /// The identifier is limited to 128 characters and may contain only letters, digits, underscores, backslashes and dashes.

--- a/src/resources/generated/payment_method_options_boleto.rs
+++ b/src/resources/generated/payment_method_options_boleto.rs
@@ -5,7 +5,7 @@
 use serde_derive::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "payment_method_options_boleto".
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct PaymentMethodOptionsBoleto {
     /// The number of calendar days before a Boleto voucher expires.
     ///

--- a/src/resources/generated/payment_method_options_oxxo.rs
+++ b/src/resources/generated/payment_method_options_oxxo.rs
@@ -5,7 +5,7 @@
 use serde_derive::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "payment_method_options_oxxo".
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct PaymentMethodOptionsOxxo {
     /// The number of calendar days before an OXXO invoice expires.
     ///

--- a/src/resources/generated/placeholders.rs
+++ b/src/resources/generated/placeholders.rs
@@ -23,14 +23,14 @@ impl Object for Account {
 #[cfg(not(feature = "connect"))]
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Application {
-    pub id: (),
+    pub id: ApplicationId,
 }
 
 #[cfg(not(feature = "connect"))]
 impl Object for Application {
-    type Id = ();
+    type Id = ApplicationId;
     fn id(&self) -> Self::Id {
-        self.id
+        self.id.clone()
     }
     fn object(&self) -> &'static str {
         "application"
@@ -74,14 +74,14 @@ impl Object for CheckoutSession {
 #[cfg(not(feature = "connect"))]
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct ConnectCollectionTransfer {
-    pub id: (),
+    pub id: ConnectCollectionTransferId,
 }
 
 #[cfg(not(feature = "connect"))]
 impl Object for ConnectCollectionTransfer {
-    type Id = ();
+    type Id = ConnectCollectionTransferId;
     fn id(&self) -> Self::Id {
-        self.id
+        self.id.clone()
     }
     fn object(&self) -> &'static str {
         "connect_collection_transfer"

--- a/src/resources/generated/platform_tax_fee.rs
+++ b/src/resources/generated/platform_tax_fee.rs
@@ -4,11 +4,15 @@
 
 use serde_derive::{Deserialize, Serialize};
 
+use crate::ids::PlatformTaxFeeId;
 use crate::params::Object;
 
 /// The resource representing a Stripe "PlatformTax".
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct PlatformTaxFee {
+    /// Unique identifier for the object.
+    pub id: PlatformTaxFeeId,
+
     /// The Connected account that incurred this charge.
     pub account: String,
 
@@ -21,8 +25,10 @@ pub struct PlatformTaxFee {
 }
 
 impl Object for PlatformTaxFee {
-    type Id = ();
-    fn id(&self) -> Self::Id {}
+    type Id = PlatformTaxFeeId;
+    fn id(&self) -> Self::Id {
+        self.id.clone()
+    }
     fn object(&self) -> &'static str {
         "platform_tax_fee"
     }

--- a/src/resources/generated/reserve_transaction.rs
+++ b/src/resources/generated/reserve_transaction.rs
@@ -4,12 +4,16 @@
 
 use serde_derive::{Deserialize, Serialize};
 
+use crate::ids::ReserveTransactionId;
 use crate::params::Object;
 use crate::resources::Currency;
 
 /// The resource representing a Stripe "ReserveTransaction".
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct ReserveTransaction {
+    /// Unique identifier for the object.
+    pub id: ReserveTransactionId,
+
     pub amount: i64,
 
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
@@ -25,8 +29,10 @@ pub struct ReserveTransaction {
 }
 
 impl Object for ReserveTransaction {
-    type Id = ();
-    fn id(&self) -> Self::Id {}
+    type Id = ReserveTransactionId;
+    fn id(&self) -> Self::Id {
+        self.id.clone()
+    }
     fn object(&self) -> &'static str {
         "reserve_transaction"
     }

--- a/src/resources/generated/tax_deducted_at_source.rs
+++ b/src/resources/generated/tax_deducted_at_source.rs
@@ -4,11 +4,15 @@
 
 use serde_derive::{Deserialize, Serialize};
 
+use crate::ids::TaxDeductedAtSourceId;
 use crate::params::{Object, Timestamp};
 
 /// The resource representing a Stripe "TaxDeductedAtSource".
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct TaxDeductedAtSource {
+    /// Unique identifier for the object.
+    pub id: TaxDeductedAtSourceId,
+
     /// The end of the invoicing period.
     ///
     /// This TDS applies to Stripe fees collected during this invoicing period.
@@ -24,8 +28,10 @@ pub struct TaxDeductedAtSource {
 }
 
 impl Object for TaxDeductedAtSource {
-    type Id = ();
-    fn id(&self) -> Self::Id {}
+    type Id = TaxDeductedAtSourceId;
+    fn id(&self) -> Self::Id {
+        self.id.clone()
+    }
     fn object(&self) -> &'static str {
         "tax_deducted_at_source"
     }

--- a/tests/charge.rs
+++ b/tests/charge.rs
@@ -25,22 +25,7 @@ fn is_charge_retrievable() {
 fn is_charge_expandable() {
     mock::with_client(|client| {
         let id = "ch_123".parse().unwrap();
-        let result = stripe::Charge::retrieve(
-            client,
-            &id,
-            &[
-                "application",
-                // "application_fee",
-                // "balance_transaction",
-                // "customer",
-                // "dispute",
-                // "invoice",
-                // "review",
-                // FIXME: Figure out what the `py_` id prefix is for
-                // "source_transfer",
-                // "transfer",
-            ],
-        );
+        let result = stripe::Charge::retrieve(client, &id, &[]);
         let charge = match result {
             Err(err) => panic!("{}", err),
             Ok(ok) => ok,


### PR DESCRIPTION
Turns out checking for x-resourceId is over-eager, and misses Ids that do not exist as root resource types.

See https://github.com/stripe/openapi/issues/83

Closes #183 