### PR TITLE
Add command to locate identical duplicate types

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -21,6 +21,13 @@ for filename in src/resources/generated/*.rs ; do
 done
 '''
 
+[tasks.duplicates]
+script = '''
+rg -N --no-filename -i '^pub (struct|enum) ([A-Z][a-zA-z0-9]+).*?$'  src/resources/generated -g '!placeholders.rs'  -r '$2'\
+ | sort\
+ | uniq -cd
+'''
+
 [tasks.openapi-fetch]
 cwd = "openapi"
 command = "wget"


### PR DESCRIPTION
```
> cargo make duplicates
      3 AccountRequirementsAlternative
      3 AccountRequirementsError
      3 AccountRequirementsErrorCode
      2 AddInvoiceItems
      2 Address
      2 CapabilityStatus
      2 CreditNoteTaxAmount
      2 CustomerPaymentSourceCard
      4 DiscountsResourceDiscountAmount
      3 InvoiceItemPriceData
      3 InvoiceItemPriceDataTaxBehavior
      2 InvoicePaymentMethodOptionsCard
      2 InvoicePaymentMethodOptionsCardRequestThreeDSecure
      2 InvoiceSettingCustomField
      3 LineItemsDiscountAmount
      3 LineItemsTaxAmount
      2 PaymentMethodOptionsBoleto
      2 PaymentMethodOptionsOxxo
      3 PlanInterval
      2 SubscriptionItemPriceData
      2 SubscriptionItemPriceDataRecurring
      2 SubscriptionItemPriceDataTaxBehavior
      2 SubscriptionPaymentBehavior
      3 SubscriptionProrationBehavior
      2 SubscriptionScheduleInvoiceSettings
      2 TaxAmount
      3 TaxIdType
      2 TransferData
```