### PR TITLE
Expose UsageRecord and add UsageRecord::create extension

### DIFF
--- a/src/ids.rs
+++ b/src/ids.rs
@@ -570,6 +570,7 @@ def_id!(
 def_id!(TopupId, "tu_");
 def_id!(TransferId, "tr_");
 def_id!(TransferReversalId, "trr_");
+def_id!(UsageRecordId, "mbur_");
 def_id!(UsageRecordSummaryId, "urs_");
 def_id!(WebhookEndpointId, "we_");
 

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -41,6 +41,7 @@ mod billing {
     pub mod invoice_ext;
     pub mod line_item_ext;
     pub mod subscription_ext;
+    pub mod usage_record_ext;
 }
 
 #[path = "resources"]
@@ -163,7 +164,8 @@ pub use {
     billing::{
         invoice_ext::*,
         line_item_ext::*,
-        subscription_ext::*
+        subscription_ext::*,
+        usage_record_ext::*,
     },
     generated::billing::{
         billing_portal_session::*,

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -200,6 +200,7 @@ pub use {
         subscription_item_billing_thresholds::*,
         tax_id::*,
         tax_rate::*,
+        usage_record::*,
         usage_record_summary::*,
     },
 };

--- a/src/resources/generated.rs
+++ b/src/resources/generated.rs
@@ -87,6 +87,7 @@ pub mod billing {
     pub mod subscription_schedule;
     pub mod tax_id;
     pub mod tax_rate;
+    pub mod usage_record;
     pub mod usage_record_summary;
 }
 

--- a/src/resources/usage_record_ext.rs
+++ b/src/resources/usage_record_ext.rs
@@ -1,0 +1,44 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{Client, Response, SubscriptionItemId, Timestamp, UsageRecord};
+
+impl UsageRecord {
+    pub fn create(
+        client: &Client,
+        subscription_item_id: &SubscriptionItemId,
+        params: CreateUsageRecord,
+    ) -> Response<UsageRecord> {
+        client.post_form(
+            &format!("/subscription_items/{}/usage_records", subscription_item_id),
+            &params,
+        )
+    }
+}
+
+/// The parameters for `UsageRecord::create`.
+#[derive(Clone, Debug, Serialize, Default)]
+pub struct CreateUsageRecord {
+    /// The usage quantity for the specified timestamp.
+    pub quantity: u64,
+    /// Valid values are `increment` (default) or `set`.
+    /// When using `increment` the specified `quantity` will be added to the usage at the specified timestamp.
+    /// The `set` action will overwrite the usage quantity at that timestamp.
+    /// If the subscription has [billing thresholds](https://stripe.com/docs/api/subscriptions/object#subscription_object-billing_thresholds),
+    /// `increment` is the only allowed value.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub action: Option<UsageRecordAction>,
+    /// The timestamp for the usage event.
+    /// This timestamp must be within the current billing period of the subscription of the provided `subscription_item`,
+    /// and must not be in the future. When passing `"now"`, Stripe records usage for the current time.
+    /// Default is `"now"` if a value is not provided.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<Timestamp>,
+}
+
+/// An enum representing the possible values of a `UsageRecord`'s `account` field.
+#[derive(Copy, Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum UsageRecordAction {
+    Increment,
+    Set,
+}

--- a/tests/subscription_item.rs
+++ b/tests/subscription_item.rs
@@ -1,0 +1,20 @@
+use chrono::Utc;
+
+mod mock;
+
+#[test]
+#[cfg(feature = "blocking")]
+fn can_create_usage_record() {
+    let subscription_item_id = "si_JVbsG8wiy20ycs".parse().unwrap();
+    mock::with_client(|client| {
+        let usage_record = stripe::UsageRecord::create(
+            client,
+            &subscription_item_id,
+            stripe::CreateUsageRecord {
+                quantity: 42,
+                action: Some(stripe::UsageRecordAction::Increment),
+                timestamp: Some(Utc::now().timestamp()),
+            },
+        );
+    });
+}


### PR DESCRIPTION
See #213.

I tried to follow the existing code, but especially regarding the names of `CreateUsageRecord` and `UsageRecordAction` I'm not sure if those are the correct names to use to stay forwards compatible to what will eventually be generated automatically.