### PR TITLE
CI: pin deps requiring 2021 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,8 +112,8 @@ hex = { version = "0.4", optional = true }
 # pinned deps to prevent msrv breakage
 indexmap = {version = "1.0,<1.9.0", optional = true}
 time = {version = "0.3,<0.3.10", optional = true}
-security-framework = {version = "<2.7.0", optional = true}
-security-framework-sys = {version = "<2.7.0", optional = true}
+# >=2.7.0 requires 2021 edition
+security-framework = {version = "~2.6.0", optional = true}
 
 [dev-dependencies]
 anyhow = "1.0.38"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,8 @@ hex = { version = "0.4", optional = true }
 # pinned deps to prevent msrv breakage
 indexmap = {version = "1.0,<1.9.0", optional = true}
 time = {version = "0.3,<0.3.10", optional = true}
+security-framework = {version = "<2.7.0", optional = true}
+security-framework-sys = {version = "<2.7.0", optional = true}
 
 [dev-dependencies]
 anyhow = "1.0.38"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,6 +114,8 @@ indexmap = {version = "1.0,<1.9.0", optional = true}
 time = {version = "0.3,<0.3.10", optional = true}
 # >=2.7.0 requires 2021 edition
 security-framework = {version = "~2.6.0", optional = true}
+# >=3.11.0 requires 2021 edition
+bumpalo = {version = "~3.10.0", optional = true}
 
 [dev-dependencies]
 anyhow = "1.0.38"

--- a/openapi/version.json
+++ b/openapi/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v172"
+  "version": "v180"
 }


### PR DESCRIPTION
`security-framework 2.7.0` requires 2021 edition, so trying to pin to fix CI