### PR TITLE
Remove RUST_FILES from fmt cmd

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,6 +1,3 @@
-[env]
-RUST_FILES = { glob = "./**/*.rs", include_files = true, include_dirs = false, ignore_type = "git" }
-
 [tasks.openapi-delete]
 cwd = "openapi"
 command = "rm"
@@ -49,13 +46,13 @@ args = ["-a", "out/.", "../src/resources/generated"]
 command = "cargo"
 toolchain = "nightly"
 install_crate = "rustfmt"
-args = ["fmt", "--", "@@split(RUST_FILES,;)"]
+args = ["fmt", "--"]
 
 [tasks.check]
 command = "cargo"
 toolchain = "nightly"
 install_crate = "rustfmt"
-args = ["fmt", "--", "--check", "@@split(RUST_FILES,;)"]
+args = ["fmt", "--", "--check"]
 
 [tasks.openapi-install]
 dependencies = ["openapi-generate", "openapi-copy", "fmt"]


### PR DESCRIPTION
Saw this was added in https://github.com/arlyon/async-stripe/commit/d7a8a9f30bc6ca00f66633c92752d294be132c2e. Wanted to check if still necessary (seems fine locally), because I think it causes formatting issues in CI like https://github.com/arlyon/async-stripe/pull/261 because `RUST_FILES` is defined before the codegen step, then codegen creates a new file, but that new file is not included in `RUST_FILES`, so it is not properly formatted.