### PR TITLE
Add cancel SetupIntent

### DIFF
--- a/src/resources/setup_intent_ext.rs
+++ b/src/resources/setup_intent_ext.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::client::{Client, Response};
 use crate::resources::SetupIntent;
-use crate::{SetupIntentId, SetupIntentCancellationReason};
+use crate::{SetupIntentCancellationReason, SetupIntentId};
 
 #[derive(Clone, Debug, Serialize)]
 pub struct ConfirmSetupIntent {
@@ -29,7 +29,6 @@ pub struct CancelSetupIntent {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cancellation_reason: Option<SetupIntentCancellationReason>,
 }
-
 
 impl SetupIntent {
     pub fn confirm(

--- a/src/resources/setup_intent_ext.rs
+++ b/src/resources/setup_intent_ext.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 
 use crate::client::{Client, Response};
 use crate::resources::SetupIntent;
-use crate::SetupIntentId;
+use crate::{SetupIntentId, SetupIntentCancellationReason};
 
 #[derive(Clone, Debug, Serialize)]
 pub struct ConfirmSetupIntent {
@@ -21,8 +21,15 @@ pub struct ConfirmSetupIntent {
     pub redirect_url: Option<String>,
 }
 
-#[derive(Clone, Debug, Serialize)]
-pub struct CancelSetupIntent {}
+/// The set of parameters that can be used when canceling a setup_intent object.
+///
+/// For more details see <https://stripe.com/docs/api/setup_intents/cancel>
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct CancelSetupIntent {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cancellation_reason: Option<SetupIntentCancellationReason>,
+}
+
 
 impl SetupIntent {
     pub fn confirm(
@@ -31,6 +38,17 @@ impl SetupIntent {
         params: ConfirmSetupIntent,
     ) -> Response<SetupIntent> {
         client.post_form(&format!("/setup_intents/{}/confirm", setup_id), &params)
+    }
+
+    /// A SetupIntent object can be canceled when it is in one of these statuses: requires_payment_method, requires_confirmation, or requires_action.
+    ///
+    /// For more details see <https://stripe.com/docs/api/setup_intents/cancel>.
+    pub fn cancel(
+        client: &Client,
+        setup_id: &SetupIntentId,
+        params: CancelSetupIntent,
+    ) -> Response<SetupIntent> {
+        client.post_form(&format!("/setup_intents/{}/cancel", setup_id), params)
     }
 }
 


### PR DESCRIPTION
Hi!
This implements cancel for SetupIntents. The API is very similar to cancel for PaymentIntents.

Fixes #266.