### PR TITLE
Emit compile error when no runtime feature specified

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,29 @@
 #![warn(clippy::unwrap_used, clippy::missing_errors_doc, clippy::missing_panics_doc)]
 #![forbid(unsafe_code)]
 
+// Give a clear error when a required runtime error is not present. Would be better for this
+// to be a fatal error preventing emission of further compile errors relating to lack of
+// a runtime feature, but that does not seem currently possible:
+// https://github.com/rust-lang/rust/issues/68838
+
+#[cfg(not(any(
+    feature = "runtime-tokio-hyper",
+    feature = "runtime-tokio-hyper-rustls",
+    feature = "runtime-blocking",
+    feature = "runtime-blocking-rustls",
+    feature = "runtime-async-std-surf",
+)))]
+compile_error!(
+    r"one of the following runtime features must be enabled:
+    [
+        'runtime-tokio-hyper', 
+        'runtime-tokio-hyper-rustls',
+        'runtime-blocking', 
+        'runtime-blocking-rustls', 
+        'runtime-async-std-surf'
+    ]"
+);
+
 mod client;
 mod error;
 mod ids;


### PR DESCRIPTION
Inspired by an error I saw when using https://github.com/launchbadge/sqlx. Hopefully gives a bit quicker feedback about how to solve an otherwise giant compilation error when forgetting to specify a runtime feature, though could still be improved as mentioned in the comment.