### PR TITLE
Remove tokio-test dep

### DIFF
--- a/.github/workflows/async-stripe.yml
+++ b/.github/workflows/async-stripe.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: make
-          args: openapi-install-no-fetch
+          args: openapi-install
       - name: ensure generated files unchanged
         uses: tj-actions/verify-changed-files@v11.1
         id: verify-changed-files

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,6 @@ time = {version = "0.3,<0.3.10", optional = true}
 [dev-dependencies]
 async-std = { version = "1.10.0", features = ["attributes"] }
 httpmock = "0.6.6"
-lazy_static = "1.4"
 tokio = { version = "1.2", features = ["rt", "macros"] }
 axum = "0.4.8"
 actix-web = "4.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,6 @@ lazy_static = "1.4"
 tokio = { version = "1.2", features = ["rt", "macros"] }
 axum = "0.4.8"
 actix-web = "4.0.1"
-tokio-test = "0.4.2"
 
 [[example]]
 name = "checkout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,6 @@ hex = { version = "0.4", optional = true }
 time = {version = "0.3,<0.3.10", optional = true}
 
 [dev-dependencies]
-anyhow = "1.0.38"
 async-std = { version = "1.10.0", features = ["attributes"] }
 httpmock = "0.6.6"
 lazy_static = "1.4"

--- a/src/params.rs
+++ b/src/params.rs
@@ -254,9 +254,6 @@ where
     /// ```no_run
     /// # use stripe::{Customer, ListCustomers, StripeError, Client};
     /// # use futures_util::TryStreamExt;
-    /// # fn main() {
-    /// # tokio_test::block_on(run());
-    /// # }
     /// # async fn run() -> Result<(), StripeError> {
     /// # let client = Client::new("sk_test_123");
     /// # let params = ListCustomers { ..Default::default() };


### PR DESCRIPTION
Since the `tokio::test` macro is in `tokio` which is already a dev dep, can avoid needing `tokio-test` as well with a small doctest change