### PR TITLE
Deny build/test warnings in CI

### DIFF
--- a/.github/workflows/async-stripe.yml
+++ b/.github/workflows/async-stripe.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: make
-          args: openapi-install-no-fetch
+          args: openapi-install
       - name: ensure generated files unchanged
         uses: tj-actions/verify-changed-files@v11.1
         id: verify-changed-files

--- a/.github/workflows/async-stripe.yml
+++ b/.github/workflows/async-stripe.yml
@@ -92,6 +92,8 @@ jobs:
             --features runtime-${{ matrix.runtime }}
   test:
     runs-on: ubuntu-20.04
+    env:
+      RUSTFLAGS: -D warnings
     strategy:
       matrix:
         runtime:

--- a/src/client/base/tokio.rs
+++ b/src/client/base/tokio.rs
@@ -273,7 +273,10 @@ mod tests {
 
         #[derive(Debug, Deserialize)]
         struct DataType {
+            // Allowing dead code since used for deserialization
+            #[allow(dead_code)]
             id: String,
+            #[allow(dead_code)]
             name: String,
         }
 

--- a/src/resources/webhook_events.rs
+++ b/src/resources/webhook_events.rs
@@ -557,7 +557,6 @@ impl Webhook {
 struct Signature<'r> {
     t: i64,
     v1: &'r str,
-    v0: Option<&'r str>,
 }
 
 #[cfg(feature = "webhook-events")]
@@ -579,8 +578,7 @@ impl<'r> Signature<'r> {
             .collect();
         let t = headers.get("t").ok_or(WebhookError::BadSignature)?;
         let v1 = headers.get("v1").ok_or(WebhookError::BadSignature)?;
-        let v0 = headers.get("v0").map(|r| *r);
-        Ok(Signature { t: t.parse::<i64>().map_err(WebhookError::BadHeader)?, v1, v0 })
+        Ok(Signature { t: t.parse::<i64>().map_err(WebhookError::BadHeader)?, v1 })
     }
 }
 
@@ -599,7 +597,6 @@ mod tests {
             signature.v1,
             "5257a869e7ecebeda32affa62cdca3fa51cad7e77a0e56ff536d0ce8e108d8bd"
         );
-        assert_eq!(signature.v0, None);
 
         let raw_signature_with_test_mode = "t=1492774577,v1=5257a869e7ecebeda32affa62cdca3fa51cad7e77a0e56ff536d0ce8e108d8bd,v0=6ffbb59b2300aae63f272406069a9788598b792a944a07aba816edb039989a39";
         let signature = Signature::parse(raw_signature_with_test_mode).unwrap();
@@ -607,10 +604,6 @@ mod tests {
         assert_eq!(
             signature.v1,
             "5257a869e7ecebeda32affa62cdca3fa51cad7e77a0e56ff536d0ce8e108d8bd"
-        );
-        assert_eq!(
-            signature.v0,
-            Some("6ffbb59b2300aae63f272406069a9788598b792a944a07aba816edb039989a39")
         );
     }
 

--- a/tests/subscription_item.rs
+++ b/tests/subscription_item.rs
@@ -1,5 +1,3 @@
-use chrono::Utc;
-
 mod mock;
 
 #[test]
@@ -13,8 +11,11 @@ fn can_create_usage_record() {
             stripe::CreateUsageRecord {
                 quantity: 42,
                 action: Some(stripe::UsageRecordAction::Increment),
-                timestamp: Some(Utc::now().timestamp()),
+                timestamp: Some(chrono::Utc::now().timestamp()),
             },
-        );
+        )
+        .unwrap();
+        assert_eq!(usage_record.quantity, 42);
+        assert_eq!(usage_record.subscription_item, subscription_item_id.as_str());
     });
 }


### PR DESCRIPTION
This was the approach for denying warnings recommended by https://matklad.github.io/2021/09/04/fast-rust-builds.html (there are other potential CI neat tricks in there as well)

Should ensure that in future releases building with the `async-stripe` dep won't leak any warnings to the end-user (like the current `v0` unused)