### PR TITLE
upstream fixes from stripe-rs to async-stripe

### DIFF
--- a/src/client/base/tokio.rs
+++ b/src/client/base/tokio.rs
@@ -56,7 +56,9 @@ pub struct TokioClient {
 
 impl TokioClient {
     pub fn new() -> Self {
-        Self { client: hyper::Client::builder().build(connector::create()) }
+        Self {
+            client: hyper::Client::builder().pool_max_idle_per_host(0).build(connector::create()),
+        }
     }
 
     pub fn execute<T: DeserializeOwned + Send + 'static>(

--- a/src/error.rs
+++ b/src/error.rs
@@ -85,6 +85,7 @@ pub enum ErrorCode {
     BankAccountExists,
     BankAccountUnusable,
     BankAccountUnverified,
+    BankAccountVerificationFailed,
     BitcoinUpgradeRequired,
     CardDeclined,
     ChargeAlreadyCaptured,

--- a/src/ids.rs
+++ b/src/ids.rs
@@ -125,14 +125,26 @@ macro_rules! def_id {
         impl $struct_name {
             /// The prefix of the id type (e.g. `cus_` for a `CustomerId`).
             #[inline(always)]
+            #[deprecated(note = "Please use prefixes or is_valid_prefix")]
             pub fn prefix() -> &'static str {
                 $prefix
+            }
+
+            /// The valid prefixes of the id type (e.g. [`ch_`, `py_`\ for a `ChargeId`).
+            #[inline(always)]
+            pub fn prefixes() -> &'static [&'static str] {
+                &[$prefix$(, $alt_prefix)*]
             }
 
             /// Extracts a string slice containing the entire id.
             #[inline(always)]
             pub fn as_str(&self) -> &str {
                 self.0.as_str()
+            }
+
+            /// Check is provided prefix would be a valid prefix for id's of this type
+            pub fn is_valid_prefix(prefix: &str) -> bool {
+                prefix == $prefix $( || prefix == $alt_prefix )*
             }
         }
 
@@ -287,7 +299,7 @@ macro_rules! def_id {
                     })?;
 
                 match prefix {
-                    $(_ if prefix == $($variant_type)*::prefix() => {
+                    $(_ if $($variant_type)*::is_valid_prefix(prefix) => {
                         Ok($enum_name::$variant_name(s.parse()?))
                     })*
                     _ => {
@@ -394,7 +406,7 @@ macro_rules! def_id {
                     })?;
 
                 match prefix {
-                    $(_ if prefix == $($variant_type)*::prefix() => {
+                    $(_ if $($variant_type)*::is_valid_prefix(prefix) => {
                         Ok($enum_name::$variant_name(s.parse()?))
                     })*
                     _ => {
@@ -488,7 +500,7 @@ def_id!(ConnectCollectionTransferId, "connct_");
 def_id!(CouponId: String); // N.B. A coupon id can be user-provided so can be any arbitrary string
 def_id!(CustomerId, "cus_");
 def_id!(DiscountId, "di_");
-def_id!(DisputeId, "dp_");
+def_id!(DisputeId, "dp_" | "du_");
 def_id!(EphemeralKeyId, "ephkey_");
 def_id!(EventId, "evt_");
 def_id!(FileId, "file_");


### PR DESCRIPTION
My team's encountered a number of issues with stripe, which we've already implemented fixes for in stripe-rs. We're planning to migrate to async-stripe, so I'm opening this PR to upstream those fixes.

- Add BankAccountVerificationFailed to ErrorCode enum - https://github.com/wyyerd/stripe-rs/commit/9a17aaebb4970080eb452ec43d8406e94eb3f1d9
  - not much to say about this one. it can be returned, and we've had to handle it in the past
- Add `prefixes` and `is_valid_prefix` methods to better support ids with multiple valid prefixes - https://github.com/wyyerd/stripe-rs/pull/171/commits/30f10149c77e4cb2a437d1de6f9cd0236197a1f6
- Allow tokio clients to be used in multi-threaded scenarios - https://github.com/wyyerd/stripe-rs/pull/171/commits/b5ad42bebe680c394b2c3c46326924d4f8c22b71
- Disable connection pooling - https://github.com/wyyerd/stripe-rs/commit/40beb9e4aacde594d111ad1541ab2cbcb94a5718
  - fixes `error communicating with stripe: connection closed before message completed` errors
- Support dispute ids with a du_ prefix - https://github.com/wyyerd/stripe-rs/commit/35031816222e5f5b560705bf4f1ff08a220e944c
  - stripe uses multiple ID prefixes for disputes