### PR TITLE
fix(params): do not print "next" while iterating

### DIFF
--- a/src/params.rs
+++ b/src/params.rs
@@ -326,7 +326,6 @@ where
                     p
                 };
 
-                println!("next");
                 let page = client.get_query(&path, &params_next);
 
                 ListPaginator::create_paginator(page, params_next)


### PR DESCRIPTION
Perhaps this should be replaced with something configurable, like `tracing::debug`?

Signed-off-by: Sean Pianka <pianka@eml.cc>