### PR TITLE
build: add support for webpki (alt. to native-certs)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,20 +66,57 @@ events = []
 async = ["futures-util"]
 blocking = []
 
-runtime-tokio-hyper = ["tokio", "hyper-client", "hyper-tls", "async"]
-runtime-tokio-hyper-rustls = ["tokio", "hyper-client", "hyper-rustls", "async"]
-runtime-blocking = ["tokio", "tokio/rt", "hyper-client", "hyper-tls", "blocking"]
-runtime-blocking-rustls = [
-  "tokio",
-  "tokio/rt",
-  "hyper-client",
-  "hyper-rustls",
-  "blocking",
+runtime-tokio-hyper = [
+    "tokio",
+    "hyper-client",
+    "hyper-tls",
+    "async",
 ]
-runtime-async-std-surf = ["async-std", "surf", "async"]
+runtime-tokio-hyper-rustls = [
+    "tokio",
+    "hyper-client",
+    "hyper-rustls",
+    "hyper-rustls-native",
+    "async",
+]
+runtime-tokio-hyper-rustls-webpki = [
+    "tokio",
+    "hyper-client",
+    "hyper-rustls-webpki",
+    "async",
+]
+runtime-blocking = [
+    "tokio",
+    "tokio/rt",
+    "hyper-client",
+    "hyper-tls",
+    "blocking",
+]
+runtime-blocking-rustls = [
+    "tokio",
+    "tokio/rt",
+    "hyper-client",
+    "hyper-rustls-native",
+    "blocking",
+]
+runtime-blocking-rustls-webpki = [
+    "tokio",
+    "tokio/rt",
+    "hyper-client",
+    "hyper-rustls-webpki",
+    "blocking",
+]
+runtime-async-std-surf = [
+    "async-std",
+    "surf",
+    "async",
+]
 
 # we need the compat crate if using hyper
 hyper-client = ["hyper", "http-types/hyperium_http"]
+
+hyper-rustls-native = ["hyper-rustls", "hyper-rustls/native-tokio"]
+hyper-rustls-webpki = ["hyper-rustls", "hyper-rustls/webpki-tokio"]
 
 [dependencies]
 async-std = {version = "1.8,<1.11", optional = true}
@@ -89,7 +126,7 @@ thiserror = "1.0.24"
 http-types = { version = "2.12.0", default-features = false }
 hyper = { version = "0.14", default-features = false, features = ["http1", "http2", "client", "tcp"], optional = true }
 hyper-tls = { version = "0.5", optional = true }
-hyper-rustls = { version = "0.22", optional = true }
+hyper-rustls = { version = "0.23", default-features = false, features = ["http1", "http2", "tls12", "logging"], optional = true }
 serde = {version = ">=1.0.79", features = ["derive"] } # we use `serde(other)` which was introduced in 1.0.79
 serde_json = "1.0"
 serde_qs = "0.10.1"

--- a/src/client/base/tokio.rs
+++ b/src/client/base/tokio.rs
@@ -10,23 +10,35 @@ use tokio::time::sleep;
 use crate::client::request_strategy::{Outcome, RequestStrategy};
 use crate::error::{ErrorResponse, StripeError};
 
-#[cfg(feature = "hyper-rustls")]
+#[cfg(feature = "hyper-rustls-native")]
 mod connector {
     use hyper::client::{connect::dns::GaiResolver, HttpConnector};
     pub use hyper_rustls::HttpsConnector;
+    use hyper_rustls::HttpsConnectorBuilder;
 
     pub fn create() -> HttpsConnector<HttpConnector<GaiResolver>> {
-        HttpsConnector::with_native_roots()
+        HttpsConnectorBuilder::new()
+            .with_native_roots()
+            .https_only()
+            .enable_http1()
+            .enable_http2()
+            .build()
     }
 }
 
-#[cfg(feature = "hyper-tls")]
+#[cfg(feature = "hyper-rustls-webpki")]
 mod connector {
     use hyper::client::{connect::dns::GaiResolver, HttpConnector};
-    pub use hyper_tls::HttpsConnector;
+    pub use hyper_rustls::HttpsConnector;
+    use hyper_rustls::HttpsConnectorBuilder;
 
     pub fn create() -> HttpsConnector<HttpConnector<GaiResolver>> {
-        HttpsConnector::new()
+        HttpsConnectorBuilder::new()
+            .with_webpki_roots()
+            .https_only()
+            .enable_http1()
+            .enable_http2()
+            .build()
     }
 }
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -5,25 +5,39 @@ mod base {
     #[cfg(any(
         feature = "runtime-tokio-hyper",
         feature = "runtime-tokio-hyper-rustls",
+        feature = "runtime-tokio-hyper-rustls-webpki",
         feature = "runtime-blocking",
         feature = "runtime-blocking-rustls",
+        feature = "runtime-blocking-rustls-webpki",
     ))]
     pub mod tokio;
 
     #[cfg(feature = "runtime-async-std-surf")]
     pub mod async_std;
 
-    #[cfg(any(feature = "runtime-blocking", feature = "runtime-blocking-rustls"))]
+    #[cfg(any(
+        feature = "runtime-blocking",
+        feature = "runtime-blocking-rustls",
+        feature = "runtime-blocking-rustls-webpki"
+    ))]
     pub mod tokio_blocking;
 }
 
-#[cfg(any(feature = "runtime-blocking", feature = "runtime-blocking-rustls"))]
+#[cfg(any(
+    feature = "runtime-blocking",
+    feature = "runtime-blocking-rustls",
+    feature = "runtime-blocking-rustls-webpki"
+))]
 pub(crate) mod config {
     pub(crate) use super::base::tokio_blocking::{err, ok};
     pub use super::base::tokio_blocking::{Response, TokioBlockingClient as BaseClient};
 }
 
-#[cfg(any(feature = "runtime-tokio-hyper", feature = "runtime-tokio-hyper-rustls"))]
+#[cfg(any(
+    feature = "runtime-tokio-hyper",
+    feature = "runtime-tokio-hyper-rustls",
+    feature = "runtime-tokio-hyper-rustls-webpki"
+))]
 pub(crate) mod config {
     pub(crate) use super::base::tokio::{err, ok};
     pub use super::base::tokio::{Response, TokioClient as BaseClient};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,17 +44,21 @@
 #[cfg(not(any(
     feature = "runtime-tokio-hyper",
     feature = "runtime-tokio-hyper-rustls",
+    feature = "runtime-tokio-hyper-rustls-webpki",
     feature = "runtime-blocking",
     feature = "runtime-blocking-rustls",
+    feature = "runtime-blocking-rustls-webpki",
     feature = "runtime-async-std-surf",
 )))]
 compile_error!(
     r"one of the following runtime features must be enabled:
     [
-        'runtime-tokio-hyper', 
+        'runtime-tokio-hyper',
         'runtime-tokio-hyper-rustls',
-        'runtime-blocking', 
-        'runtime-blocking-rustls', 
+        'runtime-tokio-hyper-rustls-webpki',
+        'runtime-blocking',
+        'runtime-blocking-rustls',
+        'runtime-blocking-rustls-webpki',
         'runtime-async-std-surf'
     ]"
 );


### PR DESCRIPTION
hyper-rustls pulls in [rustls-native-certs](https://github.com/rustls/rustls-native-certs) by default and has [a feature flag](https://github.com/rustls/hyper-rustls/blob/main/Cargo.toml#L33) for swapping it out with [webpki](https://github.com/briansmith/webpki). This PR adds two alternative feature-flags for tokio-based selections that will enable webpki in hyper-rustls.

See the "why" for using webpki [here](https://github.com/rustls/rustls-native-certs#should-i-use-this-or-webpki-roots).

I also snuck in an `hyper-rustls` upgrade from 0.22 to 0.23, but this can be excluded if needed.

Signed-off-by: Sean Pianka <pianka@eml.cc>