### PR TITLE
fix: add idempotency_error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -48,6 +48,8 @@ pub enum ErrorType {
     Authentication,
     #[serde(rename = "card_error")]
     Card,
+    #[serde(rename = "idempotency_error")]
+    IdempotencyError,
     #[serde(rename = "invalid_request_error")]
     InvalidRequest,
     #[serde(rename = "rate_limit_error")]


### PR DESCRIPTION
When calling the [UsageRecord::create](https://docs.rs/async-stripe/latest/stripe/struct.UsageRecord.html#method.create) function I get this error:
```
JSONSerialize(Error("unknown variant `idempotency_error`, expected one of `api_error`, `api_connection_error`, `authentication_error`, `card_error`, `invalid_request_error`, `rate_limit_error`, `validation_error`"))
```

I initialize the client with the strategy `stripe::RequestStrategy::Idempotent`.

I guess the fix is to add the `idempotency_error` to this enum.