### PR TITLE
use prebuilt cargo-make in CI

### DIFF
--- a/.github/workflows/async-stripe.yml
+++ b/.github/workflows/async-stripe.yml
@@ -116,11 +116,7 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-test-${{ hashFiles('**/Cargo.lock') }}
-      - name: install cargo-llvm-cov
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: cargo-llvm-cov
+      - uses: taiki-e/install-action@cargo-llvm-cov
       - name: Test and gather coverage
         run: cargo llvm-cov --lcov --output-path lcov.info --features runtime-${{ matrix.runtime }}
       - name: Upload to codecov.io

--- a/.github/workflows/async-stripe.yml
+++ b/.github/workflows/async-stripe.yml
@@ -16,11 +16,7 @@ jobs:
           profile: minimal
           toolchain: nightly
           components: rustfmt
-      - name: install cargo-make
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: --debug cargo-make
+      - uses: davidB/rust-cargo-make@v1
       - name: regenerate openapi
         uses: actions-rs/cargo@v1
         with:
@@ -36,11 +32,7 @@ jobs:
           profile: minimal
           toolchain: nightly
           components: rustfmt
-      - name: install cargo-make
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: --debug cargo-make
+      - uses: davidB/rust-cargo-make@v1
       - name: regenerate openapi
         uses: actions-rs/cargo@v1
         with:
@@ -124,7 +116,7 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-test-${{ hashFiles('**/Cargo.lock') }}
-      - name: install cargo-make
+      - name: install cargo-llvm-cov
         uses: actions-rs/cargo@v1
         with:
           command: install

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -14,11 +14,7 @@ jobs:
           profile: minimal
           toolchain: nightly
           components: rustfmt
-      - name: install cargo-make
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: --debug cargo-make
+      - uses: davidB/rust-cargo-make@v1
       - name: regenerate openapi
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
# Summary

Replace cargo make install action with a cached prebuilt version.

### Checklist

- [x] ran `cargo make fmt`
- [x] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features
  <!--
  EXAMPLES:
  feat: you can now add and remove principals from a project
  fix: fixes an issue where the combobox was displaying incorrect values
  -->
