### PR TITLE
remove cargo args

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ edition = "2021"
 
 [package.metadata.docs.rs]
 features = ["runtime-tokio-hyper"]
-cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples=examples"]
 
 [lib]
 name = "stripe"


### PR DESCRIPTION
Closes #333. Rustdoc examples scraping is now turned on by default. https://github.com/rust-lang/docs.rs/pull/1954

- [x] ran `cargo make fmt`
- [x] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features
  <!--
  EXAMPLES:
  feat: you can now add and remove principals from a project
  fix: fixes an issue where the combobox was displaying incorrect values
  -->
