### PR TITLE
Add missing prefix for CheckoutSessionItemId

### DIFF
--- a/src/ids.rs
+++ b/src/ids.rs
@@ -495,7 +495,7 @@ def_id!(CardId, "card_");
 def_id!(CardTokenId, "tok_");
 def_id!(ChargeId, "ch_" | "py_"); // TODO: Understand (and then document) why "py_" is a valid charge id
 def_id!(CheckoutSessionId, "cs_");
-def_id!(CheckoutSessionItemId: String); // TODO: Figure out what prefix this id has
+def_id!(CheckoutSessionItemId, "li_");
 def_id!(ConnectCollectionTransferId, "connct_");
 def_id!(CouponId: String); // N.B. A coupon id can be user-provided so can be any arbitrary string
 def_id!(CustomerId, "cus_");


### PR DESCRIPTION
# Summary

Adds the missing "li_" prefix for CheckoutSessionItemId.

This can be seen in the documentation here:
https://stripe.com/docs/api/checkout/sessions/line_items

I also see the same prefix with the Stripe CLI, using `stripe checkout sessions list --expand data.line_items`

### Checklist

- [x] ran `cargo make fmt`
- [x] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features
  <!--
  EXAMPLES:
  feat: you can now add and remove principals from a project
  fix: fixes an issue where the combobox was displaying incorrect values
  -->
