### PR TITLE
fix: Move feature check to `build.rs`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,23 @@
+fn main() {
+    #[cfg(not(any(
+        feature = "runtime-tokio-hyper",
+        feature = "runtime-tokio-hyper-rustls",
+        feature = "runtime-tokio-hyper-rustls-webpki",
+        feature = "runtime-blocking",
+        feature = "runtime-blocking-rustls",
+        feature = "runtime-blocking-rustls-webpki",
+        feature = "runtime-async-std-surf",
+    )))]
+    compile_error!(
+        r"one of the following runtime features must be enabled:
+        [
+            'runtime-tokio-hyper',
+            'runtime-tokio-hyper-rustls',
+            'runtime-tokio-hyper-rustls-webpki',
+            'runtime-blocking',
+            'runtime-blocking-rustls',
+            'runtime-blocking-rustls-webpki',
+            'runtime-async-std-surf'
+        ]"
+    );
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,28 +41,6 @@
 // a runtime feature, but that does not seem currently possible:
 // https://github.com/rust-lang/rust/issues/68838
 
-#[cfg(not(any(
-    feature = "runtime-tokio-hyper",
-    feature = "runtime-tokio-hyper-rustls",
-    feature = "runtime-tokio-hyper-rustls-webpki",
-    feature = "runtime-blocking",
-    feature = "runtime-blocking-rustls",
-    feature = "runtime-blocking-rustls-webpki",
-    feature = "runtime-async-std-surf",
-)))]
-compile_error!(
-    r"one of the following runtime features must be enabled:
-    [
-        'runtime-tokio-hyper',
-        'runtime-tokio-hyper-rustls',
-        'runtime-tokio-hyper-rustls-webpki',
-        'runtime-blocking',
-        'runtime-blocking-rustls',
-        'runtime-blocking-rustls-webpki',
-        'runtime-async-std-surf'
-    ]"
-);
-
 mod client;
 mod error;
 mod ids;


### PR DESCRIPTION
# Summary

Moves feature checking to `build.rs` to minimize noise.

With the new check when running `cargo build` you get:

```
jonathan@jonathan-System-Product-Name:~/Projects/async-stripe$ cargo build
   Compiling proc-macro2 v1.0.52
   Compiling quote v1.0.26
   Compiling unicode-ident v1.0.8
   Compiling serde_derive v1.0.157
   Compiling cfg-if v1.0.0
   Compiling serde v1.0.157
   Compiling libc v0.2.140
   Compiling version_check v0.9.4
   Compiling typenum v1.16.0
   Compiling autocfg v1.1.0
   Compiling getrandom v0.1.16
   Compiling percent-encoding v2.2.0
   Compiling futures-core v0.3.27
   Compiling tinyvec_macros v0.1.1
   Compiling thiserror v1.0.40
   Compiling crossbeam-utils v0.8.15
   Compiling memchr v2.5.0
   Compiling itoa v1.0.6
   Compiling serde_json v1.0.94
   Compiling anyhow v1.0.70
   Compiling ryu v1.0.13
   Compiling unicode-bidi v0.3.12
   Compiling subtle v2.4.1
   Compiling syn v1.0.109
   Compiling tinyvec v1.6.0
   Compiling ppv-lite86 v0.2.17
   Compiling form_urlencoded v1.1.0
   Compiling http-types v2.12.0
   Compiling fastrand v1.9.0
   Compiling futures-io v0.3.27
   Compiling event-listener v2.5.3
   Compiling pin-project-lite v0.2.9
   Compiling generic-array v0.14.6
   Compiling num-traits v0.2.15
   Compiling num-integer v0.1.45
   Compiling parking v2.0.0
   Compiling waker-fn v1.1.0
   Compiling base64 v0.13.1
   Compiling cpufeatures v0.2.5
   Compiling infer v0.2.3
   Compiling async-stripe v0.20.0 (/home/jonathan/Projects/async-stripe)
   Compiling iana-time-zone v0.1.53
   Compiling hex v0.4.3
error: one of the following runtime features must be enabled:
               [
                   'runtime-tokio-hyper',
                   'runtime-tokio-hyper-rustls',
                   'runtime-tokio-hyper-rustls-webpki',
                   'runtime-blocking',
                   'runtime-blocking-rustls',
                   'runtime-blocking-rustls-webpki',
                   'runtime-async-std-surf'
               ]
  --> build.rs:11:5
   |
11 | /     compile_error!(
12 | |         r"one of the following runtime features must be enabled:
13 | |         [
14 | |             'runtime-tokio-hyper',
...  |
21 | |         ]"
22 | |     );
   | |_____^

error: could not compile `async-stripe` (build script) due to previous error
warning: build failed, waiting for other jobs to finish...
jonathan@jonathan-System-Product-Name:~/Projects/async-stripe$ 
```

With the current check when running `cargo build` you get:

```
jonathan@jonathan-System-Product-Name:~/Projects/async-stripe$ 
jonathan@jonathan-System-Product-Name:~/Projects/async-stripe$ cargo build
   Compiling proc-macro2 v1.0.52
   Compiling quote v1.0.26
   Compiling unicode-ident v1.0.8
   Compiling serde_derive v1.0.157
   Compiling serde v1.0.157
   Compiling cfg-if v1.0.0
   Compiling libc v0.2.140
   Compiling version_check v0.9.4
   Compiling typenum v1.16.0
   Compiling autocfg v1.1.0
   Compiling getrandom v0.1.16
   Compiling percent-encoding v2.2.0
   Compiling crossbeam-utils v0.8.15
   Compiling tinyvec_macros v0.1.1
   Compiling futures-core v0.3.27
   Compiling thiserror v1.0.40
   Compiling memchr v2.5.0
   Compiling anyhow v1.0.70
   Compiling serde_json v1.0.94
   Compiling subtle v2.4.1
   Compiling syn v1.0.109
   Compiling unicode-bidi v0.3.12
   Compiling itoa v1.0.6
   Compiling ryu v1.0.13
   Compiling tinyvec v1.6.0
   Compiling ppv-lite86 v0.2.17
   Compiling futures-io v0.3.27
   Compiling form_urlencoded v1.1.0
   Compiling parking v2.0.0
   Compiling event-listener v2.5.3
   Compiling fastrand v1.9.0
   Compiling waker-fn v1.1.0
   Compiling generic-array v0.14.6
   Compiling http-types v2.12.0
   Compiling pin-project-lite v0.2.9
   Compiling num-traits v0.2.15
   Compiling num-integer v0.1.45
   Compiling iana-time-zone v0.1.53
   Compiling infer v0.2.3
   Compiling cpufeatures v0.2.5
   Compiling base64 v0.13.1
   Compiling hex v0.4.3
   Compiling concurrent-queue v2.1.0
   Compiling async-channel v1.8.0
   Compiling unicode-normalization v0.1.22
   Compiling futures-lite v1.12.0
   Compiling getrandom v0.2.8
   Compiling syn v2.0.0
   Compiling uuid v0.8.2
   Compiling rand_core v0.5.1
   Compiling idna v0.3.0
   Compiling rand_chacha v0.2.2
   Compiling rand v0.7.3
   Compiling block-buffer v0.10.4
   Compiling crypto-common v0.1.6
   Compiling digest v0.10.6
   Compiling hmac v0.12.1
   Compiling sha2 v0.10.6
   Compiling thiserror-impl v1.0.40
   Compiling smart-default v0.6.0
   Compiling url v2.3.1
   Compiling serde_qs v0.8.5
   Compiling serde_urlencoded v0.7.1
   Compiling smol_str v0.1.24
   Compiling chrono v0.4.24
   Compiling serde_path_to_error v0.1.10
   Compiling serde_qs v0.10.1
   Compiling async-stripe v0.20.0 (/home/jonathan/Projects/async-stripe)
error: one of the following runtime features must be enabled:
           [
               'runtime-tokio-hyper',
               'runtime-tokio-hyper-rustls',
               'runtime-tokio-hyper-rustls-webpki',
               'runtime-blocking',
               'runtime-blocking-rustls',
               'runtime-blocking-rustls-webpki',
               'runtime-async-std-surf'
           ]
  --> src/lib.rs:53:1
   |
53 | / compile_error!(
54 | |     r"one of the following runtime features must be enabled:
55 | |     [
56 | |         'runtime-tokio-hyper',
...  |
63 | |     ]"
64 | | );
   | |_^

error[E0432]: unresolved import `crate::client::config`
  --> src/params.rs:10:9
   |
10 |         config::{err, ok},
   |         ^^^^^^ could not find `config` in `client`

error[E0432]: unresolved import `config`
  --> src/client/mod.rs:52:9
   |
52 | pub use config::BaseClient;
   |         ^^^^^^ use of undeclared crate or module `config`

error[E0432]: unresolved import `config`
  --> src/client/mod.rs:66:9
   |
66 | pub use config::Response;
   |         ^^^^^^ use of undeclared crate or module `config`

error[E0432]: unresolved imports `crate::config`, `crate::client::BaseClient`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::client::Response`, `crate::Response`, `crate::client::Response`, `crate::client::Response`
  --> src/client/stripe.rs:5:49
   |
5  |     client::{request_strategy::RequestStrategy, BaseClient, Response},
   |                                                 ^^^^^^^^^^  ^^^^^^^^
6  |     config::err,
   |     ^^^^^^ could not find `config` in the crate root
   |
  ::: src/params.rs:11:17
   |
11 |         Client, Response,
   |                 ^^^^^^^^
   |
  ::: src/resources/generated/balance_transaction.rs:7:29
   |
7  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/generated/charge.rs:7:29
   |
7  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/generated/customer.rs:7:29
   |
7  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/generated/dispute.rs:7:29
   |
7  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/generated/ephemeral_key.rs:7:29
   |
7  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/generated/file.rs:7:29
   |
7  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/generated/file_link.rs:7:29
   |
7  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/generated/mandate.rs:7:29
   |
7  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/generated/payment_intent.rs:7:29
   |
7  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/generated/payout.rs:7:29
   |
7  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/generated/price.rs:7:29
   |
7  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/generated/product.rs:7:29
   |
7  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/generated/refund.rs:7:29
   |
7  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/generated/setup_attempt.rs:7:29
   |
7  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/generated/setup_intent.rs:7:29
   |
7  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/generated/shipping_rate.rs:7:29
   |
7  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/generated/tax_code.rs:7:29
   |
7  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/generated/token.rs:7:29
   |
7  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/generated/payment_method.rs:7:29
   |
7  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/generated/source.rs:7:29
   |
7  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/generated/checkout_session.rs:7:29
   |
7  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/generated/payment_link.rs:7:29
   |
7  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/generated/billing_portal_session.rs:7:29
   |
7  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/generated/coupon.rs:7:29
   |
7  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/generated/credit_note.rs:7:29
   |
7  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/generated/invoice.rs:7:29
   |
7  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/generated/invoiceitem.rs:7:29
   |
7  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/generated/plan.rs:7:29
   |
7  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/generated/promotion_code.rs:7:29
   |
7  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/generated/quote.rs:7:29
   |
7  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/generated/subscription.rs:7:29
   |
7  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/generated/subscription_item.rs:7:29
   |
7  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/generated/subscription_schedule.rs:7:29
   |
7  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/generated/tax_rate.rs:7:29
   |
7  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/generated/account.rs:7:29
   |
7  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/generated/account_link.rs:7:29
   |
7  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/generated/application_fee.rs:7:29
   |
7  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/generated/topup.rs:7:29
   |
7  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/generated/transfer.rs:7:29
   |
7  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/generated/review.rs:7:29
   |
7  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/generated/event.rs:7:29
   |
7  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/generated/webhook_endpoint.rs:7:29
   |
7  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/balance_ext.rs:1:29
   |
1  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/charge_ext.rs:3:29
   |
3  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/customer_ext.rs:3:29
   |
3  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/payment_intent_ext.rs:3:29
   |
3  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/payout_ext.rs:3:29
   |
3  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/setup_intent_ext.rs:3:29
   |
3  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/payment_method_ext.rs:3:29
   |
3  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/credit_note_ext.rs:1:29
   |
1  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/customer_balance_transaction_ext.rs:3:29
   |
3  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/invoice_ext.rs:3:29
   |
3  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/line_item_ext.rs:3:29
   |
3  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/subscription_ext.rs:3:29
   |
3  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/usage_record_ext.rs:3:21
   |
3  | use crate::{Client, Response, SubscriptionItemId, Timestamp, UsageRecord};
   |                     ^^^^^^^^
   |
  ::: src/resources/checkout_session_ext.rs:1:29
   |
1  | use crate::client::{Client, Response};
   |                             ^^^^^^^^
   |
  ::: src/resources/login_links_ext.rs:3:29
   |
3  | use crate::client::{Client, Response};
   |                             ^^^^^^^^

error[E0599]: no function or associated item named `create_paginator` found for struct `ListPaginator` in the current scope
   --> src/params.rs:331:32
    |
183 | pub struct ListPaginator<T, P> {
    | ------------------------------ function or associated item `create_paginator` not found for this struct
...
331 |                 ListPaginator::create_paginator(page, params_next)
    |                                ^^^^^^^^^^^^^^^^ function or associated item not found in `ListPaginator<_, _>`

Some errors have detailed explanations: E0432, E0599.
For more information about an error, try `rustc --explain E0432`.
error: could not compile `async-stripe` (lib) due to 6 previous errors
jonathan@jonathan-System-Product-Name:~/Projects/async-stripe$ 
```

### Checklist

- [x] ran `cargo make fmt`
- [x] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features