### PR TITLE
Refactor/webhooks

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -40,13 +40,13 @@ dependencies = ["openapi-delete-out"]
 cwd = "openapi"
 command = "cargo"
 args = ["run", "spec3.sdk.json", "--fetch", "current"]
-dependencies = ["openapi-delete"]
+dependencies = ["openapi-delete-out"]
 
 [tasks.openapi-generate-latest]
 cwd = "openapi"
 command = "cargo"
 args = ["run", "spec3.sdk.json", "--fetch", "latest"]
-dependencies = ["openapi-delete"]
+dependencies = ["openapi-delete-out"]
 
 [tasks.openapi-copy]
 cwd = "openapi"

--- a/examples/webhook-actix.rs
+++ b/examples/webhook-actix.rs
@@ -36,7 +36,7 @@ pub fn handle_webhook(req: HttpRequest, payload: web::Bytes) -> Result<(), Webho
     let stripe_signature = get_header_value(&req, "Stripe-Signature").unwrap_or_default();
 
     if let Ok(event) = Webhook::construct_event(payload_str, stripe_signature, "whsec_xxxxx") {
-        match event.event_type {
+        match event.type_ {
             EventType::AccountUpdated => {
                 if let EventObject::Account(account) = event.data.object {
                     handle_account_updated(account)?;
@@ -48,7 +48,7 @@ pub fn handle_webhook(req: HttpRequest, payload: web::Bytes) -> Result<(), Webho
                 }
             }
             _ => {
-                println!("Unknown event encountered in webhook: {:?}", event.event_type);
+                println!("Unknown event encountered in webhook: {:?}", event.type_);
             }
         }
     } else {

--- a/openapi/src/codegen.rs
+++ b/openapi/src/codegen.rs
@@ -187,6 +187,7 @@ pub fn gen_generated_schemas(
     while let Some(schema_name) =
         state.generated_schemas.iter().find_map(|(k, &v)| if !v { Some(k) } else { None }).cloned()
     {
+        log::trace!("generating schema {}", schema_name);
         let struct_name = meta.schema_to_rust_type(&schema_name);
         out.push('\n');
         out.push_str("#[derive(Clone, Debug, Default, Deserialize, Serialize)]\n");
@@ -1237,6 +1238,9 @@ pub fn gen_field_rust_type<T: Borrow<Schema>>(
         } else {
             "Timestamp".into()
         };
+    } else if field_name == "type" && object == "event" {
+        state.use_resources.insert("EventType".into());
+        return "EventType".into();
     }
 
     let ty = gen_schema_or_ref_type(

--- a/openapi/src/spec_fetch.rs
+++ b/openapi/src/spec_fetch.rs
@@ -60,25 +60,62 @@ fn get_current_openapi_tag() -> anyhow::Result<String> {
 
 pub fn fetch_spec(version: SpecVersion, in_path: &str) -> anyhow::Result<Value> {
     let client = Client::new();
-    let version = match version {
+
+    let desired_version = match version {
         SpecVersion::Latest => get_latest_openapi_tag(&client)?,
         SpecVersion::Current => get_current_openapi_tag()?,
         SpecVersion::Version(v) => v,
     };
-    log::info!("Fetching OpenAPI spec version {}", version);
+
+    log::info!("fetching OpenAPI spec version {}", desired_version);
+
+    if let Some(value) = fs::File::open(in_path)
+        .ok()
+        .and_then(|f| serde_json::from_reader(f).ok())
+        .filter(|value| read_x_stripe_tag(value) == Some(&desired_version))
+    {
+        return Ok(value);
+    }
+
+    if let Ok(file) = fs::File::open(in_path) {
+        if let Ok(value) = serde_json::from_reader(file) {
+            let cached_version = read_x_stripe_tag(&value);
+            if cached_version == Some(&desired_version) {
+                return Ok(value);
+            }
+        }
+    }
 
     let url = format!(
         "https://raw.githubusercontent.com/stripe/openapi/{}/openapi/spec3.sdk.json",
-        version
+        &desired_version
     );
 
-    let spec: Value = client.get(url).send()?.error_for_status()?.json()?;
+    let mut spec: Value = client.get(url).send()?.error_for_status()?.json()?;
+    write_x_stripe_tag(&mut spec, &desired_version)?;
+
     let writer = fs::File::create(in_path)?;
     serde_json::to_writer_pretty(writer, &spec)?;
     log::info!("Wrote OpenAPI spec to {}", in_path);
 
     let version_file_writer = fs::File::create(VERSION_FILE_PATH)?;
-    serde_json::to_writer_pretty(version_file_writer, &VersionFile { version })?;
+    serde_json::to_writer_pretty(version_file_writer, &VersionFile { version: desired_version })?;
 
     Ok(spec)
+}
+
+fn write_x_stripe_tag(spec: &mut Value, version: &str) -> anyhow::Result<()> {
+    spec.as_object_mut()
+        .context("must be an object")?
+        .get_mut("info")
+        .context("must have info field")?
+        .as_object_mut()
+        .context("must be an object")?
+        .insert("x-stripeTag".to_string(), version.into());
+
+    Ok(())
+}
+
+fn read_x_stripe_tag(spec: &Value) -> Option<&str> {
+    spec.as_object()?.get("info")?.as_object()?.get("x-stripeTag")?.as_str()
 }

--- a/openapi/src/url_finder.rs
+++ b/openapi/src/url_finder.rs
@@ -18,7 +18,6 @@ impl UrlFinder {
         if resp.status().is_success() {
             let text = resp.text()?;
             if let Some(line) = text.lines().find(|l| l.contains("flattenedAPISections: {")) {
-                println!("{}", line);
                 Ok(Self {
                     flattened_api_sections: serde_json::from_str(
                         line.trim()

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -160,6 +160,7 @@ pub use {
 #[cfg(feature = "events")]
 pub use {
     webhook_events::*,
+    webhook_events::NotificationEventData,
     generated::event::*,
 };
 

--- a/src/resources/generated/event.rs
+++ b/src/resources/generated/event.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use crate::client::{Client, Response};
 use crate::ids::EventId;
 use crate::params::{Expand, List, Object, Paginable, RangeQuery, Timestamp};
-use crate::resources::NotificationEventData;
+use crate::resources::{EventType, NotificationEventData};
 
 /// The resource representing a Stripe "NotificationEvent".
 ///
@@ -44,7 +44,7 @@ pub struct Event {
 
     /// Description of the event (e.g., `invoice.created` or `charge.refunded`).
     #[serde(rename = "type")]
-    pub type_: String,
+    pub type_: EventType,
 }
 
 impl Event {


### PR DESCRIPTION
# Summary

This removes the manual impl of the NotificationEvent and adjusts the codegen to use the new path. This is a breaking change, as the variable name changes.

Closes #344

### Checklist

- [x] ran `cargo make fmt`
- [x] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features
  <!--
  EXAMPLES:
  feat: you can now add and remove principals from a project
  fix: fixes an issue where the combobox was displaying incorrect values
  -->
