### PR TITLE
fix: Add sis_ id prefix for usage record summaries

### DIFF
--- a/src/ids.rs
+++ b/src/ids.rs
@@ -589,7 +589,7 @@ def_id!(TopupId, "tu_");
 def_id!(TransferId, "tr_");
 def_id!(TransferReversalId, "trr_");
 def_id!(UsageRecordId, "mbur_");
-def_id!(UsageRecordSummaryId, "urs_");
+def_id!(UsageRecordSummaryId, "urs_" | "sis_");
 def_id!(WebhookEndpointId, "we_");
 
 impl InvoiceId {


### PR DESCRIPTION
# Summary

<!--
A quick summary of what this PR does, why is needs to be applied, what has changed, etc.
-->

Adds the `sis_` id as an option for `UsageRecordSummaryId`s, as seen in the Stripe API docs - see the Response example at https://stripe.com/docs/api/usage_records/subscription_item_summary_list

### Checklist

- [x] ran `cargo make fmt`
- [x] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features
  <!--
  EXAMPLES:
  feat: you can now add and remove principals from a project
  fix: fixes an issue where the combobox was displaying incorrect values
  -->
