### PR TITLE
pin cargo-llvm-cov to 0.5.18 to avoid msrv bump

### DIFF
--- a/.github/workflows/async-stripe.yml
+++ b/.github/workflows/async-stripe.yml
@@ -120,7 +120,9 @@ jobs:
             ~/.cargo/git
             target
           key: ${{ runner.os }}-test-${{ matrix.runtime }}-${{ hashFiles('**/Cargo.lock') }}
-      - uses: taiki-e/install-action@cargo-llvm-cov
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov@0.5.18
       - name: Test and gather coverage
         run: cargo llvm-cov --lcov --output-path lcov.info --features runtime-${{ matrix.runtime }}
       - name: Upload to codecov.io


### PR DESCRIPTION
# Summary

This pins cargo-llvm-cov which recently raised its msrv above ours.

### Checklist

- [x] ran `cargo make fmt`
- [x] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features
  <!--
  EXAMPLES:
  feat: you can now add and remove principals from a project
  fix: fixes an issue where the combobox was displaying incorrect values
  -->
