### PR TITLE
feat: add tax calculation api behind a feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ full = [
   "sigma",
   "terminal",
   "webhook-endpoints",
+  "tax-calculation",
 ]
 
 stream = []
@@ -56,6 +57,7 @@ orders = []
 sigma = []
 terminal = []
 webhook-endpoints = []
+tax-calculation = []
 
 # deserialize events from webhooks
 webhook-events = ["events", "hmac", "sha2", "chrono", "hex"]

--- a/src/ids.rs
+++ b/src/ids.rs
@@ -571,6 +571,8 @@ def_id!(SubscriptionItemId, "si_");
 def_id!(SubscriptionLineId, "sli_");
 def_id!(SubscriptionScheduleId, "sub_sched_");
 def_id!(TaxIdId, "txi_");
+def_id!(TaxCalculationId: String);
+def_id!(TaxCalculationLineItemId: String);
 def_id!(TaxCodeId, "txcd_");
 def_id!(TaxDeductedAtSourceId, "itds");
 def_id!(TaxRateId, "txr_");

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -235,6 +235,16 @@ pub use {
 };
 
 #[rustfmt::skip]
+#[cfg(feature = "tax-calculation")]
+pub use {
+    generated::tax_calculation::{
+        tax_calculation::*,
+        tax_calculation_line_item::*,
+        tax_product_resource_customer_details::*,
+    }
+};
+
+#[rustfmt::skip]
 #[cfg(feature = "connect")]
 pub use {
     connect::{

--- a/src/resources/generated.rs
+++ b/src/resources/generated.rs
@@ -70,6 +70,14 @@ pub mod checkout {
 }
 
 #[path = "generated"]
+#[cfg(feature = "tax-calculation")]
+pub mod tax_calculation {
+    pub mod tax_calculation;
+    pub mod tax_calculation_line_item;
+    pub mod tax_product_resource_customer_details;
+}
+
+#[path = "generated"]
 #[cfg(feature = "billing")]
 pub mod billing {
     pub mod billing_portal_configuration;

--- a/src/resources/generated/tax_calculation.rs
+++ b/src/resources/generated/tax_calculation.rs
@@ -2,10 +2,11 @@
 // This file was automatically generated.
 // ======================================
 
-use crate::ids::{TaxCalculationId};
+use serde::{Deserialize, Serialize};
+
+use crate::ids::TaxCalculationId;
 use crate::params::{List, Object, Timestamp};
 use crate::resources::{Currency, TaxCalculationLineItem, TaxProductResourceCustomerDetails};
-use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "TaxProductResourceTaxCalculation".
 ///
@@ -65,7 +66,6 @@ impl Object for TaxCalculation {
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct TaxProductResourceTaxBreakdown {
-
     /// The amount of tax, in integer cents.
     pub amount: i64,
 
@@ -85,7 +85,6 @@ pub struct TaxProductResourceTaxBreakdown {
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct TaxProductResourceTaxCalculationShippingCost {
-
     /// The shipping amount in integer cents.
     ///
     /// If `tax_behavior=inclusive`, then this amount includes taxes.
@@ -114,7 +113,6 @@ pub struct TaxProductResourceTaxCalculationShippingCost {
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct TaxProductResourceLineItemTaxBreakdown {
-
     /// The amount of tax, in integer cents.
     pub amount: i64,
 
@@ -139,7 +137,6 @@ pub struct TaxProductResourceLineItemTaxBreakdown {
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct TaxProductResourceJurisdiction {
-
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
     pub country: String,
 
@@ -157,7 +154,6 @@ pub struct TaxProductResourceJurisdiction {
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct TaxProductResourceLineItemTaxRateDetails {
-
     /// A localized display name for tax type, intended to be human-readable.
     ///
     /// For example, "Local Sales and Use Tax", "Value-added tax (VAT)", or "Umsatzsteuer (USt.)".
@@ -174,7 +170,6 @@ pub struct TaxProductResourceLineItemTaxRateDetails {
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct TaxProductResourceTaxRateDetails {
-
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
     pub country: Option<String>,
 
@@ -288,20 +283,44 @@ pub enum TaxProductResourceLineItemTaxBreakdownTaxabilityReason {
 impl TaxProductResourceLineItemTaxBreakdownTaxabilityReason {
     pub fn as_str(self) -> &'static str {
         match self {
-            TaxProductResourceLineItemTaxBreakdownTaxabilityReason::CustomerExempt => "customer_exempt",
-            TaxProductResourceLineItemTaxBreakdownTaxabilityReason::NotCollecting => "not_collecting",
-            TaxProductResourceLineItemTaxBreakdownTaxabilityReason::NotSubjectToTax => "not_subject_to_tax",
+            TaxProductResourceLineItemTaxBreakdownTaxabilityReason::CustomerExempt => {
+                "customer_exempt"
+            }
+            TaxProductResourceLineItemTaxBreakdownTaxabilityReason::NotCollecting => {
+                "not_collecting"
+            }
+            TaxProductResourceLineItemTaxBreakdownTaxabilityReason::NotSubjectToTax => {
+                "not_subject_to_tax"
+            }
             TaxProductResourceLineItemTaxBreakdownTaxabilityReason::NotSupported => "not_supported",
-            TaxProductResourceLineItemTaxBreakdownTaxabilityReason::PortionProductExempt => "portion_product_exempt",
-            TaxProductResourceLineItemTaxBreakdownTaxabilityReason::PortionReducedRated => "portion_reduced_rated",
-            TaxProductResourceLineItemTaxBreakdownTaxabilityReason::PortionStandardRated => "portion_standard_rated",
-            TaxProductResourceLineItemTaxBreakdownTaxabilityReason::ProductExempt => "product_exempt",
-            TaxProductResourceLineItemTaxBreakdownTaxabilityReason::ProductExemptHoliday => "product_exempt_holiday",
-            TaxProductResourceLineItemTaxBreakdownTaxabilityReason::ProportionallyRated => "proportionally_rated",
+            TaxProductResourceLineItemTaxBreakdownTaxabilityReason::PortionProductExempt => {
+                "portion_product_exempt"
+            }
+            TaxProductResourceLineItemTaxBreakdownTaxabilityReason::PortionReducedRated => {
+                "portion_reduced_rated"
+            }
+            TaxProductResourceLineItemTaxBreakdownTaxabilityReason::PortionStandardRated => {
+                "portion_standard_rated"
+            }
+            TaxProductResourceLineItemTaxBreakdownTaxabilityReason::ProductExempt => {
+                "product_exempt"
+            }
+            TaxProductResourceLineItemTaxBreakdownTaxabilityReason::ProductExemptHoliday => {
+                "product_exempt_holiday"
+            }
+            TaxProductResourceLineItemTaxBreakdownTaxabilityReason::ProportionallyRated => {
+                "proportionally_rated"
+            }
             TaxProductResourceLineItemTaxBreakdownTaxabilityReason::ReducedRated => "reduced_rated",
-            TaxProductResourceLineItemTaxBreakdownTaxabilityReason::ReverseCharge => "reverse_charge",
-            TaxProductResourceLineItemTaxBreakdownTaxabilityReason::StandardRated => "standard_rated",
-            TaxProductResourceLineItemTaxBreakdownTaxabilityReason::TaxableBasisReduced => "taxable_basis_reduced",
+            TaxProductResourceLineItemTaxBreakdownTaxabilityReason::ReverseCharge => {
+                "reverse_charge"
+            }
+            TaxProductResourceLineItemTaxBreakdownTaxabilityReason::StandardRated => {
+                "standard_rated"
+            }
+            TaxProductResourceLineItemTaxBreakdownTaxabilityReason::TaxableBasisReduced => {
+                "taxable_basis_reduced"
+            }
             TaxProductResourceLineItemTaxBreakdownTaxabilityReason::ZeroRated => "zero_rated",
         }
     }
@@ -402,16 +421,28 @@ impl TaxProductResourceTaxBreakdownTaxabilityReason {
             TaxProductResourceTaxBreakdownTaxabilityReason::NotCollecting => "not_collecting",
             TaxProductResourceTaxBreakdownTaxabilityReason::NotSubjectToTax => "not_subject_to_tax",
             TaxProductResourceTaxBreakdownTaxabilityReason::NotSupported => "not_supported",
-            TaxProductResourceTaxBreakdownTaxabilityReason::PortionProductExempt => "portion_product_exempt",
-            TaxProductResourceTaxBreakdownTaxabilityReason::PortionReducedRated => "portion_reduced_rated",
-            TaxProductResourceTaxBreakdownTaxabilityReason::PortionStandardRated => "portion_standard_rated",
+            TaxProductResourceTaxBreakdownTaxabilityReason::PortionProductExempt => {
+                "portion_product_exempt"
+            }
+            TaxProductResourceTaxBreakdownTaxabilityReason::PortionReducedRated => {
+                "portion_reduced_rated"
+            }
+            TaxProductResourceTaxBreakdownTaxabilityReason::PortionStandardRated => {
+                "portion_standard_rated"
+            }
             TaxProductResourceTaxBreakdownTaxabilityReason::ProductExempt => "product_exempt",
-            TaxProductResourceTaxBreakdownTaxabilityReason::ProductExemptHoliday => "product_exempt_holiday",
-            TaxProductResourceTaxBreakdownTaxabilityReason::ProportionallyRated => "proportionally_rated",
+            TaxProductResourceTaxBreakdownTaxabilityReason::ProductExemptHoliday => {
+                "product_exempt_holiday"
+            }
+            TaxProductResourceTaxBreakdownTaxabilityReason::ProportionallyRated => {
+                "proportionally_rated"
+            }
             TaxProductResourceTaxBreakdownTaxabilityReason::ReducedRated => "reduced_rated",
             TaxProductResourceTaxBreakdownTaxabilityReason::ReverseCharge => "reverse_charge",
             TaxProductResourceTaxBreakdownTaxabilityReason::StandardRated => "standard_rated",
-            TaxProductResourceTaxBreakdownTaxabilityReason::TaxableBasisReduced => "taxable_basis_reduced",
+            TaxProductResourceTaxBreakdownTaxabilityReason::TaxableBasisReduced => {
+                "taxable_basis_reduced"
+            }
             TaxProductResourceTaxBreakdownTaxabilityReason::ZeroRated => "zero_rated",
         }
     }

--- a/src/resources/generated/tax_calculation_line_item.rs
+++ b/src/resources/generated/tax_calculation_line_item.rs
@@ -2,9 +2,10 @@
 // This file was automatically generated.
 // ======================================
 
-use crate::ids::{TaxCalculationLineItemId};
-use crate::params::{Object};
 use serde::{Deserialize, Serialize};
+
+use crate::ids::TaxCalculationLineItemId;
+use crate::params::Object;
 
 /// The resource representing a Stripe "TaxProductResourceTaxCalculationLineItem".
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
@@ -59,7 +60,6 @@ impl Object for TaxCalculationLineItem {
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct TaxProductResourceLineItemTaxBreakdown {
-
     /// The amount of tax, in integer cents.
     pub amount: i64,
 
@@ -84,7 +84,6 @@ pub struct TaxProductResourceLineItemTaxBreakdown {
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct TaxProductResourceJurisdiction {
-
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
     pub country: String,
 
@@ -102,7 +101,6 @@ pub struct TaxProductResourceJurisdiction {
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct TaxProductResourceLineItemTaxRateDetails {
-
     /// A localized display name for tax type, intended to be human-readable.
     ///
     /// For example, "Local Sales and Use Tax", "Value-added tax (VAT)", or "Umsatzsteuer (USt.)".
@@ -249,20 +247,44 @@ pub enum TaxProductResourceLineItemTaxBreakdownTaxabilityReason {
 impl TaxProductResourceLineItemTaxBreakdownTaxabilityReason {
     pub fn as_str(self) -> &'static str {
         match self {
-            TaxProductResourceLineItemTaxBreakdownTaxabilityReason::CustomerExempt => "customer_exempt",
-            TaxProductResourceLineItemTaxBreakdownTaxabilityReason::NotCollecting => "not_collecting",
-            TaxProductResourceLineItemTaxBreakdownTaxabilityReason::NotSubjectToTax => "not_subject_to_tax",
+            TaxProductResourceLineItemTaxBreakdownTaxabilityReason::CustomerExempt => {
+                "customer_exempt"
+            }
+            TaxProductResourceLineItemTaxBreakdownTaxabilityReason::NotCollecting => {
+                "not_collecting"
+            }
+            TaxProductResourceLineItemTaxBreakdownTaxabilityReason::NotSubjectToTax => {
+                "not_subject_to_tax"
+            }
             TaxProductResourceLineItemTaxBreakdownTaxabilityReason::NotSupported => "not_supported",
-            TaxProductResourceLineItemTaxBreakdownTaxabilityReason::PortionProductExempt => "portion_product_exempt",
-            TaxProductResourceLineItemTaxBreakdownTaxabilityReason::PortionReducedRated => "portion_reduced_rated",
-            TaxProductResourceLineItemTaxBreakdownTaxabilityReason::PortionStandardRated => "portion_standard_rated",
-            TaxProductResourceLineItemTaxBreakdownTaxabilityReason::ProductExempt => "product_exempt",
-            TaxProductResourceLineItemTaxBreakdownTaxabilityReason::ProductExemptHoliday => "product_exempt_holiday",
-            TaxProductResourceLineItemTaxBreakdownTaxabilityReason::ProportionallyRated => "proportionally_rated",
+            TaxProductResourceLineItemTaxBreakdownTaxabilityReason::PortionProductExempt => {
+                "portion_product_exempt"
+            }
+            TaxProductResourceLineItemTaxBreakdownTaxabilityReason::PortionReducedRated => {
+                "portion_reduced_rated"
+            }
+            TaxProductResourceLineItemTaxBreakdownTaxabilityReason::PortionStandardRated => {
+                "portion_standard_rated"
+            }
+            TaxProductResourceLineItemTaxBreakdownTaxabilityReason::ProductExempt => {
+                "product_exempt"
+            }
+            TaxProductResourceLineItemTaxBreakdownTaxabilityReason::ProductExemptHoliday => {
+                "product_exempt_holiday"
+            }
+            TaxProductResourceLineItemTaxBreakdownTaxabilityReason::ProportionallyRated => {
+                "proportionally_rated"
+            }
             TaxProductResourceLineItemTaxBreakdownTaxabilityReason::ReducedRated => "reduced_rated",
-            TaxProductResourceLineItemTaxBreakdownTaxabilityReason::ReverseCharge => "reverse_charge",
-            TaxProductResourceLineItemTaxBreakdownTaxabilityReason::StandardRated => "standard_rated",
-            TaxProductResourceLineItemTaxBreakdownTaxabilityReason::TaxableBasisReduced => "taxable_basis_reduced",
+            TaxProductResourceLineItemTaxBreakdownTaxabilityReason::ReverseCharge => {
+                "reverse_charge"
+            }
+            TaxProductResourceLineItemTaxBreakdownTaxabilityReason::StandardRated => {
+                "standard_rated"
+            }
+            TaxProductResourceLineItemTaxBreakdownTaxabilityReason::TaxableBasisReduced => {
+                "taxable_basis_reduced"
+            }
             TaxProductResourceLineItemTaxBreakdownTaxabilityReason::ZeroRated => "zero_rated",
         }
     }

--- a/src/resources/generated/tax_product_resource_customer_details.rs
+++ b/src/resources/generated/tax_product_resource_customer_details.rs
@@ -7,7 +7,6 @@ use serde::{Deserialize, Serialize};
 /// The resource representing a Stripe "TaxProductResourceCustomerDetails".
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct TaxProductResourceCustomerDetails {
-
     /// The customer's postal address (for example, home or business location).
     pub address: Option<TaxProductResourcePostalAddress>,
 
@@ -26,7 +25,6 @@ pub struct TaxProductResourceCustomerDetails {
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct TaxProductResourceCustomerDetailsResourceTaxId {
-
     /// The type of the tax ID, one of `eu_vat`, `br_cnpj`, `br_cpf`, `eu_oss_vat`, `gb_vat`, `nz_gst`, `au_abn`, `au_arn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ru_kpp`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `my_sst`, `sg_gst`, `ae_trn`, `cl_tin`, `sa_vat`, `id_npwp`, `my_frp`, `il_vat`, `ge_vat`, `ua_vat`, `is_vat`, `bg_uic`, `hu_tin`, `si_tin`, `ke_pin`, `tr_tin`, `eg_tin`, `ph_tin`, or `unknown`.
     #[serde(rename = "type")]
     pub type_: TaxProductResourceCustomerDetailsResourceTaxIdType,
@@ -37,7 +35,6 @@ pub struct TaxProductResourceCustomerDetailsResourceTaxId {
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct TaxProductResourcePostalAddress {
-
     /// City, district, suburb, town, or village.
     pub city: Option<String>,
 
@@ -239,7 +236,9 @@ pub enum TaxProductResourceCustomerDetailsTaxabilityOverride {
 impl TaxProductResourceCustomerDetailsTaxabilityOverride {
     pub fn as_str(self) -> &'static str {
         match self {
-            TaxProductResourceCustomerDetailsTaxabilityOverride::CustomerExempt => "customer_exempt",
+            TaxProductResourceCustomerDetailsTaxabilityOverride::CustomerExempt => {
+                "customer_exempt"
+            }
             TaxProductResourceCustomerDetailsTaxabilityOverride::None => "none",
             TaxProductResourceCustomerDetailsTaxabilityOverride::ReverseCharge => "reverse_charge",
         }


### PR DESCRIPTION
# Summary

Exposes the tax calculation API as requested in https://github.com/arlyon/async-stripe/discussions/365

### Checklist

- [x] ran `cargo make fmt`
- [x] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features
  <!--
  EXAMPLES:
  feat: you can now add and remove principals from a project
  fix: fixes an issue where the combobox was displaying incorrect values
  -->
