### PR TITLE
Fixes for Charge

### DIFF
--- a/src/resources/generated/charge.rs
+++ b/src/resources/generated/charge.rs
@@ -106,7 +106,7 @@ pub struct Charge {
     pub failure_message: Option<String>,
 
     /// Information on fraud assessments for the charge.
-    pub fraud_details: Option<FraudDetails>,
+    // pub fraud_details: Option<FraudDetails>,
 
     /// ID of the invoice this charge is for if one exists.
     pub invoice: Option<Expandable<Invoice>>,
@@ -167,7 +167,8 @@ pub struct Charge {
     pub refunded: bool,
 
     /// A list of refunds that have been applied to the charge.
-    pub refunds: List<Refund>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refunds: Option<List<Refund>>,
 
     /// ID of the review associated with this charge if one exists.
     pub review: Option<Expandable<Review>>,


### PR DESCRIPTION
# Summary

Charge was not deserializing successfully... I had to go in and do line by line checks with the API response I was getting to see why.

I realize that I am not doing the right thing for `fraud_details`... here is what the API was giving in reality:
<img width="222" alt="Screenshot 2023-06-28 at 12 33 13 PM" src="https://github.com/arlyon/async-stripe/assets/1409121/080c8558-387f-4eba-acf5-f42d54ea0760">
an empty object. 
What's the recommendation?


Note, I was using Charge in the context of `BalanceTransactionSourceUnion` not sure if that matters.


### Checklist

- [ ] ran `cargo make fmt`
- [ ] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features
  <!--
  EXAMPLES:
  feat: you can now add and remove principals from a project
  fix: fixes an issue where the combobox was displaying incorrect values
  -->
