### PR TITLE
Correct fields for CancelSubscription

### DIFF
--- a/src/resources/subscription_ext.rs
+++ b/src/resources/subscription_ext.rs
@@ -1,5 +1,6 @@
 use serde::Serialize;
 
+use crate::CancellationDetails;
 use crate::client::{Client, Response};
 use crate::ids::SubscriptionId;
 use crate::resources::{CreateSubscriptionItems, Subscription};
@@ -7,12 +8,16 @@ use crate::resources::{CreateSubscriptionItems, Subscription};
 #[derive(Clone, Debug, Default, Serialize)]
 pub struct CancelSubscription {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub at_period_end: Option<bool>,
+    pub cancellation_details: Option<CancellationDetails>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub invoice_now: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prorate: Option<bool>,
 }
 
 impl CancelSubscription {
     pub fn new() -> CancelSubscription {
-        CancelSubscription { at_period_end: None }
+        CancelSubscription { cancellation_details: None, invoice_now: None, prorate: None }
     }
 }
 


### PR DESCRIPTION



# Corrected CancelSubscription fields for current Stripe API version.

<!--
A quick summary of what this PR does, why is needs to be applied, what has changed, etc.
-->

A fix for #394 

https://stripe.com/docs/api/subscriptions/cancel

According to the current Stripe API in the link above, there is no "reason" field within cancellation_details any longer. This also aligns with my testing where it did not recognize the parameter.
Consider removing this struct in future versions. For now, users can leave this as None.

- Replaced `at_period_end` with `invoice_now`
- Added `cancellation_details` field
- Added `prorate` field

### Checklist

- [x] ran `cargo make fmt`
- [x] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features
  <!--
  EXAMPLES:
  feat: you can now add and remove principals from a project
  fix: fixes an issue where the combobox was displaying incorrect values
  -->
