### PR TITLE
Update Charge struct

### DIFF
--- a/src/resources/generated/charge.rs
+++ b/src/resources/generated/charge.rs
@@ -1794,7 +1794,7 @@ impl std::default::Default for ChargeStatus {
     }
 }
 
-/// An enum representing the possible values of an `FraudDetailsParams`'s `user_report` field.
+/// An enum representing the possible values of an `FraudDetailsParams`'s `stripe_report` field.
 #[derive(Copy, Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum FraudDetailsParamsStripeReport {

--- a/src/resources/generated/charge.rs
+++ b/src/resources/generated/charge.rs
@@ -167,6 +167,7 @@ pub struct Charge {
     pub refunded: bool,
 
     /// A list of refunds that have been applied to the charge.
+    #[serde(default)]
     pub refunds: List<Refund>,
 
     /// ID of the review associated with this charge if one exists.
@@ -1739,6 +1740,8 @@ pub struct CreateChargeRadarOptions {
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct FraudDetailsParams {
+    /// If set, can only be `fraudulent`.
+    pub stripe_report: FraudDetailsParamsStripeReport,
     /// Either `safe` or `fraudulent`.
     pub user_report: FraudDetailsParamsUserReport,
 }
@@ -1788,6 +1791,38 @@ impl std::fmt::Display for ChargeStatus {
 impl std::default::Default for ChargeStatus {
     fn default() -> Self {
         Self::Failed
+    }
+}
+
+/// An enum representing the possible values of an `FraudDetailsParams`'s `user_report` field.
+#[derive(Copy, Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum FraudDetailsParamsStripeReport {
+    Fraudulent,
+}
+
+impl FraudDetailsParamsStripeReport {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            FraudDetailsParamsStripeReport::Fraudulent => "fraudulent",
+        }
+    }
+}
+
+impl AsRef<str> for FraudDetailsParamsStripeReport {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl std::fmt::Display for FraudDetailsParamsStripeReport {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        self.as_str().fmt(f)
+    }
+}
+impl std::default::Default for FraudDetailsParamsStripeReport {
+    fn default() -> Self {
+        Self::Fraudulent
     }
 }
 


### PR DESCRIPTION
# Summary

Repost of #398 using different branch instead of master.

Fixed de/serialization of Charge struct. "refunds" attribute is expandable and is not sent in webhook events as the most minimum size is sent so deserialization fails. This can be seen by running stripe trigger charge.succeeded in the stripe-cli. Implemented #[serde(default)] on attribute. Also added missing attribute stripe_report for fraud_details object.

This is my first pull request ever so I am not sure whether I have done things correctly so feel free to give any suggestions for improvement.

Thanks!

### Checklist

- [x] ran `cargo make fmt`
- [x] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features
  <!--
  EXAMPLES:
  feat: you can now add and remove principals from a project
  fix: fixes an issue where the combobox was displaying incorrect values
  -->
