### PR TITLE
Added webhook event types

### DIFF
--- a/src/resources/webhook_events.rs
+++ b/src/resources/webhook_events.rs
@@ -107,10 +107,14 @@ pub enum EventType {
     CustomerSubscriptionCreated,
     #[serde(rename = "customer.subscription.deleted")]
     CustomerSubscriptionDeleted,
+    #[serde(rename = "customer.subscription.paused")]
+    CustomerSubscriptionPaused,
     #[serde(rename = "customer.subscription.pending_update_applied")]
     CustomerSubscriptionPendingUpdateApplied,
     #[serde(rename = "customer.subscription.pending_update_expired")]
     CustomerSubscriptionPendingUpdateExpired,
+    #[serde(rename = "customer.subscription.resumed")]
+    CustomerSubscriptionResumed,
     #[serde(rename = "customer.subscription.trial_will_end")]
     CustomerSubscriptionTrialWillEnd,
     #[serde(rename = "customer.subscription.updated")]


### PR DESCRIPTION
# Summary

Added webhook event types for "customer.subscription.created" and "customer.subscription.paused" events.

### Checklist

- [x] ran `cargo make fmt`
- [x] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features
  <!--
  EXAMPLES:
  feat: you can now add and remove principals from a project
  fix: fixes an issue where the combobox was displaying incorrect values
  -->
