### PR TITLE
Added attribute for previous event object

### DIFF
--- a/src/resources/webhook_events.rs
+++ b/src/resources/webhook_events.rs
@@ -1,7 +1,9 @@
+use std::collections::HashMap;
 use chrono::Utc;
 #[cfg(feature = "webhook-events")]
 use hmac::{Hmac, Mac};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 #[cfg(feature = "webhook-events")]
 use sha2::Sha256;
 use smart_default::SmartDefault;
@@ -409,7 +411,8 @@ impl std::fmt::Display for EventType {
 #[derive(Clone, Debug, Deserialize, Serialize, Default)]
 pub struct NotificationEventData {
     pub object: EventObject,
-    // previous_attributes: ...
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub previous_attributes: Option<HashMap<String, Value>>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/src/resources/webhook_events.rs
+++ b/src/resources/webhook_events.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use chrono::Utc;
 #[cfg(feature = "webhook-events")]
 use hmac::{Hmac, Mac};
@@ -7,6 +6,7 @@ use serde_json::Value;
 #[cfg(feature = "webhook-events")]
 use sha2::Sha256;
 use smart_default::SmartDefault;
+use std::collections::HashMap;
 
 use crate::error::WebhookError;
 use crate::resources::*;
@@ -537,7 +537,6 @@ struct Signature<'r> {
 #[cfg(feature = "webhook-events")]
 impl<'r> Signature<'r> {
     fn parse(raw: &'r str) -> Result<Signature<'r>, WebhookError> {
-        use std::collections::HashMap;
         let headers: HashMap<&str, &str> = raw
             .split(',')
             .map(|header| {

--- a/src/resources/webhook_events.rs
+++ b/src/resources/webhook_events.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use chrono::Utc;
 #[cfg(feature = "webhook-events")]
 use hmac::{Hmac, Mac};
@@ -6,7 +8,6 @@ use serde_json::Value;
 #[cfg(feature = "webhook-events")]
 use sha2::Sha256;
 use smart_default::SmartDefault;
-use std::collections::HashMap;
 
 use crate::error::WebhookError;
 use crate::resources::*;


### PR DESCRIPTION
# Summary

Added attribute for previous event object in webhook events. Used a `HashMap<String, Value>` to represent it but I am not sure if this is a good choice. My reasoning is that not all attributes of the object are present, only ones that have been updated, so deserializing to a specific EventObject variant may not be a good fit as all the attributes in the EventObject struct will need to be iterated to check which ones are set. Additionally, since the developer doesn't know which attributes will be updated, it is best to keep the entries flexible and let the developer choose how to access the data in `"previous_attributes"` depending on the attributes present. 

Open to feedback. Thanks!

### Checklist

- [x] ran `cargo make fmt`
- [x] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features
  <!--
  EXAMPLES:
  feat: you can now add and remove principals from a project
  fix: fixes an issue where the combobox was displaying incorrect values
  -->
