### PR TITLE
pin rust version instead of time-core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ documentation = "https://docs.rs/async-stripe"
 keywords = ["stripe", "v1", "api", "async"]
 categories = ["api-bindings"]
 edition = "2021"
+rust-version = "1.62.0"
 
 [package.metadata.docs.rs]
 features = ["runtime-tokio-hyper"]
@@ -148,8 +149,6 @@ hex = { version = "0.4", optional = true }
 
 rocket = { version = "0.4", optional = true }
 
-# msrv pin
-time-core = "<=0.1.0"
 
 [dev-dependencies]
 async-std = { version = "1.10.0", features = ["attributes"] }


### PR DESCRIPTION
# Summary

We ran into issue closes #395 and propose the following solution

### Checklist

- [-] ran `cargo make fmt`
- [-] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features
  <!--
  EXAMPLES:
  feat: you can now add and remove principals from a project
  fix: fixes an issue where the combobox was displaying incorrect values
  -->
