### PR TITLE
Pin rust version to 1.65 instead of pinning time-core

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -51,7 +51,7 @@ body:
     id: language-version
     attributes:
       label: Rust version
-      placeholder: Our MSRV is 1.65.0
+      placeholder: Our MSRV is 1.67.0
     validations:
       required: true
   - type: input

--- a/.github/workflows/async-stripe.yml
+++ b/.github/workflows/async-stripe.yml
@@ -111,7 +111,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: "1.65.0"
+          toolchain: "1.67.0"
           override: true
       - uses: actions/cache@v2
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,9 +148,6 @@ hex = { version = "0.4", optional = true }
 
 rocket = { version = "0.4", optional = true }
 
-# msrv pin
-time-core = "<=0.1.0"
-
 [dev-dependencies]
 async-std = { version = "1.10.0", features = ["attributes"] }
 httpmock = "0.6.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 name = "async-stripe"
 version = "0.22.2"
 description = "API bindings for the Stripe HTTP API"
-rust-version = "1.65.0"
+rust-version = "1.67.0"
 authors = [
   "Anna Baldwin <abaldwin@developers.wyyerd.com>",
   "Kevin Stenerson <kestred@users.noreply.github.com>",

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ If you don't see the specific version you are on, prefer the next available vers
 
 ## MSRV
 
-We currently have `1.65.0` pinned in CI, so any version of rustc newer than that should work.
+We currently have `1.67.0` pinned in CI, so any version of rustc newer than that should work.
 If this is not the case, please open an issue. As a policy, we permit MSRV increases in non-breaking releases.
 If you have a compelling usecase for bumping it, we are usually open to do so, as long as
 the rust version is not too new (generally 3 releases).


### PR DESCRIPTION
# Summary

See https://github.com/arlyon/async-stripe/pull/421#issuecomment-1683880259

### Checklist

- [x] ran `cargo make fmt`
- [x] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features
