### PR TITLE
fix: resource updated_price currency_options field type

### DIFF
--- a/src/resources/generated/price.rs
+++ b/src/resources/generated/price.rs
@@ -486,7 +486,7 @@ pub struct UpdatePrice<'a> {
     ///
     /// Each key must be a three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html) and a [supported currency](https://stripe.com/docs/currencies).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub currency_options: Option<CurrencyMap<Option<CurrencyMap<UpdatePriceCurrencyOptions>>>>,
+    pub currency_options: Option<CurrencyMap<UpdatePriceCurrencyOptions>>,
 
     /// Specifies which fields in the response should be expanded.
     #[serde(skip_serializing_if = "Expand::is_empty")]


### PR DESCRIPTION
Fixing resource update_price currency_options field type.


It should be optional currency with update options as a value

![Screenshot 2023-08-19 at 08 20 34](https://github.com/arlyon/async-stripe/assets/4499780/739b8163-8894-4fe9-8b06-a76bf32c129e)


Docs: https://stripe.com/docs/api/prices/update

Codegen: https://github.com/arlyon/async-stripe/blob/master/openapi/src/codegen.rs#L1280

### Checklist

- [x] ran `cargo make fmt`
- [x] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features
