### PR TITLE
Update hyper-rustls to fix RUSTSEC-2023-0052

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,7 @@ thiserror = "1.0.24"
 http-types = { version = "2.12.0", default-features = false }
 hyper = { version = "0.14", default-features = false, features = ["http1", "http2", "client", "tcp"], optional = true }
 hyper-tls = { version = "0.5", optional = true }
-hyper-rustls = { version = "0.23", default-features = false, features = ["http1", "http2", "tls12", "logging"], optional = true }
+hyper-rustls = { version = "0.24", default-features = false, features = ["http1", "http2", "tls12", "logging"], optional = true }
 serde = {version = ">=1.0.79", features = ["derive"] } # we use `serde(other)` which was introduced in 1.0.79
 serde_json = "1.0"
 serde_qs = "0.10.1"


### PR DESCRIPTION
# Summary

The update fixes a denial of service in the transitive dependency webpki


### Checklist

- [x] ran `cargo make fmt`
- [x] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features
