### PR TITLE
fix: don't pin time-core for msrv

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,9 +148,6 @@ hex = { version = "0.4", optional = true }
 
 rocket = { version = "0.4", optional = true }
 
-# msrv pin
-time-core = "<=0.1.0"
-
 [dev-dependencies]
 async-std = { version = "1.10.0", features = ["attributes"] }
 httpmock = "0.6.6"


### PR DESCRIPTION
# Summary

Unpin time-core
