### PR TITLE
fix: Make subscription_details.metadata optional

### DIFF
--- a/openapi/src/codegen.rs
+++ b/openapi/src/codegen.rs
@@ -767,7 +767,7 @@ pub fn gen_enums(out: &mut String, enums: &BTreeMap<String, InferredEnum>, meta:
                 self.as_str()
             }}
         }}
-        
+
         impl std::fmt::Display for {enum_name} {{
             fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {{
                 self.as_str().fmt(f)
@@ -1234,7 +1234,11 @@ pub fn gen_field_rust_type<T: Borrow<Schema>>(
     }
     if field_name == "metadata" {
         state.use_params.insert("Metadata");
-        return "Metadata".into();
+        return if !required || is_nullable {
+            "Option<Metadata>".into()
+        } else {
+            "Metadata".into()
+        };
     } else if (field_name == "currency" || field_name.ends_with("_currency"))
         && matches!(maybe_schema.map(|s| &s.schema_kind), Some(SchemaKind::Type(Type::String(_))))
     {

--- a/src/resources/generated/invoice.rs
+++ b/src/resources/generated/invoice.rs
@@ -670,7 +670,7 @@ pub struct SubscriptionDetailsData {
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that will reflect the metadata of the subscription at the time of invoice creation.
     ///
     /// *Note: This attribute is populated only for invoices created on or after June 29, 2023.*.
-    pub metadata: Metadata,
+    pub metadata: Option<Metadata>,
 }
 
 /// The parameters for `Invoice::create`.


### PR DESCRIPTION
# Summary

Looking at the OpenAPI spec, this field is `nullable`, and therefore should be an `Option`. All of our invoice webhook events are failing because the webhook events has

```
{ metadata: null }
```
On both the latest and last API version of stripe.

### Checklist

- [x] ran `cargo make fmt`
- [x] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features
