### PR TITLE
Add missing  byn and mmk currency in the Currency enum

### DIFF
--- a/openapi/src/metadata.rs
+++ b/openapi/src/metadata.rs
@@ -314,5 +314,5 @@ pub fn feature_groups() -> BTreeMap<&'static str, &'static str> {
 	]
 	.iter()
 	.copied()
-	.collect() 
+	.collect()
 }

--- a/src/resources/currency.rs
+++ b/src/resources/currency.rs
@@ -7,6 +7,10 @@ use crate::params::to_snakecase;
 /// For more details see <https://support.stripe.com/questions/which-currencies-does-stripe-support>.
 #[derive(Copy, Clone, Debug, Deserialize, Serialize, Eq, PartialEq, Hash)]
 pub enum Currency {
+    #[serde(rename = "byn")]
+    BYN, // Belarusian Ruble
+    #[serde(rename = "mmk")]
+    MMK, // Myanmar Kyat
     #[serde(rename = "aed")]
     AED, // United Arab Emirates Dirham
     #[serde(rename = "afn")]


### PR DESCRIPTION
# Summary

fixes #459 
### Checklist

- [x] ran `cargo make fmt`
(Most of the changes come from fmt)
- [x] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features
  <!--
  EXAMPLES:
  feat: you can now add and remove principals from a project
  fix: fixes an issue where the combobox was displaying incorrect values
  -->

# TO DECIDE: 

- [ ] We could use [ serde rename_all](https://serde.rs/container-attrs.html#rename_all) to rename all enum values to lower-case in the Currency Enum. I would be happy to implement this.