### PR TITLE
Fixed infinite loop on list pagination when the result had more than 1 item

### DIFF
--- a/examples/connect.rs
+++ b/examples/connect.rs
@@ -48,6 +48,7 @@ async fn main() {
             expand: &[],
             refresh_url: Some("https://test.com/refresh"),
             return_url: Some("https://test.com/return"),
+            collection_options: None,
         },
     )
     .await


### PR DESCRIPTION
# Summary

<!--
A quick summary of what this PR does, why is needs to be applied, what has changed, etc.
-->

### Checklist

- [ X ] ran `cargo make fmt`
- [ X ] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features
 
fix: Fixed infinite loop on list pagination when the result had more than 1 item

I also added tests with 2 elements, so this never happens again.

What was happening: 
The `get_data` implementations of `PaginableList` was cloning the data every single time.
When the data was "popped" in the `unfold_stream` function, it was popping from the cloned vector.
Specifically the `if paginator.page.data.len() > 1 { ...` as with anything less than than 2 elements, the condition was false and it either ended the stream or requested the next page.

