### PR TITLE
fix: avoid generating nested currency options map

### DIFF
--- a/openapi/src/codegen.rs
+++ b/openapi/src/codegen.rs
@@ -1290,6 +1290,11 @@ pub fn gen_field_rust_type<T: Borrow<Schema>>(
     // currency_options field is represented by an optional HashMap<String, T>, where the String is the currency code in ISO 4217 format.
     if field_name == "currency_options" {
         state.use_params.insert("CurrencyMap");
+
+        if ty.contains("CurrencyMap<") {
+            return ty;
+        }
+
         return format!("Option<CurrencyMap<{}>>", ty);
     }
 

--- a/src/resources/generated/price.rs
+++ b/src/resources/generated/price.rs
@@ -487,7 +487,7 @@ pub struct UpdatePrice<'a> {
     ///
     /// Each key must be a three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html) and a [supported currency](https://stripe.com/docs/currencies).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub currency_options: Option<CurrencyMap<Option<CurrencyMap<UpdatePriceCurrencyOptions>>>>,
+    pub currency_options: Option<CurrencyMap<UpdatePriceCurrencyOptions>>,
 
     /// Specifies which fields in the response should be expanded.
     #[serde(skip_serializing_if = "Expand::is_empty")]


### PR DESCRIPTION
# Summary
This PR adds a check to verify if the `ty` is already a `CurrencyMap` to avoid generating any nested `Option<CurrencyMap<...>>` as shown on #480 .

On a side note: this is something that will also be fixed on #452.

Closes #480 
Closes #427 

### Checklist

- [x] ran `cargo make fmt`
- [x] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features
