### PR TITLE
Fixed typo in checkout.rs

### DIFF
--- a/examples/checkout.rs
+++ b/examples/checkout.rs
@@ -41,7 +41,7 @@ async fn main() {
 
     println!("created a customer at https://dashboard.stripe.com/test/customers/{}", customer.id);
 
-    // create a new exmaple project
+    // create a new example project
     let product = {
         let mut create_product = CreateProduct::new("T-Shirt");
         create_product.metadata = Some(std::collections::HashMap::from([(


### PR DESCRIPTION
# Summary

Fixes the typo `exmaple` in the `checkout.rs` file.

### Checklist

- [x] ran `cargo make fmt`
- [x] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features