### PR TITLE
Add products to features list in cargo.toml and export from reso…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ full = [
   "terminal",
   "webhook-endpoints",
   "tax-calculation",
+  "products",
 ]
 
 stream = []
@@ -58,6 +59,7 @@ sigma = []
 terminal = []
 webhook-endpoints = []
 tax-calculation = []
+products = []
 
 # deserialize events from webhooks
 webhook-events = ["events", "hmac", "sha2", "chrono", "hex"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,7 @@ pub use crate::client::*;
 pub use crate::error::{ErrorCode, ErrorType, RequestError, StripeError, WebhookError};
 pub use crate::ids::*;
 pub use crate::params::{
-    Expandable, Headers, IdOrCreate, List, Metadata, Object, RangeBounds, RangeQuery, Timestamp,
+    Expandable, Headers, IdOrCreate, List, Metadata, Object, RangeBounds, RangeQuery, SearchList,
+    Timestamp,
 };
 pub use crate::resources::*;

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -192,6 +192,15 @@ pub use {
 };
 
 #[rustfmt::skip]
+#[cfg(feature = "products")]
+pub use {
+    products::{
+        product_ext::*,
+        price_ext::*,
+    }
+};
+
+#[rustfmt::skip]
 #[cfg(feature = "billing")]
 pub use {
     billing::{


### PR DESCRIPTION
# Summary

[PR-414](https://github.com/arlyon/async-stripe/pull/414/files) uses a new feature flag `#[cfg(feature = "products")]`.

This PR adds this feature to the `[features]` table in `Cargo.toml` and exports the product module from `resources.rs`.

This allows users of this library to add the following to their `Cargo.toml`:

```
async-stripe = { 
  version = "0.31.0",
  default-features = false,
  features= ["runtime-tokio-hyper", "products",],
 }
```

And make use of the new search API functionality for products and prices.

### Checklist

- [x] ran `cargo make fmt`
- [x] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features
  <!--
  EXAMPLES:
  feat: you can now add and remove principals from a project
  fix: fixes an issue where the combobox was displaying incorrect values
  -->
