### PR TITLE
Expose the `auto_advance` field from the `FinalizeInvoiceParams` struct

### DIFF
--- a/src/resources/invoice_ext.rs
+++ b/src/resources/invoice_ext.rs
@@ -109,5 +109,5 @@ impl<'a> InvoiceSearchParams<'a> {
 #[derive(Clone, Debug, Default, Serialize)]
 pub struct FinalizeInvoiceParams {
     #[serde(skip_serializing_if = "Option::is_none")]
-    auto_advance: Option<bool>,
+    pub auto_advance: Option<bool>,
 }


### PR DESCRIPTION
This pull request exposes the `auto_advance` field from the `FinalizeInvoiceParams` struct, allowing users to access it outside its defining module.

# Summary

<!--
A quick summary of what this PR does, why is needs to be applied, what has changed, etc.
-->

### Checklist

- [x] ran `cargo make fmt`
- [x] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features