### PR TITLE
fix: rename serde for Self_ to "self" for direct deserialization of JSON

### DIFF
--- a/src/resources/generated/checkout_session.rs
+++ b/src/resources/generated/checkout_session.rs
@@ -4721,6 +4721,7 @@ impl std::default::Default for CheckoutUsBankAccountPaymentMethodOptionsVerifica
 #[serde(rename_all = "snake_case")]
 pub enum CreateCheckoutSessionAutomaticTaxLiabilityType {
     Account,
+    #[serde(rename = "self")]
     Self_,
 }
 
@@ -5035,6 +5036,7 @@ impl std::default::Default for CreateCheckoutSessionCustomerUpdateShipping {
 #[serde(rename_all = "snake_case")]
 pub enum CreateCheckoutSessionInvoiceCreationInvoiceDataIssuerType {
     Account,
+    #[serde(rename = "self")]
     Self_,
 }
 
@@ -7857,6 +7859,7 @@ impl std::default::Default for CreateCheckoutSessionShippingOptionsShippingRateD
 #[serde(rename_all = "snake_case")]
 pub enum CreateCheckoutSessionSubscriptionDataInvoiceSettingsIssuerType {
     Account,
+    #[serde(rename = "self")]
     Self_,
 }
 

--- a/src/resources/generated/connect_account_reference.rs
+++ b/src/resources/generated/connect_account_reference.rs
@@ -24,6 +24,7 @@ pub struct ConnectAccountReference {
 #[serde(rename_all = "snake_case")]
 pub enum ConnectAccountReferenceType {
     Account,
+    #[serde(rename = "self")]
     Self_,
 }
 

--- a/src/resources/generated/invoice.rs
+++ b/src/resources/generated/invoice.rs
@@ -1555,6 +1555,7 @@ impl std::default::Default for CollectionMethod {
 #[serde(rename_all = "snake_case")]
 pub enum CreateInvoiceAutomaticTaxLiabilityType {
     Account,
+    #[serde(rename = "self")]
     Self_,
 }
 
@@ -1621,6 +1622,7 @@ impl std::default::Default for CreateInvoiceFromInvoiceAction {
 #[serde(rename_all = "snake_case")]
 pub enum CreateInvoiceIssuerType {
     Account,
+    #[serde(rename = "self")]
     Self_,
 }
 

--- a/src/resources/generated/payment_link.rs
+++ b/src/resources/generated/payment_link.rs
@@ -1788,6 +1788,7 @@ impl std::default::Default for CreatePaymentLinkAfterCompletionType {
 #[serde(rename_all = "snake_case")]
 pub enum CreatePaymentLinkAutomaticTaxLiabilityType {
     Account,
+    #[serde(rename = "self")]
     Self_,
 }
 
@@ -1996,6 +1997,7 @@ impl std::default::Default for CreatePaymentLinkCustomFieldsType {
 #[serde(rename_all = "snake_case")]
 pub enum CreatePaymentLinkInvoiceCreationInvoiceDataIssuerType {
     Account,
+    #[serde(rename = "self")]
     Self_,
 }
 
@@ -2967,6 +2969,7 @@ impl std::default::Default for CreatePaymentLinkShippingAddressCollectionAllowed
 #[serde(rename_all = "snake_case")]
 pub enum CreatePaymentLinkSubscriptionDataInvoiceSettingsIssuerType {
     Account,
+    #[serde(rename = "self")]
     Self_,
 }
 
@@ -4318,6 +4321,7 @@ impl std::default::Default for UpdatePaymentLinkAfterCompletionType {
 #[serde(rename_all = "snake_case")]
 pub enum UpdatePaymentLinkAutomaticTaxLiabilityType {
     Account,
+    #[serde(rename = "self")]
     Self_,
 }
 
@@ -4420,6 +4424,7 @@ impl std::default::Default for UpdatePaymentLinkCustomFieldsType {
 #[serde(rename_all = "snake_case")]
 pub enum UpdatePaymentLinkInvoiceCreationInvoiceDataIssuerType {
     Account,
+    #[serde(rename = "self")]
     Self_,
 }
 
@@ -5321,6 +5326,7 @@ impl std::default::Default for UpdatePaymentLinkShippingAddressCollectionAllowed
 #[serde(rename_all = "snake_case")]
 pub enum UpdatePaymentLinkSubscriptionDataInvoiceSettingsIssuerType {
     Account,
+    #[serde(rename = "self")]
     Self_,
 }
 

--- a/src/resources/generated/subscription.rs
+++ b/src/resources/generated/subscription.rs
@@ -1958,6 +1958,7 @@ impl std::default::Default for CancellationDetailsReason {
 #[serde(rename_all = "snake_case")]
 pub enum CreateSubscriptionAutomaticTaxLiabilityType {
     Account,
+    #[serde(rename = "self")]
     Self_,
 }
 
@@ -1992,6 +1993,7 @@ impl std::default::Default for CreateSubscriptionAutomaticTaxLiabilityType {
 #[serde(rename_all = "snake_case")]
 pub enum CreateSubscriptionInvoiceSettingsIssuerType {
     Account,
+    #[serde(rename = "self")]
     Self_,
 }
 
@@ -3173,6 +3175,7 @@ impl std::default::Default for SubscriptionsResourcePaymentSettingsSaveDefaultPa
 #[serde(rename_all = "snake_case")]
 pub enum UpdateSubscriptionAutomaticTaxLiabilityType {
     Account,
+    #[serde(rename = "self")]
     Self_,
 }
 
@@ -3253,6 +3256,7 @@ impl std::default::Default for UpdateSubscriptionCancellationDetailsFeedback {
 #[serde(rename_all = "snake_case")]
 pub enum UpdateSubscriptionInvoiceSettingsIssuerType {
     Account,
+    #[serde(rename = "self")]
     Self_,
 }
 

--- a/src/resources/generated/subscription_schedule.rs
+++ b/src/resources/generated/subscription_schedule.rs
@@ -1287,6 +1287,7 @@ pub struct UpdateSubscriptionSchedulePhasesItemsPriceDataRecurring {
 #[serde(rename_all = "snake_case")]
 pub enum CreateSubscriptionSchedulePhasesAutomaticTaxLiabilityType {
     Account,
+    #[serde(rename = "self")]
     Self_,
 }
 
@@ -1571,6 +1572,7 @@ impl std::default::Default for SubscriptionScheduleDefaultSettingsCollectionMeth
 #[serde(rename_all = "snake_case")]
 pub enum SubscriptionScheduleDefaultSettingsParamsAutomaticTaxLiabilityType {
     Account,
+    #[serde(rename = "self")]
     Self_,
 }
 
@@ -1681,6 +1683,7 @@ impl std::default::Default for SubscriptionScheduleEndBehavior {
 #[serde(rename_all = "snake_case")]
 pub enum SubscriptionScheduleInvoiceSettingsIssuerType {
     Account,
+    #[serde(rename = "self")]
     Self_,
 }
 
@@ -1789,6 +1792,7 @@ impl std::default::Default for SubscriptionScheduleStatus {
 #[serde(rename_all = "snake_case")]
 pub enum UpdateSubscriptionSchedulePhasesAutomaticTaxLiabilityType {
     Account,
+    #[serde(rename = "self")]
     Self_,
 }
 

--- a/src/resources/generated/tax_id.rs
+++ b/src/resources/generated/tax_id.rs
@@ -245,6 +245,7 @@ pub enum CreateTaxIdOwnerType {
     Account,
     Application,
     Customer,
+    #[serde(rename = "self")]
     Self_,
 }
 
@@ -283,6 +284,7 @@ pub enum ListTaxIdsOwnerType {
     Account,
     Application,
     Customer,
+    #[serde(rename = "self")]
     Self_,
 }
 
@@ -321,6 +323,7 @@ pub enum TaxIDsOwnerType {
     Account,
     Application,
     Customer,
+    #[serde(rename = "self")]
     Self_,
 }
 

--- a/src/resources/subscription_ext.rs
+++ b/src/resources/subscription_ext.rs
@@ -1,10 +1,10 @@
 use serde::Serialize;
 
-use crate::CancellationDetails;
 use crate::client::{Client, Response};
 use crate::ids::SubscriptionId;
 use crate::params::SearchList;
 use crate::resources::{CreateSubscriptionItems, Subscription};
+use crate::CancellationDetails;
 
 #[derive(Clone, Debug, Default, Serialize)]
 pub struct CancelSubscription {


### PR DESCRIPTION
# Summary

This renames the serde of the `Self_` field to be `self`. This allows the structs to be directly deserialized from JSON.

### Checklist

- [x] ran `cargo make fmt`
- [x] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features
  <!--
  EXAMPLES:
  feat: you can now add and remove principals from a project
  fix: fixes an issue where the combobox was displaying incorrect values
  -->
