### PR TITLE
fix: correctly generate types for optional lists

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,7 @@ hyper-rustls-native = ["hyper-rustls", "hyper-rustls/native-tokio"]
 hyper-rustls-webpki = ["hyper-rustls", "hyper-rustls/webpki-tokio"]
 
 [dependencies]
+ahash = ">=0.8.0, <=0.8.7" # pin to avoid msrv bump
 async-std = {version = "1.8,<1.11", optional = true}
 
 chrono = { version = "0.4", default-features = false, features = ["serde", "clock"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,6 @@ hyper-rustls-native = ["hyper-rustls", "hyper-rustls/native-tokio"]
 hyper-rustls-webpki = ["hyper-rustls", "hyper-rustls/webpki-tokio"]
 
 [dependencies]
-ahash = ">=0.8.0, <=0.8.7" # pin to avoid msrv bump
 async-std = {version = "1.8,<1.11", optional = true}
 
 chrono = { version = "0.4", default-features = false, features = ["serde", "clock"], optional = true }
@@ -135,7 +134,7 @@ serde_qs = "0.10.1"
 serde_path_to_error = "0.1.8"
 smol_str = "0.1"
 surf = { version = "2.1", optional = true }
-tokio = { version = "1.2", optional = true }
+tokio = { version = "1", optional = true }
 smart-default = "0.6.0"
 uuid = { version = "0.8", optional=true, features=["v4"] }
 
@@ -156,6 +155,12 @@ tokio = { version = "1.24.1", features = ["rt", "macros"] }
 axum = { version = "0.6.18", features = ["macros"] }
 async-trait = "0.1"
 actix-web = "4.2.1"
+
+# MSRV PINS
+#
+# We have a few deps that have MSRVs that are higher than our own. 
+# We pin them here to ensure that we can run tests on the MSRV
+bumpalo = ">=3.0.0, <= 3.15.0"
 
 [[example]]
 name = "checkout"

--- a/examples/checkout.rs
+++ b/examples/checkout.rs
@@ -87,17 +87,18 @@ async fn main() {
         CheckoutSession::create(&client, params).await.unwrap()
     };
 
+    let line_items = checkout_session.line_items.unwrap();
+
     println!(
         "created a {} checkout session for {} {:?} for {} {} at {}",
         checkout_session.payment_status,
-        checkout_session.line_items.data[0].quantity.unwrap(),
-        match checkout_session.line_items.data[0].price.as_ref().unwrap().product.as_ref().unwrap()
-        {
+        line_items.data[0].quantity.unwrap(),
+        match line_items.data[0].price.as_ref().unwrap().product.as_ref().unwrap() {
             Expandable::Object(p) => p.name.as_ref().unwrap(),
             _ => panic!("product not found"),
         },
         checkout_session.amount_subtotal.unwrap() / 100,
-        checkout_session.line_items.data[0].price.as_ref().unwrap().currency.unwrap(),
+        line_items.data[0].price.as_ref().unwrap().currency.unwrap(),
         checkout_session.url.unwrap()
     );
 }

--- a/openapi/src/codegen.rs
+++ b/openapi/src/codegen.rs
@@ -1299,10 +1299,6 @@ pub fn gen_field_rust_type<T: Borrow<Schema>>(
         // Not sure why this is here, but we want to preserve it for now
         return "bool".into();
     }
-    if ty.contains("List<") {
-        // N.B. return immediately; we use `Default` for list rather than `Option`
-        return ty;
-    }
 
     // currency_options field is represented by an optional HashMap<String, T>, where the String is the currency code in ISO 4217 format.
     if field_name == "currency_options" {

--- a/src/resources/generated/account.rs
+++ b/src/resources/generated/account.rs
@@ -80,8 +80,8 @@ pub struct Account {
     /// External accounts (bank accounts and debit cards) currently attached to this account.
     ///
     /// External accounts are only returned for requests where `controller[is_controller]` is true.
-    #[serde(default)]
-    pub external_accounts: List<ExternalAccount>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub external_accounts: Option<List<ExternalAccount>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub future_requirements: Option<AccountFutureRequirements>,

--- a/src/resources/generated/charge.rs
+++ b/src/resources/generated/charge.rs
@@ -158,7 +158,7 @@ pub struct Charge {
     pub refunded: bool,
 
     /// A list of refunds that have been applied to the charge.
-    pub refunds: List<Refund>,
+    pub refunds: Option<List<Refund>>,
 
     /// ID of the review associated with this charge if one exists.
     pub review: Option<Expandable<Review>>,

--- a/src/resources/generated/checkout_session.rs
+++ b/src/resources/generated/checkout_session.rs
@@ -115,8 +115,8 @@ pub struct CheckoutSession {
     pub invoice_creation: Option<PaymentPagesCheckoutSessionInvoiceCreation>,
 
     /// The line items purchased by the customer.
-    #[serde(default)]
-    pub line_items: List<CheckoutSessionItem>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line_items: Option<List<CheckoutSessionItem>>,
 
     /// Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
     pub livemode: bool,

--- a/src/resources/generated/customer.rs
+++ b/src/resources/generated/customer.rs
@@ -139,8 +139,8 @@ pub struct Customer {
     pub sources: List<PaymentSource>,
 
     /// The customer's current subscriptions, if any.
-    #[serde(default)]
-    pub subscriptions: List<Subscription>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subscriptions: Option<List<Subscription>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tax: Option<CustomerTax>,
@@ -152,8 +152,8 @@ pub struct Customer {
     pub tax_exempt: Option<CustomerTaxExempt>,
 
     /// The customer's tax IDs.
-    #[serde(default)]
-    pub tax_ids: List<TaxId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tax_ids: Option<List<TaxId>>,
 
     /// ID of the test clock that this customer belongs to.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/resources/generated/file.rs
+++ b/src/resources/generated/file.rs
@@ -29,8 +29,8 @@ pub struct File {
     pub filename: Option<String>,
 
     /// A list of [file links](https://stripe.com/docs/api#file_links) that point at this file.
-    #[serde(default)]
-    pub links: List<FileLink>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub links: Option<List<FileLink>>,
 
     /// The [purpose](https://stripe.com/docs/file-upload#uploading-a-file) of the uploaded file.
     pub purpose: FilePurpose,

--- a/src/resources/generated/invoice.rs
+++ b/src/resources/generated/invoice.rs
@@ -284,8 +284,8 @@ pub struct Invoice {
     /// The individual line items that make up the invoice.
     ///
     /// `lines` is sorted as follows: (1) pending invoice items (including prorations) in reverse chronological order, (2) subscription items in reverse chronological order, and (3) invoice items added after invoice creation in chronological order.
-    #[serde(default)]
-    pub lines: List<InvoiceLineItem>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lines: Option<List<InvoiceLineItem>>,
 
     /// Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/resources/generated/payment_link.rs
+++ b/src/resources/generated/payment_link.rs
@@ -69,8 +69,8 @@ pub struct PaymentLink {
     pub invoice_creation: Option<PaymentLinksResourceInvoiceCreation>,
 
     /// The line items representing what is being sold.
-    #[serde(default)]
-    pub line_items: List<CheckoutSessionItem>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line_items: Option<List<CheckoutSessionItem>>,
 
     /// Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
     pub livemode: bool,

--- a/src/resources/generated/quote.rs
+++ b/src/resources/generated/quote.rs
@@ -100,8 +100,8 @@ pub struct Quote {
     pub invoice_settings: InvoiceSettingQuoteSetting,
 
     /// A list of items the customer is being quoted for.
-    #[serde(default)]
-    pub line_items: List<CheckoutSessionItem>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line_items: Option<List<CheckoutSessionItem>>,
 
     /// Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
     pub livemode: bool,
@@ -302,8 +302,8 @@ pub struct QuotesResourceUpfront {
     /// The line items that will appear on the next invoice after this quote is accepted.
     ///
     /// This does not include pending invoice items that exist on the customer but may still be included in the next invoice.
-    #[serde(default)]
-    pub line_items: List<CheckoutSessionItem>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line_items: Option<List<CheckoutSessionItem>>,
 
     pub total_details: QuotesResourceTotalDetails,
 }

--- a/src/resources/generated/radar_value_list.rs
+++ b/src/resources/generated/radar_value_list.rs
@@ -40,8 +40,8 @@ pub struct RadarValueList {
     pub item_type: Option<RadarValueListItemType>,
 
     /// List of items contained within this value list.
-    #[serde(default)]
-    pub list_items: List<RadarValueListItem>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub list_items: Option<List<RadarValueListItem>>,
 
     /// Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/resources/generated/tax_calculation.rs
+++ b/src/resources/generated/tax_calculation.rs
@@ -33,7 +33,7 @@ pub struct TaxCalculation {
     pub expires_at: Option<Timestamp>,
 
     /// The list of items the customer is purchasing.
-    pub line_items: List<TaxCalculationLineItem>,
+    pub line_items: Option<List<TaxCalculationLineItem>>,
 
     /// Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
     pub livemode: bool,

--- a/src/resources/generated/tax_id.rs
+++ b/src/resources/generated/tax_id.rs
@@ -245,6 +245,7 @@ pub enum CreateTaxIdOwnerType {
     Account,
     Application,
     Customer,
+    #[serde(rename = "self")]
     Self_,
 }
 
@@ -283,6 +284,7 @@ pub enum ListTaxIdsOwnerType {
     Account,
     Application,
     Customer,
+    #[serde(rename = "self")]
     Self_,
 }
 
@@ -321,6 +323,7 @@ pub enum TaxIDsOwnerType {
     Account,
     Application,
     Customer,
+    #[serde(rename = "self")]
     Self_,
 }
 

--- a/src/resources/generated/tax_transaction.rs
+++ b/src/resources/generated/tax_transaction.rs
@@ -31,7 +31,7 @@ pub struct TaxTransaction {
     pub customer_details: TaxProductResourceCustomerDetails,
 
     /// The tax collected or refunded, by line item.
-    pub line_items: List<TaxTransactionLineItem>,
+    pub line_items: Option<List<TaxTransactionLineItem>>,
 
     /// Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
     pub livemode: bool,

--- a/src/resources/generated/treasury_transaction.rs
+++ b/src/resources/generated/treasury_transaction.rs
@@ -36,7 +36,7 @@ pub struct TreasuryTransaction {
     /// A list of TransactionEntries that are part of this Transaction.
     ///
     /// This cannot be expanded in any list endpoints.
-    pub entries: List<TreasuryTransactionEntry>,
+    pub entries: Option<List<TreasuryTransactionEntry>>,
 
     /// The FinancialAccount associated with this object.
     pub financial_account: String,


### PR DESCRIPTION
# Summary

We were special casing optional lists, rather than following the spec. This code path has been around forever and has likely been invalid. This is a breaking change.

Closes https://github.com/arlyon/async-stripe/issues/456 and https://github.com/arlyon/async-stripe/issues/496

### Checklist

- [x] ran `cargo make fmt`
- [x] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features
  <!--
  EXAMPLES:
  feat: you can now add and remove principals from a project
  fix: fixes an issue where the combobox was displaying incorrect values
  -->
