### PR TITLE
fix: Repaired the Axum example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,7 +152,7 @@ rocket = { version = "0.4", optional = true }
 async-std = { version = "1.10.0", features = ["attributes"] }
 httpmock = "0.6.6"
 tokio = { version = "1.24.1", features = ["rt", "macros"] }
-axum = { version = "0.6.18", features = ["macros"] }
+axum = { version = "0.7.4", features = ["macros"] }
 async-trait = "0.1"
 actix-web = "4.2.1"
 


### PR DESCRIPTION
# Summary

Fixes the Axum example. Closes #473

### Checklist

- [x] ran `cargo make fmt`
- [x] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features

