### PR TITLE
fix: Remove "Some()" from RequestError's display

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -166,7 +166,9 @@ impl std::fmt::Display for ErrorCode {
 ///
 /// For more details see <https://stripe.com/docs/api#errors>.
 #[derive(Debug, Default, Deserialize, Error)]
-#[error("{error_type} ({http_status}) with message: {message:?}")]
+#[error("{error_type} ({http_status}){}", message.as_ref().map(|msg| {
+    format!(" with message: {msg:?}")
+}).unwrap_or_default())]
 pub struct RequestError {
     /// The HTTP status in the response.
     #[serde(skip_deserializing)]


### PR DESCRIPTION
The Display implementation for RequestError previously was:
```
invalid_request_error (400) with message: Some("Product already exists.")
invalid_request_error (400) with message: None
```
This PR changes it to:
```
invalid_request_error (400) with message: "Product already exists."
invalid_request_error (400)
```
Goal is to be shorter and look a bit friendlier.

Thanks for this library! Lmk if you'd like any changes (or edits by maintainers is also enabled).