### PR TITLE
Enum generated FromStr improvements

### DIFF
--- a/generated/stripe_billing/src/billing_portal_configuration/requests.rs
+++ b/generated/stripe_billing/src/billing_portal_configuration/requests.rs
@@ -188,7 +188,7 @@ impl CreateBillingPortalConfigurationFeaturesCustomerUpdateAllowedUpdates {
 }
 
 impl std::str::FromStr for CreateBillingPortalConfigurationFeaturesCustomerUpdateAllowedUpdates {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateBillingPortalConfigurationFeaturesCustomerUpdateAllowedUpdates::*;
         match s {
@@ -198,7 +198,7 @@ impl std::str::FromStr for CreateBillingPortalConfigurationFeaturesCustomerUpdat
             "phone" => Ok(Phone),
             "shipping" => Ok(Shipping),
             "tax_id" => Ok(TaxId),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -325,7 +325,7 @@ impl CreateBillingPortalConfigurationFeaturesSubscriptionCancelCancellationReaso
 impl std::str::FromStr
     for CreateBillingPortalConfigurationFeaturesSubscriptionCancelCancellationReasonOptions
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateBillingPortalConfigurationFeaturesSubscriptionCancelCancellationReasonOptions::*;
         match s {
@@ -337,7 +337,7 @@ impl std::str::FromStr
             "too_complex" => Ok(TooComplex),
             "too_expensive" => Ok(TooExpensive),
             "unused" => Ok(Unused),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -393,13 +393,13 @@ impl CreateBillingPortalConfigurationFeaturesSubscriptionCancelMode {
 }
 
 impl std::str::FromStr for CreateBillingPortalConfigurationFeaturesSubscriptionCancelMode {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateBillingPortalConfigurationFeaturesSubscriptionCancelMode::*;
         match s {
             "at_period_end" => Ok(AtPeriodEnd),
             "immediately" => Ok(Immediately),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -459,14 +459,14 @@ impl CreateBillingPortalConfigurationFeaturesSubscriptionCancelProrationBehavior
 impl std::str::FromStr
     for CreateBillingPortalConfigurationFeaturesSubscriptionCancelProrationBehavior
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateBillingPortalConfigurationFeaturesSubscriptionCancelProrationBehavior::*;
         match s {
             "always_invoice" => Ok(AlwaysInvoice),
             "create_prorations" => Ok(CreateProrations),
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -551,14 +551,14 @@ impl CreateBillingPortalConfigurationFeaturesSubscriptionUpdateDefaultAllowedUpd
 impl std::str::FromStr
     for CreateBillingPortalConfigurationFeaturesSubscriptionUpdateDefaultAllowedUpdates
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateBillingPortalConfigurationFeaturesSubscriptionUpdateDefaultAllowedUpdates::*;
         match s {
             "price" => Ok(Price),
             "promotion_code" => Ok(PromotionCode),
             "quantity" => Ok(Quantity),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -619,14 +619,14 @@ impl CreateBillingPortalConfigurationFeaturesSubscriptionUpdateProrationBehavior
 impl std::str::FromStr
     for CreateBillingPortalConfigurationFeaturesSubscriptionUpdateProrationBehavior
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateBillingPortalConfigurationFeaturesSubscriptionUpdateProrationBehavior::*;
         match s {
             "always_invoice" => Ok(AlwaysInvoice),
             "create_prorations" => Ok(CreateProrations),
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -806,7 +806,7 @@ impl UpdateBillingPortalConfigurationFeaturesCustomerUpdateAllowedUpdates {
 }
 
 impl std::str::FromStr for UpdateBillingPortalConfigurationFeaturesCustomerUpdateAllowedUpdates {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateBillingPortalConfigurationFeaturesCustomerUpdateAllowedUpdates::*;
         match s {
@@ -816,7 +816,7 @@ impl std::str::FromStr for UpdateBillingPortalConfigurationFeaturesCustomerUpdat
             "phone" => Ok(Phone),
             "shipping" => Ok(Shipping),
             "tax_id" => Ok(TaxId),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -943,7 +943,7 @@ impl UpdateBillingPortalConfigurationFeaturesSubscriptionCancelCancellationReaso
 impl std::str::FromStr
     for UpdateBillingPortalConfigurationFeaturesSubscriptionCancelCancellationReasonOptions
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateBillingPortalConfigurationFeaturesSubscriptionCancelCancellationReasonOptions::*;
         match s {
@@ -955,7 +955,7 @@ impl std::str::FromStr
             "too_complex" => Ok(TooComplex),
             "too_expensive" => Ok(TooExpensive),
             "unused" => Ok(Unused),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1011,13 +1011,13 @@ impl UpdateBillingPortalConfigurationFeaturesSubscriptionCancelMode {
 }
 
 impl std::str::FromStr for UpdateBillingPortalConfigurationFeaturesSubscriptionCancelMode {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateBillingPortalConfigurationFeaturesSubscriptionCancelMode::*;
         match s {
             "at_period_end" => Ok(AtPeriodEnd),
             "immediately" => Ok(Immediately),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1077,14 +1077,14 @@ impl UpdateBillingPortalConfigurationFeaturesSubscriptionCancelProrationBehavior
 impl std::str::FromStr
     for UpdateBillingPortalConfigurationFeaturesSubscriptionCancelProrationBehavior
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateBillingPortalConfigurationFeaturesSubscriptionCancelProrationBehavior::*;
         match s {
             "always_invoice" => Ok(AlwaysInvoice),
             "create_prorations" => Ok(CreateProrations),
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1169,14 +1169,14 @@ impl UpdateBillingPortalConfigurationFeaturesSubscriptionUpdateDefaultAllowedUpd
 impl std::str::FromStr
     for UpdateBillingPortalConfigurationFeaturesSubscriptionUpdateDefaultAllowedUpdates
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateBillingPortalConfigurationFeaturesSubscriptionUpdateDefaultAllowedUpdates::*;
         match s {
             "price" => Ok(Price),
             "promotion_code" => Ok(PromotionCode),
             "quantity" => Ok(Quantity),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1237,14 +1237,14 @@ impl UpdateBillingPortalConfigurationFeaturesSubscriptionUpdateProrationBehavior
 impl std::str::FromStr
     for UpdateBillingPortalConfigurationFeaturesSubscriptionUpdateProrationBehavior
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateBillingPortalConfigurationFeaturesSubscriptionUpdateProrationBehavior::*;
         match s {
             "always_invoice" => Ok(AlwaysInvoice),
             "create_prorations" => Ok(CreateProrations),
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_billing/src/billing_portal_session/requests.rs
+++ b/generated/stripe_billing/src/billing_portal_session/requests.rs
@@ -133,14 +133,14 @@ impl CreateBillingPortalSessionFlowDataAfterCompletionType {
 }
 
 impl std::str::FromStr for CreateBillingPortalSessionFlowDataAfterCompletionType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateBillingPortalSessionFlowDataAfterCompletionType::*;
         match s {
             "hosted_confirmation" => Ok(HostedConfirmation),
             "portal_homepage" => Ok(PortalHomepage),
             "redirect" => Ok(Redirect),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -232,12 +232,12 @@ impl CreateBillingPortalSessionFlowDataSubscriptionCancelRetentionType {
 }
 
 impl std::str::FromStr for CreateBillingPortalSessionFlowDataSubscriptionCancelRetentionType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateBillingPortalSessionFlowDataSubscriptionCancelRetentionType::*;
         match s {
             "coupon_offer" => Ok(CouponOffer),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -359,7 +359,7 @@ impl CreateBillingPortalSessionFlowDataType {
 }
 
 impl std::str::FromStr for CreateBillingPortalSessionFlowDataType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateBillingPortalSessionFlowDataType::*;
         match s {
@@ -367,7 +367,7 @@ impl std::str::FromStr for CreateBillingPortalSessionFlowDataType {
             "subscription_cancel" => Ok(SubscriptionCancel),
             "subscription_update" => Ok(SubscriptionUpdate),
             "subscription_update_confirm" => Ok(SubscriptionUpdateConfirm),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_billing/src/billing_portal_session/types.rs
+++ b/generated/stripe_billing/src/billing_portal_session/types.rs
@@ -313,7 +313,7 @@ impl BillingPortalSessionLocale {
 }
 
 impl std::str::FromStr for BillingPortalSessionLocale {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use BillingPortalSessionLocale::*;
         match s {
@@ -364,7 +364,7 @@ impl std::str::FromStr for BillingPortalSessionLocale {
             "zh" => Ok(Zh),
             "zh-HK" => Ok(ZhMinusHk),
             "zh-TW" => Ok(ZhMinusTw),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -396,9 +396,7 @@ impl miniserde::Deserialize for BillingPortalSessionLocale {
 impl miniserde::de::Visitor for crate::Place<BillingPortalSessionLocale> {
     fn string(&mut self, s: &str) -> miniserde::Result<()> {
         use std::str::FromStr;
-        self.out = Some(
-            BillingPortalSessionLocale::from_str(s).unwrap_or(BillingPortalSessionLocale::Unknown),
-        );
+        self.out = Some(BillingPortalSessionLocale::from_str(s).unwrap());
         Ok(())
     }
 }
@@ -409,6 +407,6 @@ impl<'de> serde::Deserialize<'de> for BillingPortalSessionLocale {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }

--- a/generated/stripe_billing/src/credit_note/requests.rs
+++ b/generated/stripe_billing/src/credit_note/requests.rs
@@ -195,13 +195,13 @@ impl PreviewCreditNoteLinesType {
 }
 
 impl std::str::FromStr for PreviewCreditNoteLinesType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PreviewCreditNoteLinesType::*;
         match s {
             "custom_line_item" => Ok(CustomLineItem),
             "invoice_line_item" => Ok(InvoiceLineItem),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -389,13 +389,13 @@ impl PreviewLinesCreditNoteLinesType {
 }
 
 impl std::str::FromStr for PreviewLinesCreditNoteLinesType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PreviewLinesCreditNoteLinesType::*;
         match s {
             "custom_line_item" => Ok(CustomLineItem),
             "invoice_line_item" => Ok(InvoiceLineItem),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -576,13 +576,13 @@ impl CreateCreditNoteLinesType {
 }
 
 impl std::str::FromStr for CreateCreditNoteLinesType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCreditNoteLinesType::*;
         match s {
             "custom_line_item" => Ok(CustomLineItem),
             "invoice_line_item" => Ok(InvoiceLineItem),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_billing/src/invoice/requests.rs
+++ b/generated/stripe_billing/src/invoice/requests.rs
@@ -295,13 +295,13 @@ impl UpcomingInvoiceAutomaticTaxLiabilityType {
 }
 
 impl std::str::FromStr for UpcomingInvoiceAutomaticTaxLiabilityType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpcomingInvoiceAutomaticTaxLiabilityType::*;
         match s {
             "account" => Ok(Account),
             "self" => Ok(Self_),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -378,14 +378,14 @@ impl UpcomingInvoiceCustomerDetailsTaxExempt {
 }
 
 impl std::str::FromStr for UpcomingInvoiceCustomerDetailsTaxExempt {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpcomingInvoiceCustomerDetailsTaxExempt::*;
         match s {
             "exempt" => Ok(Exempt),
             "none" => Ok(None),
             "reverse" => Ok(Reverse),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -581,7 +581,7 @@ impl UpcomingInvoiceCustomerDetailsTaxIdsType {
 }
 
 impl std::str::FromStr for UpcomingInvoiceCustomerDetailsTaxIdsType {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpcomingInvoiceCustomerDetailsTaxIdsType::*;
         match s {
@@ -651,7 +651,7 @@ impl std::str::FromStr for UpcomingInvoiceCustomerDetailsTaxIdsType {
             "ve_rif" => Ok(VeRif),
             "vn_tin" => Ok(VnTin),
             "za_vat" => Ok(ZaVat),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -679,7 +679,7 @@ impl<'de> serde::Deserialize<'de> for UpcomingInvoiceCustomerDetailsTaxIdsType {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// List of invoice items to add or update in the upcoming invoice preview.
@@ -805,14 +805,14 @@ impl UpcomingInvoiceInvoiceItemsPriceDataTaxBehavior {
 }
 
 impl std::str::FromStr for UpcomingInvoiceInvoiceItemsPriceDataTaxBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpcomingInvoiceInvoiceItemsPriceDataTaxBehavior::*;
         match s {
             "exclusive" => Ok(Exclusive),
             "inclusive" => Ok(Inclusive),
             "unspecified" => Ok(Unspecified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -869,14 +869,14 @@ impl UpcomingInvoiceInvoiceItemsTaxBehavior {
 }
 
 impl std::str::FromStr for UpcomingInvoiceInvoiceItemsTaxBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpcomingInvoiceInvoiceItemsTaxBehavior::*;
         match s {
             "exclusive" => Ok(Exclusive),
             "inclusive" => Ok(Inclusive),
             "unspecified" => Ok(Unspecified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -942,13 +942,13 @@ impl UpcomingInvoiceIssuerType {
 }
 
 impl std::str::FromStr for UpcomingInvoiceIssuerType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpcomingInvoiceIssuerType::*;
         match s {
             "account" => Ok(Account),
             "self" => Ok(Self_),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1114,7 +1114,7 @@ impl UpcomingInvoiceSubscriptionItemsPriceDataRecurringInterval {
 }
 
 impl std::str::FromStr for UpcomingInvoiceSubscriptionItemsPriceDataRecurringInterval {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpcomingInvoiceSubscriptionItemsPriceDataRecurringInterval::*;
         match s {
@@ -1122,7 +1122,7 @@ impl std::str::FromStr for UpcomingInvoiceSubscriptionItemsPriceDataRecurringInt
             "month" => Ok(Month),
             "week" => Ok(Week),
             "year" => Ok(Year),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1179,14 +1179,14 @@ impl UpcomingInvoiceSubscriptionItemsPriceDataTaxBehavior {
 }
 
 impl std::str::FromStr for UpcomingInvoiceSubscriptionItemsPriceDataTaxBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpcomingInvoiceSubscriptionItemsPriceDataTaxBehavior::*;
         match s {
             "exclusive" => Ok(Exclusive),
             "inclusive" => Ok(Inclusive),
             "unspecified" => Ok(Unspecified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1241,14 +1241,14 @@ impl UpcomingInvoiceSubscriptionProrationBehavior {
 }
 
 impl std::str::FromStr for UpcomingInvoiceSubscriptionProrationBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpcomingInvoiceSubscriptionProrationBehavior::*;
         match s {
             "always_invoice" => Ok(AlwaysInvoice),
             "create_prorations" => Ok(CreateProrations),
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1298,12 +1298,12 @@ impl UpcomingInvoiceSubscriptionResumeAt {
 }
 
 impl std::str::FromStr for UpcomingInvoiceSubscriptionResumeAt {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpcomingInvoiceSubscriptionResumeAt::*;
         match s {
             "now" => Ok(Now),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1536,13 +1536,13 @@ impl UpcomingLinesInvoiceAutomaticTaxLiabilityType {
 }
 
 impl std::str::FromStr for UpcomingLinesInvoiceAutomaticTaxLiabilityType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpcomingLinesInvoiceAutomaticTaxLiabilityType::*;
         match s {
             "account" => Ok(Account),
             "self" => Ok(Self_),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1621,14 +1621,14 @@ impl UpcomingLinesInvoiceCustomerDetailsTaxExempt {
 }
 
 impl std::str::FromStr for UpcomingLinesInvoiceCustomerDetailsTaxExempt {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpcomingLinesInvoiceCustomerDetailsTaxExempt::*;
         match s {
             "exempt" => Ok(Exempt),
             "none" => Ok(None),
             "reverse" => Ok(Reverse),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1826,7 +1826,7 @@ impl UpcomingLinesInvoiceCustomerDetailsTaxIdsType {
 }
 
 impl std::str::FromStr for UpcomingLinesInvoiceCustomerDetailsTaxIdsType {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpcomingLinesInvoiceCustomerDetailsTaxIdsType::*;
         match s {
@@ -1896,7 +1896,7 @@ impl std::str::FromStr for UpcomingLinesInvoiceCustomerDetailsTaxIdsType {
             "ve_rif" => Ok(VeRif),
             "vn_tin" => Ok(VnTin),
             "za_vat" => Ok(ZaVat),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -1924,7 +1924,7 @@ impl<'de> serde::Deserialize<'de> for UpcomingLinesInvoiceCustomerDetailsTaxIdsT
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// List of invoice items to add or update in the upcoming invoice preview.
@@ -2050,14 +2050,14 @@ impl UpcomingLinesInvoiceInvoiceItemsPriceDataTaxBehavior {
 }
 
 impl std::str::FromStr for UpcomingLinesInvoiceInvoiceItemsPriceDataTaxBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpcomingLinesInvoiceInvoiceItemsPriceDataTaxBehavior::*;
         match s {
             "exclusive" => Ok(Exclusive),
             "inclusive" => Ok(Inclusive),
             "unspecified" => Ok(Unspecified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2114,14 +2114,14 @@ impl UpcomingLinesInvoiceInvoiceItemsTaxBehavior {
 }
 
 impl std::str::FromStr for UpcomingLinesInvoiceInvoiceItemsTaxBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpcomingLinesInvoiceInvoiceItemsTaxBehavior::*;
         match s {
             "exclusive" => Ok(Exclusive),
             "inclusive" => Ok(Inclusive),
             "unspecified" => Ok(Unspecified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2189,13 +2189,13 @@ impl UpcomingLinesInvoiceIssuerType {
 }
 
 impl std::str::FromStr for UpcomingLinesInvoiceIssuerType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpcomingLinesInvoiceIssuerType::*;
         match s {
             "account" => Ok(Account),
             "self" => Ok(Self_),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2362,7 +2362,7 @@ impl UpcomingLinesInvoiceSubscriptionItemsPriceDataRecurringInterval {
 }
 
 impl std::str::FromStr for UpcomingLinesInvoiceSubscriptionItemsPriceDataRecurringInterval {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpcomingLinesInvoiceSubscriptionItemsPriceDataRecurringInterval::*;
         match s {
@@ -2370,7 +2370,7 @@ impl std::str::FromStr for UpcomingLinesInvoiceSubscriptionItemsPriceDataRecurri
             "month" => Ok(Month),
             "week" => Ok(Week),
             "year" => Ok(Year),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2429,14 +2429,14 @@ impl UpcomingLinesInvoiceSubscriptionItemsPriceDataTaxBehavior {
 }
 
 impl std::str::FromStr for UpcomingLinesInvoiceSubscriptionItemsPriceDataTaxBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpcomingLinesInvoiceSubscriptionItemsPriceDataTaxBehavior::*;
         match s {
             "exclusive" => Ok(Exclusive),
             "inclusive" => Ok(Inclusive),
             "unspecified" => Ok(Unspecified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2491,14 +2491,14 @@ impl UpcomingLinesInvoiceSubscriptionProrationBehavior {
 }
 
 impl std::str::FromStr for UpcomingLinesInvoiceSubscriptionProrationBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpcomingLinesInvoiceSubscriptionProrationBehavior::*;
         match s {
             "always_invoice" => Ok(AlwaysInvoice),
             "create_prorations" => Ok(CreateProrations),
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2548,12 +2548,12 @@ impl UpcomingLinesInvoiceSubscriptionResumeAt {
 }
 
 impl std::str::FromStr for UpcomingLinesInvoiceSubscriptionResumeAt {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpcomingLinesInvoiceSubscriptionResumeAt::*;
         match s {
             "now" => Ok(Now),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2798,13 +2798,13 @@ impl CreateInvoiceAutomaticTaxLiabilityType {
 }
 
 impl std::str::FromStr for CreateInvoiceAutomaticTaxLiabilityType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateInvoiceAutomaticTaxLiabilityType::*;
         match s {
             "account" => Ok(Account),
             "self" => Ok(Self_),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2886,12 +2886,12 @@ impl CreateInvoiceFromInvoiceAction {
 }
 
 impl std::str::FromStr for CreateInvoiceFromInvoiceAction {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateInvoiceFromInvoiceAction::*;
         match s {
             "revision" => Ok(Revision),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2957,13 +2957,13 @@ impl CreateInvoiceIssuerType {
 }
 
 impl std::str::FromStr for CreateInvoiceIssuerType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateInvoiceIssuerType::*;
         match s {
             "account" => Ok(Account),
             "self" => Ok(Self_),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3094,13 +3094,13 @@ impl CreateInvoicePaymentSettingsPaymentMethodOptionsAcssDebitMandateOptionsTran
 impl std::str::FromStr
     for CreateInvoicePaymentSettingsPaymentMethodOptionsAcssDebitMandateOptionsTransactionType
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateInvoicePaymentSettingsPaymentMethodOptionsAcssDebitMandateOptionsTransactionType::*;
         match s {
             "business" => Ok(Business),
             "personal" => Ok(Personal),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3160,14 +3160,14 @@ impl CreateInvoicePaymentSettingsPaymentMethodOptionsAcssDebitVerificationMethod
 impl std::str::FromStr
     for CreateInvoicePaymentSettingsPaymentMethodOptionsAcssDebitVerificationMethod
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateInvoicePaymentSettingsPaymentMethodOptionsAcssDebitVerificationMethod::*;
         match s {
             "automatic" => Ok(Automatic),
             "instant" => Ok(Instant),
             "microdeposits" => Ok(Microdeposits),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3242,7 +3242,7 @@ impl CreateInvoicePaymentSettingsPaymentMethodOptionsBancontactPreferredLanguage
 impl std::str::FromStr
     for CreateInvoicePaymentSettingsPaymentMethodOptionsBancontactPreferredLanguage
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateInvoicePaymentSettingsPaymentMethodOptionsBancontactPreferredLanguage::*;
         match s {
@@ -3250,7 +3250,7 @@ impl std::str::FromStr
             "en" => Ok(En),
             "fr" => Ok(Fr),
             "nl" => Ok(Nl),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3366,12 +3366,12 @@ impl CreateInvoicePaymentSettingsPaymentMethodOptionsCardInstallmentsPlanInterva
 impl std::str::FromStr
     for CreateInvoicePaymentSettingsPaymentMethodOptionsCardInstallmentsPlanInterval
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateInvoicePaymentSettingsPaymentMethodOptionsCardInstallmentsPlanInterval::*;
         match s {
             "month" => Ok(Month),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3427,12 +3427,12 @@ impl CreateInvoicePaymentSettingsPaymentMethodOptionsCardInstallmentsPlanType {
 impl std::str::FromStr
     for CreateInvoicePaymentSettingsPaymentMethodOptionsCardInstallmentsPlanType
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateInvoicePaymentSettingsPaymentMethodOptionsCardInstallmentsPlanType::*;
         match s {
             "fixed_count" => Ok(FixedCount),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3488,14 +3488,14 @@ impl CreateInvoicePaymentSettingsPaymentMethodOptionsCardRequestThreeDSecure {
 }
 
 impl std::str::FromStr for CreateInvoicePaymentSettingsPaymentMethodOptionsCardRequestThreeDSecure {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateInvoicePaymentSettingsPaymentMethodOptionsCardRequestThreeDSecure::*;
         match s {
             "any" => Ok(Any),
             "automatic" => Ok(Automatic),
             "challenge" => Ok(Challenge),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3590,7 +3590,7 @@ impl CreateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccountFinancialConne
 impl std::str::FromStr
     for CreateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccountFinancialConnectionsPermissions
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccountFinancialConnectionsPermissions::*;
         match s {
@@ -3598,7 +3598,7 @@ impl std::str::FromStr
             "ownership" => Ok(Ownership),
             "payment_method" => Ok(PaymentMethod),
             "transactions" => Ok(Transactions),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3656,13 +3656,13 @@ impl CreateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccountFinancialConne
 impl std::str::FromStr
     for CreateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccountFinancialConnectionsPrefetch
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccountFinancialConnectionsPrefetch::*;
         match s {
             "balances" => Ok(Balances),
             "transactions" => Ok(Transactions),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3722,14 +3722,14 @@ impl CreateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccountVerificationMe
 impl std::str::FromStr
     for CreateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccountVerificationMethod
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccountVerificationMethod::*;
         match s {
             "automatic" => Ok(Automatic),
             "instant" => Ok(Instant),
             "microdeposits" => Ok(Microdeposits),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3839,7 +3839,7 @@ impl CreateInvoicePaymentSettingsPaymentMethodTypes {
 }
 
 impl std::str::FromStr for CreateInvoicePaymentSettingsPaymentMethodTypes {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateInvoicePaymentSettingsPaymentMethodTypes::*;
         match s {
@@ -3869,7 +3869,7 @@ impl std::str::FromStr for CreateInvoicePaymentSettingsPaymentMethodTypes {
             "sofort" => Ok(Sofort),
             "us_bank_account" => Ok(UsBankAccount),
             "wechat_pay" => Ok(WechatPay),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -3897,7 +3897,7 @@ impl<'de> serde::Deserialize<'de> for CreateInvoicePaymentSettingsPaymentMethodT
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// How to handle pending invoice items on invoice creation.
@@ -3923,14 +3923,14 @@ impl CreateInvoicePendingInvoiceItemsBehavior {
 }
 
 impl std::str::FromStr for CreateInvoicePendingInvoiceItemsBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateInvoicePendingInvoiceItemsBehavior::*;
         match s {
             "exclude" => Ok(Exclude),
             "include" => Ok(Include),
             "include_and_require" => Ok(IncludeAndRequire),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4001,13 +4001,13 @@ impl CreateInvoiceRenderingAmountTaxDisplay {
 }
 
 impl std::str::FromStr for CreateInvoiceRenderingAmountTaxDisplay {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateInvoiceRenderingAmountTaxDisplay::*;
         match s {
             "exclude_tax" => Ok(ExcludeTax),
             "include_inclusive_tax" => Ok(IncludeInclusiveTax),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4075,14 +4075,14 @@ impl CreateInvoiceRenderingPdfPageSize {
 }
 
 impl std::str::FromStr for CreateInvoiceRenderingPdfPageSize {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateInvoiceRenderingPdfPageSize::*;
         match s {
             "a4" => Ok(A4),
             "auto" => Ok(Auto),
             "letter" => Ok(Letter),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4152,13 +4152,13 @@ impl CreateInvoiceRenderingOptionsAmountTaxDisplay {
 }
 
 impl std::str::FromStr for CreateInvoiceRenderingOptionsAmountTaxDisplay {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateInvoiceRenderingOptionsAmountTaxDisplay::*;
         match s {
             "exclude_tax" => Ok(ExcludeTax),
             "include_inclusive_tax" => Ok(IncludeInclusiveTax),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4308,7 +4308,7 @@ impl CreateInvoiceShippingCostShippingRateDataDeliveryEstimateMaximumUnit {
 }
 
 impl std::str::FromStr for CreateInvoiceShippingCostShippingRateDataDeliveryEstimateMaximumUnit {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateInvoiceShippingCostShippingRateDataDeliveryEstimateMaximumUnit::*;
         match s {
@@ -4317,7 +4317,7 @@ impl std::str::FromStr for CreateInvoiceShippingCostShippingRateDataDeliveryEsti
             "hour" => Ok(Hour),
             "month" => Ok(Month),
             "week" => Ok(Week),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4389,7 +4389,7 @@ impl CreateInvoiceShippingCostShippingRateDataDeliveryEstimateMinimumUnit {
 }
 
 impl std::str::FromStr for CreateInvoiceShippingCostShippingRateDataDeliveryEstimateMinimumUnit {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateInvoiceShippingCostShippingRateDataDeliveryEstimateMinimumUnit::*;
         match s {
@@ -4398,7 +4398,7 @@ impl std::str::FromStr for CreateInvoiceShippingCostShippingRateDataDeliveryEsti
             "hour" => Ok(Hour),
             "month" => Ok(Month),
             "week" => Ok(Week),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4493,14 +4493,14 @@ impl CreateInvoiceShippingCostShippingRateDataFixedAmountCurrencyOptionsTaxBehav
 impl std::str::FromStr
     for CreateInvoiceShippingCostShippingRateDataFixedAmountCurrencyOptionsTaxBehavior
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateInvoiceShippingCostShippingRateDataFixedAmountCurrencyOptionsTaxBehavior::*;
         match s {
             "exclusive" => Ok(Exclusive),
             "inclusive" => Ok(Inclusive),
             "unspecified" => Ok(Unspecified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4559,14 +4559,14 @@ impl CreateInvoiceShippingCostShippingRateDataTaxBehavior {
 }
 
 impl std::str::FromStr for CreateInvoiceShippingCostShippingRateDataTaxBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateInvoiceShippingCostShippingRateDataTaxBehavior::*;
         match s {
             "exclusive" => Ok(Exclusive),
             "inclusive" => Ok(Inclusive),
             "unspecified" => Ok(Unspecified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4616,12 +4616,12 @@ impl CreateInvoiceShippingCostShippingRateDataType {
 }
 
 impl std::str::FromStr for CreateInvoiceShippingCostShippingRateDataType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateInvoiceShippingCostShippingRateDataType::*;
         match s {
             "fixed_amount" => Ok(FixedAmount),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4831,13 +4831,13 @@ impl UpdateInvoiceAutomaticTaxLiabilityType {
 }
 
 impl std::str::FromStr for UpdateInvoiceAutomaticTaxLiabilityType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateInvoiceAutomaticTaxLiabilityType::*;
         match s {
             "account" => Ok(Account),
             "self" => Ok(Self_),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4919,13 +4919,13 @@ impl UpdateInvoiceIssuerType {
 }
 
 impl std::str::FromStr for UpdateInvoiceIssuerType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateInvoiceIssuerType::*;
         match s {
             "account" => Ok(Account),
             "self" => Ok(Self_),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5056,13 +5056,13 @@ impl UpdateInvoicePaymentSettingsPaymentMethodOptionsAcssDebitMandateOptionsTran
 impl std::str::FromStr
     for UpdateInvoicePaymentSettingsPaymentMethodOptionsAcssDebitMandateOptionsTransactionType
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateInvoicePaymentSettingsPaymentMethodOptionsAcssDebitMandateOptionsTransactionType::*;
         match s {
             "business" => Ok(Business),
             "personal" => Ok(Personal),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5122,14 +5122,14 @@ impl UpdateInvoicePaymentSettingsPaymentMethodOptionsAcssDebitVerificationMethod
 impl std::str::FromStr
     for UpdateInvoicePaymentSettingsPaymentMethodOptionsAcssDebitVerificationMethod
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateInvoicePaymentSettingsPaymentMethodOptionsAcssDebitVerificationMethod::*;
         match s {
             "automatic" => Ok(Automatic),
             "instant" => Ok(Instant),
             "microdeposits" => Ok(Microdeposits),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5204,7 +5204,7 @@ impl UpdateInvoicePaymentSettingsPaymentMethodOptionsBancontactPreferredLanguage
 impl std::str::FromStr
     for UpdateInvoicePaymentSettingsPaymentMethodOptionsBancontactPreferredLanguage
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateInvoicePaymentSettingsPaymentMethodOptionsBancontactPreferredLanguage::*;
         match s {
@@ -5212,7 +5212,7 @@ impl std::str::FromStr
             "en" => Ok(En),
             "fr" => Ok(Fr),
             "nl" => Ok(Nl),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5328,12 +5328,12 @@ impl UpdateInvoicePaymentSettingsPaymentMethodOptionsCardInstallmentsPlanInterva
 impl std::str::FromStr
     for UpdateInvoicePaymentSettingsPaymentMethodOptionsCardInstallmentsPlanInterval
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateInvoicePaymentSettingsPaymentMethodOptionsCardInstallmentsPlanInterval::*;
         match s {
             "month" => Ok(Month),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5389,12 +5389,12 @@ impl UpdateInvoicePaymentSettingsPaymentMethodOptionsCardInstallmentsPlanType {
 impl std::str::FromStr
     for UpdateInvoicePaymentSettingsPaymentMethodOptionsCardInstallmentsPlanType
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateInvoicePaymentSettingsPaymentMethodOptionsCardInstallmentsPlanType::*;
         match s {
             "fixed_count" => Ok(FixedCount),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5450,14 +5450,14 @@ impl UpdateInvoicePaymentSettingsPaymentMethodOptionsCardRequestThreeDSecure {
 }
 
 impl std::str::FromStr for UpdateInvoicePaymentSettingsPaymentMethodOptionsCardRequestThreeDSecure {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateInvoicePaymentSettingsPaymentMethodOptionsCardRequestThreeDSecure::*;
         match s {
             "any" => Ok(Any),
             "automatic" => Ok(Automatic),
             "challenge" => Ok(Challenge),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5552,7 +5552,7 @@ impl UpdateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccountFinancialConne
 impl std::str::FromStr
     for UpdateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccountFinancialConnectionsPermissions
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccountFinancialConnectionsPermissions::*;
         match s {
@@ -5560,7 +5560,7 @@ impl std::str::FromStr
             "ownership" => Ok(Ownership),
             "payment_method" => Ok(PaymentMethod),
             "transactions" => Ok(Transactions),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5618,13 +5618,13 @@ impl UpdateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccountFinancialConne
 impl std::str::FromStr
     for UpdateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccountFinancialConnectionsPrefetch
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccountFinancialConnectionsPrefetch::*;
         match s {
             "balances" => Ok(Balances),
             "transactions" => Ok(Transactions),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5684,14 +5684,14 @@ impl UpdateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccountVerificationMe
 impl std::str::FromStr
     for UpdateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccountVerificationMethod
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccountVerificationMethod::*;
         match s {
             "automatic" => Ok(Automatic),
             "instant" => Ok(Instant),
             "microdeposits" => Ok(Microdeposits),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5801,7 +5801,7 @@ impl UpdateInvoicePaymentSettingsPaymentMethodTypes {
 }
 
 impl std::str::FromStr for UpdateInvoicePaymentSettingsPaymentMethodTypes {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateInvoicePaymentSettingsPaymentMethodTypes::*;
         match s {
@@ -5831,7 +5831,7 @@ impl std::str::FromStr for UpdateInvoicePaymentSettingsPaymentMethodTypes {
             "sofort" => Ok(Sofort),
             "us_bank_account" => Ok(UsBankAccount),
             "wechat_pay" => Ok(WechatPay),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -5859,7 +5859,7 @@ impl<'de> serde::Deserialize<'de> for UpdateInvoicePaymentSettingsPaymentMethodT
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// The rendering-related settings that control how the invoice is displayed on customer-facing surfaces such as PDF and Hosted Invoice Page.
@@ -5900,13 +5900,13 @@ impl UpdateInvoiceRenderingAmountTaxDisplay {
 }
 
 impl std::str::FromStr for UpdateInvoiceRenderingAmountTaxDisplay {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateInvoiceRenderingAmountTaxDisplay::*;
         match s {
             "exclude_tax" => Ok(ExcludeTax),
             "include_inclusive_tax" => Ok(IncludeInclusiveTax),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5974,14 +5974,14 @@ impl UpdateInvoiceRenderingPdfPageSize {
 }
 
 impl std::str::FromStr for UpdateInvoiceRenderingPdfPageSize {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateInvoiceRenderingPdfPageSize::*;
         match s {
             "a4" => Ok(A4),
             "auto" => Ok(Auto),
             "letter" => Ok(Letter),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -6051,13 +6051,13 @@ impl UpdateInvoiceRenderingOptionsAmountTaxDisplay {
 }
 
 impl std::str::FromStr for UpdateInvoiceRenderingOptionsAmountTaxDisplay {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateInvoiceRenderingOptionsAmountTaxDisplay::*;
         match s {
             "exclude_tax" => Ok(ExcludeTax),
             "include_inclusive_tax" => Ok(IncludeInclusiveTax),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -6207,7 +6207,7 @@ impl UpdateInvoiceShippingCostShippingRateDataDeliveryEstimateMaximumUnit {
 }
 
 impl std::str::FromStr for UpdateInvoiceShippingCostShippingRateDataDeliveryEstimateMaximumUnit {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateInvoiceShippingCostShippingRateDataDeliveryEstimateMaximumUnit::*;
         match s {
@@ -6216,7 +6216,7 @@ impl std::str::FromStr for UpdateInvoiceShippingCostShippingRateDataDeliveryEsti
             "hour" => Ok(Hour),
             "month" => Ok(Month),
             "week" => Ok(Week),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -6288,7 +6288,7 @@ impl UpdateInvoiceShippingCostShippingRateDataDeliveryEstimateMinimumUnit {
 }
 
 impl std::str::FromStr for UpdateInvoiceShippingCostShippingRateDataDeliveryEstimateMinimumUnit {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateInvoiceShippingCostShippingRateDataDeliveryEstimateMinimumUnit::*;
         match s {
@@ -6297,7 +6297,7 @@ impl std::str::FromStr for UpdateInvoiceShippingCostShippingRateDataDeliveryEsti
             "hour" => Ok(Hour),
             "month" => Ok(Month),
             "week" => Ok(Week),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -6392,14 +6392,14 @@ impl UpdateInvoiceShippingCostShippingRateDataFixedAmountCurrencyOptionsTaxBehav
 impl std::str::FromStr
     for UpdateInvoiceShippingCostShippingRateDataFixedAmountCurrencyOptionsTaxBehavior
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateInvoiceShippingCostShippingRateDataFixedAmountCurrencyOptionsTaxBehavior::*;
         match s {
             "exclusive" => Ok(Exclusive),
             "inclusive" => Ok(Inclusive),
             "unspecified" => Ok(Unspecified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -6458,14 +6458,14 @@ impl UpdateInvoiceShippingCostShippingRateDataTaxBehavior {
 }
 
 impl std::str::FromStr for UpdateInvoiceShippingCostShippingRateDataTaxBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateInvoiceShippingCostShippingRateDataTaxBehavior::*;
         match s {
             "exclusive" => Ok(Exclusive),
             "inclusive" => Ok(Inclusive),
             "unspecified" => Ok(Unspecified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -6515,12 +6515,12 @@ impl UpdateInvoiceShippingCostShippingRateDataType {
 }
 
 impl std::str::FromStr for UpdateInvoiceShippingCostShippingRateDataType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateInvoiceShippingCostShippingRateDataType::*;
         match s {
             "fixed_amount" => Ok(FixedAmount),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_billing/src/invoice_item/requests.rs
+++ b/generated/stripe_billing/src/invoice_item/requests.rs
@@ -247,14 +247,14 @@ impl CreateInvoiceItemPriceDataTaxBehavior {
 }
 
 impl std::str::FromStr for CreateInvoiceItemPriceDataTaxBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateInvoiceItemPriceDataTaxBehavior::*;
         match s {
             "exclusive" => Ok(Exclusive),
             "inclusive" => Ok(Inclusive),
             "unspecified" => Ok(Unspecified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -309,14 +309,14 @@ impl CreateInvoiceItemTaxBehavior {
 }
 
 impl std::str::FromStr for CreateInvoiceItemTaxBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateInvoiceItemTaxBehavior::*;
         match s {
             "exclusive" => Ok(Exclusive),
             "inclusive" => Ok(Inclusive),
             "unspecified" => Ok(Unspecified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -477,14 +477,14 @@ impl UpdateInvoiceItemPriceDataTaxBehavior {
 }
 
 impl std::str::FromStr for UpdateInvoiceItemPriceDataTaxBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateInvoiceItemPriceDataTaxBehavior::*;
         match s {
             "exclusive" => Ok(Exclusive),
             "inclusive" => Ok(Inclusive),
             "unspecified" => Ok(Unspecified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -539,14 +539,14 @@ impl UpdateInvoiceItemTaxBehavior {
 }
 
 impl std::str::FromStr for UpdateInvoiceItemTaxBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateInvoiceItemTaxBehavior::*;
         match s {
             "exclusive" => Ok(Exclusive),
             "inclusive" => Ok(Inclusive),
             "unspecified" => Ok(Unspecified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_billing/src/invoice_line_item/requests.rs
+++ b/generated/stripe_billing/src/invoice_line_item/requests.rs
@@ -223,14 +223,14 @@ impl UpdateInvoiceLineItemPriceDataTaxBehavior {
 }
 
 impl std::str::FromStr for UpdateInvoiceLineItemPriceDataTaxBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateInvoiceLineItemPriceDataTaxBehavior::*;
         match s {
             "exclusive" => Ok(Exclusive),
             "inclusive" => Ok(Inclusive),
             "unspecified" => Ok(Unspecified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -382,7 +382,7 @@ impl UpdateInvoiceLineItemTaxAmountsTaxRateDataTaxType {
 }
 
 impl std::str::FromStr for UpdateInvoiceLineItemTaxAmountsTaxRateDataTaxType {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateInvoiceLineItemTaxAmountsTaxRateDataTaxType::*;
         match s {
@@ -399,7 +399,7 @@ impl std::str::FromStr for UpdateInvoiceLineItemTaxAmountsTaxRateDataTaxType {
             "sales_tax" => Ok(SalesTax),
             "service_tax" => Ok(ServiceTax),
             "vat" => Ok(Vat),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -427,7 +427,7 @@ impl<'de> serde::Deserialize<'de> for UpdateInvoiceLineItemTaxAmountsTaxRateData
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 impl<'a> UpdateInvoiceLineItem<'a> {

--- a/generated/stripe_billing/src/plan/requests.rs
+++ b/generated/stripe_billing/src/plan/requests.rs
@@ -312,13 +312,13 @@ impl CreatePlanTransformUsageRound {
 }
 
 impl std::str::FromStr for CreatePlanTransformUsageRound {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePlanTransformUsageRound::*;
         match s {
             "down" => Ok(Down),
             "up" => Ok(Up),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_billing/src/portal_customer_update.rs
+++ b/generated/stripe_billing/src/portal_customer_update.rs
@@ -124,7 +124,7 @@ impl PortalCustomerUpdateAllowedUpdates {
 }
 
 impl std::str::FromStr for PortalCustomerUpdateAllowedUpdates {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PortalCustomerUpdateAllowedUpdates::*;
         match s {
@@ -134,7 +134,7 @@ impl std::str::FromStr for PortalCustomerUpdateAllowedUpdates {
             "phone" => Ok(Phone),
             "shipping" => Ok(Shipping),
             "tax_id" => Ok(TaxId),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_billing/src/portal_flows_flow.rs
+++ b/generated/stripe_billing/src/portal_flows_flow.rs
@@ -154,7 +154,7 @@ impl PortalFlowsFlowType {
 }
 
 impl std::str::FromStr for PortalFlowsFlowType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PortalFlowsFlowType::*;
         match s {
@@ -162,7 +162,7 @@ impl std::str::FromStr for PortalFlowsFlowType {
             "subscription_cancel" => Ok(SubscriptionCancel),
             "subscription_update" => Ok(SubscriptionUpdate),
             "subscription_update_confirm" => Ok(SubscriptionUpdateConfirm),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_billing/src/portal_flows_flow_after_completion.rs
+++ b/generated/stripe_billing/src/portal_flows_flow_after_completion.rs
@@ -132,14 +132,14 @@ impl PortalFlowsFlowAfterCompletionType {
 }
 
 impl std::str::FromStr for PortalFlowsFlowAfterCompletionType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PortalFlowsFlowAfterCompletionType::*;
         match s {
             "hosted_confirmation" => Ok(HostedConfirmation),
             "portal_homepage" => Ok(PortalHomepage),
             "redirect" => Ok(Redirect),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_billing/src/portal_flows_retention.rs
+++ b/generated/stripe_billing/src/portal_flows_retention.rs
@@ -112,12 +112,12 @@ impl PortalFlowsRetentionType {
 }
 
 impl std::str::FromStr for PortalFlowsRetentionType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PortalFlowsRetentionType::*;
         match s {
             "coupon_offer" => Ok(CouponOffer),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_billing/src/portal_subscription_cancel.rs
+++ b/generated/stripe_billing/src/portal_subscription_cancel.rs
@@ -137,13 +137,13 @@ impl PortalSubscriptionCancelMode {
 }
 
 impl std::str::FromStr for PortalSubscriptionCancelMode {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PortalSubscriptionCancelMode::*;
         match s {
             "at_period_end" => Ok(AtPeriodEnd),
             "immediately" => Ok(Immediately),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -211,14 +211,14 @@ impl PortalSubscriptionCancelProrationBehavior {
 }
 
 impl std::str::FromStr for PortalSubscriptionCancelProrationBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PortalSubscriptionCancelProrationBehavior::*;
         match s {
             "always_invoice" => Ok(AlwaysInvoice),
             "create_prorations" => Ok(CreateProrations),
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_billing/src/portal_subscription_cancellation_reason.rs
+++ b/generated/stripe_billing/src/portal_subscription_cancellation_reason.rs
@@ -125,7 +125,7 @@ impl PortalSubscriptionCancellationReasonOptions {
 }
 
 impl std::str::FromStr for PortalSubscriptionCancellationReasonOptions {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PortalSubscriptionCancellationReasonOptions::*;
         match s {
@@ -137,7 +137,7 @@ impl std::str::FromStr for PortalSubscriptionCancellationReasonOptions {
             "too_complex" => Ok(TooComplex),
             "too_expensive" => Ok(TooExpensive),
             "unused" => Ok(Unused),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_billing/src/portal_subscription_update.rs
+++ b/generated/stripe_billing/src/portal_subscription_update.rs
@@ -142,14 +142,14 @@ impl PortalSubscriptionUpdateDefaultAllowedUpdates {
 }
 
 impl std::str::FromStr for PortalSubscriptionUpdateDefaultAllowedUpdates {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PortalSubscriptionUpdateDefaultAllowedUpdates::*;
         match s {
             "price" => Ok(Price),
             "promotion_code" => Ok(PromotionCode),
             "quantity" => Ok(Quantity),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -223,14 +223,14 @@ impl PortalSubscriptionUpdateProrationBehavior {
 }
 
 impl std::str::FromStr for PortalSubscriptionUpdateProrationBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PortalSubscriptionUpdateProrationBehavior::*;
         match s {
             "always_invoice" => Ok(AlwaysInvoice),
             "create_prorations" => Ok(CreateProrations),
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_billing/src/quote/requests.rs
+++ b/generated/stripe_billing/src/quote/requests.rs
@@ -292,13 +292,13 @@ impl CreateQuoteAutomaticTaxLiabilityType {
 }
 
 impl std::str::FromStr for CreateQuoteAutomaticTaxLiabilityType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateQuoteAutomaticTaxLiabilityType::*;
         match s {
             "account" => Ok(Account),
             "self" => Ok(Self_),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -397,13 +397,13 @@ impl CreateQuoteInvoiceSettingsIssuerType {
 }
 
 impl std::str::FromStr for CreateQuoteInvoiceSettingsIssuerType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateQuoteInvoiceSettingsIssuerType::*;
         match s {
             "account" => Ok(Account),
             "self" => Ok(Self_),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -535,7 +535,7 @@ impl CreateQuoteLineItemsPriceDataRecurringInterval {
 }
 
 impl std::str::FromStr for CreateQuoteLineItemsPriceDataRecurringInterval {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateQuoteLineItemsPriceDataRecurringInterval::*;
         match s {
@@ -543,7 +543,7 @@ impl std::str::FromStr for CreateQuoteLineItemsPriceDataRecurringInterval {
             "month" => Ok(Month),
             "week" => Ok(Week),
             "year" => Ok(Year),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -600,14 +600,14 @@ impl CreateQuoteLineItemsPriceDataTaxBehavior {
 }
 
 impl std::str::FromStr for CreateQuoteLineItemsPriceDataTaxBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateQuoteLineItemsPriceDataTaxBehavior::*;
         match s {
             "exclusive" => Ok(Exclusive),
             "inclusive" => Ok(Inclusive),
             "unspecified" => Ok(Unspecified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -815,13 +815,13 @@ impl UpdateQuoteAutomaticTaxLiabilityType {
 }
 
 impl std::str::FromStr for UpdateQuoteAutomaticTaxLiabilityType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateQuoteAutomaticTaxLiabilityType::*;
         match s {
             "account" => Ok(Account),
             "self" => Ok(Self_),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -904,13 +904,13 @@ impl UpdateQuoteInvoiceSettingsIssuerType {
 }
 
 impl std::str::FromStr for UpdateQuoteInvoiceSettingsIssuerType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateQuoteInvoiceSettingsIssuerType::*;
         match s {
             "account" => Ok(Account),
             "self" => Ok(Self_),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1045,7 +1045,7 @@ impl UpdateQuoteLineItemsPriceDataRecurringInterval {
 }
 
 impl std::str::FromStr for UpdateQuoteLineItemsPriceDataRecurringInterval {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateQuoteLineItemsPriceDataRecurringInterval::*;
         match s {
@@ -1053,7 +1053,7 @@ impl std::str::FromStr for UpdateQuoteLineItemsPriceDataRecurringInterval {
             "month" => Ok(Month),
             "week" => Ok(Week),
             "year" => Ok(Year),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1110,14 +1110,14 @@ impl UpdateQuoteLineItemsPriceDataTaxBehavior {
 }
 
 impl std::str::FromStr for UpdateQuoteLineItemsPriceDataTaxBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateQuoteLineItemsPriceDataTaxBehavior::*;
         match s {
             "exclusive" => Ok(Exclusive),
             "inclusive" => Ok(Inclusive),
             "unspecified" => Ok(Unspecified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_billing/src/subscription/requests.rs
+++ b/generated/stripe_billing/src/subscription/requests.rs
@@ -62,7 +62,7 @@ impl CancelSubscriptionCancellationDetailsFeedback {
 }
 
 impl std::str::FromStr for CancelSubscriptionCancellationDetailsFeedback {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CancelSubscriptionCancellationDetailsFeedback::*;
         match s {
@@ -74,7 +74,7 @@ impl std::str::FromStr for CancelSubscriptionCancellationDetailsFeedback {
             "too_complex" => Ok(TooComplex),
             "too_expensive" => Ok(TooExpensive),
             "unused" => Ok(Unused),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -260,7 +260,7 @@ impl ListSubscriptionStatus {
 }
 
 impl std::str::FromStr for ListSubscriptionStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ListSubscriptionStatus::*;
         match s {
@@ -274,7 +274,7 @@ impl std::str::FromStr for ListSubscriptionStatus {
             "paused" => Ok(Paused),
             "trialing" => Ok(Trialing),
             "unpaid" => Ok(Unpaid),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -662,14 +662,14 @@ impl CreateSubscriptionAddInvoiceItemsPriceDataTaxBehavior {
 }
 
 impl std::str::FromStr for CreateSubscriptionAddInvoiceItemsPriceDataTaxBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSubscriptionAddInvoiceItemsPriceDataTaxBehavior::*;
         match s {
             "exclusive" => Ok(Exclusive),
             "inclusive" => Ok(Inclusive),
             "unspecified" => Ok(Unspecified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -755,13 +755,13 @@ impl CreateSubscriptionAutomaticTaxLiabilityType {
 }
 
 impl std::str::FromStr for CreateSubscriptionAutomaticTaxLiabilityType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSubscriptionAutomaticTaxLiabilityType::*;
         match s {
             "account" => Ok(Account),
             "self" => Ok(Self_),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -870,13 +870,13 @@ impl CreateSubscriptionInvoiceSettingsIssuerType {
 }
 
 impl std::str::FromStr for CreateSubscriptionInvoiceSettingsIssuerType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSubscriptionInvoiceSettingsIssuerType::*;
         match s {
             "account" => Ok(Account),
             "self" => Ok(Self_),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1024,7 +1024,7 @@ impl CreateSubscriptionItemsPriceDataRecurringInterval {
 }
 
 impl std::str::FromStr for CreateSubscriptionItemsPriceDataRecurringInterval {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSubscriptionItemsPriceDataRecurringInterval::*;
         match s {
@@ -1032,7 +1032,7 @@ impl std::str::FromStr for CreateSubscriptionItemsPriceDataRecurringInterval {
             "month" => Ok(Month),
             "week" => Ok(Week),
             "year" => Ok(Year),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1089,14 +1089,14 @@ impl CreateSubscriptionItemsPriceDataTaxBehavior {
 }
 
 impl std::str::FromStr for CreateSubscriptionItemsPriceDataTaxBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSubscriptionItemsPriceDataTaxBehavior::*;
         match s {
             "exclusive" => Ok(Exclusive),
             "inclusive" => Ok(Inclusive),
             "unspecified" => Ok(Unspecified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1173,7 +1173,7 @@ impl CreateSubscriptionPaymentBehavior {
 }
 
 impl std::str::FromStr for CreateSubscriptionPaymentBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSubscriptionPaymentBehavior::*;
         match s {
@@ -1181,7 +1181,7 @@ impl std::str::FromStr for CreateSubscriptionPaymentBehavior {
             "default_incomplete" => Ok(DefaultIncomplete),
             "error_if_incomplete" => Ok(ErrorIfIncomplete),
             "pending_if_incomplete" => Ok(PendingIfIncomplete),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1316,13 +1316,13 @@ impl CreateSubscriptionPaymentSettingsPaymentMethodOptionsAcssDebitMandateOption
 impl std::str::FromStr
     for CreateSubscriptionPaymentSettingsPaymentMethodOptionsAcssDebitMandateOptionsTransactionType
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSubscriptionPaymentSettingsPaymentMethodOptionsAcssDebitMandateOptionsTransactionType::*;
         match s {
             "business" => Ok(Business),
             "personal" => Ok(Personal),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1382,14 +1382,14 @@ impl CreateSubscriptionPaymentSettingsPaymentMethodOptionsAcssDebitVerificationM
 impl std::str::FromStr
     for CreateSubscriptionPaymentSettingsPaymentMethodOptionsAcssDebitVerificationMethod
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSubscriptionPaymentSettingsPaymentMethodOptionsAcssDebitVerificationMethod::*;
         match s {
             "automatic" => Ok(Automatic),
             "instant" => Ok(Instant),
             "microdeposits" => Ok(Microdeposits),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1464,7 +1464,7 @@ impl CreateSubscriptionPaymentSettingsPaymentMethodOptionsBancontactPreferredLan
 impl std::str::FromStr
     for CreateSubscriptionPaymentSettingsPaymentMethodOptionsBancontactPreferredLanguage
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSubscriptionPaymentSettingsPaymentMethodOptionsBancontactPreferredLanguage::*;
         match s {
@@ -1472,7 +1472,7 @@ impl std::str::FromStr
             "en" => Ok(En),
             "fr" => Ok(Fr),
             "nl" => Ok(Nl),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1577,13 +1577,13 @@ impl CreateSubscriptionPaymentSettingsPaymentMethodOptionsCardMandateOptionsAmou
 impl std::str::FromStr
     for CreateSubscriptionPaymentSettingsPaymentMethodOptionsCardMandateOptionsAmountType
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSubscriptionPaymentSettingsPaymentMethodOptionsCardMandateOptionsAmountType::*;
         match s {
             "fixed" => Ok(Fixed),
             "maximum" => Ok(Maximum),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1659,7 +1659,7 @@ impl CreateSubscriptionPaymentSettingsPaymentMethodOptionsCardNetwork {
 }
 
 impl std::str::FromStr for CreateSubscriptionPaymentSettingsPaymentMethodOptionsCardNetwork {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSubscriptionPaymentSettingsPaymentMethodOptionsCardNetwork::*;
         match s {
@@ -1674,7 +1674,7 @@ impl std::str::FromStr for CreateSubscriptionPaymentSettingsPaymentMethodOptions
             "unionpay" => Ok(Unionpay),
             "unknown" => Ok(Unknown),
             "visa" => Ok(Visa),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1730,14 +1730,14 @@ impl CreateSubscriptionPaymentSettingsPaymentMethodOptionsCardRequestThreeDSecur
 impl std::str::FromStr
     for CreateSubscriptionPaymentSettingsPaymentMethodOptionsCardRequestThreeDSecure
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSubscriptionPaymentSettingsPaymentMethodOptionsCardRequestThreeDSecure::*;
         match s {
             "any" => Ok(Any),
             "automatic" => Ok(Automatic),
             "challenge" => Ok(Challenge),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1840,7 +1840,7 @@ Transactions => "transactions",
 }
 
 impl std::str::FromStr for CreateSubscriptionPaymentSettingsPaymentMethodOptionsUsBankAccountFinancialConnectionsPermissions {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSubscriptionPaymentSettingsPaymentMethodOptionsUsBankAccountFinancialConnectionsPermissions::*;
         match s {
@@ -1848,7 +1848,7 @@ impl std::str::FromStr for CreateSubscriptionPaymentSettingsPaymentMethodOptions
 "ownership" => Ok(Ownership),
 "payment_method" => Ok(PaymentMethod),
 "transactions" => Ok(Transactions),
-_ => Err(())
+_ => Err(stripe_types::StripeParseError)
 
         }
     }
@@ -1897,13 +1897,13 @@ impl
 }
 
 impl std::str::FromStr for CreateSubscriptionPaymentSettingsPaymentMethodOptionsUsBankAccountFinancialConnectionsPrefetch {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSubscriptionPaymentSettingsPaymentMethodOptionsUsBankAccountFinancialConnectionsPrefetch::*;
         match s {
     "balances" => Ok(Balances),
 "transactions" => Ok(Transactions),
-_ => Err(())
+_ => Err(stripe_types::StripeParseError)
 
         }
     }
@@ -1953,14 +1953,14 @@ impl CreateSubscriptionPaymentSettingsPaymentMethodOptionsUsBankAccountVerificat
 impl std::str::FromStr
     for CreateSubscriptionPaymentSettingsPaymentMethodOptionsUsBankAccountVerificationMethod
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSubscriptionPaymentSettingsPaymentMethodOptionsUsBankAccountVerificationMethod::*;
         match s {
             "automatic" => Ok(Automatic),
             "instant" => Ok(Instant),
             "microdeposits" => Ok(Microdeposits),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2070,7 +2070,7 @@ impl CreateSubscriptionPaymentSettingsPaymentMethodTypes {
 }
 
 impl std::str::FromStr for CreateSubscriptionPaymentSettingsPaymentMethodTypes {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSubscriptionPaymentSettingsPaymentMethodTypes::*;
         match s {
@@ -2100,7 +2100,7 @@ impl std::str::FromStr for CreateSubscriptionPaymentSettingsPaymentMethodTypes {
             "sofort" => Ok(Sofort),
             "us_bank_account" => Ok(UsBankAccount),
             "wechat_pay" => Ok(WechatPay),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -2128,7 +2128,7 @@ impl<'de> serde::Deserialize<'de> for CreateSubscriptionPaymentSettingsPaymentMe
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// Either `off`, or `on_subscription`.
@@ -2149,13 +2149,13 @@ impl CreateSubscriptionPaymentSettingsSaveDefaultPaymentMethod {
 }
 
 impl std::str::FromStr for CreateSubscriptionPaymentSettingsSaveDefaultPaymentMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSubscriptionPaymentSettingsSaveDefaultPaymentMethod::*;
         match s {
             "off" => Ok(Off),
             "on_subscription" => Ok(OnSubscription),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2228,7 +2228,7 @@ impl CreateSubscriptionPendingInvoiceItemIntervalInterval {
 }
 
 impl std::str::FromStr for CreateSubscriptionPendingInvoiceItemIntervalInterval {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSubscriptionPendingInvoiceItemIntervalInterval::*;
         match s {
@@ -2236,7 +2236,7 @@ impl std::str::FromStr for CreateSubscriptionPendingInvoiceItemIntervalInterval 
             "month" => Ok(Month),
             "week" => Ok(Week),
             "year" => Ok(Year),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2291,14 +2291,14 @@ impl CreateSubscriptionProrationBehavior {
 }
 
 impl std::str::FromStr for CreateSubscriptionProrationBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSubscriptionProrationBehavior::*;
         match s {
             "always_invoice" => Ok(AlwaysInvoice),
             "create_prorations" => Ok(CreateProrations),
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2385,14 +2385,14 @@ impl CreateSubscriptionTrialSettingsEndBehaviorMissingPaymentMethod {
 }
 
 impl std::str::FromStr for CreateSubscriptionTrialSettingsEndBehaviorMissingPaymentMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSubscriptionTrialSettingsEndBehaviorMissingPaymentMethod::*;
         match s {
             "cancel" => Ok(Cancel),
             "create_invoice" => Ok(CreateInvoice),
             "pause" => Ok(Pause),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2487,13 +2487,13 @@ impl ResumeSubscriptionBillingCycleAnchor {
 }
 
 impl std::str::FromStr for ResumeSubscriptionBillingCycleAnchor {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ResumeSubscriptionBillingCycleAnchor::*;
         match s {
             "now" => Ok(Now),
             "unchanged" => Ok(Unchanged),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2546,14 +2546,14 @@ impl ResumeSubscriptionProrationBehavior {
 }
 
 impl std::str::FromStr for ResumeSubscriptionProrationBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ResumeSubscriptionProrationBehavior::*;
         match s {
             "always_invoice" => Ok(AlwaysInvoice),
             "create_prorations" => Ok(CreateProrations),
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2834,14 +2834,14 @@ impl UpdateSubscriptionAddInvoiceItemsPriceDataTaxBehavior {
 }
 
 impl std::str::FromStr for UpdateSubscriptionAddInvoiceItemsPriceDataTaxBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSubscriptionAddInvoiceItemsPriceDataTaxBehavior::*;
         match s {
             "exclusive" => Ok(Exclusive),
             "inclusive" => Ok(Inclusive),
             "unspecified" => Ok(Unspecified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2927,13 +2927,13 @@ impl UpdateSubscriptionAutomaticTaxLiabilityType {
 }
 
 impl std::str::FromStr for UpdateSubscriptionAutomaticTaxLiabilityType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSubscriptionAutomaticTaxLiabilityType::*;
         match s {
             "account" => Ok(Account),
             "self" => Ok(Self_),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2987,13 +2987,13 @@ impl UpdateSubscriptionBillingCycleAnchor {
 }
 
 impl std::str::FromStr for UpdateSubscriptionBillingCycleAnchor {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSubscriptionBillingCycleAnchor::*;
         match s {
             "now" => Ok(Now),
             "unchanged" => Ok(Unchanged),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3070,7 +3070,7 @@ impl UpdateSubscriptionCancellationDetailsFeedback {
 }
 
 impl std::str::FromStr for UpdateSubscriptionCancellationDetailsFeedback {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSubscriptionCancellationDetailsFeedback::*;
         match s {
@@ -3082,7 +3082,7 @@ impl std::str::FromStr for UpdateSubscriptionCancellationDetailsFeedback {
             "too_complex" => Ok(TooComplex),
             "too_expensive" => Ok(TooExpensive),
             "unused" => Ok(Unused),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3167,13 +3167,13 @@ impl UpdateSubscriptionInvoiceSettingsIssuerType {
 }
 
 impl std::str::FromStr for UpdateSubscriptionInvoiceSettingsIssuerType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSubscriptionInvoiceSettingsIssuerType::*;
         match s {
             "account" => Ok(Account),
             "self" => Ok(Self_),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3332,7 +3332,7 @@ impl UpdateSubscriptionItemsPriceDataRecurringInterval {
 }
 
 impl std::str::FromStr for UpdateSubscriptionItemsPriceDataRecurringInterval {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSubscriptionItemsPriceDataRecurringInterval::*;
         match s {
@@ -3340,7 +3340,7 @@ impl std::str::FromStr for UpdateSubscriptionItemsPriceDataRecurringInterval {
             "month" => Ok(Month),
             "week" => Ok(Week),
             "year" => Ok(Year),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3397,14 +3397,14 @@ impl UpdateSubscriptionItemsPriceDataTaxBehavior {
 }
 
 impl std::str::FromStr for UpdateSubscriptionItemsPriceDataTaxBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSubscriptionItemsPriceDataTaxBehavior::*;
         match s {
             "exclusive" => Ok(Exclusive),
             "inclusive" => Ok(Inclusive),
             "unspecified" => Ok(Unspecified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3474,14 +3474,14 @@ impl UpdateSubscriptionPauseCollectionBehavior {
 }
 
 impl std::str::FromStr for UpdateSubscriptionPauseCollectionBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSubscriptionPauseCollectionBehavior::*;
         match s {
             "keep_as_draft" => Ok(KeepAsDraft),
             "mark_uncollectible" => Ok(MarkUncollectible),
             "void" => Ok(Void),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3551,7 +3551,7 @@ impl UpdateSubscriptionPaymentBehavior {
 }
 
 impl std::str::FromStr for UpdateSubscriptionPaymentBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSubscriptionPaymentBehavior::*;
         match s {
@@ -3559,7 +3559,7 @@ impl std::str::FromStr for UpdateSubscriptionPaymentBehavior {
             "default_incomplete" => Ok(DefaultIncomplete),
             "error_if_incomplete" => Ok(ErrorIfIncomplete),
             "pending_if_incomplete" => Ok(PendingIfIncomplete),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3694,13 +3694,13 @@ impl UpdateSubscriptionPaymentSettingsPaymentMethodOptionsAcssDebitMandateOption
 impl std::str::FromStr
     for UpdateSubscriptionPaymentSettingsPaymentMethodOptionsAcssDebitMandateOptionsTransactionType
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSubscriptionPaymentSettingsPaymentMethodOptionsAcssDebitMandateOptionsTransactionType::*;
         match s {
             "business" => Ok(Business),
             "personal" => Ok(Personal),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3760,14 +3760,14 @@ impl UpdateSubscriptionPaymentSettingsPaymentMethodOptionsAcssDebitVerificationM
 impl std::str::FromStr
     for UpdateSubscriptionPaymentSettingsPaymentMethodOptionsAcssDebitVerificationMethod
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSubscriptionPaymentSettingsPaymentMethodOptionsAcssDebitVerificationMethod::*;
         match s {
             "automatic" => Ok(Automatic),
             "instant" => Ok(Instant),
             "microdeposits" => Ok(Microdeposits),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3842,7 +3842,7 @@ impl UpdateSubscriptionPaymentSettingsPaymentMethodOptionsBancontactPreferredLan
 impl std::str::FromStr
     for UpdateSubscriptionPaymentSettingsPaymentMethodOptionsBancontactPreferredLanguage
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSubscriptionPaymentSettingsPaymentMethodOptionsBancontactPreferredLanguage::*;
         match s {
@@ -3850,7 +3850,7 @@ impl std::str::FromStr
             "en" => Ok(En),
             "fr" => Ok(Fr),
             "nl" => Ok(Nl),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3955,13 +3955,13 @@ impl UpdateSubscriptionPaymentSettingsPaymentMethodOptionsCardMandateOptionsAmou
 impl std::str::FromStr
     for UpdateSubscriptionPaymentSettingsPaymentMethodOptionsCardMandateOptionsAmountType
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSubscriptionPaymentSettingsPaymentMethodOptionsCardMandateOptionsAmountType::*;
         match s {
             "fixed" => Ok(Fixed),
             "maximum" => Ok(Maximum),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4037,7 +4037,7 @@ impl UpdateSubscriptionPaymentSettingsPaymentMethodOptionsCardNetwork {
 }
 
 impl std::str::FromStr for UpdateSubscriptionPaymentSettingsPaymentMethodOptionsCardNetwork {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSubscriptionPaymentSettingsPaymentMethodOptionsCardNetwork::*;
         match s {
@@ -4052,7 +4052,7 @@ impl std::str::FromStr for UpdateSubscriptionPaymentSettingsPaymentMethodOptions
             "unionpay" => Ok(Unionpay),
             "unknown" => Ok(Unknown),
             "visa" => Ok(Visa),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4108,14 +4108,14 @@ impl UpdateSubscriptionPaymentSettingsPaymentMethodOptionsCardRequestThreeDSecur
 impl std::str::FromStr
     for UpdateSubscriptionPaymentSettingsPaymentMethodOptionsCardRequestThreeDSecure
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSubscriptionPaymentSettingsPaymentMethodOptionsCardRequestThreeDSecure::*;
         match s {
             "any" => Ok(Any),
             "automatic" => Ok(Automatic),
             "challenge" => Ok(Challenge),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4218,7 +4218,7 @@ Transactions => "transactions",
 }
 
 impl std::str::FromStr for UpdateSubscriptionPaymentSettingsPaymentMethodOptionsUsBankAccountFinancialConnectionsPermissions {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSubscriptionPaymentSettingsPaymentMethodOptionsUsBankAccountFinancialConnectionsPermissions::*;
         match s {
@@ -4226,7 +4226,7 @@ impl std::str::FromStr for UpdateSubscriptionPaymentSettingsPaymentMethodOptions
 "ownership" => Ok(Ownership),
 "payment_method" => Ok(PaymentMethod),
 "transactions" => Ok(Transactions),
-_ => Err(())
+_ => Err(stripe_types::StripeParseError)
 
         }
     }
@@ -4275,13 +4275,13 @@ impl
 }
 
 impl std::str::FromStr for UpdateSubscriptionPaymentSettingsPaymentMethodOptionsUsBankAccountFinancialConnectionsPrefetch {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSubscriptionPaymentSettingsPaymentMethodOptionsUsBankAccountFinancialConnectionsPrefetch::*;
         match s {
     "balances" => Ok(Balances),
 "transactions" => Ok(Transactions),
-_ => Err(())
+_ => Err(stripe_types::StripeParseError)
 
         }
     }
@@ -4331,14 +4331,14 @@ impl UpdateSubscriptionPaymentSettingsPaymentMethodOptionsUsBankAccountVerificat
 impl std::str::FromStr
     for UpdateSubscriptionPaymentSettingsPaymentMethodOptionsUsBankAccountVerificationMethod
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSubscriptionPaymentSettingsPaymentMethodOptionsUsBankAccountVerificationMethod::*;
         match s {
             "automatic" => Ok(Automatic),
             "instant" => Ok(Instant),
             "microdeposits" => Ok(Microdeposits),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4448,7 +4448,7 @@ impl UpdateSubscriptionPaymentSettingsPaymentMethodTypes {
 }
 
 impl std::str::FromStr for UpdateSubscriptionPaymentSettingsPaymentMethodTypes {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSubscriptionPaymentSettingsPaymentMethodTypes::*;
         match s {
@@ -4478,7 +4478,7 @@ impl std::str::FromStr for UpdateSubscriptionPaymentSettingsPaymentMethodTypes {
             "sofort" => Ok(Sofort),
             "us_bank_account" => Ok(UsBankAccount),
             "wechat_pay" => Ok(WechatPay),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -4506,7 +4506,7 @@ impl<'de> serde::Deserialize<'de> for UpdateSubscriptionPaymentSettingsPaymentMe
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// Either `off`, or `on_subscription`.
@@ -4527,13 +4527,13 @@ impl UpdateSubscriptionPaymentSettingsSaveDefaultPaymentMethod {
 }
 
 impl std::str::FromStr for UpdateSubscriptionPaymentSettingsSaveDefaultPaymentMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSubscriptionPaymentSettingsSaveDefaultPaymentMethod::*;
         match s {
             "off" => Ok(Off),
             "on_subscription" => Ok(OnSubscription),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4606,7 +4606,7 @@ impl UpdateSubscriptionPendingInvoiceItemIntervalInterval {
 }
 
 impl std::str::FromStr for UpdateSubscriptionPendingInvoiceItemIntervalInterval {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSubscriptionPendingInvoiceItemIntervalInterval::*;
         match s {
@@ -4614,7 +4614,7 @@ impl std::str::FromStr for UpdateSubscriptionPendingInvoiceItemIntervalInterval 
             "month" => Ok(Month),
             "week" => Ok(Week),
             "year" => Ok(Year),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4669,14 +4669,14 @@ impl UpdateSubscriptionProrationBehavior {
 }
 
 impl std::str::FromStr for UpdateSubscriptionProrationBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSubscriptionProrationBehavior::*;
         match s {
             "always_invoice" => Ok(AlwaysInvoice),
             "create_prorations" => Ok(CreateProrations),
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4763,14 +4763,14 @@ impl UpdateSubscriptionTrialSettingsEndBehaviorMissingPaymentMethod {
 }
 
 impl std::str::FromStr for UpdateSubscriptionTrialSettingsEndBehaviorMissingPaymentMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSubscriptionTrialSettingsEndBehaviorMissingPaymentMethod::*;
         match s {
             "cancel" => Ok(Cancel),
             "create_invoice" => Ok(CreateInvoice),
             "pause" => Ok(Pause),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_billing/src/subscription_item/requests.rs
+++ b/generated/stripe_billing/src/subscription_item/requests.rs
@@ -38,14 +38,14 @@ impl DeleteSubscriptionItemProrationBehavior {
 }
 
 impl std::str::FromStr for DeleteSubscriptionItemProrationBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use DeleteSubscriptionItemProrationBehavior::*;
         match s {
             "always_invoice" => Ok(AlwaysInvoice),
             "create_prorations" => Ok(CreateProrations),
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -320,7 +320,7 @@ impl CreateSubscriptionItemPaymentBehavior {
 }
 
 impl std::str::FromStr for CreateSubscriptionItemPaymentBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSubscriptionItemPaymentBehavior::*;
         match s {
@@ -328,7 +328,7 @@ impl std::str::FromStr for CreateSubscriptionItemPaymentBehavior {
             "default_incomplete" => Ok(DefaultIncomplete),
             "error_if_incomplete" => Ok(ErrorIfIncomplete),
             "pending_if_incomplete" => Ok(PendingIfIncomplete),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -438,7 +438,7 @@ impl CreateSubscriptionItemPriceDataRecurringInterval {
 }
 
 impl std::str::FromStr for CreateSubscriptionItemPriceDataRecurringInterval {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSubscriptionItemPriceDataRecurringInterval::*;
         match s {
@@ -446,7 +446,7 @@ impl std::str::FromStr for CreateSubscriptionItemPriceDataRecurringInterval {
             "month" => Ok(Month),
             "week" => Ok(Week),
             "year" => Ok(Year),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -503,14 +503,14 @@ impl CreateSubscriptionItemPriceDataTaxBehavior {
 }
 
 impl std::str::FromStr for CreateSubscriptionItemPriceDataTaxBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSubscriptionItemPriceDataTaxBehavior::*;
         match s {
             "exclusive" => Ok(Exclusive),
             "inclusive" => Ok(Inclusive),
             "unspecified" => Ok(Unspecified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -563,14 +563,14 @@ impl CreateSubscriptionItemProrationBehavior {
 }
 
 impl std::str::FromStr for CreateSubscriptionItemProrationBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSubscriptionItemProrationBehavior::*;
         match s {
             "always_invoice" => Ok(AlwaysInvoice),
             "create_prorations" => Ok(CreateProrations),
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -718,7 +718,7 @@ impl UpdateSubscriptionItemPaymentBehavior {
 }
 
 impl std::str::FromStr for UpdateSubscriptionItemPaymentBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSubscriptionItemPaymentBehavior::*;
         match s {
@@ -726,7 +726,7 @@ impl std::str::FromStr for UpdateSubscriptionItemPaymentBehavior {
             "default_incomplete" => Ok(DefaultIncomplete),
             "error_if_incomplete" => Ok(ErrorIfIncomplete),
             "pending_if_incomplete" => Ok(PendingIfIncomplete),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -836,7 +836,7 @@ impl UpdateSubscriptionItemPriceDataRecurringInterval {
 }
 
 impl std::str::FromStr for UpdateSubscriptionItemPriceDataRecurringInterval {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSubscriptionItemPriceDataRecurringInterval::*;
         match s {
@@ -844,7 +844,7 @@ impl std::str::FromStr for UpdateSubscriptionItemPriceDataRecurringInterval {
             "month" => Ok(Month),
             "week" => Ok(Week),
             "year" => Ok(Year),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -901,14 +901,14 @@ impl UpdateSubscriptionItemPriceDataTaxBehavior {
 }
 
 impl std::str::FromStr for UpdateSubscriptionItemPriceDataTaxBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSubscriptionItemPriceDataTaxBehavior::*;
         match s {
             "exclusive" => Ok(Exclusive),
             "inclusive" => Ok(Inclusive),
             "unspecified" => Ok(Unspecified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -961,14 +961,14 @@ impl UpdateSubscriptionItemProrationBehavior {
 }
 
 impl std::str::FromStr for UpdateSubscriptionItemProrationBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSubscriptionItemProrationBehavior::*;
         match s {
             "always_invoice" => Ok(AlwaysInvoice),
             "create_prorations" => Ok(CreateProrations),
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_billing/src/subscription_schedule/requests.rs
+++ b/generated/stripe_billing/src/subscription_schedule/requests.rs
@@ -223,13 +223,13 @@ impl CreateSubscriptionScheduleDefaultSettingsAutomaticTaxLiabilityType {
 }
 
 impl std::str::FromStr for CreateSubscriptionScheduleDefaultSettingsAutomaticTaxLiabilityType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSubscriptionScheduleDefaultSettingsAutomaticTaxLiabilityType::*;
         match s {
             "account" => Ok(Account),
             "self" => Ok(Self_),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -281,13 +281,13 @@ impl CreateSubscriptionScheduleDefaultSettingsBillingCycleAnchor {
 }
 
 impl std::str::FromStr for CreateSubscriptionScheduleDefaultSettingsBillingCycleAnchor {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSubscriptionScheduleDefaultSettingsBillingCycleAnchor::*;
         match s {
             "automatic" => Ok(Automatic),
             "phase_start" => Ok(PhaseStart),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -342,13 +342,13 @@ impl CreateSubscriptionScheduleDefaultSettingsCollectionMethod {
 }
 
 impl std::str::FromStr for CreateSubscriptionScheduleDefaultSettingsCollectionMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSubscriptionScheduleDefaultSettingsCollectionMethod::*;
         match s {
             "charge_automatically" => Ok(ChargeAutomatically),
             "send_invoice" => Ok(SendInvoice),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -437,13 +437,13 @@ impl CreateSubscriptionScheduleDefaultSettingsInvoiceSettingsIssuerType {
 }
 
 impl std::str::FromStr for CreateSubscriptionScheduleDefaultSettingsInvoiceSettingsIssuerType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSubscriptionScheduleDefaultSettingsInvoiceSettingsIssuerType::*;
         match s {
             "account" => Ok(Account),
             "self" => Ok(Self_),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -667,14 +667,14 @@ impl CreateSubscriptionSchedulePhasesAddInvoiceItemsPriceDataTaxBehavior {
 }
 
 impl std::str::FromStr for CreateSubscriptionSchedulePhasesAddInvoiceItemsPriceDataTaxBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSubscriptionSchedulePhasesAddInvoiceItemsPriceDataTaxBehavior::*;
         match s {
             "exclusive" => Ok(Exclusive),
             "inclusive" => Ok(Inclusive),
             "unspecified" => Ok(Unspecified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -757,13 +757,13 @@ impl CreateSubscriptionSchedulePhasesAutomaticTaxLiabilityType {
 }
 
 impl std::str::FromStr for CreateSubscriptionSchedulePhasesAutomaticTaxLiabilityType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSubscriptionSchedulePhasesAutomaticTaxLiabilityType::*;
         match s {
             "account" => Ok(Account),
             "self" => Ok(Self_),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -817,13 +817,13 @@ impl CreateSubscriptionSchedulePhasesBillingCycleAnchor {
 }
 
 impl std::str::FromStr for CreateSubscriptionSchedulePhasesBillingCycleAnchor {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSubscriptionSchedulePhasesBillingCycleAnchor::*;
         match s {
             "automatic" => Ok(Automatic),
             "phase_start" => Ok(PhaseStart),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -878,13 +878,13 @@ impl CreateSubscriptionSchedulePhasesCollectionMethod {
 }
 
 impl std::str::FromStr for CreateSubscriptionSchedulePhasesCollectionMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSubscriptionSchedulePhasesCollectionMethod::*;
         match s {
             "charge_automatically" => Ok(ChargeAutomatically),
             "send_invoice" => Ok(SendInvoice),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -973,13 +973,13 @@ impl CreateSubscriptionSchedulePhasesInvoiceSettingsIssuerType {
 }
 
 impl std::str::FromStr for CreateSubscriptionSchedulePhasesInvoiceSettingsIssuerType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSubscriptionSchedulePhasesInvoiceSettingsIssuerType::*;
         match s {
             "account" => Ok(Account),
             "self" => Ok(Self_),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1128,7 +1128,7 @@ impl CreateSubscriptionSchedulePhasesItemsPriceDataRecurringInterval {
 }
 
 impl std::str::FromStr for CreateSubscriptionSchedulePhasesItemsPriceDataRecurringInterval {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSubscriptionSchedulePhasesItemsPriceDataRecurringInterval::*;
         match s {
@@ -1136,7 +1136,7 @@ impl std::str::FromStr for CreateSubscriptionSchedulePhasesItemsPriceDataRecurri
             "month" => Ok(Month),
             "week" => Ok(Week),
             "year" => Ok(Year),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1195,14 +1195,14 @@ impl CreateSubscriptionSchedulePhasesItemsPriceDataTaxBehavior {
 }
 
 impl std::str::FromStr for CreateSubscriptionSchedulePhasesItemsPriceDataTaxBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSubscriptionSchedulePhasesItemsPriceDataTaxBehavior::*;
         match s {
             "exclusive" => Ok(Exclusive),
             "inclusive" => Ok(Inclusive),
             "unspecified" => Ok(Unspecified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1259,14 +1259,14 @@ impl CreateSubscriptionSchedulePhasesProrationBehavior {
 }
 
 impl std::str::FromStr for CreateSubscriptionSchedulePhasesProrationBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSubscriptionSchedulePhasesProrationBehavior::*;
         match s {
             "always_invoice" => Ok(AlwaysInvoice),
             "create_prorations" => Ok(CreateProrations),
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1457,13 +1457,13 @@ impl UpdateSubscriptionScheduleDefaultSettingsAutomaticTaxLiabilityType {
 }
 
 impl std::str::FromStr for UpdateSubscriptionScheduleDefaultSettingsAutomaticTaxLiabilityType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSubscriptionScheduleDefaultSettingsAutomaticTaxLiabilityType::*;
         match s {
             "account" => Ok(Account),
             "self" => Ok(Self_),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1515,13 +1515,13 @@ impl UpdateSubscriptionScheduleDefaultSettingsBillingCycleAnchor {
 }
 
 impl std::str::FromStr for UpdateSubscriptionScheduleDefaultSettingsBillingCycleAnchor {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSubscriptionScheduleDefaultSettingsBillingCycleAnchor::*;
         match s {
             "automatic" => Ok(Automatic),
             "phase_start" => Ok(PhaseStart),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1576,13 +1576,13 @@ impl UpdateSubscriptionScheduleDefaultSettingsCollectionMethod {
 }
 
 impl std::str::FromStr for UpdateSubscriptionScheduleDefaultSettingsCollectionMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSubscriptionScheduleDefaultSettingsCollectionMethod::*;
         match s {
             "charge_automatically" => Ok(ChargeAutomatically),
             "send_invoice" => Ok(SendInvoice),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1671,13 +1671,13 @@ impl UpdateSubscriptionScheduleDefaultSettingsInvoiceSettingsIssuerType {
 }
 
 impl std::str::FromStr for UpdateSubscriptionScheduleDefaultSettingsInvoiceSettingsIssuerType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSubscriptionScheduleDefaultSettingsInvoiceSettingsIssuerType::*;
         match s {
             "account" => Ok(Account),
             "self" => Ok(Self_),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1907,14 +1907,14 @@ impl UpdateSubscriptionSchedulePhasesAddInvoiceItemsPriceDataTaxBehavior {
 }
 
 impl std::str::FromStr for UpdateSubscriptionSchedulePhasesAddInvoiceItemsPriceDataTaxBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSubscriptionSchedulePhasesAddInvoiceItemsPriceDataTaxBehavior::*;
         match s {
             "exclusive" => Ok(Exclusive),
             "inclusive" => Ok(Inclusive),
             "unspecified" => Ok(Unspecified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1997,13 +1997,13 @@ impl UpdateSubscriptionSchedulePhasesAutomaticTaxLiabilityType {
 }
 
 impl std::str::FromStr for UpdateSubscriptionSchedulePhasesAutomaticTaxLiabilityType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSubscriptionSchedulePhasesAutomaticTaxLiabilityType::*;
         match s {
             "account" => Ok(Account),
             "self" => Ok(Self_),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2057,13 +2057,13 @@ impl UpdateSubscriptionSchedulePhasesBillingCycleAnchor {
 }
 
 impl std::str::FromStr for UpdateSubscriptionSchedulePhasesBillingCycleAnchor {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSubscriptionSchedulePhasesBillingCycleAnchor::*;
         match s {
             "automatic" => Ok(Automatic),
             "phase_start" => Ok(PhaseStart),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2118,13 +2118,13 @@ impl UpdateSubscriptionSchedulePhasesCollectionMethod {
 }
 
 impl std::str::FromStr for UpdateSubscriptionSchedulePhasesCollectionMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSubscriptionSchedulePhasesCollectionMethod::*;
         match s {
             "charge_automatically" => Ok(ChargeAutomatically),
             "send_invoice" => Ok(SendInvoice),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2221,13 +2221,13 @@ impl UpdateSubscriptionSchedulePhasesInvoiceSettingsIssuerType {
 }
 
 impl std::str::FromStr for UpdateSubscriptionSchedulePhasesInvoiceSettingsIssuerType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSubscriptionSchedulePhasesInvoiceSettingsIssuerType::*;
         match s {
             "account" => Ok(Account),
             "self" => Ok(Self_),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2376,7 +2376,7 @@ impl UpdateSubscriptionSchedulePhasesItemsPriceDataRecurringInterval {
 }
 
 impl std::str::FromStr for UpdateSubscriptionSchedulePhasesItemsPriceDataRecurringInterval {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSubscriptionSchedulePhasesItemsPriceDataRecurringInterval::*;
         match s {
@@ -2384,7 +2384,7 @@ impl std::str::FromStr for UpdateSubscriptionSchedulePhasesItemsPriceDataRecurri
             "month" => Ok(Month),
             "week" => Ok(Week),
             "year" => Ok(Year),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2443,14 +2443,14 @@ impl UpdateSubscriptionSchedulePhasesItemsPriceDataTaxBehavior {
 }
 
 impl std::str::FromStr for UpdateSubscriptionSchedulePhasesItemsPriceDataTaxBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSubscriptionSchedulePhasesItemsPriceDataTaxBehavior::*;
         match s {
             "exclusive" => Ok(Exclusive),
             "inclusive" => Ok(Inclusive),
             "unspecified" => Ok(Unspecified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2507,14 +2507,14 @@ impl UpdateSubscriptionSchedulePhasesProrationBehavior {
 }
 
 impl std::str::FromStr for UpdateSubscriptionSchedulePhasesProrationBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSubscriptionSchedulePhasesProrationBehavior::*;
         match s {
             "always_invoice" => Ok(AlwaysInvoice),
             "create_prorations" => Ok(CreateProrations),
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2585,14 +2585,14 @@ impl UpdateSubscriptionScheduleProrationBehavior {
 }
 
 impl std::str::FromStr for UpdateSubscriptionScheduleProrationBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSubscriptionScheduleProrationBehavior::*;
         match s {
             "always_invoice" => Ok(AlwaysInvoice),
             "create_prorations" => Ok(CreateProrations),
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_billing/src/tax_id/requests.rs
+++ b/generated/stripe_billing/src/tax_id/requests.rs
@@ -167,7 +167,7 @@ impl ListTaxIdOwnerType {
 }
 
 impl std::str::FromStr for ListTaxIdOwnerType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ListTaxIdOwnerType::*;
         match s {
@@ -175,7 +175,7 @@ impl std::str::FromStr for ListTaxIdOwnerType {
             "application" => Ok(Application),
             "customer" => Ok(Customer),
             "self" => Ok(Self_),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -405,7 +405,7 @@ impl CreateCustomerTaxIdType {
 }
 
 impl std::str::FromStr for CreateCustomerTaxIdType {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCustomerTaxIdType::*;
         match s {
@@ -475,7 +475,7 @@ impl std::str::FromStr for CreateCustomerTaxIdType {
             "ve_rif" => Ok(VeRif),
             "vn_tin" => Ok(VnTin),
             "za_vat" => Ok(ZaVat),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -503,7 +503,7 @@ impl<'de> serde::Deserialize<'de> for CreateCustomerTaxIdType {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 impl<'a> CreateCustomerTaxId<'a> {
@@ -574,7 +574,7 @@ impl CreateTaxIdOwnerType {
 }
 
 impl std::str::FromStr for CreateTaxIdOwnerType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxIdOwnerType::*;
         match s {
@@ -582,7 +582,7 @@ impl std::str::FromStr for CreateTaxIdOwnerType {
             "application" => Ok(Application),
             "customer" => Ok(Customer),
             "self" => Ok(Self_),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -763,7 +763,7 @@ impl CreateTaxIdType {
 }
 
 impl std::str::FromStr for CreateTaxIdType {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxIdType::*;
         match s {
@@ -833,7 +833,7 @@ impl std::str::FromStr for CreateTaxIdType {
             "ve_rif" => Ok(VeRif),
             "vn_tin" => Ok(VnTin),
             "za_vat" => Ok(ZaVat),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -861,7 +861,7 @@ impl<'de> serde::Deserialize<'de> for CreateTaxIdType {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 impl<'a> CreateTaxId<'a> {

--- a/generated/stripe_billing/src/usage_record/requests.rs
+++ b/generated/stripe_billing/src/usage_record/requests.rs
@@ -43,13 +43,13 @@ impl CreateSubscriptionItemUsageRecordAction {
 }
 
 impl std::str::FromStr for CreateSubscriptionItemUsageRecordAction {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSubscriptionItemUsageRecordAction::*;
         match s {
             "increment" => Ok(Increment),
             "set" => Ok(Set),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_checkout/src/checkout_acss_debit_mandate_options.rs
+++ b/generated/stripe_checkout/src/checkout_acss_debit_mandate_options.rs
@@ -147,13 +147,13 @@ impl CheckoutAcssDebitMandateOptionsDefaultFor {
 }
 
 impl std::str::FromStr for CheckoutAcssDebitMandateOptionsDefaultFor {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CheckoutAcssDebitMandateOptionsDefaultFor::*;
         match s {
             "invoice" => Ok(Invoice),
             "subscription" => Ok(Subscription),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -223,14 +223,14 @@ impl CheckoutAcssDebitMandateOptionsPaymentSchedule {
 }
 
 impl std::str::FromStr for CheckoutAcssDebitMandateOptionsPaymentSchedule {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CheckoutAcssDebitMandateOptionsPaymentSchedule::*;
         match s {
             "combined" => Ok(Combined),
             "interval" => Ok(Interval),
             "sporadic" => Ok(Sporadic),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -301,13 +301,13 @@ impl CheckoutAcssDebitMandateOptionsTransactionType {
 }
 
 impl std::str::FromStr for CheckoutAcssDebitMandateOptionsTransactionType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CheckoutAcssDebitMandateOptionsTransactionType::*;
         match s {
             "business" => Ok(Business),
             "personal" => Ok(Personal),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_checkout/src/checkout_acss_debit_payment_method_options.rs
+++ b/generated/stripe_checkout/src/checkout_acss_debit_payment_method_options.rs
@@ -141,13 +141,13 @@ impl CheckoutAcssDebitPaymentMethodOptionsCurrency {
 }
 
 impl std::str::FromStr for CheckoutAcssDebitPaymentMethodOptionsCurrency {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CheckoutAcssDebitPaymentMethodOptionsCurrency::*;
         match s {
             "cad" => Ok(Cad),
             "usd" => Ok(Usd),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -225,14 +225,14 @@ impl CheckoutAcssDebitPaymentMethodOptionsSetupFutureUsage {
 }
 
 impl std::str::FromStr for CheckoutAcssDebitPaymentMethodOptionsSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CheckoutAcssDebitPaymentMethodOptionsSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -307,14 +307,14 @@ impl CheckoutAcssDebitPaymentMethodOptionsVerificationMethod {
 }
 
 impl std::str::FromStr for CheckoutAcssDebitPaymentMethodOptionsVerificationMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CheckoutAcssDebitPaymentMethodOptionsVerificationMethod::*;
         match s {
             "automatic" => Ok(Automatic),
             "instant" => Ok(Instant),
             "microdeposits" => Ok(Microdeposits),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_checkout/src/checkout_affirm_payment_method_options.rs
+++ b/generated/stripe_checkout/src/checkout_affirm_payment_method_options.rs
@@ -118,12 +118,12 @@ impl CheckoutAffirmPaymentMethodOptionsSetupFutureUsage {
 }
 
 impl std::str::FromStr for CheckoutAffirmPaymentMethodOptionsSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CheckoutAffirmPaymentMethodOptionsSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_checkout/src/checkout_afterpay_clearpay_payment_method_options.rs
+++ b/generated/stripe_checkout/src/checkout_afterpay_clearpay_payment_method_options.rs
@@ -119,12 +119,12 @@ impl CheckoutAfterpayClearpayPaymentMethodOptionsSetupFutureUsage {
 }
 
 impl std::str::FromStr for CheckoutAfterpayClearpayPaymentMethodOptionsSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CheckoutAfterpayClearpayPaymentMethodOptionsSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_checkout/src/checkout_alipay_payment_method_options.rs
+++ b/generated/stripe_checkout/src/checkout_alipay_payment_method_options.rs
@@ -118,12 +118,12 @@ impl CheckoutAlipayPaymentMethodOptionsSetupFutureUsage {
 }
 
 impl std::str::FromStr for CheckoutAlipayPaymentMethodOptionsSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CheckoutAlipayPaymentMethodOptionsSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_checkout/src/checkout_au_becs_debit_payment_method_options.rs
+++ b/generated/stripe_checkout/src/checkout_au_becs_debit_payment_method_options.rs
@@ -118,12 +118,12 @@ impl CheckoutAuBecsDebitPaymentMethodOptionsSetupFutureUsage {
 }
 
 impl std::str::FromStr for CheckoutAuBecsDebitPaymentMethodOptionsSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CheckoutAuBecsDebitPaymentMethodOptionsSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_checkout/src/checkout_bacs_debit_payment_method_options.rs
+++ b/generated/stripe_checkout/src/checkout_bacs_debit_payment_method_options.rs
@@ -122,14 +122,14 @@ impl CheckoutBacsDebitPaymentMethodOptionsSetupFutureUsage {
 }
 
 impl std::str::FromStr for CheckoutBacsDebitPaymentMethodOptionsSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CheckoutBacsDebitPaymentMethodOptionsSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_checkout/src/checkout_bancontact_payment_method_options.rs
+++ b/generated/stripe_checkout/src/checkout_bancontact_payment_method_options.rs
@@ -118,12 +118,12 @@ impl CheckoutBancontactPaymentMethodOptionsSetupFutureUsage {
 }
 
 impl std::str::FromStr for CheckoutBancontactPaymentMethodOptionsSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CheckoutBancontactPaymentMethodOptionsSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_checkout/src/checkout_boleto_payment_method_options.rs
+++ b/generated/stripe_checkout/src/checkout_boleto_payment_method_options.rs
@@ -136,14 +136,14 @@ impl CheckoutBoletoPaymentMethodOptionsSetupFutureUsage {
 }
 
 impl std::str::FromStr for CheckoutBoletoPaymentMethodOptionsSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CheckoutBoletoPaymentMethodOptionsSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_checkout/src/checkout_card_payment_method_options.rs
+++ b/generated/stripe_checkout/src/checkout_card_payment_method_options.rs
@@ -160,14 +160,14 @@ impl CheckoutCardPaymentMethodOptionsSetupFutureUsage {
 }
 
 impl std::str::FromStr for CheckoutCardPaymentMethodOptionsSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CheckoutCardPaymentMethodOptionsSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_checkout/src/checkout_cashapp_payment_method_options.rs
+++ b/generated/stripe_checkout/src/checkout_cashapp_payment_method_options.rs
@@ -118,12 +118,12 @@ impl CheckoutCashappPaymentMethodOptionsSetupFutureUsage {
 }
 
 impl std::str::FromStr for CheckoutCashappPaymentMethodOptionsSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CheckoutCashappPaymentMethodOptionsSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_checkout/src/checkout_customer_balance_bank_transfer_payment_method_options.rs
+++ b/generated/stripe_checkout/src/checkout_customer_balance_bank_transfer_payment_method_options.rs
@@ -152,7 +152,7 @@ impl CheckoutCustomerBalanceBankTransferPaymentMethodOptionsRequestedAddressType
 impl std::str::FromStr
     for CheckoutCustomerBalanceBankTransferPaymentMethodOptionsRequestedAddressTypes
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CheckoutCustomerBalanceBankTransferPaymentMethodOptionsRequestedAddressTypes::*;
         match s {
@@ -163,7 +163,7 @@ impl std::str::FromStr
             "spei" => Ok(Spei),
             "swift" => Ok(Swift),
             "zengin" => Ok(Zengin),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -252,7 +252,7 @@ impl CheckoutCustomerBalanceBankTransferPaymentMethodOptionsType {
 }
 
 impl std::str::FromStr for CheckoutCustomerBalanceBankTransferPaymentMethodOptionsType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CheckoutCustomerBalanceBankTransferPaymentMethodOptionsType::*;
         match s {
@@ -261,7 +261,7 @@ impl std::str::FromStr for CheckoutCustomerBalanceBankTransferPaymentMethodOptio
             "jp_bank_transfer" => Ok(JpBankTransfer),
             "mx_bank_transfer" => Ok(MxBankTransfer),
             "us_bank_transfer" => Ok(UsBankTransfer),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_checkout/src/checkout_customer_balance_payment_method_options.rs
+++ b/generated/stripe_checkout/src/checkout_customer_balance_payment_method_options.rs
@@ -134,12 +134,12 @@ impl CheckoutCustomerBalancePaymentMethodOptionsFundingType {
 }
 
 impl std::str::FromStr for CheckoutCustomerBalancePaymentMethodOptionsFundingType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CheckoutCustomerBalancePaymentMethodOptionsFundingType::*;
         match s {
             "bank_transfer" => Ok(BankTransfer),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -215,12 +215,12 @@ impl CheckoutCustomerBalancePaymentMethodOptionsSetupFutureUsage {
 }
 
 impl std::str::FromStr for CheckoutCustomerBalancePaymentMethodOptionsSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CheckoutCustomerBalancePaymentMethodOptionsSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_checkout/src/checkout_eps_payment_method_options.rs
+++ b/generated/stripe_checkout/src/checkout_eps_payment_method_options.rs
@@ -118,12 +118,12 @@ impl CheckoutEpsPaymentMethodOptionsSetupFutureUsage {
 }
 
 impl std::str::FromStr for CheckoutEpsPaymentMethodOptionsSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CheckoutEpsPaymentMethodOptionsSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_checkout/src/checkout_fpx_payment_method_options.rs
+++ b/generated/stripe_checkout/src/checkout_fpx_payment_method_options.rs
@@ -118,12 +118,12 @@ impl CheckoutFpxPaymentMethodOptionsSetupFutureUsage {
 }
 
 impl std::str::FromStr for CheckoutFpxPaymentMethodOptionsSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CheckoutFpxPaymentMethodOptionsSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_checkout/src/checkout_giropay_payment_method_options.rs
+++ b/generated/stripe_checkout/src/checkout_giropay_payment_method_options.rs
@@ -118,12 +118,12 @@ impl CheckoutGiropayPaymentMethodOptionsSetupFutureUsage {
 }
 
 impl std::str::FromStr for CheckoutGiropayPaymentMethodOptionsSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CheckoutGiropayPaymentMethodOptionsSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_checkout/src/checkout_grab_pay_payment_method_options.rs
+++ b/generated/stripe_checkout/src/checkout_grab_pay_payment_method_options.rs
@@ -118,12 +118,12 @@ impl CheckoutGrabPayPaymentMethodOptionsSetupFutureUsage {
 }
 
 impl std::str::FromStr for CheckoutGrabPayPaymentMethodOptionsSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CheckoutGrabPayPaymentMethodOptionsSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_checkout/src/checkout_ideal_payment_method_options.rs
+++ b/generated/stripe_checkout/src/checkout_ideal_payment_method_options.rs
@@ -118,12 +118,12 @@ impl CheckoutIdealPaymentMethodOptionsSetupFutureUsage {
 }
 
 impl std::str::FromStr for CheckoutIdealPaymentMethodOptionsSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CheckoutIdealPaymentMethodOptionsSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_checkout/src/checkout_klarna_payment_method_options.rs
+++ b/generated/stripe_checkout/src/checkout_klarna_payment_method_options.rs
@@ -122,14 +122,14 @@ impl CheckoutKlarnaPaymentMethodOptionsSetupFutureUsage {
 }
 
 impl std::str::FromStr for CheckoutKlarnaPaymentMethodOptionsSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CheckoutKlarnaPaymentMethodOptionsSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_checkout/src/checkout_konbini_payment_method_options.rs
+++ b/generated/stripe_checkout/src/checkout_konbini_payment_method_options.rs
@@ -132,12 +132,12 @@ impl CheckoutKonbiniPaymentMethodOptionsSetupFutureUsage {
 }
 
 impl std::str::FromStr for CheckoutKonbiniPaymentMethodOptionsSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CheckoutKonbiniPaymentMethodOptionsSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_checkout/src/checkout_link_payment_method_options.rs
+++ b/generated/stripe_checkout/src/checkout_link_payment_method_options.rs
@@ -120,13 +120,13 @@ impl CheckoutLinkPaymentMethodOptionsSetupFutureUsage {
 }
 
 impl std::str::FromStr for CheckoutLinkPaymentMethodOptionsSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CheckoutLinkPaymentMethodOptionsSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_checkout/src/checkout_oxxo_payment_method_options.rs
+++ b/generated/stripe_checkout/src/checkout_oxxo_payment_method_options.rs
@@ -132,12 +132,12 @@ impl CheckoutOxxoPaymentMethodOptionsSetupFutureUsage {
 }
 
 impl std::str::FromStr for CheckoutOxxoPaymentMethodOptionsSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CheckoutOxxoPaymentMethodOptionsSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_checkout/src/checkout_p24_payment_method_options.rs
+++ b/generated/stripe_checkout/src/checkout_p24_payment_method_options.rs
@@ -118,12 +118,12 @@ impl CheckoutP24PaymentMethodOptionsSetupFutureUsage {
 }
 
 impl std::str::FromStr for CheckoutP24PaymentMethodOptionsSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CheckoutP24PaymentMethodOptionsSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_checkout/src/checkout_paynow_payment_method_options.rs
+++ b/generated/stripe_checkout/src/checkout_paynow_payment_method_options.rs
@@ -118,12 +118,12 @@ impl CheckoutPaynowPaymentMethodOptionsSetupFutureUsage {
 }
 
 impl std::str::FromStr for CheckoutPaynowPaymentMethodOptionsSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CheckoutPaynowPaymentMethodOptionsSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_checkout/src/checkout_paypal_payment_method_options.rs
+++ b/generated/stripe_checkout/src/checkout_paypal_payment_method_options.rs
@@ -139,12 +139,12 @@ impl CheckoutPaypalPaymentMethodOptionsCaptureMethod {
 }
 
 impl std::str::FromStr for CheckoutPaypalPaymentMethodOptionsCaptureMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CheckoutPaypalPaymentMethodOptionsCaptureMethod::*;
         match s {
             "manual" => Ok(Manual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -220,13 +220,13 @@ impl CheckoutPaypalPaymentMethodOptionsSetupFutureUsage {
 }
 
 impl std::str::FromStr for CheckoutPaypalPaymentMethodOptionsSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CheckoutPaypalPaymentMethodOptionsSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_checkout/src/checkout_sepa_debit_payment_method_options.rs
+++ b/generated/stripe_checkout/src/checkout_sepa_debit_payment_method_options.rs
@@ -122,14 +122,14 @@ impl CheckoutSepaDebitPaymentMethodOptionsSetupFutureUsage {
 }
 
 impl std::str::FromStr for CheckoutSepaDebitPaymentMethodOptionsSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CheckoutSepaDebitPaymentMethodOptionsSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_checkout/src/checkout_session/requests.rs
+++ b/generated/stripe_checkout/src/checkout_session/requests.rs
@@ -411,13 +411,13 @@ impl CreateCheckoutSessionAutomaticTaxLiabilityType {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionAutomaticTaxLiabilityType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionAutomaticTaxLiabilityType::*;
         match s {
             "account" => Ok(Account),
             "self" => Ok(Self_),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -515,13 +515,13 @@ impl CreateCheckoutSessionConsentCollectionPaymentMethodReuseAgreementPosition {
 impl std::str::FromStr
     for CreateCheckoutSessionConsentCollectionPaymentMethodReuseAgreementPosition
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionConsentCollectionPaymentMethodReuseAgreementPosition::*;
         match s {
             "auto" => Ok(Auto),
             "hidden" => Ok(Hidden),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -578,13 +578,13 @@ impl CreateCheckoutSessionConsentCollectionPromotions {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionConsentCollectionPromotions {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionConsentCollectionPromotions::*;
         match s {
             "auto" => Ok(Auto),
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -637,13 +637,13 @@ impl CreateCheckoutSessionConsentCollectionTermsOfService {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionConsentCollectionTermsOfService {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionConsentCollectionTermsOfService::*;
         match s {
             "none" => Ok(None),
             "required" => Ok(Required),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -767,12 +767,12 @@ impl CreateCheckoutSessionCustomFieldsLabelType {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionCustomFieldsLabelType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionCustomFieldsLabelType::*;
         match s {
             "custom" => Ok(Custom),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -854,14 +854,14 @@ impl CreateCheckoutSessionCustomFieldsType {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionCustomFieldsType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionCustomFieldsType::*;
         match s {
             "dropdown" => Ok(Dropdown),
             "numeric" => Ok(Numeric),
             "text" => Ok(Text),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -941,13 +941,13 @@ impl CreateCheckoutSessionCustomerCreation {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionCustomerCreation {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionCustomerCreation::*;
         match s {
             "always" => Ok(Always),
             "if_required" => Ok(IfRequired),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1019,13 +1019,13 @@ impl CreateCheckoutSessionCustomerUpdateAddress {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionCustomerUpdateAddress {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionCustomerUpdateAddress::*;
         match s {
             "auto" => Ok(Auto),
             "never" => Ok(Never),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1075,13 +1075,13 @@ impl CreateCheckoutSessionCustomerUpdateName {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionCustomerUpdateName {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionCustomerUpdateName::*;
         match s {
             "auto" => Ok(Auto),
             "never" => Ok(Never),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1132,13 +1132,13 @@ impl CreateCheckoutSessionCustomerUpdateShipping {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionCustomerUpdateShipping {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionCustomerUpdateShipping::*;
         match s {
             "auto" => Ok(Auto),
             "never" => Ok(Never),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1283,13 +1283,13 @@ impl CreateCheckoutSessionInvoiceCreationInvoiceDataIssuerType {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionInvoiceCreationInvoiceDataIssuerType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionInvoiceCreationInvoiceDataIssuerType::*;
         match s {
             "account" => Ok(Account),
             "self" => Ok(Self_),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1362,13 +1362,13 @@ impl CreateCheckoutSessionInvoiceCreationInvoiceDataRenderingOptionsAmountTaxDis
 impl std::str::FromStr
     for CreateCheckoutSessionInvoiceCreationInvoiceDataRenderingOptionsAmountTaxDisplay
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionInvoiceCreationInvoiceDataRenderingOptionsAmountTaxDisplay::*;
         match s {
             "exclude_tax" => Ok(ExcludeTax),
             "include_inclusive_tax" => Ok(IncludeInclusiveTax),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1574,7 +1574,7 @@ impl CreateCheckoutSessionLineItemsPriceDataRecurringInterval {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionLineItemsPriceDataRecurringInterval {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionLineItemsPriceDataRecurringInterval::*;
         match s {
@@ -1582,7 +1582,7 @@ impl std::str::FromStr for CreateCheckoutSessionLineItemsPriceDataRecurringInter
             "month" => Ok(Month),
             "week" => Ok(Week),
             "year" => Ok(Year),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1639,14 +1639,14 @@ impl CreateCheckoutSessionLineItemsPriceDataTaxBehavior {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionLineItemsPriceDataTaxBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionLineItemsPriceDataTaxBehavior::*;
         match s {
             "exclusive" => Ok(Exclusive),
             "inclusive" => Ok(Inclusive),
             "unspecified" => Ok(Unspecified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1777,14 +1777,14 @@ impl CreateCheckoutSessionPaymentIntentDataCaptureMethod {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionPaymentIntentDataCaptureMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionPaymentIntentDataCaptureMethod::*;
         match s {
             "automatic" => Ok(Automatic),
             "automatic_async" => Ok(AutomaticAsync),
             "manual" => Ok(Manual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1855,13 +1855,13 @@ impl CreateCheckoutSessionPaymentIntentDataSetupFutureUsage {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionPaymentIntentDataSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionPaymentIntentDataSetupFutureUsage::*;
         match s {
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1989,13 +1989,13 @@ impl CreateCheckoutSessionPaymentMethodCollection {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionPaymentMethodCollection {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionPaymentMethodCollection::*;
         match s {
             "always" => Ok(Always),
             "if_required" => Ok(IfRequired),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2179,13 +2179,13 @@ impl CreateCheckoutSessionPaymentMethodOptionsAcssDebitCurrency {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionPaymentMethodOptionsAcssDebitCurrency {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionPaymentMethodOptionsAcssDebitCurrency::*;
         match s {
             "cad" => Ok(Cad),
             "usd" => Ok(Usd),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2271,13 +2271,13 @@ impl CreateCheckoutSessionPaymentMethodOptionsAcssDebitMandateOptionsDefaultFor 
 impl std::str::FromStr
     for CreateCheckoutSessionPaymentMethodOptionsAcssDebitMandateOptionsDefaultFor
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionPaymentMethodOptionsAcssDebitMandateOptionsDefaultFor::*;
         match s {
             "invoice" => Ok(Invoice),
             "subscription" => Ok(Subscription),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2337,14 +2337,14 @@ impl CreateCheckoutSessionPaymentMethodOptionsAcssDebitMandateOptionsPaymentSche
 impl std::str::FromStr
     for CreateCheckoutSessionPaymentMethodOptionsAcssDebitMandateOptionsPaymentSchedule
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionPaymentMethodOptionsAcssDebitMandateOptionsPaymentSchedule::*;
         match s {
             "combined" => Ok(Combined),
             "interval" => Ok(Interval),
             "sporadic" => Ok(Sporadic),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2402,13 +2402,13 @@ impl CreateCheckoutSessionPaymentMethodOptionsAcssDebitMandateOptionsTransaction
 impl std::str::FromStr
     for CreateCheckoutSessionPaymentMethodOptionsAcssDebitMandateOptionsTransactionType
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionPaymentMethodOptionsAcssDebitMandateOptionsTransactionType::*;
         match s {
             "business" => Ok(Business),
             "personal" => Ok(Personal),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2471,14 +2471,14 @@ impl CreateCheckoutSessionPaymentMethodOptionsAcssDebitSetupFutureUsage {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionPaymentMethodOptionsAcssDebitSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionPaymentMethodOptionsAcssDebitSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2530,14 +2530,14 @@ impl CreateCheckoutSessionPaymentMethodOptionsAcssDebitVerificationMethod {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionPaymentMethodOptionsAcssDebitVerificationMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionPaymentMethodOptionsAcssDebitVerificationMethod::*;
         match s {
             "automatic" => Ok(Automatic),
             "instant" => Ok(Instant),
             "microdeposits" => Ok(Microdeposits),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2607,12 +2607,12 @@ impl CreateCheckoutSessionPaymentMethodOptionsAffirmSetupFutureUsage {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionPaymentMethodOptionsAffirmSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionPaymentMethodOptionsAffirmSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2689,12 +2689,12 @@ impl CreateCheckoutSessionPaymentMethodOptionsAfterpayClearpaySetupFutureUsage {
 impl std::str::FromStr
     for CreateCheckoutSessionPaymentMethodOptionsAfterpayClearpaySetupFutureUsage
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionPaymentMethodOptionsAfterpayClearpaySetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2768,12 +2768,12 @@ impl CreateCheckoutSessionPaymentMethodOptionsAlipaySetupFutureUsage {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionPaymentMethodOptionsAlipaySetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionPaymentMethodOptionsAlipaySetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2848,12 +2848,12 @@ impl CreateCheckoutSessionPaymentMethodOptionsAuBecsDebitSetupFutureUsage {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionPaymentMethodOptionsAuBecsDebitSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionPaymentMethodOptionsAuBecsDebitSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2928,14 +2928,14 @@ impl CreateCheckoutSessionPaymentMethodOptionsBacsDebitSetupFutureUsage {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionPaymentMethodOptionsBacsDebitSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionPaymentMethodOptionsBacsDebitSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3006,12 +3006,12 @@ impl CreateCheckoutSessionPaymentMethodOptionsBancontactSetupFutureUsage {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionPaymentMethodOptionsBancontactSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionPaymentMethodOptionsBancontactSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3089,14 +3089,14 @@ impl CreateCheckoutSessionPaymentMethodOptionsBoletoSetupFutureUsage {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionPaymentMethodOptionsBoletoSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionPaymentMethodOptionsBoletoSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3200,13 +3200,13 @@ impl CreateCheckoutSessionPaymentMethodOptionsCardSetupFutureUsage {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionPaymentMethodOptionsCardSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionPaymentMethodOptionsCardSetupFutureUsage::*;
         match s {
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3285,14 +3285,14 @@ impl CreateCheckoutSessionPaymentMethodOptionsCashappSetupFutureUsage {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionPaymentMethodOptionsCashappSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionPaymentMethodOptionsCashappSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3419,7 +3419,7 @@ impl CreateCheckoutSessionPaymentMethodOptionsCustomerBalanceBankTransferRequest
 impl std::str::FromStr
     for CreateCheckoutSessionPaymentMethodOptionsCustomerBalanceBankTransferRequestedAddressTypes
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionPaymentMethodOptionsCustomerBalanceBankTransferRequestedAddressTypes::*;
         match s {
@@ -3430,7 +3430,7 @@ impl std::str::FromStr
             "spei" => Ok(Spei),
             "swift" => Ok(Swift),
             "zengin" => Ok(Zengin),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3494,7 +3494,7 @@ impl CreateCheckoutSessionPaymentMethodOptionsCustomerBalanceBankTransferType {
 impl std::str::FromStr
     for CreateCheckoutSessionPaymentMethodOptionsCustomerBalanceBankTransferType
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionPaymentMethodOptionsCustomerBalanceBankTransferType::*;
         match s {
@@ -3503,7 +3503,7 @@ impl std::str::FromStr
             "jp_bank_transfer" => Ok(JpBankTransfer),
             "mx_bank_transfer" => Ok(MxBankTransfer),
             "us_bank_transfer" => Ok(UsBankTransfer),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3554,12 +3554,12 @@ impl CreateCheckoutSessionPaymentMethodOptionsCustomerBalanceFundingType {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionPaymentMethodOptionsCustomerBalanceFundingType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionPaymentMethodOptionsCustomerBalanceFundingType::*;
         match s {
             "bank_transfer" => Ok(BankTransfer),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3614,12 +3614,12 @@ impl CreateCheckoutSessionPaymentMethodOptionsCustomerBalanceSetupFutureUsage {
 impl std::str::FromStr
     for CreateCheckoutSessionPaymentMethodOptionsCustomerBalanceSetupFutureUsage
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionPaymentMethodOptionsCustomerBalanceSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3691,12 +3691,12 @@ impl CreateCheckoutSessionPaymentMethodOptionsEpsSetupFutureUsage {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionPaymentMethodOptionsEpsSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionPaymentMethodOptionsEpsSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3768,12 +3768,12 @@ impl CreateCheckoutSessionPaymentMethodOptionsFpxSetupFutureUsage {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionPaymentMethodOptionsFpxSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionPaymentMethodOptionsFpxSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3846,12 +3846,12 @@ impl CreateCheckoutSessionPaymentMethodOptionsGiropaySetupFutureUsage {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionPaymentMethodOptionsGiropaySetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionPaymentMethodOptionsGiropaySetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3922,12 +3922,12 @@ impl CreateCheckoutSessionPaymentMethodOptionsGrabpaySetupFutureUsage {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionPaymentMethodOptionsGrabpaySetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionPaymentMethodOptionsGrabpaySetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3997,12 +3997,12 @@ impl CreateCheckoutSessionPaymentMethodOptionsIdealSetupFutureUsage {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionPaymentMethodOptionsIdealSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionPaymentMethodOptionsIdealSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4076,12 +4076,12 @@ impl CreateCheckoutSessionPaymentMethodOptionsKlarnaSetupFutureUsage {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionPaymentMethodOptionsKlarnaSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionPaymentMethodOptionsKlarnaSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4161,12 +4161,12 @@ impl CreateCheckoutSessionPaymentMethodOptionsKonbiniSetupFutureUsage {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionPaymentMethodOptionsKonbiniSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionPaymentMethodOptionsKonbiniSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4238,13 +4238,13 @@ impl CreateCheckoutSessionPaymentMethodOptionsLinkSetupFutureUsage {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionPaymentMethodOptionsLinkSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionPaymentMethodOptionsLinkSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4322,12 +4322,12 @@ impl CreateCheckoutSessionPaymentMethodOptionsOxxoSetupFutureUsage {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionPaymentMethodOptionsOxxoSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionPaymentMethodOptionsOxxoSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4404,12 +4404,12 @@ impl CreateCheckoutSessionPaymentMethodOptionsP24SetupFutureUsage {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionPaymentMethodOptionsP24SetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionPaymentMethodOptionsP24SetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4481,12 +4481,12 @@ impl CreateCheckoutSessionPaymentMethodOptionsPaynowSetupFutureUsage {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionPaymentMethodOptionsPaynowSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionPaymentMethodOptionsPaynowSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4570,12 +4570,12 @@ impl CreateCheckoutSessionPaymentMethodOptionsPaypalCaptureMethod {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionPaymentMethodOptionsPaypalCaptureMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionPaymentMethodOptionsPaypalCaptureMethod::*;
         match s {
             "manual" => Ok(Manual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4669,7 +4669,7 @@ impl CreateCheckoutSessionPaymentMethodOptionsPaypalPreferredLocale {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionPaymentMethodOptionsPaypalPreferredLocale {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionPaymentMethodOptionsPaypalPreferredLocale::*;
         match s {
@@ -4694,7 +4694,7 @@ impl std::str::FromStr for CreateCheckoutSessionPaymentMethodOptionsPaypalPrefer
             "pt-PT" => Ok(PtMinusPt),
             "sk-SK" => Ok(SkMinusSk),
             "sv-SE" => Ok(SvMinusSe),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -4724,7 +4724,7 @@ impl<'de> serde::Deserialize<'de>
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// Indicates that you intend to make future payments with this PaymentIntent's payment method.
@@ -4751,13 +4751,13 @@ impl CreateCheckoutSessionPaymentMethodOptionsPaypalSetupFutureUsage {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionPaymentMethodOptionsPaypalSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionPaymentMethodOptionsPaypalSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4847,13 +4847,13 @@ impl CreateCheckoutSessionPaymentMethodOptionsRevolutPaySetupFutureUsage {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionPaymentMethodOptionsRevolutPaySetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionPaymentMethodOptionsRevolutPaySetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4928,14 +4928,14 @@ impl CreateCheckoutSessionPaymentMethodOptionsSepaDebitSetupFutureUsage {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionPaymentMethodOptionsSepaDebitSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionPaymentMethodOptionsSepaDebitSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5005,12 +5005,12 @@ impl CreateCheckoutSessionPaymentMethodOptionsSofortSetupFutureUsage {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionPaymentMethodOptionsSofortSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionPaymentMethodOptionsSofortSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5129,7 +5129,7 @@ impl CreateCheckoutSessionPaymentMethodOptionsUsBankAccountFinancialConnectionsP
 impl std::str::FromStr
     for CreateCheckoutSessionPaymentMethodOptionsUsBankAccountFinancialConnectionsPermissions
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionPaymentMethodOptionsUsBankAccountFinancialConnectionsPermissions::*;
         match s {
@@ -5137,7 +5137,7 @@ impl std::str::FromStr
             "ownership" => Ok(Ownership),
             "payment_method" => Ok(PaymentMethod),
             "transactions" => Ok(Transactions),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5195,13 +5195,13 @@ impl CreateCheckoutSessionPaymentMethodOptionsUsBankAccountFinancialConnectionsP
 impl std::str::FromStr
     for CreateCheckoutSessionPaymentMethodOptionsUsBankAccountFinancialConnectionsPrefetch
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionPaymentMethodOptionsUsBankAccountFinancialConnectionsPrefetch::*;
         match s {
             "balances" => Ok(Balances),
             "transactions" => Ok(Transactions),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5264,14 +5264,14 @@ impl CreateCheckoutSessionPaymentMethodOptionsUsBankAccountSetupFutureUsage {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionPaymentMethodOptionsUsBankAccountSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionPaymentMethodOptionsUsBankAccountSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5323,13 +5323,13 @@ impl CreateCheckoutSessionPaymentMethodOptionsUsBankAccountVerificationMethod {
 impl std::str::FromStr
     for CreateCheckoutSessionPaymentMethodOptionsUsBankAccountVerificationMethod
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionPaymentMethodOptionsUsBankAccountVerificationMethod::*;
         match s {
             "automatic" => Ok(Automatic),
             "instant" => Ok(Instant),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5406,14 +5406,14 @@ impl CreateCheckoutSessionPaymentMethodOptionsWechatPayClient {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionPaymentMethodOptionsWechatPayClient {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionPaymentMethodOptionsWechatPayClient::*;
         match s {
             "android" => Ok(Android),
             "ios" => Ok(Ios),
             "web" => Ok(Web),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5468,12 +5468,12 @@ impl CreateCheckoutSessionPaymentMethodOptionsWechatPaySetupFutureUsage {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionPaymentMethodOptionsWechatPaySetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionPaymentMethodOptionsWechatPaySetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5599,7 +5599,7 @@ impl CreateCheckoutSessionPaymentMethodTypes {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionPaymentMethodTypes {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionPaymentMethodTypes::*;
         match s {
@@ -5636,7 +5636,7 @@ impl std::str::FromStr for CreateCheckoutSessionPaymentMethodTypes {
             "us_bank_account" => Ok(UsBankAccount),
             "wechat_pay" => Ok(WechatPay),
             "zip" => Ok(Zip),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -5664,7 +5664,7 @@ impl<'de> serde::Deserialize<'de> for CreateCheckoutSessionPaymentMethodTypes {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// Controls phone number collection settings for the session.
@@ -6211,7 +6211,7 @@ impl CreateCheckoutSessionShippingAddressCollectionAllowedCountries {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionShippingAddressCollectionAllowedCountries {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionShippingAddressCollectionAllowedCountries::*;
         match s {
@@ -6452,7 +6452,7 @@ impl std::str::FromStr for CreateCheckoutSessionShippingAddressCollectionAllowed
             "ZM" => Ok(Zm),
             "ZW" => Ok(Zw),
             "ZZ" => Ok(Zz),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -6482,7 +6482,7 @@ impl<'de> serde::Deserialize<'de>
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// The shipping rate options to apply to this Session. Up to a maximum of 5.
@@ -6605,7 +6605,7 @@ impl CreateCheckoutSessionShippingOptionsShippingRateDataDeliveryEstimateMaximum
 impl std::str::FromStr
     for CreateCheckoutSessionShippingOptionsShippingRateDataDeliveryEstimateMaximumUnit
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionShippingOptionsShippingRateDataDeliveryEstimateMaximumUnit::*;
         match s {
@@ -6614,7 +6614,7 @@ impl std::str::FromStr
             "hour" => Ok(Hour),
             "month" => Ok(Month),
             "week" => Ok(Week),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -6694,7 +6694,7 @@ impl CreateCheckoutSessionShippingOptionsShippingRateDataDeliveryEstimateMinimum
 impl std::str::FromStr
     for CreateCheckoutSessionShippingOptionsShippingRateDataDeliveryEstimateMinimumUnit
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionShippingOptionsShippingRateDataDeliveryEstimateMinimumUnit::*;
         match s {
@@ -6703,7 +6703,7 @@ impl std::str::FromStr
             "hour" => Ok(Hour),
             "month" => Ok(Month),
             "week" => Ok(Week),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -6805,14 +6805,14 @@ impl CreateCheckoutSessionShippingOptionsShippingRateDataFixedAmountCurrencyOpti
 impl std::str::FromStr
     for CreateCheckoutSessionShippingOptionsShippingRateDataFixedAmountCurrencyOptionsTaxBehavior
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionShippingOptionsShippingRateDataFixedAmountCurrencyOptionsTaxBehavior::*;
         match s {
             "exclusive" => Ok(Exclusive),
             "inclusive" => Ok(Inclusive),
             "unspecified" => Ok(Unspecified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -6871,14 +6871,14 @@ impl CreateCheckoutSessionShippingOptionsShippingRateDataTaxBehavior {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionShippingOptionsShippingRateDataTaxBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionShippingOptionsShippingRateDataTaxBehavior::*;
         match s {
             "exclusive" => Ok(Exclusive),
             "inclusive" => Ok(Inclusive),
             "unspecified" => Ok(Unspecified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -6930,12 +6930,12 @@ impl CreateCheckoutSessionShippingOptionsShippingRateDataType {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionShippingOptionsShippingRateDataType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionShippingOptionsShippingRateDataType::*;
         match s {
             "fixed_amount" => Ok(FixedAmount),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -7075,13 +7075,13 @@ impl CreateCheckoutSessionSubscriptionDataInvoiceSettingsIssuerType {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionSubscriptionDataInvoiceSettingsIssuerType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionSubscriptionDataInvoiceSettingsIssuerType::*;
         match s {
             "account" => Ok(Account),
             "self" => Ok(Self_),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -7136,13 +7136,13 @@ impl CreateCheckoutSessionSubscriptionDataProrationBehavior {
 }
 
 impl std::str::FromStr for CreateCheckoutSessionSubscriptionDataProrationBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionSubscriptionDataProrationBehavior::*;
         match s {
             "create_prorations" => Ok(CreateProrations),
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -7241,14 +7241,14 @@ impl CreateCheckoutSessionSubscriptionDataTrialSettingsEndBehaviorMissingPayment
 impl std::str::FromStr
     for CreateCheckoutSessionSubscriptionDataTrialSettingsEndBehaviorMissingPaymentMethod
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCheckoutSessionSubscriptionDataTrialSettingsEndBehaviorMissingPaymentMethod::*;
         match s {
             "cancel" => Ok(Cancel),
             "create_invoice" => Ok(CreateInvoice),
             "pause" => Ok(Pause),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_checkout/src/checkout_session/types.rs
+++ b/generated/stripe_checkout/src/checkout_session/types.rs
@@ -624,13 +624,13 @@ impl CheckoutSessionCustomerCreation {
 }
 
 impl std::str::FromStr for CheckoutSessionCustomerCreation {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CheckoutSessionCustomerCreation::*;
         match s {
             "always" => Ok(Always),
             "if_required" => Ok(IfRequired),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -697,13 +697,13 @@ impl CheckoutSessionPaymentMethodCollection {
 }
 
 impl std::str::FromStr for CheckoutSessionPaymentMethodCollection {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CheckoutSessionPaymentMethodCollection::*;
         match s {
             "always" => Ok(Always),
             "if_required" => Ok(IfRequired),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -774,14 +774,14 @@ impl CheckoutSessionPaymentStatus {
 }
 
 impl std::str::FromStr for CheckoutSessionPaymentStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CheckoutSessionPaymentStatus::*;
         match s {
             "no_payment_required" => Ok(NoPaymentRequired),
             "paid" => Ok(Paid),
             "unpaid" => Ok(Unpaid),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -852,13 +852,13 @@ impl CheckoutSessionBillingAddressCollection {
 }
 
 impl std::str::FromStr for CheckoutSessionBillingAddressCollection {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CheckoutSessionBillingAddressCollection::*;
         match s {
             "auto" => Ok(Auto),
             "required" => Ok(Required),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1006,7 +1006,7 @@ impl CheckoutSessionLocale {
 }
 
 impl std::str::FromStr for CheckoutSessionLocale {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CheckoutSessionLocale::*;
         match s {
@@ -1051,7 +1051,7 @@ impl std::str::FromStr for CheckoutSessionLocale {
             "zh" => Ok(Zh),
             "zh-HK" => Ok(ZhMinusHk),
             "zh-TW" => Ok(ZhMinusTw),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -1083,8 +1083,7 @@ impl miniserde::Deserialize for CheckoutSessionLocale {
 impl miniserde::de::Visitor for crate::Place<CheckoutSessionLocale> {
     fn string(&mut self, s: &str) -> miniserde::Result<()> {
         use std::str::FromStr;
-        self.out =
-            Some(CheckoutSessionLocale::from_str(s).unwrap_or(CheckoutSessionLocale::Unknown));
+        self.out = Some(CheckoutSessionLocale::from_str(s).unwrap());
         Ok(())
     }
 }
@@ -1095,7 +1094,7 @@ impl<'de> serde::Deserialize<'de> for CheckoutSessionLocale {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -1116,14 +1115,14 @@ impl CheckoutSessionMode {
 }
 
 impl std::str::FromStr for CheckoutSessionMode {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CheckoutSessionMode::*;
         match s {
             "payment" => Ok(Payment),
             "setup" => Ok(Setup),
             "subscription" => Ok(Subscription),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1188,14 +1187,14 @@ impl CheckoutSessionRedirectOnCompletion {
 }
 
 impl std::str::FromStr for CheckoutSessionRedirectOnCompletion {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CheckoutSessionRedirectOnCompletion::*;
         match s {
             "always" => Ok(Always),
             "if_required" => Ok(IfRequired),
             "never" => Ok(Never),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1262,14 +1261,14 @@ impl CheckoutSessionStatus {
 }
 
 impl std::str::FromStr for CheckoutSessionStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CheckoutSessionStatus::*;
         match s {
             "complete" => Ok(Complete),
             "expired" => Ok(Expired),
             "open" => Ok(Open),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1336,7 +1335,7 @@ impl CheckoutSessionSubmitType {
 }
 
 impl std::str::FromStr for CheckoutSessionSubmitType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CheckoutSessionSubmitType::*;
         match s {
@@ -1344,7 +1343,7 @@ impl std::str::FromStr for CheckoutSessionSubmitType {
             "book" => Ok(Book),
             "donate" => Ok(Donate),
             "pay" => Ok(Pay),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1407,13 +1406,13 @@ impl CheckoutSessionUiMode {
 }
 
 impl std::str::FromStr for CheckoutSessionUiMode {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CheckoutSessionUiMode::*;
         match s {
             "embedded" => Ok(Embedded),
             "hosted" => Ok(Hosted),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_checkout/src/checkout_sofort_payment_method_options.rs
+++ b/generated/stripe_checkout/src/checkout_sofort_payment_method_options.rs
@@ -118,12 +118,12 @@ impl CheckoutSofortPaymentMethodOptionsSetupFutureUsage {
 }
 
 impl std::str::FromStr for CheckoutSofortPaymentMethodOptionsSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CheckoutSofortPaymentMethodOptionsSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_checkout/src/checkout_us_bank_account_payment_method_options.rs
+++ b/generated/stripe_checkout/src/checkout_us_bank_account_payment_method_options.rs
@@ -144,14 +144,14 @@ impl CheckoutUsBankAccountPaymentMethodOptionsSetupFutureUsage {
 }
 
 impl std::str::FromStr for CheckoutUsBankAccountPaymentMethodOptionsSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CheckoutUsBankAccountPaymentMethodOptionsSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -226,13 +226,13 @@ impl CheckoutUsBankAccountPaymentMethodOptionsVerificationMethod {
 }
 
 impl std::str::FromStr for CheckoutUsBankAccountPaymentMethodOptionsVerificationMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CheckoutUsBankAccountPaymentMethodOptionsVerificationMethod::*;
         match s {
             "automatic" => Ok(Automatic),
             "instant" => Ok(Instant),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_checkout/src/payment_pages_checkout_session_automatic_tax.rs
+++ b/generated/stripe_checkout/src/payment_pages_checkout_session_automatic_tax.rs
@@ -130,14 +130,14 @@ impl PaymentPagesCheckoutSessionAutomaticTaxStatus {
 }
 
 impl std::str::FromStr for PaymentPagesCheckoutSessionAutomaticTaxStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentPagesCheckoutSessionAutomaticTaxStatus::*;
         match s {
             "complete" => Ok(Complete),
             "failed" => Ok(Failed),
             "requires_location_inputs" => Ok(RequiresLocationInputs),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_checkout/src/payment_pages_checkout_session_consent.rs
+++ b/generated/stripe_checkout/src/payment_pages_checkout_session_consent.rs
@@ -118,13 +118,13 @@ impl PaymentPagesCheckoutSessionConsentPromotions {
 }
 
 impl std::str::FromStr for PaymentPagesCheckoutSessionConsentPromotions {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentPagesCheckoutSessionConsentPromotions::*;
         match s {
             "opt_in" => Ok(OptIn),
             "opt_out" => Ok(OptOut),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -193,12 +193,12 @@ impl PaymentPagesCheckoutSessionConsentTermsOfService {
 }
 
 impl std::str::FromStr for PaymentPagesCheckoutSessionConsentTermsOfService {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentPagesCheckoutSessionConsentTermsOfService::*;
         match s {
             "accepted" => Ok(Accepted),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_checkout/src/payment_pages_checkout_session_consent_collection.rs
+++ b/generated/stripe_checkout/src/payment_pages_checkout_session_consent_collection.rs
@@ -138,13 +138,13 @@ impl PaymentPagesCheckoutSessionConsentCollectionPromotions {
 }
 
 impl std::str::FromStr for PaymentPagesCheckoutSessionConsentCollectionPromotions {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentPagesCheckoutSessionConsentCollectionPromotions::*;
         match s {
             "auto" => Ok(Auto),
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -217,13 +217,13 @@ impl PaymentPagesCheckoutSessionConsentCollectionTermsOfService {
 }
 
 impl std::str::FromStr for PaymentPagesCheckoutSessionConsentCollectionTermsOfService {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentPagesCheckoutSessionConsentCollectionTermsOfService::*;
         match s {
             "none" => Ok(None),
             "required" => Ok(Required),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_checkout/src/payment_pages_checkout_session_custom_fields.rs
+++ b/generated/stripe_checkout/src/payment_pages_checkout_session_custom_fields.rs
@@ -155,14 +155,14 @@ impl PaymentPagesCheckoutSessionCustomFieldsType {
 }
 
 impl std::str::FromStr for PaymentPagesCheckoutSessionCustomFieldsType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentPagesCheckoutSessionCustomFieldsType::*;
         match s {
             "dropdown" => Ok(Dropdown),
             "numeric" => Ok(Numeric),
             "text" => Ok(Text),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_checkout/src/payment_pages_checkout_session_custom_fields_label.rs
+++ b/generated/stripe_checkout/src/payment_pages_checkout_session_custom_fields_label.rs
@@ -112,12 +112,12 @@ impl PaymentPagesCheckoutSessionCustomFieldsLabelType {
 }
 
 impl std::str::FromStr for PaymentPagesCheckoutSessionCustomFieldsLabelType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentPagesCheckoutSessionCustomFieldsLabelType::*;
         match s {
             "custom" => Ok(Custom),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_checkout/src/payment_pages_checkout_session_customer_details.rs
+++ b/generated/stripe_checkout/src/payment_pages_checkout_session_customer_details.rs
@@ -152,14 +152,14 @@ impl PaymentPagesCheckoutSessionCustomerDetailsTaxExempt {
 }
 
 impl std::str::FromStr for PaymentPagesCheckoutSessionCustomerDetailsTaxExempt {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentPagesCheckoutSessionCustomerDetailsTaxExempt::*;
         match s {
             "exempt" => Ok(Exempt),
             "none" => Ok(None),
             "reverse" => Ok(Reverse),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_checkout/src/payment_pages_checkout_session_payment_method_reuse_agreement.rs
+++ b/generated/stripe_checkout/src/payment_pages_checkout_session_payment_method_reuse_agreement.rs
@@ -116,13 +116,13 @@ impl PaymentPagesCheckoutSessionPaymentMethodReuseAgreementPosition {
 }
 
 impl std::str::FromStr for PaymentPagesCheckoutSessionPaymentMethodReuseAgreementPosition {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentPagesCheckoutSessionPaymentMethodReuseAgreementPosition::*;
         match s {
             "auto" => Ok(Auto),
             "hidden" => Ok(Hidden),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_checkout/src/payment_pages_checkout_session_shipping_address_collection.rs
+++ b/generated/stripe_checkout/src/payment_pages_checkout_session_shipping_address_collection.rs
@@ -590,7 +590,7 @@ impl PaymentPagesCheckoutSessionShippingAddressCollectionAllowedCountries {
 }
 
 impl std::str::FromStr for PaymentPagesCheckoutSessionShippingAddressCollectionAllowedCountries {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentPagesCheckoutSessionShippingAddressCollectionAllowedCountries::*;
         match s {
@@ -831,7 +831,7 @@ impl std::str::FromStr for PaymentPagesCheckoutSessionShippingAddressCollectionA
             "ZM" => Ok(Zm),
             "ZW" => Ok(Zw),
             "ZZ" => Ok(Zz),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -870,9 +870,7 @@ impl miniserde::de::Visitor
         use std::str::FromStr;
         self.out = Some(
             PaymentPagesCheckoutSessionShippingAddressCollectionAllowedCountries::from_str(s)
-                .unwrap_or(
-                    PaymentPagesCheckoutSessionShippingAddressCollectionAllowedCountries::Unknown,
-                ),
+                .unwrap(),
         );
         Ok(())
     }
@@ -888,6 +886,6 @@ impl<'de> serde::Deserialize<'de>
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }

--- a/generated/stripe_checkout/src/payment_pages_checkout_session_tax_id.rs
+++ b/generated/stripe_checkout/src/payment_pages_checkout_session_tax_id.rs
@@ -244,7 +244,7 @@ impl PaymentPagesCheckoutSessionTaxIdType {
 }
 
 impl std::str::FromStr for PaymentPagesCheckoutSessionTaxIdType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentPagesCheckoutSessionTaxIdType::*;
         match s {
@@ -315,7 +315,7 @@ impl std::str::FromStr for PaymentPagesCheckoutSessionTaxIdType {
             "ve_rif" => Ok(VeRif),
             "vn_tin" => Ok(VnTin),
             "za_vat" => Ok(ZaVat),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_connect/src/account/requests.rs
+++ b/generated/stripe_connect/src/account/requests.rs
@@ -477,7 +477,7 @@ impl CreateAccountCompanyStructure {
 }
 
 impl std::str::FromStr for CreateAccountCompanyStructure {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateAccountCompanyStructure::*;
         match s {
@@ -504,7 +504,7 @@ impl std::str::FromStr for CreateAccountCompanyStructure {
             "unincorporated_association" => Ok(UnincorporatedAssociation),
             "unincorporated_non_profit" => Ok(UnincorporatedNonProfit),
             "unincorporated_partnership" => Ok(UnincorporatedPartnership),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -532,7 +532,7 @@ impl<'de> serde::Deserialize<'de> for CreateAccountCompanyStructure {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// Information about the person represented by the account.
@@ -699,13 +699,13 @@ impl CreateAccountIndividualPoliticalExposure {
 }
 
 impl std::str::FromStr for CreateAccountIndividualPoliticalExposure {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateAccountIndividualPoliticalExposure::*;
         match s {
             "existing" => Ok(Existing),
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -854,7 +854,7 @@ impl CreateAccountSettingsPayoutsScheduleInterval {
 }
 
 impl std::str::FromStr for CreateAccountSettingsPayoutsScheduleInterval {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateAccountSettingsPayoutsScheduleInterval::*;
         match s {
@@ -862,7 +862,7 @@ impl std::str::FromStr for CreateAccountSettingsPayoutsScheduleInterval {
             "manual" => Ok(Manual),
             "monthly" => Ok(Monthly),
             "weekly" => Ok(Weekly),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -925,7 +925,7 @@ impl CreateAccountSettingsPayoutsScheduleWeeklyAnchor {
 }
 
 impl std::str::FromStr for CreateAccountSettingsPayoutsScheduleWeeklyAnchor {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateAccountSettingsPayoutsScheduleWeeklyAnchor::*;
         match s {
@@ -936,7 +936,7 @@ impl std::str::FromStr for CreateAccountSettingsPayoutsScheduleWeeklyAnchor {
             "thursday" => Ok(Thursday),
             "tuesday" => Ok(Tuesday),
             "wednesday" => Ok(Wednesday),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1254,7 +1254,7 @@ impl UpdateAccountCompanyStructure {
 }
 
 impl std::str::FromStr for UpdateAccountCompanyStructure {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateAccountCompanyStructure::*;
         match s {
@@ -1281,7 +1281,7 @@ impl std::str::FromStr for UpdateAccountCompanyStructure {
             "unincorporated_association" => Ok(UnincorporatedAssociation),
             "unincorporated_non_profit" => Ok(UnincorporatedNonProfit),
             "unincorporated_partnership" => Ok(UnincorporatedPartnership),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -1309,7 +1309,7 @@ impl<'de> serde::Deserialize<'de> for UpdateAccountCompanyStructure {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// Information about the person represented by the account.
@@ -1476,13 +1476,13 @@ impl UpdateAccountIndividualPoliticalExposure {
 }
 
 impl std::str::FromStr for UpdateAccountIndividualPoliticalExposure {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateAccountIndividualPoliticalExposure::*;
         match s {
             "existing" => Ok(Existing),
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1647,7 +1647,7 @@ impl UpdateAccountSettingsPayoutsScheduleInterval {
 }
 
 impl std::str::FromStr for UpdateAccountSettingsPayoutsScheduleInterval {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateAccountSettingsPayoutsScheduleInterval::*;
         match s {
@@ -1655,7 +1655,7 @@ impl std::str::FromStr for UpdateAccountSettingsPayoutsScheduleInterval {
             "manual" => Ok(Manual),
             "monthly" => Ok(Monthly),
             "weekly" => Ok(Weekly),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1718,7 +1718,7 @@ impl UpdateAccountSettingsPayoutsScheduleWeeklyAnchor {
 }
 
 impl std::str::FromStr for UpdateAccountSettingsPayoutsScheduleWeeklyAnchor {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateAccountSettingsPayoutsScheduleWeeklyAnchor::*;
         match s {
@@ -1729,7 +1729,7 @@ impl std::str::FromStr for UpdateAccountSettingsPayoutsScheduleWeeklyAnchor {
             "thursday" => Ok(Thursday),
             "tuesday" => Ok(Tuesday),
             "wednesday" => Ok(Wednesday),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_connect/src/account_link/requests.rs
+++ b/generated/stripe_connect/src/account_link/requests.rs
@@ -54,13 +54,13 @@ impl CreateAccountLinkCollect {
 }
 
 impl std::str::FromStr for CreateAccountLinkCollect {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateAccountLinkCollect::*;
         match s {
             "currently_due" => Ok(CurrentlyDue),
             "eventually_due" => Ok(EventuallyDue),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -126,13 +126,13 @@ impl CreateAccountLinkCollectionOptionsFields {
 }
 
 impl std::str::FromStr for CreateAccountLinkCollectionOptionsFields {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateAccountLinkCollectionOptionsFields::*;
         match s {
             "currently_due" => Ok(CurrentlyDue),
             "eventually_due" => Ok(EventuallyDue),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -183,13 +183,13 @@ impl CreateAccountLinkCollectionOptionsFutureRequirements {
 }
 
 impl std::str::FromStr for CreateAccountLinkCollectionOptionsFutureRequirements {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateAccountLinkCollectionOptionsFutureRequirements::*;
         match s {
             "include" => Ok(Include),
             "omit" => Ok(Omit),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -242,13 +242,13 @@ impl CreateAccountLinkType {
 }
 
 impl std::str::FromStr for CreateAccountLinkType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateAccountLinkType::*;
         match s {
             "account_onboarding" => Ok(AccountOnboarding),
             "account_update" => Ok(AccountUpdate),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_connect/src/apps_secret/requests.rs
+++ b/generated/stripe_connect/src/apps_secret/requests.rs
@@ -60,13 +60,13 @@ impl ListAppsSecretScopeType {
 }
 
 impl std::str::FromStr for ListAppsSecretScopeType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ListAppsSecretScopeType::*;
         match s {
             "account" => Ok(Account),
             "user" => Ok(User),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -160,13 +160,13 @@ impl FindAppsSecretScopeType {
 }
 
 impl std::str::FromStr for FindAppsSecretScopeType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use FindAppsSecretScopeType::*;
         match s {
             "account" => Ok(Account),
             "user" => Ok(User),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -259,13 +259,13 @@ impl CreateAppsSecretScopeType {
 }
 
 impl std::str::FromStr for CreateAppsSecretScopeType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateAppsSecretScopeType::*;
         match s {
             "account" => Ok(Account),
             "user" => Ok(User),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -353,13 +353,13 @@ impl DeleteWhereAppsSecretScopeType {
 }
 
 impl std::str::FromStr for DeleteWhereAppsSecretScopeType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use DeleteWhereAppsSecretScopeType::*;
         match s {
             "account" => Ok(Account),
             "user" => Ok(User),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_connect/src/external_account/requests.rs
+++ b/generated/stripe_connect/src/external_account/requests.rs
@@ -65,13 +65,13 @@ impl ListAccountExternalAccountObject {
 }
 
 impl std::str::FromStr for ListAccountExternalAccountObject {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ListAccountExternalAccountObject::*;
         match s {
             "bank_account" => Ok(BankAccount),
             "card" => Ok(Card),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -259,13 +259,13 @@ impl UpdateExternalAccountAccountHolderType {
 }
 
 impl std::str::FromStr for UpdateExternalAccountAccountHolderType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateExternalAccountAccountHolderType::*;
         match s {
             "company" => Ok(Company),
             "individual" => Ok(Individual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -321,7 +321,7 @@ impl UpdateExternalAccountAccountType {
 }
 
 impl std::str::FromStr for UpdateExternalAccountAccountType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateExternalAccountAccountType::*;
         match s {
@@ -329,7 +329,7 @@ impl std::str::FromStr for UpdateExternalAccountAccountType {
             "futsu" => Ok(Futsu),
             "savings" => Ok(Savings),
             "toza" => Ok(Toza),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_connect/src/secret_service_resource_scope.rs
+++ b/generated/stripe_connect/src/secret_service_resource_scope.rs
@@ -114,13 +114,13 @@ impl SecretServiceResourceScopeType {
 }
 
 impl std::str::FromStr for SecretServiceResourceScopeType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use SecretServiceResourceScopeType::*;
         match s {
             "account" => Ok(Account),
             "user" => Ok(User),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_connect/src/topup/requests.rs
+++ b/generated/stripe_connect/src/topup/requests.rs
@@ -56,7 +56,7 @@ impl ListTopupStatus {
 }
 
 impl std::str::FromStr for ListTopupStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ListTopupStatus::*;
         match s {
@@ -64,7 +64,7 @@ impl std::str::FromStr for ListTopupStatus {
             "failed" => Ok(Failed),
             "pending" => Ok(Pending),
             "succeeded" => Ok(Succeeded),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_connect/src/transfer/requests.rs
+++ b/generated/stripe_connect/src/transfer/requests.rs
@@ -139,14 +139,14 @@ impl CreateTransferSourceType {
 }
 
 impl std::str::FromStr for CreateTransferSourceType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTransferSourceType::*;
         match s {
             "bank_account" => Ok(BankAccount),
             "card" => Ok(Card),
             "fpx" => Ok(Fpx),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_core/src/cash_balance/requests.rs
+++ b/generated/stripe_core/src/cash_balance/requests.rs
@@ -68,14 +68,14 @@ impl UpdateCashBalanceSettingsReconciliationMode {
 }
 
 impl std::str::FromStr for UpdateCashBalanceSettingsReconciliationMode {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateCashBalanceSettingsReconciliationMode::*;
         match s {
             "automatic" => Ok(Automatic),
             "manual" => Ok(Manual),
             "merchant_default" => Ok(MerchantDefault),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_core/src/charge/requests.rs
+++ b/generated/stripe_core/src/charge/requests.rs
@@ -331,13 +331,13 @@ impl UpdateChargeFraudDetailsUserReport {
 }
 
 impl std::str::FromStr for UpdateChargeFraudDetailsUserReport {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateChargeFraudDetailsUserReport::*;
         match s {
             "fraudulent" => Ok(Fraudulent),
             "safe" => Ok(Safe),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_core/src/customer/requests.rs
+++ b/generated/stripe_core/src/customer/requests.rs
@@ -347,7 +347,7 @@ impl ListPaymentMethodsCustomerType {
 }
 
 impl std::str::FromStr for ListPaymentMethodsCustomerType {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ListPaymentMethodsCustomerType::*;
         match s {
@@ -384,7 +384,7 @@ impl std::str::FromStr for ListPaymentMethodsCustomerType {
             "us_bank_account" => Ok(UsBankAccount),
             "wechat_pay" => Ok(WechatPay),
             "zip" => Ok(Zip),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -412,7 +412,7 @@ impl<'de> serde::Deserialize<'de> for ListPaymentMethodsCustomerType {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 impl<'a> ListPaymentMethodsCustomer<'a> {
@@ -630,14 +630,14 @@ impl CreateCustomerCashBalanceSettingsReconciliationMode {
 }
 
 impl std::str::FromStr for CreateCustomerCashBalanceSettingsReconciliationMode {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCustomerCashBalanceSettingsReconciliationMode::*;
         match s {
             "automatic" => Ok(Automatic),
             "manual" => Ok(Manual),
             "merchant_default" => Ok(MerchantDefault),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -729,13 +729,13 @@ impl CreateCustomerInvoiceSettingsRenderingOptionsAmountTaxDisplay {
 }
 
 impl std::str::FromStr for CreateCustomerInvoiceSettingsRenderingOptionsAmountTaxDisplay {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCustomerInvoiceSettingsRenderingOptionsAmountTaxDisplay::*;
         match s {
             "exclude_tax" => Ok(ExcludeTax),
             "include_inclusive_tax" => Ok(IncludeInclusiveTax),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -808,13 +808,13 @@ impl CreateCustomerTaxValidateLocation {
 }
 
 impl std::str::FromStr for CreateCustomerTaxValidateLocation {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCustomerTaxValidateLocation::*;
         match s {
             "deferred" => Ok(Deferred),
             "immediately" => Ok(Immediately),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1010,7 +1010,7 @@ impl CreateCustomerTaxIdDataType {
 }
 
 impl std::str::FromStr for CreateCustomerTaxIdDataType {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateCustomerTaxIdDataType::*;
         match s {
@@ -1080,7 +1080,7 @@ impl std::str::FromStr for CreateCustomerTaxIdDataType {
             "ve_rif" => Ok(VeRif),
             "vn_tin" => Ok(VnTin),
             "za_vat" => Ok(ZaVat),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -1108,7 +1108,7 @@ impl<'de> serde::Deserialize<'de> for CreateCustomerTaxIdDataType {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 impl<'a> CreateCustomer<'a> {
@@ -1248,14 +1248,14 @@ impl UpdateCustomerCashBalanceSettingsReconciliationMode {
 }
 
 impl std::str::FromStr for UpdateCustomerCashBalanceSettingsReconciliationMode {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateCustomerCashBalanceSettingsReconciliationMode::*;
         match s {
             "automatic" => Ok(Automatic),
             "manual" => Ok(Manual),
             "merchant_default" => Ok(MerchantDefault),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1347,13 +1347,13 @@ impl UpdateCustomerInvoiceSettingsRenderingOptionsAmountTaxDisplay {
 }
 
 impl std::str::FromStr for UpdateCustomerInvoiceSettingsRenderingOptionsAmountTaxDisplay {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateCustomerInvoiceSettingsRenderingOptionsAmountTaxDisplay::*;
         match s {
             "exclude_tax" => Ok(ExcludeTax),
             "include_inclusive_tax" => Ok(IncludeInclusiveTax),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1426,13 +1426,13 @@ impl UpdateCustomerTaxValidateLocation {
 }
 
 impl std::str::FromStr for UpdateCustomerTaxValidateLocation {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateCustomerTaxValidateLocation::*;
         match s {
             "deferred" => Ok(Deferred),
             "immediately" => Ok(Immediately),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1562,7 +1562,7 @@ impl CreateFundingInstructionsCustomerBankTransferRequestedAddressTypes {
 }
 
 impl std::str::FromStr for CreateFundingInstructionsCustomerBankTransferRequestedAddressTypes {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateFundingInstructionsCustomerBankTransferRequestedAddressTypes::*;
         match s {
@@ -1570,7 +1570,7 @@ impl std::str::FromStr for CreateFundingInstructionsCustomerBankTransferRequeste
             "sort_code" => Ok(SortCode),
             "spei" => Ok(Spei),
             "zengin" => Ok(Zengin),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1626,7 +1626,7 @@ impl CreateFundingInstructionsCustomerBankTransferType {
 }
 
 impl std::str::FromStr for CreateFundingInstructionsCustomerBankTransferType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateFundingInstructionsCustomerBankTransferType::*;
         match s {
@@ -1635,7 +1635,7 @@ impl std::str::FromStr for CreateFundingInstructionsCustomerBankTransferType {
             "jp_bank_transfer" => Ok(JpBankTransfer),
             "mx_bank_transfer" => Ok(MxBankTransfer),
             "us_bank_transfer" => Ok(UsBankTransfer),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1685,12 +1685,12 @@ impl CreateFundingInstructionsCustomerFundingType {
 }
 
 impl std::str::FromStr for CreateFundingInstructionsCustomerFundingType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateFundingInstructionsCustomerFundingType::*;
         match s {
             "bank_transfer" => Ok(BankTransfer),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_core/src/payment_intent/requests.rs
+++ b/generated/stripe_core/src/payment_intent/requests.rs
@@ -329,13 +329,13 @@ impl CreatePaymentIntentAutomaticPaymentMethodsAllowRedirects {
 }
 
 impl std::str::FromStr for CreatePaymentIntentAutomaticPaymentMethodsAllowRedirects {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentAutomaticPaymentMethodsAllowRedirects::*;
         match s {
             "always" => Ok(Always),
             "never" => Ok(Never),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -423,13 +423,13 @@ impl CreatePaymentIntentMandateDataCustomerAcceptanceType {
 }
 
 impl std::str::FromStr for CreatePaymentIntentMandateDataCustomerAcceptanceType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentMandateDataCustomerAcceptanceType::*;
         match s {
             "offline" => Ok(Offline),
             "online" => Ok(Online),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -833,7 +833,7 @@ impl CreatePaymentIntentPaymentMethodDataEpsBank {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodDataEpsBank {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodDataEpsBank::*;
         match s {
@@ -865,7 +865,7 @@ impl std::str::FromStr for CreatePaymentIntentPaymentMethodDataEpsBank {
             "volksbank_gruppe" => Ok(VolksbankGruppe),
             "volkskreditbank_ag" => Ok(VolkskreditbankAg),
             "vr_bank_braunau" => Ok(VrBankBraunau),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -893,7 +893,7 @@ impl<'de> serde::Deserialize<'de> for CreatePaymentIntentPaymentMethodDataEpsBan
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// If this is an `fpx` PaymentMethod, this hash contains details about the FPX payment method.
@@ -927,13 +927,13 @@ impl CreatePaymentIntentPaymentMethodDataFpxAccountHolderType {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodDataFpxAccountHolderType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodDataFpxAccountHolderType::*;
         match s {
             "company" => Ok(Company),
             "individual" => Ok(Individual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1029,7 +1029,7 @@ impl CreatePaymentIntentPaymentMethodDataFpxBank {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodDataFpxBank {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodDataFpxBank::*;
         match s {
@@ -1055,7 +1055,7 @@ impl std::str::FromStr for CreatePaymentIntentPaymentMethodDataFpxBank {
             "rhb" => Ok(Rhb),
             "standard_chartered" => Ok(StandardChartered),
             "uob" => Ok(Uob),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -1083,7 +1083,7 @@ impl<'de> serde::Deserialize<'de> for CreatePaymentIntentPaymentMethodDataFpxBan
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// If this is an `ideal` PaymentMethod, this hash contains details about the iDEAL payment method.
@@ -1147,7 +1147,7 @@ impl CreatePaymentIntentPaymentMethodDataIdealBank {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodDataIdealBank {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodDataIdealBank::*;
         match s {
@@ -1167,7 +1167,7 @@ impl std::str::FromStr for CreatePaymentIntentPaymentMethodDataIdealBank {
             "triodos_bank" => Ok(TriodosBank),
             "van_lanschot" => Ok(VanLanschot),
             "yoursafe" => Ok(Yoursafe),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -1195,7 +1195,7 @@ impl<'de> serde::Deserialize<'de> for CreatePaymentIntentPaymentMethodDataIdealB
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// If this is a `klarna` PaymentMethod, this hash contains details about the Klarna payment method.
@@ -1291,7 +1291,7 @@ impl CreatePaymentIntentPaymentMethodDataP24Bank {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodDataP24Bank {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodDataP24Bank::*;
         match s {
@@ -1321,7 +1321,7 @@ impl std::str::FromStr for CreatePaymentIntentPaymentMethodDataP24Bank {
             "toyota_bank" => Ok(ToyotaBank),
             "velobank" => Ok(Velobank),
             "volkswagen_bank" => Ok(VolkswagenBank),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -1349,7 +1349,7 @@ impl<'de> serde::Deserialize<'de> for CreatePaymentIntentPaymentMethodDataP24Ban
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// Options to configure Radar.
@@ -1412,7 +1412,7 @@ impl CreatePaymentIntentPaymentMethodDataSofortCountry {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodDataSofortCountry {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodDataSofortCountry::*;
         match s {
@@ -1422,7 +1422,7 @@ impl std::str::FromStr for CreatePaymentIntentPaymentMethodDataSofortCountry {
             "ES" => Ok(Es),
             "IT" => Ok(It),
             "NL" => Ok(Nl),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1540,7 +1540,7 @@ impl CreatePaymentIntentPaymentMethodDataType {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodDataType {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodDataType::*;
         match s {
@@ -1576,7 +1576,7 @@ impl std::str::FromStr for CreatePaymentIntentPaymentMethodDataType {
             "us_bank_account" => Ok(UsBankAccount),
             "wechat_pay" => Ok(WechatPay),
             "zip" => Ok(Zip),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -1604,7 +1604,7 @@ impl<'de> serde::Deserialize<'de> for CreatePaymentIntentPaymentMethodDataType {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// If this is an `us_bank_account` PaymentMethod, this hash contains details about the US bank account payment method.
@@ -1649,13 +1649,13 @@ impl CreatePaymentIntentPaymentMethodDataUsBankAccountAccountHolderType {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodDataUsBankAccountAccountHolderType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodDataUsBankAccountAccountHolderType::*;
         match s {
             "company" => Ok(Company),
             "individual" => Ok(Individual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1705,13 +1705,13 @@ impl CreatePaymentIntentPaymentMethodDataUsBankAccountAccountType {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodDataUsBankAccountAccountType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodDataUsBankAccountAccountType::*;
         match s {
             "checking" => Ok(Checking),
             "savings" => Ok(Savings),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1935,14 +1935,14 @@ impl CreatePaymentIntentPaymentMethodOptionsAcssDebitMandateOptionsPaymentSchedu
 impl std::str::FromStr
     for CreatePaymentIntentPaymentMethodOptionsAcssDebitMandateOptionsPaymentSchedule
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsAcssDebitMandateOptionsPaymentSchedule::*;
         match s {
             "combined" => Ok(Combined),
             "interval" => Ok(Interval),
             "sporadic" => Ok(Sporadic),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2000,13 +2000,13 @@ impl CreatePaymentIntentPaymentMethodOptionsAcssDebitMandateOptionsTransactionTy
 impl std::str::FromStr
     for CreatePaymentIntentPaymentMethodOptionsAcssDebitMandateOptionsTransactionType
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsAcssDebitMandateOptionsTransactionType::*;
         match s {
             "business" => Ok(Business),
             "personal" => Ok(Personal),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2071,14 +2071,14 @@ impl CreatePaymentIntentPaymentMethodOptionsAcssDebitSetupFutureUsage {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsAcssDebitSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsAcssDebitSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2130,14 +2130,14 @@ impl CreatePaymentIntentPaymentMethodOptionsAcssDebitVerificationMethod {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsAcssDebitVerificationMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsAcssDebitVerificationMethod::*;
         match s {
             "automatic" => Ok(Automatic),
             "instant" => Ok(Instant),
             "microdeposits" => Ok(Microdeposits),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2218,12 +2218,12 @@ impl CreatePaymentIntentPaymentMethodOptionsAffirmCaptureMethod {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsAffirmCaptureMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsAffirmCaptureMethod::*;
         match s {
             "manual" => Ok(Manual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2280,12 +2280,12 @@ impl CreatePaymentIntentPaymentMethodOptionsAffirmSetupFutureUsage {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsAffirmSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsAffirmSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2374,12 +2374,12 @@ impl CreatePaymentIntentPaymentMethodOptionsAfterpayClearpayCaptureMethod {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsAfterpayClearpayCaptureMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsAfterpayClearpayCaptureMethod::*;
         match s {
             "manual" => Ok(Manual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2434,12 +2434,12 @@ impl CreatePaymentIntentPaymentMethodOptionsAfterpayClearpaySetupFutureUsage {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsAfterpayClearpaySetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsAfterpayClearpaySetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2515,13 +2515,13 @@ impl CreatePaymentIntentPaymentMethodOptionsAlipaySetupFutureUsage {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsAlipaySetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsAlipaySetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2604,14 +2604,14 @@ impl CreatePaymentIntentPaymentMethodOptionsAuBecsDebitSetupFutureUsage {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsAuBecsDebitSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsAuBecsDebitSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2690,14 +2690,14 @@ impl CreatePaymentIntentPaymentMethodOptionsBacsDebitSetupFutureUsage {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsBacsDebitSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsBacsDebitSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2775,7 +2775,7 @@ impl CreatePaymentIntentPaymentMethodOptionsBancontactPreferredLanguage {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsBancontactPreferredLanguage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsBancontactPreferredLanguage::*;
         match s {
@@ -2783,7 +2783,7 @@ impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsBancontactPref
             "en" => Ok(En),
             "fr" => Ok(Fr),
             "nl" => Ok(Nl),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2840,13 +2840,13 @@ impl CreatePaymentIntentPaymentMethodOptionsBancontactSetupFutureUsage {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsBancontactSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsBancontactSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2924,12 +2924,12 @@ impl CreatePaymentIntentPaymentMethodOptionsBlikSetupFutureUsage {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsBlikSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsBlikSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3013,14 +3013,14 @@ impl CreatePaymentIntentPaymentMethodOptionsBoletoSetupFutureUsage {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsBoletoSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsBoletoSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3167,12 +3167,12 @@ impl CreatePaymentIntentPaymentMethodOptionsCardCaptureMethod {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsCardCaptureMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsCardCaptureMethod::*;
         match s {
             "manual" => Ok(Manual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3265,12 +3265,12 @@ impl CreatePaymentIntentPaymentMethodOptionsCardInstallmentsPlanInterval {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsCardInstallmentsPlanInterval {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsCardInstallmentsPlanInterval::*;
         match s {
             "month" => Ok(Month),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3318,12 +3318,12 @@ impl CreatePaymentIntentPaymentMethodOptionsCardInstallmentsPlanType {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsCardInstallmentsPlanType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsCardInstallmentsPlanType::*;
         match s {
             "fixed_count" => Ok(FixedCount),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3434,13 +3434,13 @@ impl CreatePaymentIntentPaymentMethodOptionsCardMandateOptionsAmountType {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsCardMandateOptionsAmountType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsCardMandateOptionsAmountType::*;
         match s {
             "fixed" => Ok(Fixed),
             "maximum" => Ok(Maximum),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3496,7 +3496,7 @@ impl CreatePaymentIntentPaymentMethodOptionsCardMandateOptionsInterval {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsCardMandateOptionsInterval {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsCardMandateOptionsInterval::*;
         match s {
@@ -3505,7 +3505,7 @@ impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsCardMandateOpt
             "sporadic" => Ok(Sporadic),
             "week" => Ok(Week),
             "year" => Ok(Year),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3553,12 +3553,12 @@ impl CreatePaymentIntentPaymentMethodOptionsCardMandateOptionsSupportedTypes {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsCardMandateOptionsSupportedTypes {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsCardMandateOptionsSupportedTypes::*;
         match s {
             "india" => Ok(India),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3628,7 +3628,7 @@ impl CreatePaymentIntentPaymentMethodOptionsCardNetwork {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsCardNetwork {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsCardNetwork::*;
         match s {
@@ -3643,7 +3643,7 @@ impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsCardNetwork {
             "unionpay" => Ok(Unionpay),
             "unknown" => Ok(Unknown),
             "visa" => Ok(Visa),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3695,13 +3695,13 @@ impl CreatePaymentIntentPaymentMethodOptionsCardRequestExtendedAuthorization {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsCardRequestExtendedAuthorization {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsCardRequestExtendedAuthorization::*;
         match s {
             "if_available" => Ok(IfAvailable),
             "never" => Ok(Never),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3753,13 +3753,13 @@ impl CreatePaymentIntentPaymentMethodOptionsCardRequestIncrementalAuthorization 
 impl std::str::FromStr
     for CreatePaymentIntentPaymentMethodOptionsCardRequestIncrementalAuthorization
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsCardRequestIncrementalAuthorization::*;
         match s {
             "if_available" => Ok(IfAvailable),
             "never" => Ok(Never),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3815,13 +3815,13 @@ impl CreatePaymentIntentPaymentMethodOptionsCardRequestMulticapture {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsCardRequestMulticapture {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsCardRequestMulticapture::*;
         match s {
             "if_available" => Ok(IfAvailable),
             "never" => Ok(Never),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3875,13 +3875,13 @@ impl CreatePaymentIntentPaymentMethodOptionsCardRequestOvercapture {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsCardRequestOvercapture {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsCardRequestOvercapture::*;
         match s {
             "if_available" => Ok(IfAvailable),
             "never" => Ok(Never),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3940,14 +3940,14 @@ impl CreatePaymentIntentPaymentMethodOptionsCardRequestThreeDSecure {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsCardRequestThreeDSecure {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsCardRequestThreeDSecure::*;
         match s {
             "any" => Ok(Any),
             "automatic" => Ok(Automatic),
             "challenge" => Ok(Challenge),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4010,14 +4010,14 @@ impl CreatePaymentIntentPaymentMethodOptionsCardSetupFutureUsage {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsCardSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsCardSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4135,7 +4135,7 @@ impl CreatePaymentIntentPaymentMethodOptionsCardThreeDSecureAresTransStatus {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsCardThreeDSecureAresTransStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsCardThreeDSecureAresTransStatus::*;
         match s {
@@ -4146,7 +4146,7 @@ impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsCardThreeDSecu
             "R" => Ok(R),
             "U" => Ok(U),
             "Y" => Ok(Y),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4205,7 +4205,7 @@ impl CreatePaymentIntentPaymentMethodOptionsCardThreeDSecureElectronicCommerceIn
 impl std::str::FromStr
     for CreatePaymentIntentPaymentMethodOptionsCardThreeDSecureElectronicCommerceIndicator
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsCardThreeDSecureElectronicCommerceIndicator::*;
         match s {
@@ -4214,7 +4214,7 @@ impl std::str::FromStr
             "05" => Ok(V05),
             "06" => Ok(V06),
             "07" => Ok(V07),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4272,13 +4272,13 @@ impl CreatePaymentIntentPaymentMethodOptionsCardThreeDSecureExemptionIndicator {
 impl std::str::FromStr
     for CreatePaymentIntentPaymentMethodOptionsCardThreeDSecureExemptionIndicator
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsCardThreeDSecureExemptionIndicator::*;
         match s {
             "low_risk" => Ok(LowRisk),
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4387,7 +4387,7 @@ impl CreatePaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartes
 impl std::str::FromStr
     for CreatePaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancairesCbAvalgo
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancairesCbAvalgo::*;
         match s {
@@ -4397,7 +4397,7 @@ impl std::str::FromStr
             "3" => Ok(V3),
             "4" => Ok(V4),
             "A" => Ok(A),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4455,14 +4455,14 @@ impl CreatePaymentIntentPaymentMethodOptionsCardThreeDSecureVersion {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsCardThreeDSecureVersion {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsCardThreeDSecureVersion::*;
         match s {
             "1.0.2" => Ok(V1_0_2),
             "2.1.0" => Ok(V2_1_0),
             "2.2.0" => Ok(V2_2_0),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4544,12 +4544,12 @@ impl CreatePaymentIntentPaymentMethodOptionsCashappCaptureMethod {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsCashappCaptureMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsCashappCaptureMethod::*;
         match s {
             "manual" => Ok(Manual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4610,14 +4610,14 @@ impl CreatePaymentIntentPaymentMethodOptionsCashappSetupFutureUsage {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsCashappSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsCashappSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4738,7 +4738,7 @@ impl CreatePaymentIntentPaymentMethodOptionsCustomerBalanceBankTransferRequested
 impl std::str::FromStr
     for CreatePaymentIntentPaymentMethodOptionsCustomerBalanceBankTransferRequestedAddressTypes
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsCustomerBalanceBankTransferRequestedAddressTypes::*;
         match s {
@@ -4749,7 +4749,7 @@ impl std::str::FromStr
             "spei" => Ok(Spei),
             "swift" => Ok(Swift),
             "zengin" => Ok(Zengin),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4811,7 +4811,7 @@ impl CreatePaymentIntentPaymentMethodOptionsCustomerBalanceBankTransferType {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsCustomerBalanceBankTransferType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsCustomerBalanceBankTransferType::*;
         match s {
@@ -4820,7 +4820,7 @@ impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsCustomerBalanc
             "jp_bank_transfer" => Ok(JpBankTransfer),
             "mx_bank_transfer" => Ok(MxBankTransfer),
             "us_bank_transfer" => Ok(UsBankTransfer),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4869,12 +4869,12 @@ impl CreatePaymentIntentPaymentMethodOptionsCustomerBalanceFundingType {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsCustomerBalanceFundingType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsCustomerBalanceFundingType::*;
         match s {
             "bank_transfer" => Ok(BankTransfer),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4929,12 +4929,12 @@ impl CreatePaymentIntentPaymentMethodOptionsCustomerBalanceSetupFutureUsage {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsCustomerBalanceSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsCustomerBalanceSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5008,12 +5008,12 @@ impl CreatePaymentIntentPaymentMethodOptionsEpsSetupFutureUsage {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsEpsSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsEpsSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5089,12 +5089,12 @@ impl CreatePaymentIntentPaymentMethodOptionsFpxSetupFutureUsage {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsFpxSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsFpxSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5170,12 +5170,12 @@ impl CreatePaymentIntentPaymentMethodOptionsGiropaySetupFutureUsage {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsGiropaySetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsGiropaySetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5253,12 +5253,12 @@ impl CreatePaymentIntentPaymentMethodOptionsGrabpaySetupFutureUsage {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsGrabpaySetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsGrabpaySetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5338,13 +5338,13 @@ impl CreatePaymentIntentPaymentMethodOptionsIdealSetupFutureUsage {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsIdealSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsIdealSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5427,12 +5427,12 @@ impl CreatePaymentIntentPaymentMethodOptionsKlarnaCaptureMethod {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsKlarnaCaptureMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsKlarnaCaptureMethod::*;
         match s {
             "manual" => Ok(Manual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5572,7 +5572,7 @@ impl CreatePaymentIntentPaymentMethodOptionsKlarnaPreferredLocale {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsKlarnaPreferredLocale {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsKlarnaPreferredLocale::*;
         match s {
@@ -5620,7 +5620,7 @@ impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsKlarnaPreferre
             "pt-PT" => Ok(PtMinusPt),
             "sv-FI" => Ok(SvMinusFi),
             "sv-SE" => Ok(SvMinusSe),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -5648,7 +5648,7 @@ impl<'de> serde::Deserialize<'de> for CreatePaymentIntentPaymentMethodOptionsKla
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// Indicates that you intend to make future payments with this PaymentIntent's payment method.
@@ -5673,12 +5673,12 @@ impl CreatePaymentIntentPaymentMethodOptionsKlarnaSetupFutureUsage {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsKlarnaSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsKlarnaSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5773,12 +5773,12 @@ impl CreatePaymentIntentPaymentMethodOptionsKonbiniSetupFutureUsage {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsKonbiniSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsKonbiniSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5863,12 +5863,12 @@ impl CreatePaymentIntentPaymentMethodOptionsLinkCaptureMethod {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsLinkCaptureMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsLinkCaptureMethod::*;
         match s {
             "manual" => Ok(Manual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5927,13 +5927,13 @@ impl CreatePaymentIntentPaymentMethodOptionsLinkSetupFutureUsage {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsLinkSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsLinkSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -6013,12 +6013,12 @@ impl CreatePaymentIntentPaymentMethodOptionsOxxoSetupFutureUsage {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsOxxoSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsOxxoSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -6097,12 +6097,12 @@ impl CreatePaymentIntentPaymentMethodOptionsP24SetupFutureUsage {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsP24SetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsP24SetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -6178,12 +6178,12 @@ impl CreatePaymentIntentPaymentMethodOptionsPaynowSetupFutureUsage {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsPaynowSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsPaynowSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -6267,12 +6267,12 @@ impl CreatePaymentIntentPaymentMethodOptionsPaypalCaptureMethod {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsPaypalCaptureMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsPaypalCaptureMethod::*;
         match s {
             "manual" => Ok(Manual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -6366,7 +6366,7 @@ impl CreatePaymentIntentPaymentMethodOptionsPaypalPreferredLocale {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsPaypalPreferredLocale {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsPaypalPreferredLocale::*;
         match s {
@@ -6391,7 +6391,7 @@ impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsPaypalPreferre
             "pt-PT" => Ok(PtMinusPt),
             "sk-SK" => Ok(SkMinusSk),
             "sv-SE" => Ok(SvMinusSe),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -6419,7 +6419,7 @@ impl<'de> serde::Deserialize<'de> for CreatePaymentIntentPaymentMethodOptionsPay
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// Indicates that you intend to make future payments with this PaymentIntent's payment method.
@@ -6446,13 +6446,13 @@ impl CreatePaymentIntentPaymentMethodOptionsPaypalSetupFutureUsage {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsPaypalSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsPaypalSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -6538,12 +6538,12 @@ impl CreatePaymentIntentPaymentMethodOptionsPixSetupFutureUsage {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsPixSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsPixSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -6620,12 +6620,12 @@ impl CreatePaymentIntentPaymentMethodOptionsPromptpaySetupFutureUsage {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsPromptpaySetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsPromptpaySetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -6698,13 +6698,13 @@ impl CreatePaymentIntentPaymentMethodOptionsRevolutPaySetupFutureUsage {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsRevolutPaySetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsRevolutPaySetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -6787,14 +6787,14 @@ impl CreatePaymentIntentPaymentMethodOptionsSepaDebitSetupFutureUsage {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsSepaDebitSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsSepaDebitSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -6876,7 +6876,7 @@ impl CreatePaymentIntentPaymentMethodOptionsSofortPreferredLanguage {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsSofortPreferredLanguage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsSofortPreferredLanguage::*;
         match s {
@@ -6887,7 +6887,7 @@ impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsSofortPreferre
             "it" => Ok(It),
             "nl" => Ok(Nl),
             "pl" => Ok(Pl),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -6948,13 +6948,13 @@ impl CreatePaymentIntentPaymentMethodOptionsSofortSetupFutureUsage {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsSofortSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsSofortSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -7035,12 +7035,12 @@ impl CreatePaymentIntentPaymentMethodOptionsSwishSetupFutureUsage {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsSwishSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsSwishSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -7163,7 +7163,7 @@ impl CreatePaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPer
 impl std::str::FromStr
     for CreatePaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPermissions
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPermissions::*;
         match s {
@@ -7171,7 +7171,7 @@ impl std::str::FromStr
             "ownership" => Ok(Ownership),
             "payment_method" => Ok(PaymentMethod),
             "transactions" => Ok(Transactions),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -7229,13 +7229,13 @@ impl CreatePaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPre
 impl std::str::FromStr
     for CreatePaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPrefetch
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPrefetch::*;
         match s {
             "balances" => Ok(Balances),
             "transactions" => Ok(Transactions),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -7304,12 +7304,12 @@ impl CreatePaymentIntentPaymentMethodOptionsUsBankAccountMandateOptionsCollectio
 impl std::str::FromStr
     for CreatePaymentIntentPaymentMethodOptionsUsBankAccountMandateOptionsCollectionMethod
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsUsBankAccountMandateOptionsCollectionMethod::*;
         match s {
             "paper" => Ok(Paper),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -7378,13 +7378,13 @@ impl CreatePaymentIntentPaymentMethodOptionsUsBankAccountNetworksRequested {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsUsBankAccountNetworksRequested {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsUsBankAccountNetworksRequested::*;
         match s {
             "ach" => Ok(Ach),
             "us_domestic_wire" => Ok(UsDomesticWire),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -7436,13 +7436,13 @@ impl CreatePaymentIntentPaymentMethodOptionsUsBankAccountPreferredSettlementSpee
 impl std::str::FromStr
     for CreatePaymentIntentPaymentMethodOptionsUsBankAccountPreferredSettlementSpeed
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsUsBankAccountPreferredSettlementSpeed::*;
         match s {
             "fastest" => Ok(Fastest),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -7507,14 +7507,14 @@ impl CreatePaymentIntentPaymentMethodOptionsUsBankAccountSetupFutureUsage {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsUsBankAccountSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsUsBankAccountSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -7566,14 +7566,14 @@ impl CreatePaymentIntentPaymentMethodOptionsUsBankAccountVerificationMethod {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsUsBankAccountVerificationMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsUsBankAccountVerificationMethod::*;
         match s {
             "automatic" => Ok(Automatic),
             "instant" => Ok(Instant),
             "microdeposits" => Ok(Microdeposits),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -7650,14 +7650,14 @@ impl CreatePaymentIntentPaymentMethodOptionsWechatPayClient {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsWechatPayClient {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsWechatPayClient::*;
         match s {
             "android" => Ok(Android),
             "ios" => Ok(Ios),
             "web" => Ok(Web),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -7714,12 +7714,12 @@ impl CreatePaymentIntentPaymentMethodOptionsWechatPaySetupFutureUsage {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsWechatPaySetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsWechatPaySetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -7793,12 +7793,12 @@ impl CreatePaymentIntentPaymentMethodOptionsZipSetupFutureUsage {
 }
 
 impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsZipSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentIntentPaymentMethodOptionsZipSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -8393,7 +8393,7 @@ impl UpdatePaymentIntentPaymentMethodDataEpsBank {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodDataEpsBank {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodDataEpsBank::*;
         match s {
@@ -8425,7 +8425,7 @@ impl std::str::FromStr for UpdatePaymentIntentPaymentMethodDataEpsBank {
             "volksbank_gruppe" => Ok(VolksbankGruppe),
             "volkskreditbank_ag" => Ok(VolkskreditbankAg),
             "vr_bank_braunau" => Ok(VrBankBraunau),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -8453,7 +8453,7 @@ impl<'de> serde::Deserialize<'de> for UpdatePaymentIntentPaymentMethodDataEpsBan
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// If this is an `fpx` PaymentMethod, this hash contains details about the FPX payment method.
@@ -8487,13 +8487,13 @@ impl UpdatePaymentIntentPaymentMethodDataFpxAccountHolderType {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodDataFpxAccountHolderType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodDataFpxAccountHolderType::*;
         match s {
             "company" => Ok(Company),
             "individual" => Ok(Individual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -8589,7 +8589,7 @@ impl UpdatePaymentIntentPaymentMethodDataFpxBank {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodDataFpxBank {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodDataFpxBank::*;
         match s {
@@ -8615,7 +8615,7 @@ impl std::str::FromStr for UpdatePaymentIntentPaymentMethodDataFpxBank {
             "rhb" => Ok(Rhb),
             "standard_chartered" => Ok(StandardChartered),
             "uob" => Ok(Uob),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -8643,7 +8643,7 @@ impl<'de> serde::Deserialize<'de> for UpdatePaymentIntentPaymentMethodDataFpxBan
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// If this is an `ideal` PaymentMethod, this hash contains details about the iDEAL payment method.
@@ -8707,7 +8707,7 @@ impl UpdatePaymentIntentPaymentMethodDataIdealBank {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodDataIdealBank {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodDataIdealBank::*;
         match s {
@@ -8727,7 +8727,7 @@ impl std::str::FromStr for UpdatePaymentIntentPaymentMethodDataIdealBank {
             "triodos_bank" => Ok(TriodosBank),
             "van_lanschot" => Ok(VanLanschot),
             "yoursafe" => Ok(Yoursafe),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -8755,7 +8755,7 @@ impl<'de> serde::Deserialize<'de> for UpdatePaymentIntentPaymentMethodDataIdealB
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// If this is a `klarna` PaymentMethod, this hash contains details about the Klarna payment method.
@@ -8851,7 +8851,7 @@ impl UpdatePaymentIntentPaymentMethodDataP24Bank {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodDataP24Bank {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodDataP24Bank::*;
         match s {
@@ -8881,7 +8881,7 @@ impl std::str::FromStr for UpdatePaymentIntentPaymentMethodDataP24Bank {
             "toyota_bank" => Ok(ToyotaBank),
             "velobank" => Ok(Velobank),
             "volkswagen_bank" => Ok(VolkswagenBank),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -8909,7 +8909,7 @@ impl<'de> serde::Deserialize<'de> for UpdatePaymentIntentPaymentMethodDataP24Ban
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// Options to configure Radar.
@@ -8972,7 +8972,7 @@ impl UpdatePaymentIntentPaymentMethodDataSofortCountry {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodDataSofortCountry {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodDataSofortCountry::*;
         match s {
@@ -8982,7 +8982,7 @@ impl std::str::FromStr for UpdatePaymentIntentPaymentMethodDataSofortCountry {
             "ES" => Ok(Es),
             "IT" => Ok(It),
             "NL" => Ok(Nl),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -9100,7 +9100,7 @@ impl UpdatePaymentIntentPaymentMethodDataType {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodDataType {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodDataType::*;
         match s {
@@ -9136,7 +9136,7 @@ impl std::str::FromStr for UpdatePaymentIntentPaymentMethodDataType {
             "us_bank_account" => Ok(UsBankAccount),
             "wechat_pay" => Ok(WechatPay),
             "zip" => Ok(Zip),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -9164,7 +9164,7 @@ impl<'de> serde::Deserialize<'de> for UpdatePaymentIntentPaymentMethodDataType {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// If this is an `us_bank_account` PaymentMethod, this hash contains details about the US bank account payment method.
@@ -9209,13 +9209,13 @@ impl UpdatePaymentIntentPaymentMethodDataUsBankAccountAccountHolderType {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodDataUsBankAccountAccountHolderType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodDataUsBankAccountAccountHolderType::*;
         match s {
             "company" => Ok(Company),
             "individual" => Ok(Individual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -9265,13 +9265,13 @@ impl UpdatePaymentIntentPaymentMethodDataUsBankAccountAccountType {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodDataUsBankAccountAccountType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodDataUsBankAccountAccountType::*;
         match s {
             "checking" => Ok(Checking),
             "savings" => Ok(Savings),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -9495,14 +9495,14 @@ impl UpdatePaymentIntentPaymentMethodOptionsAcssDebitMandateOptionsPaymentSchedu
 impl std::str::FromStr
     for UpdatePaymentIntentPaymentMethodOptionsAcssDebitMandateOptionsPaymentSchedule
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsAcssDebitMandateOptionsPaymentSchedule::*;
         match s {
             "combined" => Ok(Combined),
             "interval" => Ok(Interval),
             "sporadic" => Ok(Sporadic),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -9560,13 +9560,13 @@ impl UpdatePaymentIntentPaymentMethodOptionsAcssDebitMandateOptionsTransactionTy
 impl std::str::FromStr
     for UpdatePaymentIntentPaymentMethodOptionsAcssDebitMandateOptionsTransactionType
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsAcssDebitMandateOptionsTransactionType::*;
         match s {
             "business" => Ok(Business),
             "personal" => Ok(Personal),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -9631,14 +9631,14 @@ impl UpdatePaymentIntentPaymentMethodOptionsAcssDebitSetupFutureUsage {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsAcssDebitSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsAcssDebitSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -9690,14 +9690,14 @@ impl UpdatePaymentIntentPaymentMethodOptionsAcssDebitVerificationMethod {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsAcssDebitVerificationMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsAcssDebitVerificationMethod::*;
         match s {
             "automatic" => Ok(Automatic),
             "instant" => Ok(Instant),
             "microdeposits" => Ok(Microdeposits),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -9778,12 +9778,12 @@ impl UpdatePaymentIntentPaymentMethodOptionsAffirmCaptureMethod {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsAffirmCaptureMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsAffirmCaptureMethod::*;
         match s {
             "manual" => Ok(Manual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -9840,12 +9840,12 @@ impl UpdatePaymentIntentPaymentMethodOptionsAffirmSetupFutureUsage {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsAffirmSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsAffirmSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -9934,12 +9934,12 @@ impl UpdatePaymentIntentPaymentMethodOptionsAfterpayClearpayCaptureMethod {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsAfterpayClearpayCaptureMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsAfterpayClearpayCaptureMethod::*;
         match s {
             "manual" => Ok(Manual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -9994,12 +9994,12 @@ impl UpdatePaymentIntentPaymentMethodOptionsAfterpayClearpaySetupFutureUsage {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsAfterpayClearpaySetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsAfterpayClearpaySetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -10075,13 +10075,13 @@ impl UpdatePaymentIntentPaymentMethodOptionsAlipaySetupFutureUsage {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsAlipaySetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsAlipaySetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -10164,14 +10164,14 @@ impl UpdatePaymentIntentPaymentMethodOptionsAuBecsDebitSetupFutureUsage {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsAuBecsDebitSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsAuBecsDebitSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -10250,14 +10250,14 @@ impl UpdatePaymentIntentPaymentMethodOptionsBacsDebitSetupFutureUsage {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsBacsDebitSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsBacsDebitSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -10335,7 +10335,7 @@ impl UpdatePaymentIntentPaymentMethodOptionsBancontactPreferredLanguage {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsBancontactPreferredLanguage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsBancontactPreferredLanguage::*;
         match s {
@@ -10343,7 +10343,7 @@ impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsBancontactPref
             "en" => Ok(En),
             "fr" => Ok(Fr),
             "nl" => Ok(Nl),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -10400,13 +10400,13 @@ impl UpdatePaymentIntentPaymentMethodOptionsBancontactSetupFutureUsage {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsBancontactSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsBancontactSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -10484,12 +10484,12 @@ impl UpdatePaymentIntentPaymentMethodOptionsBlikSetupFutureUsage {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsBlikSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsBlikSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -10573,14 +10573,14 @@ impl UpdatePaymentIntentPaymentMethodOptionsBoletoSetupFutureUsage {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsBoletoSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsBoletoSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -10727,12 +10727,12 @@ impl UpdatePaymentIntentPaymentMethodOptionsCardCaptureMethod {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsCardCaptureMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsCardCaptureMethod::*;
         match s {
             "manual" => Ok(Manual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -10825,12 +10825,12 @@ impl UpdatePaymentIntentPaymentMethodOptionsCardInstallmentsPlanInterval {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsCardInstallmentsPlanInterval {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsCardInstallmentsPlanInterval::*;
         match s {
             "month" => Ok(Month),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -10878,12 +10878,12 @@ impl UpdatePaymentIntentPaymentMethodOptionsCardInstallmentsPlanType {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsCardInstallmentsPlanType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsCardInstallmentsPlanType::*;
         match s {
             "fixed_count" => Ok(FixedCount),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -10994,13 +10994,13 @@ impl UpdatePaymentIntentPaymentMethodOptionsCardMandateOptionsAmountType {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsCardMandateOptionsAmountType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsCardMandateOptionsAmountType::*;
         match s {
             "fixed" => Ok(Fixed),
             "maximum" => Ok(Maximum),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -11056,7 +11056,7 @@ impl UpdatePaymentIntentPaymentMethodOptionsCardMandateOptionsInterval {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsCardMandateOptionsInterval {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsCardMandateOptionsInterval::*;
         match s {
@@ -11065,7 +11065,7 @@ impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsCardMandateOpt
             "sporadic" => Ok(Sporadic),
             "week" => Ok(Week),
             "year" => Ok(Year),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -11113,12 +11113,12 @@ impl UpdatePaymentIntentPaymentMethodOptionsCardMandateOptionsSupportedTypes {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsCardMandateOptionsSupportedTypes {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsCardMandateOptionsSupportedTypes::*;
         match s {
             "india" => Ok(India),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -11188,7 +11188,7 @@ impl UpdatePaymentIntentPaymentMethodOptionsCardNetwork {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsCardNetwork {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsCardNetwork::*;
         match s {
@@ -11203,7 +11203,7 @@ impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsCardNetwork {
             "unionpay" => Ok(Unionpay),
             "unknown" => Ok(Unknown),
             "visa" => Ok(Visa),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -11255,13 +11255,13 @@ impl UpdatePaymentIntentPaymentMethodOptionsCardRequestExtendedAuthorization {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsCardRequestExtendedAuthorization {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsCardRequestExtendedAuthorization::*;
         match s {
             "if_available" => Ok(IfAvailable),
             "never" => Ok(Never),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -11313,13 +11313,13 @@ impl UpdatePaymentIntentPaymentMethodOptionsCardRequestIncrementalAuthorization 
 impl std::str::FromStr
     for UpdatePaymentIntentPaymentMethodOptionsCardRequestIncrementalAuthorization
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsCardRequestIncrementalAuthorization::*;
         match s {
             "if_available" => Ok(IfAvailable),
             "never" => Ok(Never),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -11375,13 +11375,13 @@ impl UpdatePaymentIntentPaymentMethodOptionsCardRequestMulticapture {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsCardRequestMulticapture {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsCardRequestMulticapture::*;
         match s {
             "if_available" => Ok(IfAvailable),
             "never" => Ok(Never),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -11435,13 +11435,13 @@ impl UpdatePaymentIntentPaymentMethodOptionsCardRequestOvercapture {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsCardRequestOvercapture {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsCardRequestOvercapture::*;
         match s {
             "if_available" => Ok(IfAvailable),
             "never" => Ok(Never),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -11500,14 +11500,14 @@ impl UpdatePaymentIntentPaymentMethodOptionsCardRequestThreeDSecure {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsCardRequestThreeDSecure {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsCardRequestThreeDSecure::*;
         match s {
             "any" => Ok(Any),
             "automatic" => Ok(Automatic),
             "challenge" => Ok(Challenge),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -11570,14 +11570,14 @@ impl UpdatePaymentIntentPaymentMethodOptionsCardSetupFutureUsage {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsCardSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsCardSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -11695,7 +11695,7 @@ impl UpdatePaymentIntentPaymentMethodOptionsCardThreeDSecureAresTransStatus {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsCardThreeDSecureAresTransStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsCardThreeDSecureAresTransStatus::*;
         match s {
@@ -11706,7 +11706,7 @@ impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsCardThreeDSecu
             "R" => Ok(R),
             "U" => Ok(U),
             "Y" => Ok(Y),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -11765,7 +11765,7 @@ impl UpdatePaymentIntentPaymentMethodOptionsCardThreeDSecureElectronicCommerceIn
 impl std::str::FromStr
     for UpdatePaymentIntentPaymentMethodOptionsCardThreeDSecureElectronicCommerceIndicator
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsCardThreeDSecureElectronicCommerceIndicator::*;
         match s {
@@ -11774,7 +11774,7 @@ impl std::str::FromStr
             "05" => Ok(V05),
             "06" => Ok(V06),
             "07" => Ok(V07),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -11832,13 +11832,13 @@ impl UpdatePaymentIntentPaymentMethodOptionsCardThreeDSecureExemptionIndicator {
 impl std::str::FromStr
     for UpdatePaymentIntentPaymentMethodOptionsCardThreeDSecureExemptionIndicator
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsCardThreeDSecureExemptionIndicator::*;
         match s {
             "low_risk" => Ok(LowRisk),
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -11947,7 +11947,7 @@ impl UpdatePaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartes
 impl std::str::FromStr
     for UpdatePaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancairesCbAvalgo
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancairesCbAvalgo::*;
         match s {
@@ -11957,7 +11957,7 @@ impl std::str::FromStr
             "3" => Ok(V3),
             "4" => Ok(V4),
             "A" => Ok(A),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -12015,14 +12015,14 @@ impl UpdatePaymentIntentPaymentMethodOptionsCardThreeDSecureVersion {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsCardThreeDSecureVersion {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsCardThreeDSecureVersion::*;
         match s {
             "1.0.2" => Ok(V1_0_2),
             "2.1.0" => Ok(V2_1_0),
             "2.2.0" => Ok(V2_2_0),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -12104,12 +12104,12 @@ impl UpdatePaymentIntentPaymentMethodOptionsCashappCaptureMethod {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsCashappCaptureMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsCashappCaptureMethod::*;
         match s {
             "manual" => Ok(Manual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -12170,14 +12170,14 @@ impl UpdatePaymentIntentPaymentMethodOptionsCashappSetupFutureUsage {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsCashappSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsCashappSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -12298,7 +12298,7 @@ impl UpdatePaymentIntentPaymentMethodOptionsCustomerBalanceBankTransferRequested
 impl std::str::FromStr
     for UpdatePaymentIntentPaymentMethodOptionsCustomerBalanceBankTransferRequestedAddressTypes
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsCustomerBalanceBankTransferRequestedAddressTypes::*;
         match s {
@@ -12309,7 +12309,7 @@ impl std::str::FromStr
             "spei" => Ok(Spei),
             "swift" => Ok(Swift),
             "zengin" => Ok(Zengin),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -12371,7 +12371,7 @@ impl UpdatePaymentIntentPaymentMethodOptionsCustomerBalanceBankTransferType {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsCustomerBalanceBankTransferType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsCustomerBalanceBankTransferType::*;
         match s {
@@ -12380,7 +12380,7 @@ impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsCustomerBalanc
             "jp_bank_transfer" => Ok(JpBankTransfer),
             "mx_bank_transfer" => Ok(MxBankTransfer),
             "us_bank_transfer" => Ok(UsBankTransfer),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -12429,12 +12429,12 @@ impl UpdatePaymentIntentPaymentMethodOptionsCustomerBalanceFundingType {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsCustomerBalanceFundingType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsCustomerBalanceFundingType::*;
         match s {
             "bank_transfer" => Ok(BankTransfer),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -12489,12 +12489,12 @@ impl UpdatePaymentIntentPaymentMethodOptionsCustomerBalanceSetupFutureUsage {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsCustomerBalanceSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsCustomerBalanceSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -12568,12 +12568,12 @@ impl UpdatePaymentIntentPaymentMethodOptionsEpsSetupFutureUsage {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsEpsSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsEpsSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -12649,12 +12649,12 @@ impl UpdatePaymentIntentPaymentMethodOptionsFpxSetupFutureUsage {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsFpxSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsFpxSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -12730,12 +12730,12 @@ impl UpdatePaymentIntentPaymentMethodOptionsGiropaySetupFutureUsage {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsGiropaySetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsGiropaySetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -12813,12 +12813,12 @@ impl UpdatePaymentIntentPaymentMethodOptionsGrabpaySetupFutureUsage {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsGrabpaySetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsGrabpaySetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -12898,13 +12898,13 @@ impl UpdatePaymentIntentPaymentMethodOptionsIdealSetupFutureUsage {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsIdealSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsIdealSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -12987,12 +12987,12 @@ impl UpdatePaymentIntentPaymentMethodOptionsKlarnaCaptureMethod {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsKlarnaCaptureMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsKlarnaCaptureMethod::*;
         match s {
             "manual" => Ok(Manual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -13132,7 +13132,7 @@ impl UpdatePaymentIntentPaymentMethodOptionsKlarnaPreferredLocale {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsKlarnaPreferredLocale {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsKlarnaPreferredLocale::*;
         match s {
@@ -13180,7 +13180,7 @@ impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsKlarnaPreferre
             "pt-PT" => Ok(PtMinusPt),
             "sv-FI" => Ok(SvMinusFi),
             "sv-SE" => Ok(SvMinusSe),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -13208,7 +13208,7 @@ impl<'de> serde::Deserialize<'de> for UpdatePaymentIntentPaymentMethodOptionsKla
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// Indicates that you intend to make future payments with this PaymentIntent's payment method.
@@ -13233,12 +13233,12 @@ impl UpdatePaymentIntentPaymentMethodOptionsKlarnaSetupFutureUsage {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsKlarnaSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsKlarnaSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -13333,12 +13333,12 @@ impl UpdatePaymentIntentPaymentMethodOptionsKonbiniSetupFutureUsage {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsKonbiniSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsKonbiniSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -13423,12 +13423,12 @@ impl UpdatePaymentIntentPaymentMethodOptionsLinkCaptureMethod {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsLinkCaptureMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsLinkCaptureMethod::*;
         match s {
             "manual" => Ok(Manual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -13487,13 +13487,13 @@ impl UpdatePaymentIntentPaymentMethodOptionsLinkSetupFutureUsage {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsLinkSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsLinkSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -13573,12 +13573,12 @@ impl UpdatePaymentIntentPaymentMethodOptionsOxxoSetupFutureUsage {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsOxxoSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsOxxoSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -13657,12 +13657,12 @@ impl UpdatePaymentIntentPaymentMethodOptionsP24SetupFutureUsage {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsP24SetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsP24SetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -13738,12 +13738,12 @@ impl UpdatePaymentIntentPaymentMethodOptionsPaynowSetupFutureUsage {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsPaynowSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsPaynowSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -13827,12 +13827,12 @@ impl UpdatePaymentIntentPaymentMethodOptionsPaypalCaptureMethod {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsPaypalCaptureMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsPaypalCaptureMethod::*;
         match s {
             "manual" => Ok(Manual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -13926,7 +13926,7 @@ impl UpdatePaymentIntentPaymentMethodOptionsPaypalPreferredLocale {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsPaypalPreferredLocale {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsPaypalPreferredLocale::*;
         match s {
@@ -13951,7 +13951,7 @@ impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsPaypalPreferre
             "pt-PT" => Ok(PtMinusPt),
             "sk-SK" => Ok(SkMinusSk),
             "sv-SE" => Ok(SvMinusSe),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -13979,7 +13979,7 @@ impl<'de> serde::Deserialize<'de> for UpdatePaymentIntentPaymentMethodOptionsPay
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// Indicates that you intend to make future payments with this PaymentIntent's payment method.
@@ -14006,13 +14006,13 @@ impl UpdatePaymentIntentPaymentMethodOptionsPaypalSetupFutureUsage {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsPaypalSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsPaypalSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -14098,12 +14098,12 @@ impl UpdatePaymentIntentPaymentMethodOptionsPixSetupFutureUsage {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsPixSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsPixSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -14180,12 +14180,12 @@ impl UpdatePaymentIntentPaymentMethodOptionsPromptpaySetupFutureUsage {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsPromptpaySetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsPromptpaySetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -14258,13 +14258,13 @@ impl UpdatePaymentIntentPaymentMethodOptionsRevolutPaySetupFutureUsage {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsRevolutPaySetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsRevolutPaySetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -14347,14 +14347,14 @@ impl UpdatePaymentIntentPaymentMethodOptionsSepaDebitSetupFutureUsage {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsSepaDebitSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsSepaDebitSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -14436,7 +14436,7 @@ impl UpdatePaymentIntentPaymentMethodOptionsSofortPreferredLanguage {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsSofortPreferredLanguage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsSofortPreferredLanguage::*;
         match s {
@@ -14447,7 +14447,7 @@ impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsSofortPreferre
             "it" => Ok(It),
             "nl" => Ok(Nl),
             "pl" => Ok(Pl),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -14508,13 +14508,13 @@ impl UpdatePaymentIntentPaymentMethodOptionsSofortSetupFutureUsage {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsSofortSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsSofortSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -14595,12 +14595,12 @@ impl UpdatePaymentIntentPaymentMethodOptionsSwishSetupFutureUsage {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsSwishSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsSwishSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -14723,7 +14723,7 @@ impl UpdatePaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPer
 impl std::str::FromStr
     for UpdatePaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPermissions
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPermissions::*;
         match s {
@@ -14731,7 +14731,7 @@ impl std::str::FromStr
             "ownership" => Ok(Ownership),
             "payment_method" => Ok(PaymentMethod),
             "transactions" => Ok(Transactions),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -14789,13 +14789,13 @@ impl UpdatePaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPre
 impl std::str::FromStr
     for UpdatePaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPrefetch
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPrefetch::*;
         match s {
             "balances" => Ok(Balances),
             "transactions" => Ok(Transactions),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -14864,12 +14864,12 @@ impl UpdatePaymentIntentPaymentMethodOptionsUsBankAccountMandateOptionsCollectio
 impl std::str::FromStr
     for UpdatePaymentIntentPaymentMethodOptionsUsBankAccountMandateOptionsCollectionMethod
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsUsBankAccountMandateOptionsCollectionMethod::*;
         match s {
             "paper" => Ok(Paper),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -14938,13 +14938,13 @@ impl UpdatePaymentIntentPaymentMethodOptionsUsBankAccountNetworksRequested {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsUsBankAccountNetworksRequested {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsUsBankAccountNetworksRequested::*;
         match s {
             "ach" => Ok(Ach),
             "us_domestic_wire" => Ok(UsDomesticWire),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -14996,13 +14996,13 @@ impl UpdatePaymentIntentPaymentMethodOptionsUsBankAccountPreferredSettlementSpee
 impl std::str::FromStr
     for UpdatePaymentIntentPaymentMethodOptionsUsBankAccountPreferredSettlementSpeed
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsUsBankAccountPreferredSettlementSpeed::*;
         match s {
             "fastest" => Ok(Fastest),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -15067,14 +15067,14 @@ impl UpdatePaymentIntentPaymentMethodOptionsUsBankAccountSetupFutureUsage {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsUsBankAccountSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsUsBankAccountSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -15126,14 +15126,14 @@ impl UpdatePaymentIntentPaymentMethodOptionsUsBankAccountVerificationMethod {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsUsBankAccountVerificationMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsUsBankAccountVerificationMethod::*;
         match s {
             "automatic" => Ok(Automatic),
             "instant" => Ok(Instant),
             "microdeposits" => Ok(Microdeposits),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -15210,14 +15210,14 @@ impl UpdatePaymentIntentPaymentMethodOptionsWechatPayClient {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsWechatPayClient {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsWechatPayClient::*;
         match s {
             "android" => Ok(Android),
             "ios" => Ok(Ios),
             "web" => Ok(Web),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -15274,12 +15274,12 @@ impl UpdatePaymentIntentPaymentMethodOptionsWechatPaySetupFutureUsage {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsWechatPaySetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsWechatPaySetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -15353,12 +15353,12 @@ impl UpdatePaymentIntentPaymentMethodOptionsZipSetupFutureUsage {
 }
 
 impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsZipSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentIntentPaymentMethodOptionsZipSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -15534,7 +15534,7 @@ impl CancelPaymentIntentCancellationReason {
 }
 
 impl std::str::FromStr for CancelPaymentIntentCancellationReason {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CancelPaymentIntentCancellationReason::*;
         match s {
@@ -15542,7 +15542,7 @@ impl std::str::FromStr for CancelPaymentIntentCancellationReason {
             "duplicate" => Ok(Duplicate),
             "fraudulent" => Ok(Fraudulent),
             "requested_by_customer" => Ok(RequestedByCustomer),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -15788,13 +15788,13 @@ impl ConfirmPaymentIntentSecretKeyParamCustomerAcceptanceType {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentSecretKeyParamCustomerAcceptanceType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentSecretKeyParamCustomerAcceptanceType::*;
         match s {
             "offline" => Ok(Offline),
             "online" => Ok(Online),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -15888,12 +15888,12 @@ impl ConfirmPaymentIntentClientKeyParamCustomerAcceptanceType {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentClientKeyParamCustomerAcceptanceType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentClientKeyParamCustomerAcceptanceType::*;
         match s {
             "online" => Ok(Online),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -16296,7 +16296,7 @@ impl ConfirmPaymentIntentPaymentMethodDataEpsBank {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodDataEpsBank {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodDataEpsBank::*;
         match s {
@@ -16328,7 +16328,7 @@ impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodDataEpsBank {
             "volksbank_gruppe" => Ok(VolksbankGruppe),
             "volkskreditbank_ag" => Ok(VolkskreditbankAg),
             "vr_bank_braunau" => Ok(VrBankBraunau),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -16356,7 +16356,7 @@ impl<'de> serde::Deserialize<'de> for ConfirmPaymentIntentPaymentMethodDataEpsBa
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// If this is an `fpx` PaymentMethod, this hash contains details about the FPX payment method.
@@ -16390,13 +16390,13 @@ impl ConfirmPaymentIntentPaymentMethodDataFpxAccountHolderType {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodDataFpxAccountHolderType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodDataFpxAccountHolderType::*;
         match s {
             "company" => Ok(Company),
             "individual" => Ok(Individual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -16492,7 +16492,7 @@ impl ConfirmPaymentIntentPaymentMethodDataFpxBank {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodDataFpxBank {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodDataFpxBank::*;
         match s {
@@ -16518,7 +16518,7 @@ impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodDataFpxBank {
             "rhb" => Ok(Rhb),
             "standard_chartered" => Ok(StandardChartered),
             "uob" => Ok(Uob),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -16546,7 +16546,7 @@ impl<'de> serde::Deserialize<'de> for ConfirmPaymentIntentPaymentMethodDataFpxBa
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// If this is an `ideal` PaymentMethod, this hash contains details about the iDEAL payment method.
@@ -16610,7 +16610,7 @@ impl ConfirmPaymentIntentPaymentMethodDataIdealBank {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodDataIdealBank {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodDataIdealBank::*;
         match s {
@@ -16630,7 +16630,7 @@ impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodDataIdealBank {
             "triodos_bank" => Ok(TriodosBank),
             "van_lanschot" => Ok(VanLanschot),
             "yoursafe" => Ok(Yoursafe),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -16658,7 +16658,7 @@ impl<'de> serde::Deserialize<'de> for ConfirmPaymentIntentPaymentMethodDataIdeal
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// If this is a `klarna` PaymentMethod, this hash contains details about the Klarna payment method.
@@ -16754,7 +16754,7 @@ impl ConfirmPaymentIntentPaymentMethodDataP24Bank {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodDataP24Bank {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodDataP24Bank::*;
         match s {
@@ -16784,7 +16784,7 @@ impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodDataP24Bank {
             "toyota_bank" => Ok(ToyotaBank),
             "velobank" => Ok(Velobank),
             "volkswagen_bank" => Ok(VolkswagenBank),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -16812,7 +16812,7 @@ impl<'de> serde::Deserialize<'de> for ConfirmPaymentIntentPaymentMethodDataP24Ba
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// Options to configure Radar.
@@ -16875,7 +16875,7 @@ impl ConfirmPaymentIntentPaymentMethodDataSofortCountry {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodDataSofortCountry {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodDataSofortCountry::*;
         match s {
@@ -16885,7 +16885,7 @@ impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodDataSofortCountry {
             "ES" => Ok(Es),
             "IT" => Ok(It),
             "NL" => Ok(Nl),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -17003,7 +17003,7 @@ impl ConfirmPaymentIntentPaymentMethodDataType {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodDataType {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodDataType::*;
         match s {
@@ -17039,7 +17039,7 @@ impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodDataType {
             "us_bank_account" => Ok(UsBankAccount),
             "wechat_pay" => Ok(WechatPay),
             "zip" => Ok(Zip),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -17067,7 +17067,7 @@ impl<'de> serde::Deserialize<'de> for ConfirmPaymentIntentPaymentMethodDataType 
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// If this is an `us_bank_account` PaymentMethod, this hash contains details about the US bank account payment method.
@@ -17112,13 +17112,13 @@ impl ConfirmPaymentIntentPaymentMethodDataUsBankAccountAccountHolderType {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodDataUsBankAccountAccountHolderType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodDataUsBankAccountAccountHolderType::*;
         match s {
             "company" => Ok(Company),
             "individual" => Ok(Individual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -17168,13 +17168,13 @@ impl ConfirmPaymentIntentPaymentMethodDataUsBankAccountAccountType {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodDataUsBankAccountAccountType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodDataUsBankAccountAccountType::*;
         match s {
             "checking" => Ok(Checking),
             "savings" => Ok(Savings),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -17401,14 +17401,14 @@ impl ConfirmPaymentIntentPaymentMethodOptionsAcssDebitMandateOptionsPaymentSched
 impl std::str::FromStr
     for ConfirmPaymentIntentPaymentMethodOptionsAcssDebitMandateOptionsPaymentSchedule
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsAcssDebitMandateOptionsPaymentSchedule::*;
         match s {
             "combined" => Ok(Combined),
             "interval" => Ok(Interval),
             "sporadic" => Ok(Sporadic),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -17466,13 +17466,13 @@ impl ConfirmPaymentIntentPaymentMethodOptionsAcssDebitMandateOptionsTransactionT
 impl std::str::FromStr
     for ConfirmPaymentIntentPaymentMethodOptionsAcssDebitMandateOptionsTransactionType
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsAcssDebitMandateOptionsTransactionType::*;
         match s {
             "business" => Ok(Business),
             "personal" => Ok(Personal),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -17537,14 +17537,14 @@ impl ConfirmPaymentIntentPaymentMethodOptionsAcssDebitSetupFutureUsage {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsAcssDebitSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsAcssDebitSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -17596,14 +17596,14 @@ impl ConfirmPaymentIntentPaymentMethodOptionsAcssDebitVerificationMethod {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsAcssDebitVerificationMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsAcssDebitVerificationMethod::*;
         match s {
             "automatic" => Ok(Automatic),
             "instant" => Ok(Instant),
             "microdeposits" => Ok(Microdeposits),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -17684,12 +17684,12 @@ impl ConfirmPaymentIntentPaymentMethodOptionsAffirmCaptureMethod {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsAffirmCaptureMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsAffirmCaptureMethod::*;
         match s {
             "manual" => Ok(Manual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -17746,12 +17746,12 @@ impl ConfirmPaymentIntentPaymentMethodOptionsAffirmSetupFutureUsage {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsAffirmSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsAffirmSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -17840,12 +17840,12 @@ impl ConfirmPaymentIntentPaymentMethodOptionsAfterpayClearpayCaptureMethod {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsAfterpayClearpayCaptureMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsAfterpayClearpayCaptureMethod::*;
         match s {
             "manual" => Ok(Manual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -17902,12 +17902,12 @@ impl ConfirmPaymentIntentPaymentMethodOptionsAfterpayClearpaySetupFutureUsage {
 impl std::str::FromStr
     for ConfirmPaymentIntentPaymentMethodOptionsAfterpayClearpaySetupFutureUsage
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsAfterpayClearpaySetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -17985,13 +17985,13 @@ impl ConfirmPaymentIntentPaymentMethodOptionsAlipaySetupFutureUsage {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsAlipaySetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsAlipaySetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -18074,14 +18074,14 @@ impl ConfirmPaymentIntentPaymentMethodOptionsAuBecsDebitSetupFutureUsage {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsAuBecsDebitSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsAuBecsDebitSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -18160,14 +18160,14 @@ impl ConfirmPaymentIntentPaymentMethodOptionsBacsDebitSetupFutureUsage {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsBacsDebitSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsBacsDebitSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -18245,7 +18245,7 @@ impl ConfirmPaymentIntentPaymentMethodOptionsBancontactPreferredLanguage {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsBancontactPreferredLanguage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsBancontactPreferredLanguage::*;
         match s {
@@ -18253,7 +18253,7 @@ impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsBancontactPre
             "en" => Ok(En),
             "fr" => Ok(Fr),
             "nl" => Ok(Nl),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -18310,13 +18310,13 @@ impl ConfirmPaymentIntentPaymentMethodOptionsBancontactSetupFutureUsage {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsBancontactSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsBancontactSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -18394,12 +18394,12 @@ impl ConfirmPaymentIntentPaymentMethodOptionsBlikSetupFutureUsage {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsBlikSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsBlikSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -18483,14 +18483,14 @@ impl ConfirmPaymentIntentPaymentMethodOptionsBoletoSetupFutureUsage {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsBoletoSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsBoletoSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -18637,12 +18637,12 @@ impl ConfirmPaymentIntentPaymentMethodOptionsCardCaptureMethod {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsCardCaptureMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsCardCaptureMethod::*;
         match s {
             "manual" => Ok(Manual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -18735,12 +18735,12 @@ impl ConfirmPaymentIntentPaymentMethodOptionsCardInstallmentsPlanInterval {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsCardInstallmentsPlanInterval {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsCardInstallmentsPlanInterval::*;
         match s {
             "month" => Ok(Month),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -18788,12 +18788,12 @@ impl ConfirmPaymentIntentPaymentMethodOptionsCardInstallmentsPlanType {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsCardInstallmentsPlanType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsCardInstallmentsPlanType::*;
         match s {
             "fixed_count" => Ok(FixedCount),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -18900,13 +18900,13 @@ impl ConfirmPaymentIntentPaymentMethodOptionsCardMandateOptionsAmountType {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsCardMandateOptionsAmountType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsCardMandateOptionsAmountType::*;
         match s {
             "fixed" => Ok(Fixed),
             "maximum" => Ok(Maximum),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -18962,7 +18962,7 @@ impl ConfirmPaymentIntentPaymentMethodOptionsCardMandateOptionsInterval {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsCardMandateOptionsInterval {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsCardMandateOptionsInterval::*;
         match s {
@@ -18971,7 +18971,7 @@ impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsCardMandateOp
             "sporadic" => Ok(Sporadic),
             "week" => Ok(Week),
             "year" => Ok(Year),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -19021,12 +19021,12 @@ impl ConfirmPaymentIntentPaymentMethodOptionsCardMandateOptionsSupportedTypes {
 impl std::str::FromStr
     for ConfirmPaymentIntentPaymentMethodOptionsCardMandateOptionsSupportedTypes
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsCardMandateOptionsSupportedTypes::*;
         match s {
             "india" => Ok(India),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -19098,7 +19098,7 @@ impl ConfirmPaymentIntentPaymentMethodOptionsCardNetwork {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsCardNetwork {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsCardNetwork::*;
         match s {
@@ -19113,7 +19113,7 @@ impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsCardNetwork {
             "unionpay" => Ok(Unionpay),
             "unknown" => Ok(Unknown),
             "visa" => Ok(Visa),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -19167,13 +19167,13 @@ impl ConfirmPaymentIntentPaymentMethodOptionsCardRequestExtendedAuthorization {
 impl std::str::FromStr
     for ConfirmPaymentIntentPaymentMethodOptionsCardRequestExtendedAuthorization
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsCardRequestExtendedAuthorization::*;
         match s {
             "if_available" => Ok(IfAvailable),
             "never" => Ok(Never),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -19227,13 +19227,13 @@ impl ConfirmPaymentIntentPaymentMethodOptionsCardRequestIncrementalAuthorization
 impl std::str::FromStr
     for ConfirmPaymentIntentPaymentMethodOptionsCardRequestIncrementalAuthorization
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsCardRequestIncrementalAuthorization::*;
         match s {
             "if_available" => Ok(IfAvailable),
             "never" => Ok(Never),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -19289,13 +19289,13 @@ impl ConfirmPaymentIntentPaymentMethodOptionsCardRequestMulticapture {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsCardRequestMulticapture {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsCardRequestMulticapture::*;
         match s {
             "if_available" => Ok(IfAvailable),
             "never" => Ok(Never),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -19349,13 +19349,13 @@ impl ConfirmPaymentIntentPaymentMethodOptionsCardRequestOvercapture {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsCardRequestOvercapture {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsCardRequestOvercapture::*;
         match s {
             "if_available" => Ok(IfAvailable),
             "never" => Ok(Never),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -19414,14 +19414,14 @@ impl ConfirmPaymentIntentPaymentMethodOptionsCardRequestThreeDSecure {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsCardRequestThreeDSecure {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsCardRequestThreeDSecure::*;
         match s {
             "any" => Ok(Any),
             "automatic" => Ok(Automatic),
             "challenge" => Ok(Challenge),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -19484,14 +19484,14 @@ impl ConfirmPaymentIntentPaymentMethodOptionsCardSetupFutureUsage {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsCardSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsCardSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -19609,7 +19609,7 @@ impl ConfirmPaymentIntentPaymentMethodOptionsCardThreeDSecureAresTransStatus {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsCardThreeDSecureAresTransStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsCardThreeDSecureAresTransStatus::*;
         match s {
@@ -19620,7 +19620,7 @@ impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsCardThreeDSec
             "R" => Ok(R),
             "U" => Ok(U),
             "Y" => Ok(Y),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -19679,7 +19679,7 @@ impl ConfirmPaymentIntentPaymentMethodOptionsCardThreeDSecureElectronicCommerceI
 impl std::str::FromStr
     for ConfirmPaymentIntentPaymentMethodOptionsCardThreeDSecureElectronicCommerceIndicator
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsCardThreeDSecureElectronicCommerceIndicator::*;
         match s {
@@ -19688,7 +19688,7 @@ impl std::str::FromStr
             "05" => Ok(V05),
             "06" => Ok(V06),
             "07" => Ok(V07),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -19746,13 +19746,13 @@ impl ConfirmPaymentIntentPaymentMethodOptionsCardThreeDSecureExemptionIndicator 
 impl std::str::FromStr
     for ConfirmPaymentIntentPaymentMethodOptionsCardThreeDSecureExemptionIndicator
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsCardThreeDSecureExemptionIndicator::*;
         match s {
             "low_risk" => Ok(LowRisk),
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -19861,7 +19861,7 @@ impl ConfirmPaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCarte
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancairesCbAvalgo {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancairesCbAvalgo::*;
         match s {
@@ -19871,7 +19871,7 @@ impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsCardThreeDSec
 "3" => Ok(V3),
 "4" => Ok(V4),
 "A" => Ok(A),
-_ => Err(())
+_ => Err(stripe_types::StripeParseError)
 
         }
     }
@@ -19919,14 +19919,14 @@ impl ConfirmPaymentIntentPaymentMethodOptionsCardThreeDSecureVersion {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsCardThreeDSecureVersion {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsCardThreeDSecureVersion::*;
         match s {
             "1.0.2" => Ok(V1_0_2),
             "2.1.0" => Ok(V2_1_0),
             "2.2.0" => Ok(V2_2_0),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -20008,12 +20008,12 @@ impl ConfirmPaymentIntentPaymentMethodOptionsCashappCaptureMethod {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsCashappCaptureMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsCashappCaptureMethod::*;
         match s {
             "manual" => Ok(Manual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -20074,14 +20074,14 @@ impl ConfirmPaymentIntentPaymentMethodOptionsCashappSetupFutureUsage {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsCashappSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsCashappSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -20202,7 +20202,7 @@ impl ConfirmPaymentIntentPaymentMethodOptionsCustomerBalanceBankTransferRequeste
 impl std::str::FromStr
     for ConfirmPaymentIntentPaymentMethodOptionsCustomerBalanceBankTransferRequestedAddressTypes
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsCustomerBalanceBankTransferRequestedAddressTypes::*;
         match s {
@@ -20213,7 +20213,7 @@ impl std::str::FromStr
             "spei" => Ok(Spei),
             "swift" => Ok(Swift),
             "zengin" => Ok(Zengin),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -20275,7 +20275,7 @@ impl ConfirmPaymentIntentPaymentMethodOptionsCustomerBalanceBankTransferType {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsCustomerBalanceBankTransferType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsCustomerBalanceBankTransferType::*;
         match s {
@@ -20284,7 +20284,7 @@ impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsCustomerBalan
             "jp_bank_transfer" => Ok(JpBankTransfer),
             "mx_bank_transfer" => Ok(MxBankTransfer),
             "us_bank_transfer" => Ok(UsBankTransfer),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -20333,12 +20333,12 @@ impl ConfirmPaymentIntentPaymentMethodOptionsCustomerBalanceFundingType {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsCustomerBalanceFundingType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsCustomerBalanceFundingType::*;
         match s {
             "bank_transfer" => Ok(BankTransfer),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -20393,12 +20393,12 @@ impl ConfirmPaymentIntentPaymentMethodOptionsCustomerBalanceSetupFutureUsage {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsCustomerBalanceSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsCustomerBalanceSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -20472,12 +20472,12 @@ impl ConfirmPaymentIntentPaymentMethodOptionsEpsSetupFutureUsage {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsEpsSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsEpsSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -20553,12 +20553,12 @@ impl ConfirmPaymentIntentPaymentMethodOptionsFpxSetupFutureUsage {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsFpxSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsFpxSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -20634,12 +20634,12 @@ impl ConfirmPaymentIntentPaymentMethodOptionsGiropaySetupFutureUsage {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsGiropaySetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsGiropaySetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -20717,12 +20717,12 @@ impl ConfirmPaymentIntentPaymentMethodOptionsGrabpaySetupFutureUsage {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsGrabpaySetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsGrabpaySetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -20802,13 +20802,13 @@ impl ConfirmPaymentIntentPaymentMethodOptionsIdealSetupFutureUsage {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsIdealSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsIdealSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -20893,12 +20893,12 @@ impl ConfirmPaymentIntentPaymentMethodOptionsKlarnaCaptureMethod {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsKlarnaCaptureMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsKlarnaCaptureMethod::*;
         match s {
             "manual" => Ok(Manual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -21038,7 +21038,7 @@ impl ConfirmPaymentIntentPaymentMethodOptionsKlarnaPreferredLocale {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsKlarnaPreferredLocale {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsKlarnaPreferredLocale::*;
         match s {
@@ -21086,7 +21086,7 @@ impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsKlarnaPreferr
             "pt-PT" => Ok(PtMinusPt),
             "sv-FI" => Ok(SvMinusFi),
             "sv-SE" => Ok(SvMinusSe),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -21116,7 +21116,7 @@ impl<'de> serde::Deserialize<'de>
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// Indicates that you intend to make future payments with this PaymentIntent's payment method.
@@ -21141,12 +21141,12 @@ impl ConfirmPaymentIntentPaymentMethodOptionsKlarnaSetupFutureUsage {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsKlarnaSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsKlarnaSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -21241,12 +21241,12 @@ impl ConfirmPaymentIntentPaymentMethodOptionsKonbiniSetupFutureUsage {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsKonbiniSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsKonbiniSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -21331,12 +21331,12 @@ impl ConfirmPaymentIntentPaymentMethodOptionsLinkCaptureMethod {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsLinkCaptureMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsLinkCaptureMethod::*;
         match s {
             "manual" => Ok(Manual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -21395,13 +21395,13 @@ impl ConfirmPaymentIntentPaymentMethodOptionsLinkSetupFutureUsage {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsLinkSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsLinkSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -21481,12 +21481,12 @@ impl ConfirmPaymentIntentPaymentMethodOptionsOxxoSetupFutureUsage {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsOxxoSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsOxxoSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -21565,12 +21565,12 @@ impl ConfirmPaymentIntentPaymentMethodOptionsP24SetupFutureUsage {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsP24SetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsP24SetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -21646,12 +21646,12 @@ impl ConfirmPaymentIntentPaymentMethodOptionsPaynowSetupFutureUsage {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsPaynowSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsPaynowSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -21735,12 +21735,12 @@ impl ConfirmPaymentIntentPaymentMethodOptionsPaypalCaptureMethod {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsPaypalCaptureMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsPaypalCaptureMethod::*;
         match s {
             "manual" => Ok(Manual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -21834,7 +21834,7 @@ impl ConfirmPaymentIntentPaymentMethodOptionsPaypalPreferredLocale {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsPaypalPreferredLocale {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsPaypalPreferredLocale::*;
         match s {
@@ -21859,7 +21859,7 @@ impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsPaypalPreferr
             "pt-PT" => Ok(PtMinusPt),
             "sk-SK" => Ok(SkMinusSk),
             "sv-SE" => Ok(SvMinusSe),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -21889,7 +21889,7 @@ impl<'de> serde::Deserialize<'de>
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// Indicates that you intend to make future payments with this PaymentIntent's payment method.
@@ -21916,13 +21916,13 @@ impl ConfirmPaymentIntentPaymentMethodOptionsPaypalSetupFutureUsage {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsPaypalSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsPaypalSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -22008,12 +22008,12 @@ impl ConfirmPaymentIntentPaymentMethodOptionsPixSetupFutureUsage {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsPixSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsPixSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -22090,12 +22090,12 @@ impl ConfirmPaymentIntentPaymentMethodOptionsPromptpaySetupFutureUsage {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsPromptpaySetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsPromptpaySetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -22168,13 +22168,13 @@ impl ConfirmPaymentIntentPaymentMethodOptionsRevolutPaySetupFutureUsage {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsRevolutPaySetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsRevolutPaySetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -22257,14 +22257,14 @@ impl ConfirmPaymentIntentPaymentMethodOptionsSepaDebitSetupFutureUsage {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsSepaDebitSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsSepaDebitSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -22346,7 +22346,7 @@ impl ConfirmPaymentIntentPaymentMethodOptionsSofortPreferredLanguage {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsSofortPreferredLanguage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsSofortPreferredLanguage::*;
         match s {
@@ -22357,7 +22357,7 @@ impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsSofortPreferr
             "it" => Ok(It),
             "nl" => Ok(Nl),
             "pl" => Ok(Pl),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -22418,13 +22418,13 @@ impl ConfirmPaymentIntentPaymentMethodOptionsSofortSetupFutureUsage {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsSofortSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsSofortSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -22505,12 +22505,12 @@ impl ConfirmPaymentIntentPaymentMethodOptionsSwishSetupFutureUsage {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsSwishSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsSwishSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -22633,7 +22633,7 @@ impl ConfirmPaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPe
 impl std::str::FromStr
     for ConfirmPaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPermissions
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPermissions::*;
         match s {
@@ -22641,7 +22641,7 @@ impl std::str::FromStr
             "ownership" => Ok(Ownership),
             "payment_method" => Ok(PaymentMethod),
             "transactions" => Ok(Transactions),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -22699,13 +22699,13 @@ impl ConfirmPaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPr
 impl std::str::FromStr
     for ConfirmPaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPrefetch
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPrefetch::*;
         match s {
             "balances" => Ok(Balances),
             "transactions" => Ok(Transactions),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -22774,12 +22774,12 @@ impl ConfirmPaymentIntentPaymentMethodOptionsUsBankAccountMandateOptionsCollecti
 impl std::str::FromStr
     for ConfirmPaymentIntentPaymentMethodOptionsUsBankAccountMandateOptionsCollectionMethod
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsUsBankAccountMandateOptionsCollectionMethod::*;
         match s {
             "paper" => Ok(Paper),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -22848,13 +22848,13 @@ impl ConfirmPaymentIntentPaymentMethodOptionsUsBankAccountNetworksRequested {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsUsBankAccountNetworksRequested {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsUsBankAccountNetworksRequested::*;
         match s {
             "ach" => Ok(Ach),
             "us_domestic_wire" => Ok(UsDomesticWire),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -22906,13 +22906,13 @@ impl ConfirmPaymentIntentPaymentMethodOptionsUsBankAccountPreferredSettlementSpe
 impl std::str::FromStr
     for ConfirmPaymentIntentPaymentMethodOptionsUsBankAccountPreferredSettlementSpeed
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsUsBankAccountPreferredSettlementSpeed::*;
         match s {
             "fastest" => Ok(Fastest),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -22977,14 +22977,14 @@ impl ConfirmPaymentIntentPaymentMethodOptionsUsBankAccountSetupFutureUsage {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsUsBankAccountSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsUsBankAccountSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -23036,14 +23036,14 @@ impl ConfirmPaymentIntentPaymentMethodOptionsUsBankAccountVerificationMethod {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsUsBankAccountVerificationMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsUsBankAccountVerificationMethod::*;
         match s {
             "automatic" => Ok(Automatic),
             "instant" => Ok(Instant),
             "microdeposits" => Ok(Microdeposits),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -23120,14 +23120,14 @@ impl ConfirmPaymentIntentPaymentMethodOptionsWechatPayClient {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsWechatPayClient {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsWechatPayClient::*;
         match s {
             "android" => Ok(Android),
             "ios" => Ok(Ios),
             "web" => Ok(Web),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -23184,12 +23184,12 @@ impl ConfirmPaymentIntentPaymentMethodOptionsWechatPaySetupFutureUsage {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsWechatPaySetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsWechatPaySetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -23263,12 +23263,12 @@ impl ConfirmPaymentIntentPaymentMethodOptionsZipSetupFutureUsage {
 }
 
 impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsZipSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmPaymentIntentPaymentMethodOptionsZipSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_core/src/payout/requests.rs
+++ b/generated/stripe_core/src/payout/requests.rs
@@ -144,13 +144,13 @@ impl CreatePayoutMethod {
 }
 
 impl std::str::FromStr for CreatePayoutMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePayoutMethod::*;
         match s {
             "instant" => Ok(Instant),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -204,14 +204,14 @@ impl CreatePayoutSourceType {
 }
 
 impl std::str::FromStr for CreatePayoutSourceType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePayoutSourceType::*;
         match s {
             "bank_account" => Ok(BankAccount),
             "card" => Ok(Card),
             "fpx" => Ok(Fpx),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_core/src/refund/requests.rs
+++ b/generated/stripe_core/src/refund/requests.rs
@@ -135,12 +135,12 @@ impl CreateRefundOrigin {
 }
 
 impl std::str::FromStr for CreateRefundOrigin {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateRefundOrigin::*;
         match s {
             "customer_balance" => Ok(CustomerBalance),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -193,14 +193,14 @@ impl CreateRefundReason {
 }
 
 impl std::str::FromStr for CreateRefundReason {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateRefundReason::*;
         match s {
             "duplicate" => Ok(Duplicate),
             "fraudulent" => Ok(Fraudulent),
             "requested_by_customer" => Ok(RequestedByCustomer),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_core/src/setup_intent/requests.rs
+++ b/generated/stripe_core/src/setup_intent/requests.rs
@@ -205,13 +205,13 @@ impl CreateSetupIntentAutomaticPaymentMethodsAllowRedirects {
 }
 
 impl std::str::FromStr for CreateSetupIntentAutomaticPaymentMethodsAllowRedirects {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSetupIntentAutomaticPaymentMethodsAllowRedirects::*;
         match s {
             "always" => Ok(Always),
             "never" => Ok(Never),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -299,13 +299,13 @@ impl CreateSetupIntentMandateDataCustomerAcceptanceType {
 }
 
 impl std::str::FromStr for CreateSetupIntentMandateDataCustomerAcceptanceType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSetupIntentMandateDataCustomerAcceptanceType::*;
         match s {
             "offline" => Ok(Offline),
             "online" => Ok(Online),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -650,7 +650,7 @@ impl CreateSetupIntentPaymentMethodDataEpsBank {
 }
 
 impl std::str::FromStr for CreateSetupIntentPaymentMethodDataEpsBank {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSetupIntentPaymentMethodDataEpsBank::*;
         match s {
@@ -682,7 +682,7 @@ impl std::str::FromStr for CreateSetupIntentPaymentMethodDataEpsBank {
             "volksbank_gruppe" => Ok(VolksbankGruppe),
             "volkskreditbank_ag" => Ok(VolkskreditbankAg),
             "vr_bank_braunau" => Ok(VrBankBraunau),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -710,7 +710,7 @@ impl<'de> serde::Deserialize<'de> for CreateSetupIntentPaymentMethodDataEpsBank 
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// If this is an `fpx` PaymentMethod, this hash contains details about the FPX payment method.
@@ -744,13 +744,13 @@ impl CreateSetupIntentPaymentMethodDataFpxAccountHolderType {
 }
 
 impl std::str::FromStr for CreateSetupIntentPaymentMethodDataFpxAccountHolderType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSetupIntentPaymentMethodDataFpxAccountHolderType::*;
         match s {
             "company" => Ok(Company),
             "individual" => Ok(Individual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -846,7 +846,7 @@ impl CreateSetupIntentPaymentMethodDataFpxBank {
 }
 
 impl std::str::FromStr for CreateSetupIntentPaymentMethodDataFpxBank {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSetupIntentPaymentMethodDataFpxBank::*;
         match s {
@@ -872,7 +872,7 @@ impl std::str::FromStr for CreateSetupIntentPaymentMethodDataFpxBank {
             "rhb" => Ok(Rhb),
             "standard_chartered" => Ok(StandardChartered),
             "uob" => Ok(Uob),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -900,7 +900,7 @@ impl<'de> serde::Deserialize<'de> for CreateSetupIntentPaymentMethodDataFpxBank 
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// If this is an `ideal` PaymentMethod, this hash contains details about the iDEAL payment method.
@@ -964,7 +964,7 @@ impl CreateSetupIntentPaymentMethodDataIdealBank {
 }
 
 impl std::str::FromStr for CreateSetupIntentPaymentMethodDataIdealBank {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSetupIntentPaymentMethodDataIdealBank::*;
         match s {
@@ -984,7 +984,7 @@ impl std::str::FromStr for CreateSetupIntentPaymentMethodDataIdealBank {
             "triodos_bank" => Ok(TriodosBank),
             "van_lanschot" => Ok(VanLanschot),
             "yoursafe" => Ok(Yoursafe),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -1012,7 +1012,7 @@ impl<'de> serde::Deserialize<'de> for CreateSetupIntentPaymentMethodDataIdealBan
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// If this is a `klarna` PaymentMethod, this hash contains details about the Klarna payment method.
@@ -1108,7 +1108,7 @@ impl CreateSetupIntentPaymentMethodDataP24Bank {
 }
 
 impl std::str::FromStr for CreateSetupIntentPaymentMethodDataP24Bank {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSetupIntentPaymentMethodDataP24Bank::*;
         match s {
@@ -1138,7 +1138,7 @@ impl std::str::FromStr for CreateSetupIntentPaymentMethodDataP24Bank {
             "toyota_bank" => Ok(ToyotaBank),
             "velobank" => Ok(Velobank),
             "volkswagen_bank" => Ok(VolkswagenBank),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -1166,7 +1166,7 @@ impl<'de> serde::Deserialize<'de> for CreateSetupIntentPaymentMethodDataP24Bank 
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// If this is a `sepa_debit` PaymentMethod, this hash contains details about the SEPA debit bank account.
@@ -1216,7 +1216,7 @@ impl CreateSetupIntentPaymentMethodDataSofortCountry {
 }
 
 impl std::str::FromStr for CreateSetupIntentPaymentMethodDataSofortCountry {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSetupIntentPaymentMethodDataSofortCountry::*;
         match s {
@@ -1226,7 +1226,7 @@ impl std::str::FromStr for CreateSetupIntentPaymentMethodDataSofortCountry {
             "ES" => Ok(Es),
             "IT" => Ok(It),
             "NL" => Ok(Nl),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1344,7 +1344,7 @@ impl CreateSetupIntentPaymentMethodDataType {
 }
 
 impl std::str::FromStr for CreateSetupIntentPaymentMethodDataType {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSetupIntentPaymentMethodDataType::*;
         match s {
@@ -1380,7 +1380,7 @@ impl std::str::FromStr for CreateSetupIntentPaymentMethodDataType {
             "us_bank_account" => Ok(UsBankAccount),
             "wechat_pay" => Ok(WechatPay),
             "zip" => Ok(Zip),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -1408,7 +1408,7 @@ impl<'de> serde::Deserialize<'de> for CreateSetupIntentPaymentMethodDataType {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// If this is an `us_bank_account` PaymentMethod, this hash contains details about the US bank account payment method.
@@ -1453,13 +1453,13 @@ impl CreateSetupIntentPaymentMethodDataUsBankAccountAccountHolderType {
 }
 
 impl std::str::FromStr for CreateSetupIntentPaymentMethodDataUsBankAccountAccountHolderType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSetupIntentPaymentMethodDataUsBankAccountAccountHolderType::*;
         match s {
             "company" => Ok(Company),
             "individual" => Ok(Individual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1509,13 +1509,13 @@ impl CreateSetupIntentPaymentMethodDataUsBankAccountAccountType {
 }
 
 impl std::str::FromStr for CreateSetupIntentPaymentMethodDataUsBankAccountAccountType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSetupIntentPaymentMethodDataUsBankAccountAccountType::*;
         match s {
             "checking" => Ok(Checking),
             "savings" => Ok(Savings),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1615,13 +1615,13 @@ impl CreateSetupIntentPaymentMethodOptionsAcssDebitCurrency {
 }
 
 impl std::str::FromStr for CreateSetupIntentPaymentMethodOptionsAcssDebitCurrency {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSetupIntentPaymentMethodOptionsAcssDebitCurrency::*;
         match s {
             "cad" => Ok(Cad),
             "usd" => Ok(Usd),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1703,13 +1703,13 @@ impl CreateSetupIntentPaymentMethodOptionsAcssDebitMandateOptionsDefaultFor {
 }
 
 impl std::str::FromStr for CreateSetupIntentPaymentMethodOptionsAcssDebitMandateOptionsDefaultFor {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSetupIntentPaymentMethodOptionsAcssDebitMandateOptionsDefaultFor::*;
         match s {
             "invoice" => Ok(Invoice),
             "subscription" => Ok(Subscription),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1763,14 +1763,14 @@ impl CreateSetupIntentPaymentMethodOptionsAcssDebitMandateOptionsPaymentSchedule
 impl std::str::FromStr
     for CreateSetupIntentPaymentMethodOptionsAcssDebitMandateOptionsPaymentSchedule
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSetupIntentPaymentMethodOptionsAcssDebitMandateOptionsPaymentSchedule::*;
         match s {
             "combined" => Ok(Combined),
             "interval" => Ok(Interval),
             "sporadic" => Ok(Sporadic),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1828,13 +1828,13 @@ impl CreateSetupIntentPaymentMethodOptionsAcssDebitMandateOptionsTransactionType
 impl std::str::FromStr
     for CreateSetupIntentPaymentMethodOptionsAcssDebitMandateOptionsTransactionType
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSetupIntentPaymentMethodOptionsAcssDebitMandateOptionsTransactionType::*;
         match s {
             "business" => Ok(Business),
             "personal" => Ok(Personal),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1892,14 +1892,14 @@ impl CreateSetupIntentPaymentMethodOptionsAcssDebitVerificationMethod {
 }
 
 impl std::str::FromStr for CreateSetupIntentPaymentMethodOptionsAcssDebitVerificationMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSetupIntentPaymentMethodOptionsAcssDebitVerificationMethod::*;
         match s {
             "automatic" => Ok(Automatic),
             "instant" => Ok(Instant),
             "microdeposits" => Ok(Microdeposits),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2045,13 +2045,13 @@ impl CreateSetupIntentPaymentMethodOptionsCardMandateOptionsAmountType {
 }
 
 impl std::str::FromStr for CreateSetupIntentPaymentMethodOptionsCardMandateOptionsAmountType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSetupIntentPaymentMethodOptionsCardMandateOptionsAmountType::*;
         match s {
             "fixed" => Ok(Fixed),
             "maximum" => Ok(Maximum),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2107,7 +2107,7 @@ impl CreateSetupIntentPaymentMethodOptionsCardMandateOptionsInterval {
 }
 
 impl std::str::FromStr for CreateSetupIntentPaymentMethodOptionsCardMandateOptionsInterval {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSetupIntentPaymentMethodOptionsCardMandateOptionsInterval::*;
         match s {
@@ -2116,7 +2116,7 @@ impl std::str::FromStr for CreateSetupIntentPaymentMethodOptionsCardMandateOptio
             "sporadic" => Ok(Sporadic),
             "week" => Ok(Week),
             "year" => Ok(Year),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2168,12 +2168,12 @@ impl CreateSetupIntentPaymentMethodOptionsCardMandateOptionsSupportedTypes {
 }
 
 impl std::str::FromStr for CreateSetupIntentPaymentMethodOptionsCardMandateOptionsSupportedTypes {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSetupIntentPaymentMethodOptionsCardMandateOptionsSupportedTypes::*;
         match s {
             "india" => Ok(India),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2243,7 +2243,7 @@ impl CreateSetupIntentPaymentMethodOptionsCardNetwork {
 }
 
 impl std::str::FromStr for CreateSetupIntentPaymentMethodOptionsCardNetwork {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSetupIntentPaymentMethodOptionsCardNetwork::*;
         match s {
@@ -2258,7 +2258,7 @@ impl std::str::FromStr for CreateSetupIntentPaymentMethodOptionsCardNetwork {
             "unionpay" => Ok(Unionpay),
             "unknown" => Ok(Unknown),
             "visa" => Ok(Visa),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2315,14 +2315,14 @@ impl CreateSetupIntentPaymentMethodOptionsCardRequestThreeDSecure {
 }
 
 impl std::str::FromStr for CreateSetupIntentPaymentMethodOptionsCardRequestThreeDSecure {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSetupIntentPaymentMethodOptionsCardRequestThreeDSecure::*;
         match s {
             "any" => Ok(Any),
             "automatic" => Ok(Automatic),
             "challenge" => Ok(Challenge),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2426,7 +2426,7 @@ impl CreateSetupIntentPaymentMethodOptionsCardThreeDSecureAresTransStatus {
 }
 
 impl std::str::FromStr for CreateSetupIntentPaymentMethodOptionsCardThreeDSecureAresTransStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSetupIntentPaymentMethodOptionsCardThreeDSecureAresTransStatus::*;
         match s {
@@ -2437,7 +2437,7 @@ impl std::str::FromStr for CreateSetupIntentPaymentMethodOptionsCardThreeDSecure
             "R" => Ok(R),
             "U" => Ok(U),
             "Y" => Ok(Y),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2496,7 +2496,7 @@ impl CreateSetupIntentPaymentMethodOptionsCardThreeDSecureElectronicCommerceIndi
 impl std::str::FromStr
     for CreateSetupIntentPaymentMethodOptionsCardThreeDSecureElectronicCommerceIndicator
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSetupIntentPaymentMethodOptionsCardThreeDSecureElectronicCommerceIndicator::*;
         match s {
@@ -2505,7 +2505,7 @@ impl std::str::FromStr
             "05" => Ok(V05),
             "06" => Ok(V06),
             "07" => Ok(V07),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2616,7 +2616,7 @@ impl CreateSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBa
 impl std::str::FromStr
     for CreateSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancairesCbAvalgo
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancairesCbAvalgo::*;
         match s {
@@ -2626,7 +2626,7 @@ impl std::str::FromStr
             "3" => Ok(V3),
             "4" => Ok(V4),
             "A" => Ok(A),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2684,14 +2684,14 @@ impl CreateSetupIntentPaymentMethodOptionsCardThreeDSecureVersion {
 }
 
 impl std::str::FromStr for CreateSetupIntentPaymentMethodOptionsCardThreeDSecureVersion {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSetupIntentPaymentMethodOptionsCardThreeDSecureVersion::*;
         match s {
             "1.0.2" => Ok(V1_0_2),
             "2.1.0" => Ok(V2_1_0),
             "2.2.0" => Ok(V2_2_0),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2812,7 +2812,7 @@ impl CreateSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPermi
 impl std::str::FromStr
     for CreateSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPermissions
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPermissions::*;
         match s {
@@ -2820,7 +2820,7 @@ impl std::str::FromStr
             "ownership" => Ok(Ownership),
             "payment_method" => Ok(PaymentMethod),
             "transactions" => Ok(Transactions),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2878,13 +2878,13 @@ impl CreateSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPrefe
 impl std::str::FromStr
     for CreateSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPrefetch
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPrefetch::*;
         match s {
             "balances" => Ok(Balances),
             "transactions" => Ok(Transactions),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2953,12 +2953,12 @@ impl CreateSetupIntentPaymentMethodOptionsUsBankAccountMandateOptionsCollectionM
 impl std::str::FromStr
     for CreateSetupIntentPaymentMethodOptionsUsBankAccountMandateOptionsCollectionMethod
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSetupIntentPaymentMethodOptionsUsBankAccountMandateOptionsCollectionMethod::*;
         match s {
             "paper" => Ok(Paper),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3027,13 +3027,13 @@ impl CreateSetupIntentPaymentMethodOptionsUsBankAccountNetworksRequested {
 }
 
 impl std::str::FromStr for CreateSetupIntentPaymentMethodOptionsUsBankAccountNetworksRequested {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSetupIntentPaymentMethodOptionsUsBankAccountNetworksRequested::*;
         match s {
             "ach" => Ok(Ach),
             "us_domestic_wire" => Ok(UsDomesticWire),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3085,14 +3085,14 @@ impl CreateSetupIntentPaymentMethodOptionsUsBankAccountVerificationMethod {
 }
 
 impl std::str::FromStr for CreateSetupIntentPaymentMethodOptionsUsBankAccountVerificationMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSetupIntentPaymentMethodOptionsUsBankAccountVerificationMethod::*;
         match s {
             "automatic" => Ok(Automatic),
             "instant" => Ok(Instant),
             "microdeposits" => Ok(Microdeposits),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3160,13 +3160,13 @@ impl CreateSetupIntentUsage {
 }
 
 impl std::str::FromStr for CreateSetupIntentUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSetupIntentUsage::*;
         match s {
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3573,7 +3573,7 @@ impl UpdateSetupIntentPaymentMethodDataEpsBank {
 }
 
 impl std::str::FromStr for UpdateSetupIntentPaymentMethodDataEpsBank {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSetupIntentPaymentMethodDataEpsBank::*;
         match s {
@@ -3605,7 +3605,7 @@ impl std::str::FromStr for UpdateSetupIntentPaymentMethodDataEpsBank {
             "volksbank_gruppe" => Ok(VolksbankGruppe),
             "volkskreditbank_ag" => Ok(VolkskreditbankAg),
             "vr_bank_braunau" => Ok(VrBankBraunau),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -3633,7 +3633,7 @@ impl<'de> serde::Deserialize<'de> for UpdateSetupIntentPaymentMethodDataEpsBank 
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// If this is an `fpx` PaymentMethod, this hash contains details about the FPX payment method.
@@ -3667,13 +3667,13 @@ impl UpdateSetupIntentPaymentMethodDataFpxAccountHolderType {
 }
 
 impl std::str::FromStr for UpdateSetupIntentPaymentMethodDataFpxAccountHolderType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSetupIntentPaymentMethodDataFpxAccountHolderType::*;
         match s {
             "company" => Ok(Company),
             "individual" => Ok(Individual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3769,7 +3769,7 @@ impl UpdateSetupIntentPaymentMethodDataFpxBank {
 }
 
 impl std::str::FromStr for UpdateSetupIntentPaymentMethodDataFpxBank {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSetupIntentPaymentMethodDataFpxBank::*;
         match s {
@@ -3795,7 +3795,7 @@ impl std::str::FromStr for UpdateSetupIntentPaymentMethodDataFpxBank {
             "rhb" => Ok(Rhb),
             "standard_chartered" => Ok(StandardChartered),
             "uob" => Ok(Uob),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -3823,7 +3823,7 @@ impl<'de> serde::Deserialize<'de> for UpdateSetupIntentPaymentMethodDataFpxBank 
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// If this is an `ideal` PaymentMethod, this hash contains details about the iDEAL payment method.
@@ -3887,7 +3887,7 @@ impl UpdateSetupIntentPaymentMethodDataIdealBank {
 }
 
 impl std::str::FromStr for UpdateSetupIntentPaymentMethodDataIdealBank {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSetupIntentPaymentMethodDataIdealBank::*;
         match s {
@@ -3907,7 +3907,7 @@ impl std::str::FromStr for UpdateSetupIntentPaymentMethodDataIdealBank {
             "triodos_bank" => Ok(TriodosBank),
             "van_lanschot" => Ok(VanLanschot),
             "yoursafe" => Ok(Yoursafe),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -3935,7 +3935,7 @@ impl<'de> serde::Deserialize<'de> for UpdateSetupIntentPaymentMethodDataIdealBan
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// If this is a `klarna` PaymentMethod, this hash contains details about the Klarna payment method.
@@ -4031,7 +4031,7 @@ impl UpdateSetupIntentPaymentMethodDataP24Bank {
 }
 
 impl std::str::FromStr for UpdateSetupIntentPaymentMethodDataP24Bank {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSetupIntentPaymentMethodDataP24Bank::*;
         match s {
@@ -4061,7 +4061,7 @@ impl std::str::FromStr for UpdateSetupIntentPaymentMethodDataP24Bank {
             "toyota_bank" => Ok(ToyotaBank),
             "velobank" => Ok(Velobank),
             "volkswagen_bank" => Ok(VolkswagenBank),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -4089,7 +4089,7 @@ impl<'de> serde::Deserialize<'de> for UpdateSetupIntentPaymentMethodDataP24Bank 
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// If this is a `sepa_debit` PaymentMethod, this hash contains details about the SEPA debit bank account.
@@ -4139,7 +4139,7 @@ impl UpdateSetupIntentPaymentMethodDataSofortCountry {
 }
 
 impl std::str::FromStr for UpdateSetupIntentPaymentMethodDataSofortCountry {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSetupIntentPaymentMethodDataSofortCountry::*;
         match s {
@@ -4149,7 +4149,7 @@ impl std::str::FromStr for UpdateSetupIntentPaymentMethodDataSofortCountry {
             "ES" => Ok(Es),
             "IT" => Ok(It),
             "NL" => Ok(Nl),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4267,7 +4267,7 @@ impl UpdateSetupIntentPaymentMethodDataType {
 }
 
 impl std::str::FromStr for UpdateSetupIntentPaymentMethodDataType {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSetupIntentPaymentMethodDataType::*;
         match s {
@@ -4303,7 +4303,7 @@ impl std::str::FromStr for UpdateSetupIntentPaymentMethodDataType {
             "us_bank_account" => Ok(UsBankAccount),
             "wechat_pay" => Ok(WechatPay),
             "zip" => Ok(Zip),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -4331,7 +4331,7 @@ impl<'de> serde::Deserialize<'de> for UpdateSetupIntentPaymentMethodDataType {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// If this is an `us_bank_account` PaymentMethod, this hash contains details about the US bank account payment method.
@@ -4376,13 +4376,13 @@ impl UpdateSetupIntentPaymentMethodDataUsBankAccountAccountHolderType {
 }
 
 impl std::str::FromStr for UpdateSetupIntentPaymentMethodDataUsBankAccountAccountHolderType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSetupIntentPaymentMethodDataUsBankAccountAccountHolderType::*;
         match s {
             "company" => Ok(Company),
             "individual" => Ok(Individual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4432,13 +4432,13 @@ impl UpdateSetupIntentPaymentMethodDataUsBankAccountAccountType {
 }
 
 impl std::str::FromStr for UpdateSetupIntentPaymentMethodDataUsBankAccountAccountType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSetupIntentPaymentMethodDataUsBankAccountAccountType::*;
         match s {
             "checking" => Ok(Checking),
             "savings" => Ok(Savings),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4538,13 +4538,13 @@ impl UpdateSetupIntentPaymentMethodOptionsAcssDebitCurrency {
 }
 
 impl std::str::FromStr for UpdateSetupIntentPaymentMethodOptionsAcssDebitCurrency {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSetupIntentPaymentMethodOptionsAcssDebitCurrency::*;
         match s {
             "cad" => Ok(Cad),
             "usd" => Ok(Usd),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4626,13 +4626,13 @@ impl UpdateSetupIntentPaymentMethodOptionsAcssDebitMandateOptionsDefaultFor {
 }
 
 impl std::str::FromStr for UpdateSetupIntentPaymentMethodOptionsAcssDebitMandateOptionsDefaultFor {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSetupIntentPaymentMethodOptionsAcssDebitMandateOptionsDefaultFor::*;
         match s {
             "invoice" => Ok(Invoice),
             "subscription" => Ok(Subscription),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4686,14 +4686,14 @@ impl UpdateSetupIntentPaymentMethodOptionsAcssDebitMandateOptionsPaymentSchedule
 impl std::str::FromStr
     for UpdateSetupIntentPaymentMethodOptionsAcssDebitMandateOptionsPaymentSchedule
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSetupIntentPaymentMethodOptionsAcssDebitMandateOptionsPaymentSchedule::*;
         match s {
             "combined" => Ok(Combined),
             "interval" => Ok(Interval),
             "sporadic" => Ok(Sporadic),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4751,13 +4751,13 @@ impl UpdateSetupIntentPaymentMethodOptionsAcssDebitMandateOptionsTransactionType
 impl std::str::FromStr
     for UpdateSetupIntentPaymentMethodOptionsAcssDebitMandateOptionsTransactionType
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSetupIntentPaymentMethodOptionsAcssDebitMandateOptionsTransactionType::*;
         match s {
             "business" => Ok(Business),
             "personal" => Ok(Personal),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4815,14 +4815,14 @@ impl UpdateSetupIntentPaymentMethodOptionsAcssDebitVerificationMethod {
 }
 
 impl std::str::FromStr for UpdateSetupIntentPaymentMethodOptionsAcssDebitVerificationMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSetupIntentPaymentMethodOptionsAcssDebitVerificationMethod::*;
         match s {
             "automatic" => Ok(Automatic),
             "instant" => Ok(Instant),
             "microdeposits" => Ok(Microdeposits),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4968,13 +4968,13 @@ impl UpdateSetupIntentPaymentMethodOptionsCardMandateOptionsAmountType {
 }
 
 impl std::str::FromStr for UpdateSetupIntentPaymentMethodOptionsCardMandateOptionsAmountType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSetupIntentPaymentMethodOptionsCardMandateOptionsAmountType::*;
         match s {
             "fixed" => Ok(Fixed),
             "maximum" => Ok(Maximum),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5030,7 +5030,7 @@ impl UpdateSetupIntentPaymentMethodOptionsCardMandateOptionsInterval {
 }
 
 impl std::str::FromStr for UpdateSetupIntentPaymentMethodOptionsCardMandateOptionsInterval {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSetupIntentPaymentMethodOptionsCardMandateOptionsInterval::*;
         match s {
@@ -5039,7 +5039,7 @@ impl std::str::FromStr for UpdateSetupIntentPaymentMethodOptionsCardMandateOptio
             "sporadic" => Ok(Sporadic),
             "week" => Ok(Week),
             "year" => Ok(Year),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5091,12 +5091,12 @@ impl UpdateSetupIntentPaymentMethodOptionsCardMandateOptionsSupportedTypes {
 }
 
 impl std::str::FromStr for UpdateSetupIntentPaymentMethodOptionsCardMandateOptionsSupportedTypes {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSetupIntentPaymentMethodOptionsCardMandateOptionsSupportedTypes::*;
         match s {
             "india" => Ok(India),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5166,7 +5166,7 @@ impl UpdateSetupIntentPaymentMethodOptionsCardNetwork {
 }
 
 impl std::str::FromStr for UpdateSetupIntentPaymentMethodOptionsCardNetwork {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSetupIntentPaymentMethodOptionsCardNetwork::*;
         match s {
@@ -5181,7 +5181,7 @@ impl std::str::FromStr for UpdateSetupIntentPaymentMethodOptionsCardNetwork {
             "unionpay" => Ok(Unionpay),
             "unknown" => Ok(Unknown),
             "visa" => Ok(Visa),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5238,14 +5238,14 @@ impl UpdateSetupIntentPaymentMethodOptionsCardRequestThreeDSecure {
 }
 
 impl std::str::FromStr for UpdateSetupIntentPaymentMethodOptionsCardRequestThreeDSecure {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSetupIntentPaymentMethodOptionsCardRequestThreeDSecure::*;
         match s {
             "any" => Ok(Any),
             "automatic" => Ok(Automatic),
             "challenge" => Ok(Challenge),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5349,7 +5349,7 @@ impl UpdateSetupIntentPaymentMethodOptionsCardThreeDSecureAresTransStatus {
 }
 
 impl std::str::FromStr for UpdateSetupIntentPaymentMethodOptionsCardThreeDSecureAresTransStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSetupIntentPaymentMethodOptionsCardThreeDSecureAresTransStatus::*;
         match s {
@@ -5360,7 +5360,7 @@ impl std::str::FromStr for UpdateSetupIntentPaymentMethodOptionsCardThreeDSecure
             "R" => Ok(R),
             "U" => Ok(U),
             "Y" => Ok(Y),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5419,7 +5419,7 @@ impl UpdateSetupIntentPaymentMethodOptionsCardThreeDSecureElectronicCommerceIndi
 impl std::str::FromStr
     for UpdateSetupIntentPaymentMethodOptionsCardThreeDSecureElectronicCommerceIndicator
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSetupIntentPaymentMethodOptionsCardThreeDSecureElectronicCommerceIndicator::*;
         match s {
@@ -5428,7 +5428,7 @@ impl std::str::FromStr
             "05" => Ok(V05),
             "06" => Ok(V06),
             "07" => Ok(V07),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5539,7 +5539,7 @@ impl UpdateSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBa
 impl std::str::FromStr
     for UpdateSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancairesCbAvalgo
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancairesCbAvalgo::*;
         match s {
@@ -5549,7 +5549,7 @@ impl std::str::FromStr
             "3" => Ok(V3),
             "4" => Ok(V4),
             "A" => Ok(A),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5607,14 +5607,14 @@ impl UpdateSetupIntentPaymentMethodOptionsCardThreeDSecureVersion {
 }
 
 impl std::str::FromStr for UpdateSetupIntentPaymentMethodOptionsCardThreeDSecureVersion {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSetupIntentPaymentMethodOptionsCardThreeDSecureVersion::*;
         match s {
             "1.0.2" => Ok(V1_0_2),
             "2.1.0" => Ok(V2_1_0),
             "2.2.0" => Ok(V2_2_0),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5735,7 +5735,7 @@ impl UpdateSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPermi
 impl std::str::FromStr
     for UpdateSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPermissions
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPermissions::*;
         match s {
@@ -5743,7 +5743,7 @@ impl std::str::FromStr
             "ownership" => Ok(Ownership),
             "payment_method" => Ok(PaymentMethod),
             "transactions" => Ok(Transactions),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5801,13 +5801,13 @@ impl UpdateSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPrefe
 impl std::str::FromStr
     for UpdateSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPrefetch
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPrefetch::*;
         match s {
             "balances" => Ok(Balances),
             "transactions" => Ok(Transactions),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5876,12 +5876,12 @@ impl UpdateSetupIntentPaymentMethodOptionsUsBankAccountMandateOptionsCollectionM
 impl std::str::FromStr
     for UpdateSetupIntentPaymentMethodOptionsUsBankAccountMandateOptionsCollectionMethod
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSetupIntentPaymentMethodOptionsUsBankAccountMandateOptionsCollectionMethod::*;
         match s {
             "paper" => Ok(Paper),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5950,13 +5950,13 @@ impl UpdateSetupIntentPaymentMethodOptionsUsBankAccountNetworksRequested {
 }
 
 impl std::str::FromStr for UpdateSetupIntentPaymentMethodOptionsUsBankAccountNetworksRequested {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSetupIntentPaymentMethodOptionsUsBankAccountNetworksRequested::*;
         match s {
             "ach" => Ok(Ach),
             "us_domestic_wire" => Ok(UsDomesticWire),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -6008,14 +6008,14 @@ impl UpdateSetupIntentPaymentMethodOptionsUsBankAccountVerificationMethod {
 }
 
 impl std::str::FromStr for UpdateSetupIntentPaymentMethodOptionsUsBankAccountVerificationMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSetupIntentPaymentMethodOptionsUsBankAccountVerificationMethod::*;
         match s {
             "automatic" => Ok(Automatic),
             "instant" => Ok(Instant),
             "microdeposits" => Ok(Microdeposits),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -6176,13 +6176,13 @@ impl ConfirmSetupIntentSecretKeyParamCustomerAcceptanceType {
 }
 
 impl std::str::FromStr for ConfirmSetupIntentSecretKeyParamCustomerAcceptanceType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmSetupIntentSecretKeyParamCustomerAcceptanceType::*;
         match s {
             "offline" => Ok(Offline),
             "online" => Ok(Online),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -6276,12 +6276,12 @@ impl ConfirmSetupIntentClientKeyParamCustomerAcceptanceType {
 }
 
 impl std::str::FromStr for ConfirmSetupIntentClientKeyParamCustomerAcceptanceType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmSetupIntentClientKeyParamCustomerAcceptanceType::*;
         match s {
             "online" => Ok(Online),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -6626,7 +6626,7 @@ impl ConfirmSetupIntentPaymentMethodDataEpsBank {
 }
 
 impl std::str::FromStr for ConfirmSetupIntentPaymentMethodDataEpsBank {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmSetupIntentPaymentMethodDataEpsBank::*;
         match s {
@@ -6658,7 +6658,7 @@ impl std::str::FromStr for ConfirmSetupIntentPaymentMethodDataEpsBank {
             "volksbank_gruppe" => Ok(VolksbankGruppe),
             "volkskreditbank_ag" => Ok(VolkskreditbankAg),
             "vr_bank_braunau" => Ok(VrBankBraunau),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -6686,7 +6686,7 @@ impl<'de> serde::Deserialize<'de> for ConfirmSetupIntentPaymentMethodDataEpsBank
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// If this is an `fpx` PaymentMethod, this hash contains details about the FPX payment method.
@@ -6720,13 +6720,13 @@ impl ConfirmSetupIntentPaymentMethodDataFpxAccountHolderType {
 }
 
 impl std::str::FromStr for ConfirmSetupIntentPaymentMethodDataFpxAccountHolderType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmSetupIntentPaymentMethodDataFpxAccountHolderType::*;
         match s {
             "company" => Ok(Company),
             "individual" => Ok(Individual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -6822,7 +6822,7 @@ impl ConfirmSetupIntentPaymentMethodDataFpxBank {
 }
 
 impl std::str::FromStr for ConfirmSetupIntentPaymentMethodDataFpxBank {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmSetupIntentPaymentMethodDataFpxBank::*;
         match s {
@@ -6848,7 +6848,7 @@ impl std::str::FromStr for ConfirmSetupIntentPaymentMethodDataFpxBank {
             "rhb" => Ok(Rhb),
             "standard_chartered" => Ok(StandardChartered),
             "uob" => Ok(Uob),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -6876,7 +6876,7 @@ impl<'de> serde::Deserialize<'de> for ConfirmSetupIntentPaymentMethodDataFpxBank
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// If this is an `ideal` PaymentMethod, this hash contains details about the iDEAL payment method.
@@ -6940,7 +6940,7 @@ impl ConfirmSetupIntentPaymentMethodDataIdealBank {
 }
 
 impl std::str::FromStr for ConfirmSetupIntentPaymentMethodDataIdealBank {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmSetupIntentPaymentMethodDataIdealBank::*;
         match s {
@@ -6960,7 +6960,7 @@ impl std::str::FromStr for ConfirmSetupIntentPaymentMethodDataIdealBank {
             "triodos_bank" => Ok(TriodosBank),
             "van_lanschot" => Ok(VanLanschot),
             "yoursafe" => Ok(Yoursafe),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -6988,7 +6988,7 @@ impl<'de> serde::Deserialize<'de> for ConfirmSetupIntentPaymentMethodDataIdealBa
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// If this is a `klarna` PaymentMethod, this hash contains details about the Klarna payment method.
@@ -7084,7 +7084,7 @@ impl ConfirmSetupIntentPaymentMethodDataP24Bank {
 }
 
 impl std::str::FromStr for ConfirmSetupIntentPaymentMethodDataP24Bank {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmSetupIntentPaymentMethodDataP24Bank::*;
         match s {
@@ -7114,7 +7114,7 @@ impl std::str::FromStr for ConfirmSetupIntentPaymentMethodDataP24Bank {
             "toyota_bank" => Ok(ToyotaBank),
             "velobank" => Ok(Velobank),
             "volkswagen_bank" => Ok(VolkswagenBank),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -7142,7 +7142,7 @@ impl<'de> serde::Deserialize<'de> for ConfirmSetupIntentPaymentMethodDataP24Bank
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// If this is a `sepa_debit` PaymentMethod, this hash contains details about the SEPA debit bank account.
@@ -7192,7 +7192,7 @@ impl ConfirmSetupIntentPaymentMethodDataSofortCountry {
 }
 
 impl std::str::FromStr for ConfirmSetupIntentPaymentMethodDataSofortCountry {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmSetupIntentPaymentMethodDataSofortCountry::*;
         match s {
@@ -7202,7 +7202,7 @@ impl std::str::FromStr for ConfirmSetupIntentPaymentMethodDataSofortCountry {
             "ES" => Ok(Es),
             "IT" => Ok(It),
             "NL" => Ok(Nl),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -7320,7 +7320,7 @@ impl ConfirmSetupIntentPaymentMethodDataType {
 }
 
 impl std::str::FromStr for ConfirmSetupIntentPaymentMethodDataType {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmSetupIntentPaymentMethodDataType::*;
         match s {
@@ -7356,7 +7356,7 @@ impl std::str::FromStr for ConfirmSetupIntentPaymentMethodDataType {
             "us_bank_account" => Ok(UsBankAccount),
             "wechat_pay" => Ok(WechatPay),
             "zip" => Ok(Zip),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -7384,7 +7384,7 @@ impl<'de> serde::Deserialize<'de> for ConfirmSetupIntentPaymentMethodDataType {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// If this is an `us_bank_account` PaymentMethod, this hash contains details about the US bank account payment method.
@@ -7429,13 +7429,13 @@ impl ConfirmSetupIntentPaymentMethodDataUsBankAccountAccountHolderType {
 }
 
 impl std::str::FromStr for ConfirmSetupIntentPaymentMethodDataUsBankAccountAccountHolderType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmSetupIntentPaymentMethodDataUsBankAccountAccountHolderType::*;
         match s {
             "company" => Ok(Company),
             "individual" => Ok(Individual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -7485,13 +7485,13 @@ impl ConfirmSetupIntentPaymentMethodDataUsBankAccountAccountType {
 }
 
 impl std::str::FromStr for ConfirmSetupIntentPaymentMethodDataUsBankAccountAccountType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmSetupIntentPaymentMethodDataUsBankAccountAccountType::*;
         match s {
             "checking" => Ok(Checking),
             "savings" => Ok(Savings),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -7591,13 +7591,13 @@ impl ConfirmSetupIntentPaymentMethodOptionsAcssDebitCurrency {
 }
 
 impl std::str::FromStr for ConfirmSetupIntentPaymentMethodOptionsAcssDebitCurrency {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmSetupIntentPaymentMethodOptionsAcssDebitCurrency::*;
         match s {
             "cad" => Ok(Cad),
             "usd" => Ok(Usd),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -7679,13 +7679,13 @@ impl ConfirmSetupIntentPaymentMethodOptionsAcssDebitMandateOptionsDefaultFor {
 }
 
 impl std::str::FromStr for ConfirmSetupIntentPaymentMethodOptionsAcssDebitMandateOptionsDefaultFor {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmSetupIntentPaymentMethodOptionsAcssDebitMandateOptionsDefaultFor::*;
         match s {
             "invoice" => Ok(Invoice),
             "subscription" => Ok(Subscription),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -7739,14 +7739,14 @@ impl ConfirmSetupIntentPaymentMethodOptionsAcssDebitMandateOptionsPaymentSchedul
 impl std::str::FromStr
     for ConfirmSetupIntentPaymentMethodOptionsAcssDebitMandateOptionsPaymentSchedule
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmSetupIntentPaymentMethodOptionsAcssDebitMandateOptionsPaymentSchedule::*;
         match s {
             "combined" => Ok(Combined),
             "interval" => Ok(Interval),
             "sporadic" => Ok(Sporadic),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -7804,13 +7804,13 @@ impl ConfirmSetupIntentPaymentMethodOptionsAcssDebitMandateOptionsTransactionTyp
 impl std::str::FromStr
     for ConfirmSetupIntentPaymentMethodOptionsAcssDebitMandateOptionsTransactionType
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmSetupIntentPaymentMethodOptionsAcssDebitMandateOptionsTransactionType::*;
         match s {
             "business" => Ok(Business),
             "personal" => Ok(Personal),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -7868,14 +7868,14 @@ impl ConfirmSetupIntentPaymentMethodOptionsAcssDebitVerificationMethod {
 }
 
 impl std::str::FromStr for ConfirmSetupIntentPaymentMethodOptionsAcssDebitVerificationMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmSetupIntentPaymentMethodOptionsAcssDebitVerificationMethod::*;
         match s {
             "automatic" => Ok(Automatic),
             "instant" => Ok(Instant),
             "microdeposits" => Ok(Microdeposits),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -8021,13 +8021,13 @@ impl ConfirmSetupIntentPaymentMethodOptionsCardMandateOptionsAmountType {
 }
 
 impl std::str::FromStr for ConfirmSetupIntentPaymentMethodOptionsCardMandateOptionsAmountType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmSetupIntentPaymentMethodOptionsCardMandateOptionsAmountType::*;
         match s {
             "fixed" => Ok(Fixed),
             "maximum" => Ok(Maximum),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -8083,7 +8083,7 @@ impl ConfirmSetupIntentPaymentMethodOptionsCardMandateOptionsInterval {
 }
 
 impl std::str::FromStr for ConfirmSetupIntentPaymentMethodOptionsCardMandateOptionsInterval {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmSetupIntentPaymentMethodOptionsCardMandateOptionsInterval::*;
         match s {
@@ -8092,7 +8092,7 @@ impl std::str::FromStr for ConfirmSetupIntentPaymentMethodOptionsCardMandateOpti
             "sporadic" => Ok(Sporadic),
             "week" => Ok(Week),
             "year" => Ok(Year),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -8140,12 +8140,12 @@ impl ConfirmSetupIntentPaymentMethodOptionsCardMandateOptionsSupportedTypes {
 }
 
 impl std::str::FromStr for ConfirmSetupIntentPaymentMethodOptionsCardMandateOptionsSupportedTypes {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmSetupIntentPaymentMethodOptionsCardMandateOptionsSupportedTypes::*;
         match s {
             "india" => Ok(India),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -8215,7 +8215,7 @@ impl ConfirmSetupIntentPaymentMethodOptionsCardNetwork {
 }
 
 impl std::str::FromStr for ConfirmSetupIntentPaymentMethodOptionsCardNetwork {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmSetupIntentPaymentMethodOptionsCardNetwork::*;
         match s {
@@ -8230,7 +8230,7 @@ impl std::str::FromStr for ConfirmSetupIntentPaymentMethodOptionsCardNetwork {
             "unionpay" => Ok(Unionpay),
             "unknown" => Ok(Unknown),
             "visa" => Ok(Visa),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -8287,14 +8287,14 @@ impl ConfirmSetupIntentPaymentMethodOptionsCardRequestThreeDSecure {
 }
 
 impl std::str::FromStr for ConfirmSetupIntentPaymentMethodOptionsCardRequestThreeDSecure {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmSetupIntentPaymentMethodOptionsCardRequestThreeDSecure::*;
         match s {
             "any" => Ok(Any),
             "automatic" => Ok(Automatic),
             "challenge" => Ok(Challenge),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -8400,7 +8400,7 @@ impl ConfirmSetupIntentPaymentMethodOptionsCardThreeDSecureAresTransStatus {
 }
 
 impl std::str::FromStr for ConfirmSetupIntentPaymentMethodOptionsCardThreeDSecureAresTransStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmSetupIntentPaymentMethodOptionsCardThreeDSecureAresTransStatus::*;
         match s {
@@ -8411,7 +8411,7 @@ impl std::str::FromStr for ConfirmSetupIntentPaymentMethodOptionsCardThreeDSecur
             "R" => Ok(R),
             "U" => Ok(U),
             "Y" => Ok(Y),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -8470,7 +8470,7 @@ impl ConfirmSetupIntentPaymentMethodOptionsCardThreeDSecureElectronicCommerceInd
 impl std::str::FromStr
     for ConfirmSetupIntentPaymentMethodOptionsCardThreeDSecureElectronicCommerceIndicator
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmSetupIntentPaymentMethodOptionsCardThreeDSecureElectronicCommerceIndicator::*;
         match s {
@@ -8479,7 +8479,7 @@ impl std::str::FromStr
             "05" => Ok(V05),
             "06" => Ok(V06),
             "07" => Ok(V07),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -8590,7 +8590,7 @@ impl ConfirmSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesB
 impl std::str::FromStr
     for ConfirmSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancairesCbAvalgo
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancairesCbAvalgo::*;
         match s {
@@ -8600,7 +8600,7 @@ impl std::str::FromStr
             "3" => Ok(V3),
             "4" => Ok(V4),
             "A" => Ok(A),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -8658,14 +8658,14 @@ impl ConfirmSetupIntentPaymentMethodOptionsCardThreeDSecureVersion {
 }
 
 impl std::str::FromStr for ConfirmSetupIntentPaymentMethodOptionsCardThreeDSecureVersion {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmSetupIntentPaymentMethodOptionsCardThreeDSecureVersion::*;
         match s {
             "1.0.2" => Ok(V1_0_2),
             "2.1.0" => Ok(V2_1_0),
             "2.2.0" => Ok(V2_2_0),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -8788,7 +8788,7 @@ impl ConfirmSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPerm
 impl std::str::FromStr
     for ConfirmSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPermissions
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPermissions::*;
         match s {
@@ -8796,7 +8796,7 @@ impl std::str::FromStr
             "ownership" => Ok(Ownership),
             "payment_method" => Ok(PaymentMethod),
             "transactions" => Ok(Transactions),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -8854,13 +8854,13 @@ impl ConfirmSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPref
 impl std::str::FromStr
     for ConfirmSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPrefetch
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPrefetch::*;
         match s {
             "balances" => Ok(Balances),
             "transactions" => Ok(Transactions),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -8929,12 +8929,12 @@ impl ConfirmSetupIntentPaymentMethodOptionsUsBankAccountMandateOptionsCollection
 impl std::str::FromStr
     for ConfirmSetupIntentPaymentMethodOptionsUsBankAccountMandateOptionsCollectionMethod
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmSetupIntentPaymentMethodOptionsUsBankAccountMandateOptionsCollectionMethod::*;
         match s {
             "paper" => Ok(Paper),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -9003,13 +9003,13 @@ impl ConfirmSetupIntentPaymentMethodOptionsUsBankAccountNetworksRequested {
 }
 
 impl std::str::FromStr for ConfirmSetupIntentPaymentMethodOptionsUsBankAccountNetworksRequested {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmSetupIntentPaymentMethodOptionsUsBankAccountNetworksRequested::*;
         match s {
             "ach" => Ok(Ach),
             "us_domestic_wire" => Ok(UsDomesticWire),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -9061,14 +9061,14 @@ impl ConfirmSetupIntentPaymentMethodOptionsUsBankAccountVerificationMethod {
 }
 
 impl std::str::FromStr for ConfirmSetupIntentPaymentMethodOptionsUsBankAccountVerificationMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConfirmSetupIntentPaymentMethodOptionsUsBankAccountVerificationMethod::*;
         match s {
             "automatic" => Ok(Automatic),
             "instant" => Ok(Instant),
             "microdeposits" => Ok(Microdeposits),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_core/src/token/requests.rs
+++ b/generated/stripe_core/src/token/requests.rs
@@ -98,7 +98,7 @@ impl CreateTokenAccountBusinessType {
 }
 
 impl std::str::FromStr for CreateTokenAccountBusinessType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTokenAccountBusinessType::*;
         match s {
@@ -106,7 +106,7 @@ impl std::str::FromStr for CreateTokenAccountBusinessType {
             "government_entity" => Ok(GovernmentEntity),
             "individual" => Ok(Individual),
             "non_profit" => Ok(NonProfit),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -359,7 +359,7 @@ impl CreateTokenAccountCompanyStructure {
 }
 
 impl std::str::FromStr for CreateTokenAccountCompanyStructure {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTokenAccountCompanyStructure::*;
         match s {
@@ -386,7 +386,7 @@ impl std::str::FromStr for CreateTokenAccountCompanyStructure {
             "unincorporated_association" => Ok(UnincorporatedAssociation),
             "unincorporated_non_profit" => Ok(UnincorporatedNonProfit),
             "unincorporated_partnership" => Ok(UnincorporatedPartnership),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -414,7 +414,7 @@ impl<'de> serde::Deserialize<'de> for CreateTokenAccountCompanyStructure {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// Information on the verification state of the company.
@@ -608,13 +608,13 @@ impl CreateTokenAccountIndividualPoliticalExposure {
 }
 
 impl std::str::FromStr for CreateTokenAccountIndividualPoliticalExposure {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTokenAccountIndividualPoliticalExposure::*;
         match s {
             "existing" => Ok(Existing),
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -736,13 +736,13 @@ impl CreateTokenBankAccountAccountHolderType {
 }
 
 impl std::str::FromStr for CreateTokenBankAccountAccountHolderType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTokenBankAccountAccountHolderType::*;
         match s {
             "company" => Ok(Company),
             "individual" => Ok(Individual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -798,7 +798,7 @@ impl CreateTokenBankAccountAccountType {
 }
 
 impl std::str::FromStr for CreateTokenBankAccountAccountType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTokenBankAccountAccountType::*;
         match s {
@@ -806,7 +806,7 @@ impl std::str::FromStr for CreateTokenBankAccountAccountType {
             "futsu" => Ok(Futsu),
             "savings" => Ok(Savings),
             "toza" => Ok(Toza),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_fraud/src/radar_value_list/types.rs
+++ b/generated/stripe_fraud/src/radar_value_list/types.rs
@@ -215,7 +215,7 @@ impl RadarValueListItemType {
 }
 
 impl std::str::FromStr for RadarValueListItemType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use RadarValueListItemType::*;
         match s {
@@ -229,7 +229,7 @@ impl std::str::FromStr for RadarValueListItemType {
             "sepa_debit_fingerprint" => Ok(SepaDebitFingerprint),
             "string" => Ok(String),
             "us_bank_account_fingerprint" => Ok(UsBankAccountFingerprint),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_issuing/src/issuing_authorization/requests.rs
+++ b/generated/stripe_issuing/src/issuing_authorization/requests.rs
@@ -938,7 +938,7 @@ impl CreateIssuingAuthorizationMerchantDataCategory {
 }
 
 impl std::str::FromStr for CreateIssuingAuthorizationMerchantDataCategory {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateIssuingAuthorizationMerchantDataCategory::*;
         match s {
@@ -1284,7 +1284,7 @@ impl std::str::FromStr for CreateIssuingAuthorizationMerchantDataCategory {
             "womens_accessory_and_specialty_shops" => Ok(WomensAccessoryAndSpecialtyShops),
             "womens_ready_to_wear_stores" => Ok(WomensReadyToWearStores),
             "wrecking_and_salvage_yards" => Ok(WreckingAndSalvageYards),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -1312,7 +1312,7 @@ impl<'de> serde::Deserialize<'de> for CreateIssuingAuthorizationMerchantDataCate
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// Details about the authorization, such as identifiers, set by the card network.
@@ -1375,14 +1375,14 @@ impl CreateIssuingAuthorizationVerificationDataAddressLine1Check {
 }
 
 impl std::str::FromStr for CreateIssuingAuthorizationVerificationDataAddressLine1Check {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateIssuingAuthorizationVerificationDataAddressLine1Check::*;
         match s {
             "match" => Ok(Match),
             "mismatch" => Ok(Mismatch),
             "not_provided" => Ok(NotProvided),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1436,14 +1436,14 @@ impl CreateIssuingAuthorizationVerificationDataAddressPostalCodeCheck {
 }
 
 impl std::str::FromStr for CreateIssuingAuthorizationVerificationDataAddressPostalCodeCheck {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateIssuingAuthorizationVerificationDataAddressPostalCodeCheck::*;
         match s {
             "match" => Ok(Match),
             "mismatch" => Ok(Mismatch),
             "not_provided" => Ok(NotProvided),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1512,13 +1512,13 @@ impl CreateIssuingAuthorizationVerificationDataAuthenticationExemptionClaimedBy 
 impl std::str::FromStr
     for CreateIssuingAuthorizationVerificationDataAuthenticationExemptionClaimedBy
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateIssuingAuthorizationVerificationDataAuthenticationExemptionClaimedBy::*;
         match s {
             "acquirer" => Ok(Acquirer),
             "issuer" => Ok(Issuer),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1576,14 +1576,14 @@ impl CreateIssuingAuthorizationVerificationDataAuthenticationExemptionType {
 }
 
 impl std::str::FromStr for CreateIssuingAuthorizationVerificationDataAuthenticationExemptionType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateIssuingAuthorizationVerificationDataAuthenticationExemptionType::*;
         match s {
             "low_value_transaction" => Ok(LowValueTransaction),
             "transaction_risk_analysis" => Ok(TransactionRiskAnalysis),
             "unknown" => Ok(Unknown),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1635,14 +1635,14 @@ impl CreateIssuingAuthorizationVerificationDataCvcCheck {
 }
 
 impl std::str::FromStr for CreateIssuingAuthorizationVerificationDataCvcCheck {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateIssuingAuthorizationVerificationDataCvcCheck::*;
         match s {
             "match" => Ok(Match),
             "mismatch" => Ok(Mismatch),
             "not_provided" => Ok(NotProvided),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1696,14 +1696,14 @@ impl CreateIssuingAuthorizationVerificationDataExpiryCheck {
 }
 
 impl std::str::FromStr for CreateIssuingAuthorizationVerificationDataExpiryCheck {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateIssuingAuthorizationVerificationDataExpiryCheck::*;
         match s {
             "match" => Ok(Match),
             "mismatch" => Ok(Mismatch),
             "not_provided" => Ok(NotProvided),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1770,7 +1770,7 @@ impl CreateIssuingAuthorizationVerificationDataThreeDSecureResult {
 }
 
 impl std::str::FromStr for CreateIssuingAuthorizationVerificationDataThreeDSecureResult {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateIssuingAuthorizationVerificationDataThreeDSecureResult::*;
         match s {
@@ -1778,7 +1778,7 @@ impl std::str::FromStr for CreateIssuingAuthorizationVerificationDataThreeDSecur
             "authenticated" => Ok(Authenticated),
             "failed" => Ok(Failed),
             "required" => Ok(Required),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1834,14 +1834,14 @@ impl CreateIssuingAuthorizationWallet {
 }
 
 impl std::str::FromStr for CreateIssuingAuthorizationWallet {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateIssuingAuthorizationWallet::*;
         match s {
             "apple_pay" => Ok(ApplePay),
             "google_pay" => Ok(GooglePay),
             "samsung_pay" => Ok(SamsungPay),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2029,7 +2029,7 @@ impl CaptureIssuingAuthorizationPurchaseDetailsFuelType {
 }
 
 impl std::str::FromStr for CaptureIssuingAuthorizationPurchaseDetailsFuelType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CaptureIssuingAuthorizationPurchaseDetailsFuelType::*;
         match s {
@@ -2038,7 +2038,7 @@ impl std::str::FromStr for CaptureIssuingAuthorizationPurchaseDetailsFuelType {
             "unleaded_plus" => Ok(UnleadedPlus),
             "unleaded_regular" => Ok(UnleadedRegular),
             "unleaded_super" => Ok(UnleadedSuper),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2090,13 +2090,13 @@ impl CaptureIssuingAuthorizationPurchaseDetailsFuelUnit {
 }
 
 impl std::str::FromStr for CaptureIssuingAuthorizationPurchaseDetailsFuelUnit {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CaptureIssuingAuthorizationPurchaseDetailsFuelUnit::*;
         match s {
             "liter" => Ok(Liter),
             "us_gallon" => Ok(UsGallon),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_issuing/src/issuing_card/requests.rs
+++ b/generated/stripe_issuing/src/issuing_card/requests.rs
@@ -232,14 +232,14 @@ impl CreateIssuingCardShippingService {
 }
 
 impl std::str::FromStr for CreateIssuingCardShippingService {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateIssuingCardShippingService::*;
         match s {
             "express" => Ok(Express),
             "priority" => Ok(Priority),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -289,13 +289,13 @@ impl CreateIssuingCardShippingType {
 }
 
 impl std::str::FromStr for CreateIssuingCardShippingType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateIssuingCardShippingType::*;
         match s {
             "bulk" => Ok(Bulk),
             "individual" => Ok(Individual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1004,7 +1004,7 @@ impl CreateIssuingCardSpendingControlsAllowedCategories {
 }
 
 impl std::str::FromStr for CreateIssuingCardSpendingControlsAllowedCategories {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateIssuingCardSpendingControlsAllowedCategories::*;
         match s {
@@ -1351,7 +1351,7 @@ impl std::str::FromStr for CreateIssuingCardSpendingControlsAllowedCategories {
             "womens_accessory_and_specialty_shops" => Ok(WomensAccessoryAndSpecialtyShops),
             "womens_ready_to_wear_stores" => Ok(WomensReadyToWearStores),
             "wrecking_and_salvage_yards" => Ok(WreckingAndSalvageYards),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -1379,7 +1379,7 @@ impl<'de> serde::Deserialize<'de> for CreateIssuingCardSpendingControlsAllowedCa
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to decline.
@@ -2035,7 +2035,7 @@ impl CreateIssuingCardSpendingControlsBlockedCategories {
 }
 
 impl std::str::FromStr for CreateIssuingCardSpendingControlsBlockedCategories {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateIssuingCardSpendingControlsBlockedCategories::*;
         match s {
@@ -2382,7 +2382,7 @@ impl std::str::FromStr for CreateIssuingCardSpendingControlsBlockedCategories {
             "womens_accessory_and_specialty_shops" => Ok(WomensAccessoryAndSpecialtyShops),
             "womens_ready_to_wear_stores" => Ok(WomensReadyToWearStores),
             "wrecking_and_salvage_yards" => Ok(WreckingAndSalvageYards),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -2410,7 +2410,7 @@ impl<'de> serde::Deserialize<'de> for CreateIssuingCardSpendingControlsBlockedCa
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// Limit spending with amount-based rules that apply across any cards this card replaced (i.e., its `replacement_for` card and _that_ card's `replacement_for` card, up the chain).
@@ -3085,7 +3085,7 @@ impl CreateIssuingCardSpendingControlsSpendingLimitsCategories {
 }
 
 impl std::str::FromStr for CreateIssuingCardSpendingControlsSpendingLimitsCategories {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateIssuingCardSpendingControlsSpendingLimitsCategories::*;
         match s {
@@ -3432,7 +3432,7 @@ impl std::str::FromStr for CreateIssuingCardSpendingControlsSpendingLimitsCatego
             "womens_accessory_and_specialty_shops" => Ok(WomensAccessoryAndSpecialtyShops),
             "womens_ready_to_wear_stores" => Ok(WomensReadyToWearStores),
             "wrecking_and_salvage_yards" => Ok(WreckingAndSalvageYards),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -3460,7 +3460,7 @@ impl<'de> serde::Deserialize<'de> for CreateIssuingCardSpendingControlsSpendingL
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// Interval (or event) to which the amount applies.
@@ -3488,7 +3488,7 @@ impl CreateIssuingCardSpendingControlsSpendingLimitsInterval {
 }
 
 impl std::str::FromStr for CreateIssuingCardSpendingControlsSpendingLimitsInterval {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateIssuingCardSpendingControlsSpendingLimitsInterval::*;
         match s {
@@ -3498,7 +3498,7 @@ impl std::str::FromStr for CreateIssuingCardSpendingControlsSpendingLimitsInterv
             "per_authorization" => Ok(PerAuthorization),
             "weekly" => Ok(Weekly),
             "yearly" => Ok(Yearly),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3552,13 +3552,13 @@ impl CreateIssuingCardStatus {
 }
 
 impl std::str::FromStr for CreateIssuingCardStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateIssuingCardStatus::*;
         match s {
             "active" => Ok(Active),
             "inactive" => Ok(Inactive),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3646,13 +3646,13 @@ impl UpdateIssuingCardCancellationReason {
 }
 
 impl std::str::FromStr for UpdateIssuingCardCancellationReason {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateIssuingCardCancellationReason::*;
         match s {
             "lost" => Ok(Lost),
             "stolen" => Ok(Stolen),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4361,7 +4361,7 @@ impl UpdateIssuingCardSpendingControlsAllowedCategories {
 }
 
 impl std::str::FromStr for UpdateIssuingCardSpendingControlsAllowedCategories {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateIssuingCardSpendingControlsAllowedCategories::*;
         match s {
@@ -4708,7 +4708,7 @@ impl std::str::FromStr for UpdateIssuingCardSpendingControlsAllowedCategories {
             "womens_accessory_and_specialty_shops" => Ok(WomensAccessoryAndSpecialtyShops),
             "womens_ready_to_wear_stores" => Ok(WomensReadyToWearStores),
             "wrecking_and_salvage_yards" => Ok(WreckingAndSalvageYards),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -4736,7 +4736,7 @@ impl<'de> serde::Deserialize<'de> for UpdateIssuingCardSpendingControlsAllowedCa
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to decline.
@@ -5392,7 +5392,7 @@ impl UpdateIssuingCardSpendingControlsBlockedCategories {
 }
 
 impl std::str::FromStr for UpdateIssuingCardSpendingControlsBlockedCategories {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateIssuingCardSpendingControlsBlockedCategories::*;
         match s {
@@ -5739,7 +5739,7 @@ impl std::str::FromStr for UpdateIssuingCardSpendingControlsBlockedCategories {
             "womens_accessory_and_specialty_shops" => Ok(WomensAccessoryAndSpecialtyShops),
             "womens_ready_to_wear_stores" => Ok(WomensReadyToWearStores),
             "wrecking_and_salvage_yards" => Ok(WreckingAndSalvageYards),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -5767,7 +5767,7 @@ impl<'de> serde::Deserialize<'de> for UpdateIssuingCardSpendingControlsBlockedCa
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// Limit spending with amount-based rules that apply across any cards this card replaced (i.e., its `replacement_for` card and _that_ card's `replacement_for` card, up the chain).
@@ -6442,7 +6442,7 @@ impl UpdateIssuingCardSpendingControlsSpendingLimitsCategories {
 }
 
 impl std::str::FromStr for UpdateIssuingCardSpendingControlsSpendingLimitsCategories {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateIssuingCardSpendingControlsSpendingLimitsCategories::*;
         match s {
@@ -6789,7 +6789,7 @@ impl std::str::FromStr for UpdateIssuingCardSpendingControlsSpendingLimitsCatego
             "womens_accessory_and_specialty_shops" => Ok(WomensAccessoryAndSpecialtyShops),
             "womens_ready_to_wear_stores" => Ok(WomensReadyToWearStores),
             "wrecking_and_salvage_yards" => Ok(WreckingAndSalvageYards),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -6817,7 +6817,7 @@ impl<'de> serde::Deserialize<'de> for UpdateIssuingCardSpendingControlsSpendingL
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// Interval (or event) to which the amount applies.
@@ -6845,7 +6845,7 @@ impl UpdateIssuingCardSpendingControlsSpendingLimitsInterval {
 }
 
 impl std::str::FromStr for UpdateIssuingCardSpendingControlsSpendingLimitsInterval {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateIssuingCardSpendingControlsSpendingLimitsInterval::*;
         match s {
@@ -6855,7 +6855,7 @@ impl std::str::FromStr for UpdateIssuingCardSpendingControlsSpendingLimitsInterv
             "per_authorization" => Ok(PerAuthorization),
             "weekly" => Ok(Weekly),
             "yearly" => Ok(Yearly),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_issuing/src/issuing_cardholder/requests.rs
+++ b/generated/stripe_issuing/src/issuing_cardholder/requests.rs
@@ -823,7 +823,7 @@ impl CreateIssuingCardholderSpendingControlsAllowedCategories {
 }
 
 impl std::str::FromStr for CreateIssuingCardholderSpendingControlsAllowedCategories {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateIssuingCardholderSpendingControlsAllowedCategories::*;
         match s {
@@ -1170,7 +1170,7 @@ impl std::str::FromStr for CreateIssuingCardholderSpendingControlsAllowedCategor
             "womens_accessory_and_specialty_shops" => Ok(WomensAccessoryAndSpecialtyShops),
             "womens_ready_to_wear_stores" => Ok(WomensReadyToWearStores),
             "wrecking_and_salvage_yards" => Ok(WreckingAndSalvageYards),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -1198,7 +1198,7 @@ impl<'de> serde::Deserialize<'de> for CreateIssuingCardholderSpendingControlsAll
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to decline.
@@ -1854,7 +1854,7 @@ impl CreateIssuingCardholderSpendingControlsBlockedCategories {
 }
 
 impl std::str::FromStr for CreateIssuingCardholderSpendingControlsBlockedCategories {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateIssuingCardholderSpendingControlsBlockedCategories::*;
         match s {
@@ -2201,7 +2201,7 @@ impl std::str::FromStr for CreateIssuingCardholderSpendingControlsBlockedCategor
             "womens_accessory_and_specialty_shops" => Ok(WomensAccessoryAndSpecialtyShops),
             "womens_ready_to_wear_stores" => Ok(WomensReadyToWearStores),
             "wrecking_and_salvage_yards" => Ok(WreckingAndSalvageYards),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -2229,7 +2229,7 @@ impl<'de> serde::Deserialize<'de> for CreateIssuingCardholderSpendingControlsBlo
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// Limit spending with amount-based rules that apply across this cardholder's cards.
@@ -2904,7 +2904,7 @@ impl CreateIssuingCardholderSpendingControlsSpendingLimitsCategories {
 }
 
 impl std::str::FromStr for CreateIssuingCardholderSpendingControlsSpendingLimitsCategories {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateIssuingCardholderSpendingControlsSpendingLimitsCategories::*;
         match s {
@@ -3251,7 +3251,7 @@ impl std::str::FromStr for CreateIssuingCardholderSpendingControlsSpendingLimits
             "womens_accessory_and_specialty_shops" => Ok(WomensAccessoryAndSpecialtyShops),
             "womens_ready_to_wear_stores" => Ok(WomensReadyToWearStores),
             "wrecking_and_salvage_yards" => Ok(WreckingAndSalvageYards),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -3281,7 +3281,7 @@ impl<'de> serde::Deserialize<'de>
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// Interval (or event) to which the amount applies.
@@ -3309,7 +3309,7 @@ impl CreateIssuingCardholderSpendingControlsSpendingLimitsInterval {
 }
 
 impl std::str::FromStr for CreateIssuingCardholderSpendingControlsSpendingLimitsInterval {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateIssuingCardholderSpendingControlsSpendingLimitsInterval::*;
         match s {
@@ -3319,7 +3319,7 @@ impl std::str::FromStr for CreateIssuingCardholderSpendingControlsSpendingLimits
             "per_authorization" => Ok(PerAuthorization),
             "weekly" => Ok(Weekly),
             "yearly" => Ok(Yearly),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3373,13 +3373,13 @@ impl CreateIssuingCardholderStatus {
 }
 
 impl std::str::FromStr for CreateIssuingCardholderStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateIssuingCardholderStatus::*;
         match s {
             "active" => Ok(Active),
             "inactive" => Ok(Inactive),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4146,7 +4146,7 @@ impl UpdateIssuingCardholderSpendingControlsAllowedCategories {
 }
 
 impl std::str::FromStr for UpdateIssuingCardholderSpendingControlsAllowedCategories {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateIssuingCardholderSpendingControlsAllowedCategories::*;
         match s {
@@ -4493,7 +4493,7 @@ impl std::str::FromStr for UpdateIssuingCardholderSpendingControlsAllowedCategor
             "womens_accessory_and_specialty_shops" => Ok(WomensAccessoryAndSpecialtyShops),
             "womens_ready_to_wear_stores" => Ok(WomensReadyToWearStores),
             "wrecking_and_salvage_yards" => Ok(WreckingAndSalvageYards),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -4521,7 +4521,7 @@ impl<'de> serde::Deserialize<'de> for UpdateIssuingCardholderSpendingControlsAll
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to decline.
@@ -5177,7 +5177,7 @@ impl UpdateIssuingCardholderSpendingControlsBlockedCategories {
 }
 
 impl std::str::FromStr for UpdateIssuingCardholderSpendingControlsBlockedCategories {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateIssuingCardholderSpendingControlsBlockedCategories::*;
         match s {
@@ -5524,7 +5524,7 @@ impl std::str::FromStr for UpdateIssuingCardholderSpendingControlsBlockedCategor
             "womens_accessory_and_specialty_shops" => Ok(WomensAccessoryAndSpecialtyShops),
             "womens_ready_to_wear_stores" => Ok(WomensReadyToWearStores),
             "wrecking_and_salvage_yards" => Ok(WreckingAndSalvageYards),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -5552,7 +5552,7 @@ impl<'de> serde::Deserialize<'de> for UpdateIssuingCardholderSpendingControlsBlo
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// Limit spending with amount-based rules that apply across this cardholder's cards.
@@ -6227,7 +6227,7 @@ impl UpdateIssuingCardholderSpendingControlsSpendingLimitsCategories {
 }
 
 impl std::str::FromStr for UpdateIssuingCardholderSpendingControlsSpendingLimitsCategories {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateIssuingCardholderSpendingControlsSpendingLimitsCategories::*;
         match s {
@@ -6574,7 +6574,7 @@ impl std::str::FromStr for UpdateIssuingCardholderSpendingControlsSpendingLimits
             "womens_accessory_and_specialty_shops" => Ok(WomensAccessoryAndSpecialtyShops),
             "womens_ready_to_wear_stores" => Ok(WomensReadyToWearStores),
             "wrecking_and_salvage_yards" => Ok(WreckingAndSalvageYards),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -6604,7 +6604,7 @@ impl<'de> serde::Deserialize<'de>
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// Interval (or event) to which the amount applies.
@@ -6632,7 +6632,7 @@ impl UpdateIssuingCardholderSpendingControlsSpendingLimitsInterval {
 }
 
 impl std::str::FromStr for UpdateIssuingCardholderSpendingControlsSpendingLimitsInterval {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateIssuingCardholderSpendingControlsSpendingLimitsInterval::*;
         match s {
@@ -6642,7 +6642,7 @@ impl std::str::FromStr for UpdateIssuingCardholderSpendingControlsSpendingLimits
             "per_authorization" => Ok(PerAuthorization),
             "weekly" => Ok(Weekly),
             "yearly" => Ok(Yearly),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -6696,13 +6696,13 @@ impl UpdateIssuingCardholderStatus {
 }
 
 impl std::str::FromStr for UpdateIssuingCardholderStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateIssuingCardholderStatus::*;
         match s {
             "active" => Ok(Active),
             "inactive" => Ok(Inactive),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_issuing/src/issuing_dispute/requests.rs
+++ b/generated/stripe_issuing/src/issuing_dispute/requests.rs
@@ -189,13 +189,13 @@ impl CreateIssuingDisputeEvidenceCanceledProductType {
 }
 
 impl std::str::FromStr for CreateIssuingDisputeEvidenceCanceledProductType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateIssuingDisputeEvidenceCanceledProductType::*;
         match s {
             "merchandise" => Ok(Merchandise),
             "service" => Ok(Service),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -247,13 +247,13 @@ impl CreateIssuingDisputeEvidenceCanceledReturnStatus {
 }
 
 impl std::str::FromStr for CreateIssuingDisputeEvidenceCanceledReturnStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateIssuingDisputeEvidenceCanceledReturnStatus::*;
         match s {
             "merchant_rejected" => Ok(MerchantRejected),
             "successful" => Ok(Successful),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -332,13 +332,13 @@ impl CreateIssuingDisputeEvidenceMerchandiseNotAsDescribedReturnStatus {
 }
 
 impl std::str::FromStr for CreateIssuingDisputeEvidenceMerchandiseNotAsDescribedReturnStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateIssuingDisputeEvidenceMerchandiseNotAsDescribedReturnStatus::*;
         match s {
             "merchant_rejected" => Ok(MerchantRejected),
             "successful" => Ok(Successful),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -412,13 +412,13 @@ impl CreateIssuingDisputeEvidenceNotReceivedProductType {
 }
 
 impl std::str::FromStr for CreateIssuingDisputeEvidenceNotReceivedProductType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateIssuingDisputeEvidenceNotReceivedProductType::*;
         match s {
             "merchandise" => Ok(Merchandise),
             "service" => Ok(Service),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -491,13 +491,13 @@ impl CreateIssuingDisputeEvidenceOtherProductType {
 }
 
 impl std::str::FromStr for CreateIssuingDisputeEvidenceOtherProductType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateIssuingDisputeEvidenceOtherProductType::*;
         match s {
             "merchandise" => Ok(Merchandise),
             "service" => Ok(Service),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -559,7 +559,7 @@ impl CreateIssuingDisputeEvidenceReason {
 }
 
 impl std::str::FromStr for CreateIssuingDisputeEvidenceReason {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateIssuingDisputeEvidenceReason::*;
         match s {
@@ -570,7 +570,7 @@ impl std::str::FromStr for CreateIssuingDisputeEvidenceReason {
             "not_received" => Ok(NotReceived),
             "other" => Ok(Other),
             "service_not_as_described" => Ok(ServiceNotAsDescribed),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -736,13 +736,13 @@ impl UpdateIssuingDisputeEvidenceCanceledProductType {
 }
 
 impl std::str::FromStr for UpdateIssuingDisputeEvidenceCanceledProductType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateIssuingDisputeEvidenceCanceledProductType::*;
         match s {
             "merchandise" => Ok(Merchandise),
             "service" => Ok(Service),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -794,13 +794,13 @@ impl UpdateIssuingDisputeEvidenceCanceledReturnStatus {
 }
 
 impl std::str::FromStr for UpdateIssuingDisputeEvidenceCanceledReturnStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateIssuingDisputeEvidenceCanceledReturnStatus::*;
         match s {
             "merchant_rejected" => Ok(MerchantRejected),
             "successful" => Ok(Successful),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -879,13 +879,13 @@ impl UpdateIssuingDisputeEvidenceMerchandiseNotAsDescribedReturnStatus {
 }
 
 impl std::str::FromStr for UpdateIssuingDisputeEvidenceMerchandiseNotAsDescribedReturnStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateIssuingDisputeEvidenceMerchandiseNotAsDescribedReturnStatus::*;
         match s {
             "merchant_rejected" => Ok(MerchantRejected),
             "successful" => Ok(Successful),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -959,13 +959,13 @@ impl UpdateIssuingDisputeEvidenceNotReceivedProductType {
 }
 
 impl std::str::FromStr for UpdateIssuingDisputeEvidenceNotReceivedProductType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateIssuingDisputeEvidenceNotReceivedProductType::*;
         match s {
             "merchandise" => Ok(Merchandise),
             "service" => Ok(Service),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1038,13 +1038,13 @@ impl UpdateIssuingDisputeEvidenceOtherProductType {
 }
 
 impl std::str::FromStr for UpdateIssuingDisputeEvidenceOtherProductType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateIssuingDisputeEvidenceOtherProductType::*;
         match s {
             "merchandise" => Ok(Merchandise),
             "service" => Ok(Service),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1106,7 +1106,7 @@ impl UpdateIssuingDisputeEvidenceReason {
 }
 
 impl std::str::FromStr for UpdateIssuingDisputeEvidenceReason {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateIssuingDisputeEvidenceReason::*;
         match s {
@@ -1117,7 +1117,7 @@ impl std::str::FromStr for UpdateIssuingDisputeEvidenceReason {
             "not_received" => Ok(NotReceived),
             "other" => Ok(Other),
             "service_not_as_described" => Ok(ServiceNotAsDescribed),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_issuing/src/issuing_token/requests.rs
+++ b/generated/stripe_issuing/src/issuing_token/requests.rs
@@ -106,14 +106,14 @@ impl UpdateIssuingTokenStatus {
 }
 
 impl std::str::FromStr for UpdateIssuingTokenStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateIssuingTokenStatus::*;
         match s {
             "active" => Ok(Active),
             "deleted" => Ok(Deleted),
             "suspended" => Ok(Suspended),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_issuing/src/issuing_transaction/requests.rs
+++ b/generated/stripe_issuing/src/issuing_transaction/requests.rs
@@ -856,7 +856,7 @@ impl CreateForceCaptureIssuingTransactionMerchantDataCategory {
 }
 
 impl std::str::FromStr for CreateForceCaptureIssuingTransactionMerchantDataCategory {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateForceCaptureIssuingTransactionMerchantDataCategory::*;
         match s {
@@ -1202,7 +1202,7 @@ impl std::str::FromStr for CreateForceCaptureIssuingTransactionMerchantDataCateg
             "womens_accessory_and_specialty_shops" => Ok(WomensAccessoryAndSpecialtyShops),
             "womens_ready_to_wear_stores" => Ok(WomensReadyToWearStores),
             "wrecking_and_salvage_yards" => Ok(WreckingAndSalvageYards),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -1230,7 +1230,7 @@ impl<'de> serde::Deserialize<'de> for CreateForceCaptureIssuingTransactionMercha
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// Additional purchase information that is optionally provided by the merchant.
@@ -1304,7 +1304,7 @@ impl CreateForceCaptureIssuingTransactionPurchaseDetailsFuelType {
 }
 
 impl std::str::FromStr for CreateForceCaptureIssuingTransactionPurchaseDetailsFuelType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateForceCaptureIssuingTransactionPurchaseDetailsFuelType::*;
         match s {
@@ -1313,7 +1313,7 @@ impl std::str::FromStr for CreateForceCaptureIssuingTransactionPurchaseDetailsFu
             "unleaded_plus" => Ok(UnleadedPlus),
             "unleaded_regular" => Ok(UnleadedRegular),
             "unleaded_super" => Ok(UnleadedSuper),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1365,13 +1365,13 @@ impl CreateForceCaptureIssuingTransactionPurchaseDetailsFuelUnit {
 }
 
 impl std::str::FromStr for CreateForceCaptureIssuingTransactionPurchaseDetailsFuelUnit {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateForceCaptureIssuingTransactionPurchaseDetailsFuelUnit::*;
         match s {
             "liter" => Ok(Liter),
             "us_gallon" => Ok(UsGallon),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2142,7 +2142,7 @@ impl CreateUnlinkedRefundIssuingTransactionMerchantDataCategory {
 }
 
 impl std::str::FromStr for CreateUnlinkedRefundIssuingTransactionMerchantDataCategory {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateUnlinkedRefundIssuingTransactionMerchantDataCategory::*;
         match s {
@@ -2488,7 +2488,7 @@ impl std::str::FromStr for CreateUnlinkedRefundIssuingTransactionMerchantDataCat
             "womens_accessory_and_specialty_shops" => Ok(WomensAccessoryAndSpecialtyShops),
             "womens_ready_to_wear_stores" => Ok(WomensReadyToWearStores),
             "wrecking_and_salvage_yards" => Ok(WreckingAndSalvageYards),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -2516,7 +2516,7 @@ impl<'de> serde::Deserialize<'de> for CreateUnlinkedRefundIssuingTransactionMerc
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// Additional purchase information that is optionally provided by the merchant.
@@ -2590,7 +2590,7 @@ impl CreateUnlinkedRefundIssuingTransactionPurchaseDetailsFuelType {
 }
 
 impl std::str::FromStr for CreateUnlinkedRefundIssuingTransactionPurchaseDetailsFuelType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateUnlinkedRefundIssuingTransactionPurchaseDetailsFuelType::*;
         match s {
@@ -2599,7 +2599,7 @@ impl std::str::FromStr for CreateUnlinkedRefundIssuingTransactionPurchaseDetails
             "unleaded_plus" => Ok(UnleadedPlus),
             "unleaded_regular" => Ok(UnleadedRegular),
             "unleaded_super" => Ok(UnleadedSuper),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2653,13 +2653,13 @@ impl CreateUnlinkedRefundIssuingTransactionPurchaseDetailsFuelUnit {
 }
 
 impl std::str::FromStr for CreateUnlinkedRefundIssuingTransactionPurchaseDetailsFuelUnit {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateUnlinkedRefundIssuingTransactionPurchaseDetailsFuelUnit::*;
         match s {
             "liter" => Ok(Liter),
             "us_gallon" => Ok(UsGallon),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_misc/src/bank_connections_resource_accountholder.rs
+++ b/generated/stripe_misc/src/bank_connections_resource_accountholder.rs
@@ -129,13 +129,13 @@ impl BankConnectionsResourceAccountholderType {
 }
 
 impl std::str::FromStr for BankConnectionsResourceAccountholderType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use BankConnectionsResourceAccountholderType::*;
         match s {
             "account" => Ok(Account),
             "customer" => Ok(Customer),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_misc/src/bank_connections_resource_balance.rs
+++ b/generated/stripe_misc/src/bank_connections_resource_balance.rs
@@ -148,13 +148,13 @@ impl BankConnectionsResourceBalanceType {
 }
 
 impl std::str::FromStr for BankConnectionsResourceBalanceType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use BankConnectionsResourceBalanceType::*;
         match s {
             "cash" => Ok(Cash),
             "credit" => Ok(Credit),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_misc/src/bank_connections_resource_balance_refresh.rs
+++ b/generated/stripe_misc/src/bank_connections_resource_balance_refresh.rs
@@ -134,14 +134,14 @@ impl BankConnectionsResourceBalanceRefreshStatus {
 }
 
 impl std::str::FromStr for BankConnectionsResourceBalanceRefreshStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use BankConnectionsResourceBalanceRefreshStatus::*;
         match s {
             "failed" => Ok(Failed),
             "pending" => Ok(Pending),
             "succeeded" => Ok(Succeeded),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_misc/src/bank_connections_resource_ownership_refresh.rs
+++ b/generated/stripe_misc/src/bank_connections_resource_ownership_refresh.rs
@@ -115,14 +115,14 @@ impl BankConnectionsResourceOwnershipRefreshStatus {
 }
 
 impl std::str::FromStr for BankConnectionsResourceOwnershipRefreshStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use BankConnectionsResourceOwnershipRefreshStatus::*;
         match s {
             "failed" => Ok(Failed),
             "pending" => Ok(Pending),
             "succeeded" => Ok(Succeeded),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_misc/src/bank_connections_resource_transaction_refresh.rs
+++ b/generated/stripe_misc/src/bank_connections_resource_transaction_refresh.rs
@@ -141,14 +141,14 @@ impl BankConnectionsResourceTransactionRefreshStatus {
 }
 
 impl std::str::FromStr for BankConnectionsResourceTransactionRefreshStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use BankConnectionsResourceTransactionRefreshStatus::*;
         match s {
             "failed" => Ok(Failed),
             "pending" => Ok(Pending),
             "succeeded" => Ok(Succeeded),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_misc/src/climate_order/types.rs
+++ b/generated/stripe_misc/src/climate_order/types.rs
@@ -295,14 +295,14 @@ impl ClimateOrderCancellationReason {
 }
 
 impl std::str::FromStr for ClimateOrderCancellationReason {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ClimateOrderCancellationReason::*;
         match s {
             "expired" => Ok(Expired),
             "product_unavailable" => Ok(ProductUnavailable),
             "requested" => Ok(Requested),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -374,7 +374,7 @@ impl ClimateOrderStatus {
 }
 
 impl std::str::FromStr for ClimateOrderStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ClimateOrderStatus::*;
         match s {
@@ -383,7 +383,7 @@ impl std::str::FromStr for ClimateOrderStatus {
             "confirmed" => Ok(Confirmed),
             "delivered" => Ok(Delivered),
             "open" => Ok(Open),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_misc/src/climate_supplier/types.rs
+++ b/generated/stripe_misc/src/climate_supplier/types.rs
@@ -165,14 +165,14 @@ impl ClimateSupplierRemovalPathway {
 }
 
 impl std::str::FromStr for ClimateSupplierRemovalPathway {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ClimateSupplierRemovalPathway::*;
         match s {
             "biomass_carbon_removal_and_storage" => Ok(BiomassCarbonRemovalAndStorage),
             "direct_air_capture" => Ok(DirectAirCapture),
             "enhanced_weathering" => Ok(EnhancedWeathering),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_misc/src/financial_connections_account/requests.rs
+++ b/generated/stripe_misc/src/financial_connections_account/requests.rs
@@ -187,14 +187,14 @@ impl RefreshFinancialConnectionsAccountFeatures {
 }
 
 impl std::str::FromStr for RefreshFinancialConnectionsAccountFeatures {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use RefreshFinancialConnectionsAccountFeatures::*;
         match s {
             "balance" => Ok(Balance),
             "ownership" => Ok(Ownership),
             "transactions" => Ok(Transactions),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -269,12 +269,12 @@ impl SubscribeFinancialConnectionsAccountFeatures {
 }
 
 impl std::str::FromStr for SubscribeFinancialConnectionsAccountFeatures {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use SubscribeFinancialConnectionsAccountFeatures::*;
         match s {
             "transactions" => Ok(Transactions),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -351,12 +351,12 @@ impl UnsubscribeFinancialConnectionsAccountFeatures {
 }
 
 impl std::str::FromStr for UnsubscribeFinancialConnectionsAccountFeatures {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UnsubscribeFinancialConnectionsAccountFeatures::*;
         match s {
             "transactions" => Ok(Transactions),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_misc/src/financial_connections_account/types.rs
+++ b/generated/stripe_misc/src/financial_connections_account/types.rs
@@ -287,7 +287,7 @@ impl FinancialConnectionsAccountCategory {
 }
 
 impl std::str::FromStr for FinancialConnectionsAccountCategory {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use FinancialConnectionsAccountCategory::*;
         match s {
@@ -295,7 +295,7 @@ impl std::str::FromStr for FinancialConnectionsAccountCategory {
             "credit" => Ok(Credit),
             "investment" => Ok(Investment),
             "other" => Ok(Other),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -366,7 +366,7 @@ impl FinancialConnectionsAccountPermissions {
 }
 
 impl std::str::FromStr for FinancialConnectionsAccountPermissions {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use FinancialConnectionsAccountPermissions::*;
         match s {
@@ -374,7 +374,7 @@ impl std::str::FromStr for FinancialConnectionsAccountPermissions {
             "ownership" => Ok(Ownership),
             "payment_method" => Ok(PaymentMethod),
             "transactions" => Ok(Transactions),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -444,14 +444,14 @@ impl FinancialConnectionsAccountStatus {
 }
 
 impl std::str::FromStr for FinancialConnectionsAccountStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use FinancialConnectionsAccountStatus::*;
         match s {
             "active" => Ok(Active),
             "disconnected" => Ok(Disconnected),
             "inactive" => Ok(Inactive),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -539,7 +539,7 @@ impl FinancialConnectionsAccountSubcategory {
 }
 
 impl std::str::FromStr for FinancialConnectionsAccountSubcategory {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use FinancialConnectionsAccountSubcategory::*;
         match s {
@@ -549,7 +549,7 @@ impl std::str::FromStr for FinancialConnectionsAccountSubcategory {
             "mortgage" => Ok(Mortgage),
             "other" => Ok(Other),
             "savings" => Ok(Savings),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -615,12 +615,12 @@ impl FinancialConnectionsAccountSubscriptions {
 }
 
 impl std::str::FromStr for FinancialConnectionsAccountSubscriptions {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use FinancialConnectionsAccountSubscriptions::*;
         match s {
             "transactions" => Ok(Transactions),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -688,13 +688,13 @@ impl FinancialConnectionsAccountSupportedPaymentMethodTypes {
 }
 
 impl std::str::FromStr for FinancialConnectionsAccountSupportedPaymentMethodTypes {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use FinancialConnectionsAccountSupportedPaymentMethodTypes::*;
         match s {
             "link" => Ok(Link),
             "us_bank_account" => Ok(UsBankAccount),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_misc/src/financial_connections_session/requests.rs
+++ b/generated/stripe_misc/src/financial_connections_session/requests.rs
@@ -93,13 +93,13 @@ impl CreateFinancialConnectionsSessionAccountHolderType {
 }
 
 impl std::str::FromStr for CreateFinancialConnectionsSessionAccountHolderType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateFinancialConnectionsSessionAccountHolderType::*;
         match s {
             "account" => Ok(Account),
             "customer" => Ok(Customer),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_misc/src/financial_connections_session/types.rs
+++ b/generated/stripe_misc/src/financial_connections_session/types.rs
@@ -199,7 +199,7 @@ impl FinancialConnectionsSessionPermissions {
 }
 
 impl std::str::FromStr for FinancialConnectionsSessionPermissions {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use FinancialConnectionsSessionPermissions::*;
         match s {
@@ -207,7 +207,7 @@ impl std::str::FromStr for FinancialConnectionsSessionPermissions {
             "ownership" => Ok(Ownership),
             "payment_method" => Ok(PaymentMethod),
             "transactions" => Ok(Transactions),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -275,14 +275,14 @@ impl FinancialConnectionsSessionPrefetch {
 }
 
 impl std::str::FromStr for FinancialConnectionsSessionPrefetch {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use FinancialConnectionsSessionPrefetch::*;
         match s {
             "balances" => Ok(Balances),
             "ownership" => Ok(Ownership),
             "transactions" => Ok(Transactions),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_misc/src/financial_connections_transaction/types.rs
+++ b/generated/stripe_misc/src/financial_connections_transaction/types.rs
@@ -211,14 +211,14 @@ impl FinancialConnectionsTransactionStatus {
 }
 
 impl std::str::FromStr for FinancialConnectionsTransactionStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use FinancialConnectionsTransactionStatus::*;
         match s {
             "pending" => Ok(Pending),
             "posted" => Ok(Posted),
             "void" => Ok(Void),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_misc/src/gelato_document_report.rs
+++ b/generated/stripe_misc/src/gelato_document_report.rs
@@ -191,13 +191,13 @@ impl GelatoDocumentReportStatus {
 }
 
 impl std::str::FromStr for GelatoDocumentReportStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use GelatoDocumentReportStatus::*;
         match s {
             "unverified" => Ok(Unverified),
             "verified" => Ok(Verified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -264,14 +264,14 @@ impl GelatoDocumentReportType {
 }
 
 impl std::str::FromStr for GelatoDocumentReportType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use GelatoDocumentReportType::*;
         match s {
             "driving_license" => Ok(DrivingLicense),
             "id_card" => Ok(IdCard),
             "passport" => Ok(Passport),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_misc/src/gelato_document_report_error.rs
+++ b/generated/stripe_misc/src/gelato_document_report_error.rs
@@ -116,14 +116,14 @@ impl GelatoDocumentReportErrorCode {
 }
 
 impl std::str::FromStr for GelatoDocumentReportErrorCode {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use GelatoDocumentReportErrorCode::*;
         match s {
             "document_expired" => Ok(DocumentExpired),
             "document_type_not_supported" => Ok(DocumentTypeNotSupported),
             "document_unverified_other" => Ok(DocumentUnverifiedOther),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_misc/src/gelato_id_number_report.rs
+++ b/generated/stripe_misc/src/gelato_id_number_report.rs
@@ -157,14 +157,14 @@ impl GelatoIdNumberReportIdNumberType {
 }
 
 impl std::str::FromStr for GelatoIdNumberReportIdNumberType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use GelatoIdNumberReportIdNumberType::*;
         match s {
             "br_cpf" => Ok(BrCpf),
             "sg_nric" => Ok(SgNric),
             "us_ssn" => Ok(UsSsn),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -231,13 +231,13 @@ impl GelatoIdNumberReportStatus {
 }
 
 impl std::str::FromStr for GelatoIdNumberReportStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use GelatoIdNumberReportStatus::*;
         match s {
             "unverified" => Ok(Unverified),
             "verified" => Ok(Verified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_misc/src/gelato_id_number_report_error.rs
+++ b/generated/stripe_misc/src/gelato_id_number_report_error.rs
@@ -116,14 +116,14 @@ impl GelatoIdNumberReportErrorCode {
 }
 
 impl std::str::FromStr for GelatoIdNumberReportErrorCode {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use GelatoIdNumberReportErrorCode::*;
         match s {
             "id_number_insufficient_document_data" => Ok(IdNumberInsufficientDocumentData),
             "id_number_mismatch" => Ok(IdNumberMismatch),
             "id_number_unverified_other" => Ok(IdNumberUnverifiedOther),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_misc/src/gelato_report_document_options.rs
+++ b/generated/stripe_misc/src/gelato_report_document_options.rs
@@ -142,14 +142,14 @@ impl GelatoReportDocumentOptionsAllowedTypes {
 }
 
 impl std::str::FromStr for GelatoReportDocumentOptionsAllowedTypes {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use GelatoReportDocumentOptionsAllowedTypes::*;
         match s {
             "driving_license" => Ok(DrivingLicense),
             "id_card" => Ok(IdCard),
             "passport" => Ok(Passport),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_misc/src/gelato_selfie_report.rs
+++ b/generated/stripe_misc/src/gelato_selfie_report.rs
@@ -134,13 +134,13 @@ impl GelatoSelfieReportStatus {
 }
 
 impl std::str::FromStr for GelatoSelfieReportStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use GelatoSelfieReportStatus::*;
         match s {
             "unverified" => Ok(Unverified),
             "verified" => Ok(Verified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_misc/src/gelato_selfie_report_error.rs
+++ b/generated/stripe_misc/src/gelato_selfie_report_error.rs
@@ -118,7 +118,7 @@ impl GelatoSelfieReportErrorCode {
 }
 
 impl std::str::FromStr for GelatoSelfieReportErrorCode {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use GelatoSelfieReportErrorCode::*;
         match s {
@@ -126,7 +126,7 @@ impl std::str::FromStr for GelatoSelfieReportErrorCode {
             "selfie_face_mismatch" => Ok(SelfieFaceMismatch),
             "selfie_manipulated" => Ok(SelfieManipulated),
             "selfie_unverified_other" => Ok(SelfieUnverifiedOther),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_misc/src/gelato_session_document_options.rs
+++ b/generated/stripe_misc/src/gelato_session_document_options.rs
@@ -142,14 +142,14 @@ impl GelatoSessionDocumentOptionsAllowedTypes {
 }
 
 impl std::str::FromStr for GelatoSessionDocumentOptionsAllowedTypes {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use GelatoSessionDocumentOptionsAllowedTypes::*;
         match s {
             "driving_license" => Ok(DrivingLicense),
             "id_card" => Ok(IdCard),
             "passport" => Ok(Passport),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_misc/src/gelato_session_last_error.rs
+++ b/generated/stripe_misc/src/gelato_session_last_error.rs
@@ -144,7 +144,7 @@ impl GelatoSessionLastErrorCode {
 }
 
 impl std::str::FromStr for GelatoSessionLastErrorCode {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use GelatoSessionLastErrorCode::*;
         match s {
@@ -163,7 +163,7 @@ impl std::str::FromStr for GelatoSessionLastErrorCode {
             "selfie_manipulated" => Ok(SelfieManipulated),
             "selfie_unverified_other" => Ok(SelfieUnverifiedOther),
             "under_supported_age" => Ok(UnderSupportedAge),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -196,9 +196,7 @@ impl miniserde::Deserialize for GelatoSessionLastErrorCode {
 impl miniserde::de::Visitor for crate::Place<GelatoSessionLastErrorCode> {
     fn string(&mut self, s: &str) -> miniserde::Result<()> {
         use std::str::FromStr;
-        self.out = Some(
-            GelatoSessionLastErrorCode::from_str(s).unwrap_or(GelatoSessionLastErrorCode::Unknown),
-        );
+        self.out = Some(GelatoSessionLastErrorCode::from_str(s).unwrap());
         Ok(())
     }
 }
@@ -209,6 +207,6 @@ impl<'de> serde::Deserialize<'de> for GelatoSessionLastErrorCode {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }

--- a/generated/stripe_misc/src/gelato_verified_outputs.rs
+++ b/generated/stripe_misc/src/gelato_verified_outputs.rs
@@ -149,14 +149,14 @@ impl GelatoVerifiedOutputsIdNumberType {
 }
 
 impl std::str::FromStr for GelatoVerifiedOutputsIdNumberType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use GelatoVerifiedOutputsIdNumberType::*;
         match s {
             "br_cpf" => Ok(BrCpf),
             "sg_nric" => Ok(SgNric),
             "us_ssn" => Ok(UsSsn),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_misc/src/identity_verification_report/types.rs
+++ b/generated/stripe_misc/src/identity_verification_report/types.rs
@@ -204,13 +204,13 @@ impl IdentityVerificationReportType {
 }
 
 impl std::str::FromStr for IdentityVerificationReportType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IdentityVerificationReportType::*;
         match s {
             "document" => Ok(Document),
             "id_number" => Ok(IdNumber),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_misc/src/identity_verification_session/requests.rs
+++ b/generated/stripe_misc/src/identity_verification_session/requests.rs
@@ -148,14 +148,14 @@ impl CreateIdentityVerificationSessionOptionsDocumentAllowedTypes {
 }
 
 impl std::str::FromStr for CreateIdentityVerificationSessionOptionsDocumentAllowedTypes {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateIdentityVerificationSessionOptionsDocumentAllowedTypes::*;
         match s {
             "driving_license" => Ok(DrivingLicense),
             "id_card" => Ok(IdCard),
             "passport" => Ok(Passport),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -284,14 +284,14 @@ impl UpdateIdentityVerificationSessionOptionsDocumentAllowedTypes {
 }
 
 impl std::str::FromStr for UpdateIdentityVerificationSessionOptionsDocumentAllowedTypes {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateIdentityVerificationSessionOptionsDocumentAllowedTypes::*;
         match s {
             "driving_license" => Ok(DrivingLicense),
             "id_card" => Ok(IdCard),
             "passport" => Ok(Passport),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_misc/src/identity_verification_session/types.rs
+++ b/generated/stripe_misc/src/identity_verification_session/types.rs
@@ -259,7 +259,7 @@ impl IdentityVerificationSessionStatus {
 }
 
 impl std::str::FromStr for IdentityVerificationSessionStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IdentityVerificationSessionStatus::*;
         match s {
@@ -267,7 +267,7 @@ impl std::str::FromStr for IdentityVerificationSessionStatus {
             "processing" => Ok(Processing),
             "requires_input" => Ok(RequiresInput),
             "verified" => Ok(Verified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -332,13 +332,13 @@ impl IdentityVerificationSessionType {
 }
 
 impl std::str::FromStr for IdentityVerificationSessionType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IdentityVerificationSessionType::*;
         match s {
             "document" => Ok(Document),
             "id_number" => Ok(IdNumber),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_misc/src/reporting_report_run/requests.rs
+++ b/generated/stripe_misc/src/reporting_report_run/requests.rs
@@ -206,7 +206,7 @@ impl CreateReportingReportRunParametersReportingCategory {
 }
 
 impl std::str::FromStr for CreateReportingReportRunParametersReportingCategory {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateReportingReportRunParametersReportingCategory::*;
         match s {
@@ -247,7 +247,7 @@ impl std::str::FromStr for CreateReportingReportRunParametersReportingCategory {
             "transfer" => Ok(Transfer),
             "transfer_reversal" => Ok(TransferReversal),
             "unreconciled_customer_funds" => Ok(UnreconciledCustomerFunds),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -275,7 +275,7 @@ impl<'de> serde::Deserialize<'de> for CreateReportingReportRunParametersReportin
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// Defaults to `Etc/UTC`.
@@ -1494,7 +1494,7 @@ impl CreateReportingReportRunParametersTimezone {
 }
 
 impl std::str::FromStr for CreateReportingReportRunParametersTimezone {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateReportingReportRunParametersTimezone::*;
         match s {
@@ -2096,7 +2096,7 @@ impl std::str::FromStr for CreateReportingReportRunParametersTimezone {
             "W-SU" => Ok(WMinusSu),
             "WET" => Ok(Wet),
             "Zulu" => Ok(Zulu),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -2124,7 +2124,7 @@ impl<'de> serde::Deserialize<'de> for CreateReportingReportRunParametersTimezone
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 impl<'a> CreateReportingReportRun<'a> {

--- a/generated/stripe_misc/src/tax_calculation/requests.rs
+++ b/generated/stripe_misc/src/tax_calculation/requests.rs
@@ -156,13 +156,13 @@ impl CreateTaxCalculationCustomerDetailsAddressSource {
 }
 
 impl std::str::FromStr for CreateTaxCalculationCustomerDetailsAddressSource {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxCalculationCustomerDetailsAddressSource::*;
         match s {
             "billing" => Ok(Billing),
             "shipping" => Ok(Shipping),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -362,7 +362,7 @@ impl CreateTaxCalculationCustomerDetailsTaxIdsType {
 }
 
 impl std::str::FromStr for CreateTaxCalculationCustomerDetailsTaxIdsType {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxCalculationCustomerDetailsTaxIdsType::*;
         match s {
@@ -432,7 +432,7 @@ impl std::str::FromStr for CreateTaxCalculationCustomerDetailsTaxIdsType {
             "ve_rif" => Ok(VeRif),
             "vn_tin" => Ok(VnTin),
             "za_vat" => Ok(ZaVat),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -460,7 +460,7 @@ impl<'de> serde::Deserialize<'de> for CreateTaxCalculationCustomerDetailsTaxIdsT
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// Overrides the tax calculation result to allow you to not collect tax from your customer.
@@ -484,14 +484,14 @@ impl CreateTaxCalculationCustomerDetailsTaxabilityOverride {
 }
 
 impl std::str::FromStr for CreateTaxCalculationCustomerDetailsTaxabilityOverride {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxCalculationCustomerDetailsTaxabilityOverride::*;
         match s {
             "customer_exempt" => Ok(CustomerExempt),
             "none" => Ok(None),
             "reverse_charge" => Ok(ReverseCharge),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -583,13 +583,13 @@ impl CreateTaxCalculationLineItemsTaxBehavior {
 }
 
 impl std::str::FromStr for CreateTaxCalculationLineItemsTaxBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxCalculationLineItemsTaxBehavior::*;
         match s {
             "exclusive" => Ok(Exclusive),
             "inclusive" => Ok(Inclusive),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -668,13 +668,13 @@ impl CreateTaxCalculationShippingCostTaxBehavior {
 }
 
 impl std::str::FromStr for CreateTaxCalculationShippingCostTaxBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxCalculationShippingCostTaxBehavior::*;
         match s {
             "exclusive" => Ok(Exclusive),
             "inclusive" => Ok(Inclusive),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_misc/src/tax_calculation_line_item.rs
+++ b/generated/stripe_misc/src/tax_calculation_line_item.rs
@@ -198,13 +198,13 @@ impl TaxCalculationLineItemTaxBehavior {
 }
 
 impl std::str::FromStr for TaxCalculationLineItemTaxBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TaxCalculationLineItemTaxBehavior::*;
         match s {
             "exclusive" => Ok(Exclusive),
             "inclusive" => Ok(Inclusive),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_misc/src/tax_product_registrations_resource_country_options_canada.rs
+++ b/generated/stripe_misc/src/tax_product_registrations_resource_country_options_canada.rs
@@ -122,14 +122,14 @@ impl TaxProductRegistrationsResourceCountryOptionsCanadaType {
 }
 
 impl std::str::FromStr for TaxProductRegistrationsResourceCountryOptionsCanadaType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TaxProductRegistrationsResourceCountryOptionsCanadaType::*;
         match s {
             "province_standard" => Ok(ProvinceStandard),
             "simplified" => Ok(Simplified),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_misc/src/tax_product_registrations_resource_country_options_default.rs
+++ b/generated/stripe_misc/src/tax_product_registrations_resource_country_options_default.rs
@@ -109,12 +109,12 @@ impl TaxProductRegistrationsResourceCountryOptionsDefaultType {
 }
 
 impl std::str::FromStr for TaxProductRegistrationsResourceCountryOptionsDefaultType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TaxProductRegistrationsResourceCountryOptionsDefaultType::*;
         match s {
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_misc/src/tax_product_registrations_resource_country_options_eu_standard.rs
+++ b/generated/stripe_misc/src/tax_product_registrations_resource_country_options_eu_standard.rs
@@ -116,13 +116,13 @@ impl TaxProductRegistrationsResourceCountryOptionsEuStandardPlaceOfSupplyScheme 
 impl std::str::FromStr
     for TaxProductRegistrationsResourceCountryOptionsEuStandardPlaceOfSupplyScheme
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TaxProductRegistrationsResourceCountryOptionsEuStandardPlaceOfSupplyScheme::*;
         match s {
             "small_seller" => Ok(SmallSeller),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_misc/src/tax_product_registrations_resource_country_options_europe.rs
+++ b/generated/stripe_misc/src/tax_product_registrations_resource_country_options_europe.rs
@@ -118,7 +118,7 @@ impl TaxProductRegistrationsResourceCountryOptionsEuropeType {
 }
 
 impl std::str::FromStr for TaxProductRegistrationsResourceCountryOptionsEuropeType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TaxProductRegistrationsResourceCountryOptionsEuropeType::*;
         match s {
@@ -126,7 +126,7 @@ impl std::str::FromStr for TaxProductRegistrationsResourceCountryOptionsEuropeTy
             "oss_non_union" => Ok(OssNonUnion),
             "oss_union" => Ok(OssUnion),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_misc/src/tax_product_registrations_resource_country_options_simplified.rs
+++ b/generated/stripe_misc/src/tax_product_registrations_resource_country_options_simplified.rs
@@ -109,12 +109,12 @@ impl TaxProductRegistrationsResourceCountryOptionsSimplifiedType {
 }
 
 impl std::str::FromStr for TaxProductRegistrationsResourceCountryOptionsSimplifiedType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TaxProductRegistrationsResourceCountryOptionsSimplifiedType::*;
         match s {
             "simplified" => Ok(Simplified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_misc/src/tax_product_registrations_resource_country_options_united_states.rs
+++ b/generated/stripe_misc/src/tax_product_registrations_resource_country_options_united_states.rs
@@ -146,7 +146,7 @@ impl TaxProductRegistrationsResourceCountryOptionsUnitedStatesType {
 }
 
 impl std::str::FromStr for TaxProductRegistrationsResourceCountryOptionsUnitedStatesType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TaxProductRegistrationsResourceCountryOptionsUnitedStatesType::*;
         match s {
@@ -154,7 +154,7 @@ impl std::str::FromStr for TaxProductRegistrationsResourceCountryOptionsUnitedSt
             "local_lease_tax" => Ok(LocalLeaseTax),
             "state_communications_tax" => Ok(StateCommunicationsTax),
             "state_sales_tax" => Ok(StateSalesTax),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_misc/src/tax_product_resource_customer_details.rs
+++ b/generated/stripe_misc/src/tax_product_resource_customer_details.rs
@@ -142,13 +142,13 @@ impl TaxProductResourceCustomerDetailsAddressSource {
 }
 
 impl std::str::FromStr for TaxProductResourceCustomerDetailsAddressSource {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TaxProductResourceCustomerDetailsAddressSource::*;
         match s {
             "billing" => Ok(Billing),
             "shipping" => Ok(Shipping),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -221,14 +221,14 @@ impl TaxProductResourceCustomerDetailsTaxabilityOverride {
 }
 
 impl std::str::FromStr for TaxProductResourceCustomerDetailsTaxabilityOverride {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TaxProductResourceCustomerDetailsTaxabilityOverride::*;
         match s {
             "customer_exempt" => Ok(CustomerExempt),
             "none" => Ok(None),
             "reverse_charge" => Ok(ReverseCharge),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_misc/src/tax_product_resource_customer_details_resource_tax_id.rs
+++ b/generated/stripe_misc/src/tax_product_resource_customer_details_resource_tax_id.rs
@@ -244,7 +244,7 @@ impl TaxProductResourceCustomerDetailsResourceTaxIdType {
 }
 
 impl std::str::FromStr for TaxProductResourceCustomerDetailsResourceTaxIdType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TaxProductResourceCustomerDetailsResourceTaxIdType::*;
         match s {
@@ -315,7 +315,7 @@ impl std::str::FromStr for TaxProductResourceCustomerDetailsResourceTaxIdType {
             "ve_rif" => Ok(VeRif),
             "vn_tin" => Ok(VnTin),
             "za_vat" => Ok(ZaVat),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_misc/src/tax_product_resource_jurisdiction.rs
+++ b/generated/stripe_misc/src/tax_product_resource_jurisdiction.rs
@@ -140,7 +140,7 @@ impl TaxProductResourceJurisdictionLevel {
 }
 
 impl std::str::FromStr for TaxProductResourceJurisdictionLevel {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TaxProductResourceJurisdictionLevel::*;
         match s {
@@ -149,7 +149,7 @@ impl std::str::FromStr for TaxProductResourceJurisdictionLevel {
             "county" => Ok(County),
             "district" => Ok(District),
             "state" => Ok(State),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_misc/src/tax_product_resource_line_item_tax_breakdown.rs
+++ b/generated/stripe_misc/src/tax_product_resource_line_item_tax_breakdown.rs
@@ -148,13 +148,13 @@ impl TaxProductResourceLineItemTaxBreakdownSourcing {
 }
 
 impl std::str::FromStr for TaxProductResourceLineItemTaxBreakdownSourcing {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TaxProductResourceLineItemTaxBreakdownSourcing::*;
         match s {
             "destination" => Ok(Destination),
             "origin" => Ok(Origin),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -256,7 +256,7 @@ impl TaxProductResourceLineItemTaxBreakdownTaxabilityReason {
 }
 
 impl std::str::FromStr for TaxProductResourceLineItemTaxBreakdownTaxabilityReason {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TaxProductResourceLineItemTaxBreakdownTaxabilityReason::*;
         match s {
@@ -275,7 +275,7 @@ impl std::str::FromStr for TaxProductResourceLineItemTaxBreakdownTaxabilityReaso
             "standard_rated" => Ok(StandardRated),
             "taxable_basis_reduced" => Ok(TaxableBasisReduced),
             "zero_rated" => Ok(ZeroRated),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -310,10 +310,8 @@ impl miniserde::de::Visitor
 {
     fn string(&mut self, s: &str) -> miniserde::Result<()> {
         use std::str::FromStr;
-        self.out = Some(
-            TaxProductResourceLineItemTaxBreakdownTaxabilityReason::from_str(s)
-                .unwrap_or(TaxProductResourceLineItemTaxBreakdownTaxabilityReason::Unknown),
-        );
+        self.out =
+            Some(TaxProductResourceLineItemTaxBreakdownTaxabilityReason::from_str(s).unwrap());
         Ok(())
     }
 }
@@ -324,6 +322,6 @@ impl<'de> serde::Deserialize<'de> for TaxProductResourceLineItemTaxBreakdownTaxa
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }

--- a/generated/stripe_misc/src/tax_product_resource_line_item_tax_rate_details.rs
+++ b/generated/stripe_misc/src/tax_product_resource_line_item_tax_rate_details.rs
@@ -149,7 +149,7 @@ impl TaxProductResourceLineItemTaxRateDetailsTaxType {
 }
 
 impl std::str::FromStr for TaxProductResourceLineItemTaxRateDetailsTaxType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TaxProductResourceLineItemTaxRateDetailsTaxType::*;
         match s {
@@ -165,7 +165,7 @@ impl std::str::FromStr for TaxProductResourceLineItemTaxRateDetailsTaxType {
             "rst" => Ok(Rst),
             "sales_tax" => Ok(SalesTax),
             "vat" => Ok(Vat),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_misc/src/tax_product_resource_tax_breakdown.rs
+++ b/generated/stripe_misc/src/tax_product_resource_tax_breakdown.rs
@@ -171,7 +171,7 @@ impl TaxProductResourceTaxBreakdownTaxabilityReason {
 }
 
 impl std::str::FromStr for TaxProductResourceTaxBreakdownTaxabilityReason {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TaxProductResourceTaxBreakdownTaxabilityReason::*;
         match s {
@@ -190,7 +190,7 @@ impl std::str::FromStr for TaxProductResourceTaxBreakdownTaxabilityReason {
             "standard_rated" => Ok(StandardRated),
             "taxable_basis_reduced" => Ok(TaxableBasisReduced),
             "zero_rated" => Ok(ZeroRated),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -223,10 +223,7 @@ impl miniserde::Deserialize for TaxProductResourceTaxBreakdownTaxabilityReason {
 impl miniserde::de::Visitor for crate::Place<TaxProductResourceTaxBreakdownTaxabilityReason> {
     fn string(&mut self, s: &str) -> miniserde::Result<()> {
         use std::str::FromStr;
-        self.out = Some(
-            TaxProductResourceTaxBreakdownTaxabilityReason::from_str(s)
-                .unwrap_or(TaxProductResourceTaxBreakdownTaxabilityReason::Unknown),
-        );
+        self.out = Some(TaxProductResourceTaxBreakdownTaxabilityReason::from_str(s).unwrap());
         Ok(())
     }
 }
@@ -237,6 +234,6 @@ impl<'de> serde::Deserialize<'de> for TaxProductResourceTaxBreakdownTaxabilityRe
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }

--- a/generated/stripe_misc/src/tax_product_resource_tax_calculation_shipping_cost.rs
+++ b/generated/stripe_misc/src/tax_product_resource_tax_calculation_shipping_cost.rs
@@ -151,13 +151,13 @@ impl TaxProductResourceTaxCalculationShippingCostTaxBehavior {
 }
 
 impl std::str::FromStr for TaxProductResourceTaxCalculationShippingCostTaxBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TaxProductResourceTaxCalculationShippingCostTaxBehavior::*;
         match s {
             "exclusive" => Ok(Exclusive),
             "inclusive" => Ok(Inclusive),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_misc/src/tax_product_resource_tax_rate_details.rs
+++ b/generated/stripe_misc/src/tax_product_resource_tax_rate_details.rs
@@ -155,7 +155,7 @@ impl TaxProductResourceTaxRateDetailsTaxType {
 }
 
 impl std::str::FromStr for TaxProductResourceTaxRateDetailsTaxType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TaxProductResourceTaxRateDetailsTaxType::*;
         match s {
@@ -171,7 +171,7 @@ impl std::str::FromStr for TaxProductResourceTaxRateDetailsTaxType {
             "rst" => Ok(Rst),
             "sales_tax" => Ok(SalesTax),
             "vat" => Ok(Vat),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_misc/src/tax_product_resource_tax_settings_defaults.rs
+++ b/generated/stripe_misc/src/tax_product_resource_tax_settings_defaults.rs
@@ -117,14 +117,14 @@ impl TaxProductResourceTaxSettingsDefaultsTaxBehavior {
 }
 
 impl std::str::FromStr for TaxProductResourceTaxSettingsDefaultsTaxBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TaxProductResourceTaxSettingsDefaultsTaxBehavior::*;
         match s {
             "exclusive" => Ok(Exclusive),
             "inclusive" => Ok(Inclusive),
             "inferred_by_currency" => Ok(InferredByCurrency),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_misc/src/tax_product_resource_tax_transaction_shipping_cost.rs
+++ b/generated/stripe_misc/src/tax_product_resource_tax_transaction_shipping_cost.rs
@@ -152,13 +152,13 @@ impl TaxProductResourceTaxTransactionShippingCostTaxBehavior {
 }
 
 impl std::str::FromStr for TaxProductResourceTaxTransactionShippingCostTaxBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TaxProductResourceTaxTransactionShippingCostTaxBehavior::*;
         match s {
             "exclusive" => Ok(Exclusive),
             "inclusive" => Ok(Inclusive),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_misc/src/tax_registration/requests.rs
+++ b/generated/stripe_misc/src/tax_registration/requests.rs
@@ -47,7 +47,7 @@ impl ListTaxRegistrationStatus {
 }
 
 impl std::str::FromStr for ListTaxRegistrationStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ListTaxRegistrationStatus::*;
         match s {
@@ -55,7 +55,7 @@ impl std::str::FromStr for ListTaxRegistrationStatus {
             "all" => Ok(All),
             "expired" => Ok(Expired),
             "scheduled" => Ok(Scheduled),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -340,12 +340,12 @@ impl CreateTaxRegistrationCountryOptionsAeType {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsAeType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsAeType::*;
         match s {
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -423,13 +423,13 @@ impl CreateTaxRegistrationCountryOptionsAtStandardPlaceOfSupplyScheme {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsAtStandardPlaceOfSupplyScheme {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsAtStandardPlaceOfSupplyScheme::*;
         match s {
             "small_seller" => Ok(SmallSeller),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -483,7 +483,7 @@ impl CreateTaxRegistrationCountryOptionsAtType {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsAtType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsAtType::*;
         match s {
@@ -491,7 +491,7 @@ impl std::str::FromStr for CreateTaxRegistrationCountryOptionsAtType {
             "oss_non_union" => Ok(OssNonUnion),
             "oss_union" => Ok(OssUnion),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -551,12 +551,12 @@ impl CreateTaxRegistrationCountryOptionsAuType {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsAuType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsAuType::*;
         match s {
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -634,13 +634,13 @@ impl CreateTaxRegistrationCountryOptionsBeStandardPlaceOfSupplyScheme {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsBeStandardPlaceOfSupplyScheme {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsBeStandardPlaceOfSupplyScheme::*;
         match s {
             "small_seller" => Ok(SmallSeller),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -694,7 +694,7 @@ impl CreateTaxRegistrationCountryOptionsBeType {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsBeType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsBeType::*;
         match s {
@@ -702,7 +702,7 @@ impl std::str::FromStr for CreateTaxRegistrationCountryOptionsBeType {
             "oss_non_union" => Ok(OssNonUnion),
             "oss_union" => Ok(OssUnion),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -780,13 +780,13 @@ impl CreateTaxRegistrationCountryOptionsBgStandardPlaceOfSupplyScheme {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsBgStandardPlaceOfSupplyScheme {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsBgStandardPlaceOfSupplyScheme::*;
         match s {
             "small_seller" => Ok(SmallSeller),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -840,7 +840,7 @@ impl CreateTaxRegistrationCountryOptionsBgType {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsBgType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsBgType::*;
         match s {
@@ -848,7 +848,7 @@ impl std::str::FromStr for CreateTaxRegistrationCountryOptionsBgType {
             "oss_non_union" => Ok(OssNonUnion),
             "oss_union" => Ok(OssUnion),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -926,14 +926,14 @@ impl CreateTaxRegistrationCountryOptionsCaType {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsCaType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsCaType::*;
         match s {
             "province_standard" => Ok(ProvinceStandard),
             "simplified" => Ok(Simplified),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -993,12 +993,12 @@ impl CreateTaxRegistrationCountryOptionsChType {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsChType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsChType::*;
         match s {
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1058,12 +1058,12 @@ impl CreateTaxRegistrationCountryOptionsClType {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsClType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsClType::*;
         match s {
             "simplified" => Ok(Simplified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1123,12 +1123,12 @@ impl CreateTaxRegistrationCountryOptionsCoType {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsCoType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsCoType::*;
         match s {
             "simplified" => Ok(Simplified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1206,13 +1206,13 @@ impl CreateTaxRegistrationCountryOptionsCyStandardPlaceOfSupplyScheme {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsCyStandardPlaceOfSupplyScheme {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsCyStandardPlaceOfSupplyScheme::*;
         match s {
             "small_seller" => Ok(SmallSeller),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1266,7 +1266,7 @@ impl CreateTaxRegistrationCountryOptionsCyType {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsCyType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsCyType::*;
         match s {
@@ -1274,7 +1274,7 @@ impl std::str::FromStr for CreateTaxRegistrationCountryOptionsCyType {
             "oss_non_union" => Ok(OssNonUnion),
             "oss_union" => Ok(OssUnion),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1352,13 +1352,13 @@ impl CreateTaxRegistrationCountryOptionsCzStandardPlaceOfSupplyScheme {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsCzStandardPlaceOfSupplyScheme {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsCzStandardPlaceOfSupplyScheme::*;
         match s {
             "small_seller" => Ok(SmallSeller),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1412,7 +1412,7 @@ impl CreateTaxRegistrationCountryOptionsCzType {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsCzType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsCzType::*;
         match s {
@@ -1420,7 +1420,7 @@ impl std::str::FromStr for CreateTaxRegistrationCountryOptionsCzType {
             "oss_non_union" => Ok(OssNonUnion),
             "oss_union" => Ok(OssUnion),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1498,13 +1498,13 @@ impl CreateTaxRegistrationCountryOptionsDeStandardPlaceOfSupplyScheme {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsDeStandardPlaceOfSupplyScheme {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsDeStandardPlaceOfSupplyScheme::*;
         match s {
             "small_seller" => Ok(SmallSeller),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1558,7 +1558,7 @@ impl CreateTaxRegistrationCountryOptionsDeType {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsDeType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsDeType::*;
         match s {
@@ -1566,7 +1566,7 @@ impl std::str::FromStr for CreateTaxRegistrationCountryOptionsDeType {
             "oss_non_union" => Ok(OssNonUnion),
             "oss_union" => Ok(OssUnion),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1644,13 +1644,13 @@ impl CreateTaxRegistrationCountryOptionsDkStandardPlaceOfSupplyScheme {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsDkStandardPlaceOfSupplyScheme {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsDkStandardPlaceOfSupplyScheme::*;
         match s {
             "small_seller" => Ok(SmallSeller),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1704,7 +1704,7 @@ impl CreateTaxRegistrationCountryOptionsDkType {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsDkType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsDkType::*;
         match s {
@@ -1712,7 +1712,7 @@ impl std::str::FromStr for CreateTaxRegistrationCountryOptionsDkType {
             "oss_non_union" => Ok(OssNonUnion),
             "oss_union" => Ok(OssUnion),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1790,13 +1790,13 @@ impl CreateTaxRegistrationCountryOptionsEeStandardPlaceOfSupplyScheme {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsEeStandardPlaceOfSupplyScheme {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsEeStandardPlaceOfSupplyScheme::*;
         match s {
             "small_seller" => Ok(SmallSeller),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1850,7 +1850,7 @@ impl CreateTaxRegistrationCountryOptionsEeType {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsEeType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsEeType::*;
         match s {
@@ -1858,7 +1858,7 @@ impl std::str::FromStr for CreateTaxRegistrationCountryOptionsEeType {
             "oss_non_union" => Ok(OssNonUnion),
             "oss_union" => Ok(OssUnion),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1936,13 +1936,13 @@ impl CreateTaxRegistrationCountryOptionsEsStandardPlaceOfSupplyScheme {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsEsStandardPlaceOfSupplyScheme {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsEsStandardPlaceOfSupplyScheme::*;
         match s {
             "small_seller" => Ok(SmallSeller),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1996,7 +1996,7 @@ impl CreateTaxRegistrationCountryOptionsEsType {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsEsType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsEsType::*;
         match s {
@@ -2004,7 +2004,7 @@ impl std::str::FromStr for CreateTaxRegistrationCountryOptionsEsType {
             "oss_non_union" => Ok(OssNonUnion),
             "oss_union" => Ok(OssUnion),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2082,13 +2082,13 @@ impl CreateTaxRegistrationCountryOptionsFiStandardPlaceOfSupplyScheme {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsFiStandardPlaceOfSupplyScheme {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsFiStandardPlaceOfSupplyScheme::*;
         match s {
             "small_seller" => Ok(SmallSeller),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2142,7 +2142,7 @@ impl CreateTaxRegistrationCountryOptionsFiType {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsFiType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsFiType::*;
         match s {
@@ -2150,7 +2150,7 @@ impl std::str::FromStr for CreateTaxRegistrationCountryOptionsFiType {
             "oss_non_union" => Ok(OssNonUnion),
             "oss_union" => Ok(OssUnion),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2228,13 +2228,13 @@ impl CreateTaxRegistrationCountryOptionsFrStandardPlaceOfSupplyScheme {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsFrStandardPlaceOfSupplyScheme {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsFrStandardPlaceOfSupplyScheme::*;
         match s {
             "small_seller" => Ok(SmallSeller),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2288,7 +2288,7 @@ impl CreateTaxRegistrationCountryOptionsFrType {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsFrType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsFrType::*;
         match s {
@@ -2296,7 +2296,7 @@ impl std::str::FromStr for CreateTaxRegistrationCountryOptionsFrType {
             "oss_non_union" => Ok(OssNonUnion),
             "oss_union" => Ok(OssUnion),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2356,12 +2356,12 @@ impl CreateTaxRegistrationCountryOptionsGbType {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsGbType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsGbType::*;
         match s {
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2439,13 +2439,13 @@ impl CreateTaxRegistrationCountryOptionsGrStandardPlaceOfSupplyScheme {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsGrStandardPlaceOfSupplyScheme {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsGrStandardPlaceOfSupplyScheme::*;
         match s {
             "small_seller" => Ok(SmallSeller),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2499,7 +2499,7 @@ impl CreateTaxRegistrationCountryOptionsGrType {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsGrType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsGrType::*;
         match s {
@@ -2507,7 +2507,7 @@ impl std::str::FromStr for CreateTaxRegistrationCountryOptionsGrType {
             "oss_non_union" => Ok(OssNonUnion),
             "oss_union" => Ok(OssUnion),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2585,13 +2585,13 @@ impl CreateTaxRegistrationCountryOptionsHrStandardPlaceOfSupplyScheme {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsHrStandardPlaceOfSupplyScheme {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsHrStandardPlaceOfSupplyScheme::*;
         match s {
             "small_seller" => Ok(SmallSeller),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2645,7 +2645,7 @@ impl CreateTaxRegistrationCountryOptionsHrType {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsHrType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsHrType::*;
         match s {
@@ -2653,7 +2653,7 @@ impl std::str::FromStr for CreateTaxRegistrationCountryOptionsHrType {
             "oss_non_union" => Ok(OssNonUnion),
             "oss_union" => Ok(OssUnion),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2731,13 +2731,13 @@ impl CreateTaxRegistrationCountryOptionsHuStandardPlaceOfSupplyScheme {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsHuStandardPlaceOfSupplyScheme {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsHuStandardPlaceOfSupplyScheme::*;
         match s {
             "small_seller" => Ok(SmallSeller),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2791,7 +2791,7 @@ impl CreateTaxRegistrationCountryOptionsHuType {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsHuType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsHuType::*;
         match s {
@@ -2799,7 +2799,7 @@ impl std::str::FromStr for CreateTaxRegistrationCountryOptionsHuType {
             "oss_non_union" => Ok(OssNonUnion),
             "oss_union" => Ok(OssUnion),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2859,12 +2859,12 @@ impl CreateTaxRegistrationCountryOptionsIdType {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsIdType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsIdType::*;
         match s {
             "simplified" => Ok(Simplified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2942,13 +2942,13 @@ impl CreateTaxRegistrationCountryOptionsIeStandardPlaceOfSupplyScheme {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsIeStandardPlaceOfSupplyScheme {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsIeStandardPlaceOfSupplyScheme::*;
         match s {
             "small_seller" => Ok(SmallSeller),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3002,7 +3002,7 @@ impl CreateTaxRegistrationCountryOptionsIeType {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsIeType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsIeType::*;
         match s {
@@ -3010,7 +3010,7 @@ impl std::str::FromStr for CreateTaxRegistrationCountryOptionsIeType {
             "oss_non_union" => Ok(OssNonUnion),
             "oss_union" => Ok(OssUnion),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3070,12 +3070,12 @@ impl CreateTaxRegistrationCountryOptionsIsType {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsIsType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsIsType::*;
         match s {
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3153,13 +3153,13 @@ impl CreateTaxRegistrationCountryOptionsItStandardPlaceOfSupplyScheme {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsItStandardPlaceOfSupplyScheme {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsItStandardPlaceOfSupplyScheme::*;
         match s {
             "small_seller" => Ok(SmallSeller),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3213,7 +3213,7 @@ impl CreateTaxRegistrationCountryOptionsItType {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsItType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsItType::*;
         match s {
@@ -3221,7 +3221,7 @@ impl std::str::FromStr for CreateTaxRegistrationCountryOptionsItType {
             "oss_non_union" => Ok(OssNonUnion),
             "oss_union" => Ok(OssUnion),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3281,12 +3281,12 @@ impl CreateTaxRegistrationCountryOptionsJpType {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsJpType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsJpType::*;
         match s {
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3346,12 +3346,12 @@ impl CreateTaxRegistrationCountryOptionsKrType {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsKrType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsKrType::*;
         match s {
             "simplified" => Ok(Simplified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3429,13 +3429,13 @@ impl CreateTaxRegistrationCountryOptionsLtStandardPlaceOfSupplyScheme {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsLtStandardPlaceOfSupplyScheme {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsLtStandardPlaceOfSupplyScheme::*;
         match s {
             "small_seller" => Ok(SmallSeller),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3489,7 +3489,7 @@ impl CreateTaxRegistrationCountryOptionsLtType {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsLtType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsLtType::*;
         match s {
@@ -3497,7 +3497,7 @@ impl std::str::FromStr for CreateTaxRegistrationCountryOptionsLtType {
             "oss_non_union" => Ok(OssNonUnion),
             "oss_union" => Ok(OssUnion),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3575,13 +3575,13 @@ impl CreateTaxRegistrationCountryOptionsLuStandardPlaceOfSupplyScheme {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsLuStandardPlaceOfSupplyScheme {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsLuStandardPlaceOfSupplyScheme::*;
         match s {
             "small_seller" => Ok(SmallSeller),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3635,7 +3635,7 @@ impl CreateTaxRegistrationCountryOptionsLuType {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsLuType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsLuType::*;
         match s {
@@ -3643,7 +3643,7 @@ impl std::str::FromStr for CreateTaxRegistrationCountryOptionsLuType {
             "oss_non_union" => Ok(OssNonUnion),
             "oss_union" => Ok(OssUnion),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3721,13 +3721,13 @@ impl CreateTaxRegistrationCountryOptionsLvStandardPlaceOfSupplyScheme {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsLvStandardPlaceOfSupplyScheme {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsLvStandardPlaceOfSupplyScheme::*;
         match s {
             "small_seller" => Ok(SmallSeller),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3781,7 +3781,7 @@ impl CreateTaxRegistrationCountryOptionsLvType {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsLvType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsLvType::*;
         match s {
@@ -3789,7 +3789,7 @@ impl std::str::FromStr for CreateTaxRegistrationCountryOptionsLvType {
             "oss_non_union" => Ok(OssNonUnion),
             "oss_union" => Ok(OssUnion),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3867,13 +3867,13 @@ impl CreateTaxRegistrationCountryOptionsMtStandardPlaceOfSupplyScheme {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsMtStandardPlaceOfSupplyScheme {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsMtStandardPlaceOfSupplyScheme::*;
         match s {
             "small_seller" => Ok(SmallSeller),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3927,7 +3927,7 @@ impl CreateTaxRegistrationCountryOptionsMtType {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsMtType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsMtType::*;
         match s {
@@ -3935,7 +3935,7 @@ impl std::str::FromStr for CreateTaxRegistrationCountryOptionsMtType {
             "oss_non_union" => Ok(OssNonUnion),
             "oss_union" => Ok(OssUnion),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3995,12 +3995,12 @@ impl CreateTaxRegistrationCountryOptionsMxType {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsMxType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsMxType::*;
         match s {
             "simplified" => Ok(Simplified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4060,12 +4060,12 @@ impl CreateTaxRegistrationCountryOptionsMyType {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsMyType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsMyType::*;
         match s {
             "simplified" => Ok(Simplified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4143,13 +4143,13 @@ impl CreateTaxRegistrationCountryOptionsNlStandardPlaceOfSupplyScheme {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsNlStandardPlaceOfSupplyScheme {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsNlStandardPlaceOfSupplyScheme::*;
         match s {
             "small_seller" => Ok(SmallSeller),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4203,7 +4203,7 @@ impl CreateTaxRegistrationCountryOptionsNlType {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsNlType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsNlType::*;
         match s {
@@ -4211,7 +4211,7 @@ impl std::str::FromStr for CreateTaxRegistrationCountryOptionsNlType {
             "oss_non_union" => Ok(OssNonUnion),
             "oss_union" => Ok(OssUnion),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4271,12 +4271,12 @@ impl CreateTaxRegistrationCountryOptionsNoType {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsNoType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsNoType::*;
         match s {
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4336,12 +4336,12 @@ impl CreateTaxRegistrationCountryOptionsNzType {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsNzType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsNzType::*;
         match s {
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4419,13 +4419,13 @@ impl CreateTaxRegistrationCountryOptionsPlStandardPlaceOfSupplyScheme {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsPlStandardPlaceOfSupplyScheme {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsPlStandardPlaceOfSupplyScheme::*;
         match s {
             "small_seller" => Ok(SmallSeller),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4479,7 +4479,7 @@ impl CreateTaxRegistrationCountryOptionsPlType {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsPlType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsPlType::*;
         match s {
@@ -4487,7 +4487,7 @@ impl std::str::FromStr for CreateTaxRegistrationCountryOptionsPlType {
             "oss_non_union" => Ok(OssNonUnion),
             "oss_union" => Ok(OssUnion),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4565,13 +4565,13 @@ impl CreateTaxRegistrationCountryOptionsPtStandardPlaceOfSupplyScheme {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsPtStandardPlaceOfSupplyScheme {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsPtStandardPlaceOfSupplyScheme::*;
         match s {
             "small_seller" => Ok(SmallSeller),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4625,7 +4625,7 @@ impl CreateTaxRegistrationCountryOptionsPtType {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsPtType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsPtType::*;
         match s {
@@ -4633,7 +4633,7 @@ impl std::str::FromStr for CreateTaxRegistrationCountryOptionsPtType {
             "oss_non_union" => Ok(OssNonUnion),
             "oss_union" => Ok(OssUnion),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4711,13 +4711,13 @@ impl CreateTaxRegistrationCountryOptionsRoStandardPlaceOfSupplyScheme {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsRoStandardPlaceOfSupplyScheme {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsRoStandardPlaceOfSupplyScheme::*;
         match s {
             "small_seller" => Ok(SmallSeller),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4771,7 +4771,7 @@ impl CreateTaxRegistrationCountryOptionsRoType {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsRoType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsRoType::*;
         match s {
@@ -4779,7 +4779,7 @@ impl std::str::FromStr for CreateTaxRegistrationCountryOptionsRoType {
             "oss_non_union" => Ok(OssNonUnion),
             "oss_union" => Ok(OssUnion),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4839,12 +4839,12 @@ impl CreateTaxRegistrationCountryOptionsSaType {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsSaType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsSaType::*;
         match s {
             "simplified" => Ok(Simplified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4922,13 +4922,13 @@ impl CreateTaxRegistrationCountryOptionsSeStandardPlaceOfSupplyScheme {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsSeStandardPlaceOfSupplyScheme {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsSeStandardPlaceOfSupplyScheme::*;
         match s {
             "small_seller" => Ok(SmallSeller),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4982,7 +4982,7 @@ impl CreateTaxRegistrationCountryOptionsSeType {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsSeType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsSeType::*;
         match s {
@@ -4990,7 +4990,7 @@ impl std::str::FromStr for CreateTaxRegistrationCountryOptionsSeType {
             "oss_non_union" => Ok(OssNonUnion),
             "oss_union" => Ok(OssUnion),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5050,12 +5050,12 @@ impl CreateTaxRegistrationCountryOptionsSgType {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsSgType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsSgType::*;
         match s {
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5133,13 +5133,13 @@ impl CreateTaxRegistrationCountryOptionsSiStandardPlaceOfSupplyScheme {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsSiStandardPlaceOfSupplyScheme {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsSiStandardPlaceOfSupplyScheme::*;
         match s {
             "small_seller" => Ok(SmallSeller),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5193,7 +5193,7 @@ impl CreateTaxRegistrationCountryOptionsSiType {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsSiType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsSiType::*;
         match s {
@@ -5201,7 +5201,7 @@ impl std::str::FromStr for CreateTaxRegistrationCountryOptionsSiType {
             "oss_non_union" => Ok(OssNonUnion),
             "oss_union" => Ok(OssUnion),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5279,13 +5279,13 @@ impl CreateTaxRegistrationCountryOptionsSkStandardPlaceOfSupplyScheme {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsSkStandardPlaceOfSupplyScheme {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsSkStandardPlaceOfSupplyScheme::*;
         match s {
             "small_seller" => Ok(SmallSeller),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5339,7 +5339,7 @@ impl CreateTaxRegistrationCountryOptionsSkType {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsSkType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsSkType::*;
         match s {
@@ -5347,7 +5347,7 @@ impl std::str::FromStr for CreateTaxRegistrationCountryOptionsSkType {
             "oss_non_union" => Ok(OssNonUnion),
             "oss_union" => Ok(OssUnion),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5407,12 +5407,12 @@ impl CreateTaxRegistrationCountryOptionsThType {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsThType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsThType::*;
         match s {
             "simplified" => Ok(Simplified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5472,12 +5472,12 @@ impl CreateTaxRegistrationCountryOptionsTrType {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsTrType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsTrType::*;
         match s {
             "simplified" => Ok(Simplified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5575,7 +5575,7 @@ impl CreateTaxRegistrationCountryOptionsUsType {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsUsType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsUsType::*;
         match s {
@@ -5583,7 +5583,7 @@ impl std::str::FromStr for CreateTaxRegistrationCountryOptionsUsType {
             "local_lease_tax" => Ok(LocalLeaseTax),
             "state_communications_tax" => Ok(StateCommunicationsTax),
             "state_sales_tax" => Ok(StateSalesTax),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5643,12 +5643,12 @@ impl CreateTaxRegistrationCountryOptionsVnType {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsVnType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsVnType::*;
         match s {
             "simplified" => Ok(Simplified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5708,12 +5708,12 @@ impl CreateTaxRegistrationCountryOptionsZaType {
 }
 
 impl std::str::FromStr for CreateTaxRegistrationCountryOptionsZaType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTaxRegistrationCountryOptionsZaType::*;
         match s {
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_misc/src/tax_registration/types.rs
+++ b/generated/stripe_misc/src/tax_registration/types.rs
@@ -189,14 +189,14 @@ impl TaxRegistrationStatus {
 }
 
 impl std::str::FromStr for TaxRegistrationStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TaxRegistrationStatus::*;
         match s {
             "active" => Ok(Active),
             "expired" => Ok(Expired),
             "scheduled" => Ok(Scheduled),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_misc/src/tax_settings/requests.rs
+++ b/generated/stripe_misc/src/tax_settings/requests.rs
@@ -70,14 +70,14 @@ impl UpdateTaxSettingsDefaultsTaxBehavior {
 }
 
 impl std::str::FromStr for UpdateTaxSettingsDefaultsTaxBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateTaxSettingsDefaultsTaxBehavior::*;
         match s {
             "exclusive" => Ok(Exclusive),
             "inclusive" => Ok(Inclusive),
             "inferred_by_currency" => Ok(InferredByCurrency),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_misc/src/tax_settings/types.rs
+++ b/generated/stripe_misc/src/tax_settings/types.rs
@@ -159,13 +159,13 @@ impl TaxSettingsStatus {
 }
 
 impl std::str::FromStr for TaxSettingsStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TaxSettingsStatus::*;
         match s {
             "active" => Ok(Active),
             "pending" => Ok(Pending),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_misc/src/tax_transaction/requests.rs
+++ b/generated/stripe_misc/src/tax_transaction/requests.rs
@@ -191,13 +191,13 @@ impl CreateReversalTaxTransactionMode {
 }
 
 impl std::str::FromStr for CreateReversalTaxTransactionMode {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateReversalTaxTransactionMode::*;
         match s {
             "full" => Ok(Full),
             "partial" => Ok(Partial),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_misc/src/tax_transaction/types.rs
+++ b/generated/stripe_misc/src/tax_transaction/types.rs
@@ -225,13 +225,13 @@ impl TaxTransactionType {
 }
 
 impl std::str::FromStr for TaxTransactionType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TaxTransactionType::*;
         match s {
             "reversal" => Ok(Reversal),
             "transaction" => Ok(Transaction),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_misc/src/tax_transaction_line_item.rs
+++ b/generated/stripe_misc/src/tax_transaction_line_item.rs
@@ -216,13 +216,13 @@ impl TaxTransactionLineItemTaxBehavior {
 }
 
 impl std::str::FromStr for TaxTransactionLineItemTaxBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TaxTransactionLineItemTaxBehavior::*;
         match s {
             "exclusive" => Ok(Exclusive),
             "inclusive" => Ok(Inclusive),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -289,13 +289,13 @@ impl TaxTransactionLineItemType {
 }
 
 impl std::str::FromStr for TaxTransactionLineItemType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TaxTransactionLineItemType::*;
         match s {
             "reversal" => Ok(Reversal),
             "transaction" => Ok(Transaction),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_misc/src/verification_session_redaction.rs
+++ b/generated/stripe_misc/src/verification_session_redaction.rs
@@ -108,13 +108,13 @@ impl VerificationSessionRedactionStatus {
 }
 
 impl std::str::FromStr for VerificationSessionRedactionStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use VerificationSessionRedactionStatus::*;
         match s {
             "processing" => Ok(Processing),
             "redacted" => Ok(Redacted),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_misc/src/webhook_endpoint/requests.rs
+++ b/generated/stripe_misc/src/webhook_endpoint/requests.rs
@@ -607,7 +607,7 @@ impl CreateWebhookEndpointEnabledEvents {
 }
 
 impl std::str::FromStr for CreateWebhookEndpointEnabledEvents {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateWebhookEndpointEnabledEvents::*;
         match s {
@@ -863,7 +863,7 @@ impl std::str::FromStr for CreateWebhookEndpointEnabledEvents {
             "treasury.received_credit.failed" => Ok(TreasuryReceivedCreditFailed),
             "treasury.received_credit.succeeded" => Ok(TreasuryReceivedCreditSucceeded),
             "treasury.received_debit.created" => Ok(TreasuryReceivedDebitCreated),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -891,7 +891,7 @@ impl<'de> serde::Deserialize<'de> for CreateWebhookEndpointEnabledEvents {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 impl<'a> CreateWebhookEndpoint<'a> {
@@ -1421,7 +1421,7 @@ impl UpdateWebhookEndpointEnabledEvents {
 }
 
 impl std::str::FromStr for UpdateWebhookEndpointEnabledEvents {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateWebhookEndpointEnabledEvents::*;
         match s {
@@ -1677,7 +1677,7 @@ impl std::str::FromStr for UpdateWebhookEndpointEnabledEvents {
             "treasury.received_credit.failed" => Ok(TreasuryReceivedCreditFailed),
             "treasury.received_credit.succeeded" => Ok(TreasuryReceivedCreditSucceeded),
             "treasury.received_debit.created" => Ok(TreasuryReceivedDebitCreated),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -1705,7 +1705,7 @@ impl<'de> serde::Deserialize<'de> for UpdateWebhookEndpointEnabledEvents {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 impl<'a> UpdateWebhookEndpoint<'a> {

--- a/generated/stripe_payment/src/bank_account/requests.rs
+++ b/generated/stripe_payment/src/bank_account/requests.rs
@@ -206,13 +206,13 @@ impl UpdateAccountBankAccountAccountHolderType {
 }
 
 impl std::str::FromStr for UpdateAccountBankAccountAccountHolderType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateAccountBankAccountAccountHolderType::*;
         match s {
             "company" => Ok(Company),
             "individual" => Ok(Individual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -268,7 +268,7 @@ impl UpdateAccountBankAccountAccountType {
 }
 
 impl std::str::FromStr for UpdateAccountBankAccountAccountType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateAccountBankAccountAccountType::*;
         match s {
@@ -276,7 +276,7 @@ impl std::str::FromStr for UpdateAccountBankAccountAccountType {
             "futsu" => Ok(Futsu),
             "savings" => Ok(Savings),
             "toza" => Ok(Toza),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -423,13 +423,13 @@ impl UpdateCustomerBankAccountAccountHolderType {
 }
 
 impl std::str::FromStr for UpdateCustomerBankAccountAccountHolderType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateCustomerBankAccountAccountHolderType::*;
         match s {
             "company" => Ok(Company),
             "individual" => Ok(Individual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_payment/src/card/requests.rs
+++ b/generated/stripe_payment/src/card/requests.rs
@@ -206,13 +206,13 @@ impl UpdateAccountCardAccountHolderType {
 }
 
 impl std::str::FromStr for UpdateAccountCardAccountHolderType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateAccountCardAccountHolderType::*;
         match s {
             "company" => Ok(Company),
             "individual" => Ok(Individual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -268,7 +268,7 @@ impl UpdateAccountCardAccountType {
 }
 
 impl std::str::FromStr for UpdateAccountCardAccountType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateAccountCardAccountType::*;
         match s {
@@ -276,7 +276,7 @@ impl std::str::FromStr for UpdateAccountCardAccountType {
             "futsu" => Ok(Futsu),
             "savings" => Ok(Savings),
             "toza" => Ok(Toza),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -422,13 +422,13 @@ impl UpdateCustomerCardAccountHolderType {
 }
 
 impl std::str::FromStr for UpdateCustomerCardAccountHolderType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateCustomerCardAccountHolderType::*;
         match s {
             "company" => Ok(Company),
             "individual" => Ok(Individual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_payment/src/payment_link/requests.rs
+++ b/generated/stripe_payment/src/payment_link/requests.rs
@@ -280,13 +280,13 @@ impl CreatePaymentLinkAfterCompletionType {
 }
 
 impl std::str::FromStr for CreatePaymentLinkAfterCompletionType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentLinkAfterCompletionType::*;
         match s {
             "hosted_confirmation" => Ok(HostedConfirmation),
             "redirect" => Ok(Redirect),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -369,13 +369,13 @@ impl CreatePaymentLinkAutomaticTaxLiabilityType {
 }
 
 impl std::str::FromStr for CreatePaymentLinkAutomaticTaxLiabilityType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentLinkAutomaticTaxLiabilityType::*;
         match s {
             "account" => Ok(Account),
             "self" => Ok(Self_),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -469,13 +469,13 @@ impl CreatePaymentLinkConsentCollectionPaymentMethodReuseAgreementPosition {
 }
 
 impl std::str::FromStr for CreatePaymentLinkConsentCollectionPaymentMethodReuseAgreementPosition {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentLinkConsentCollectionPaymentMethodReuseAgreementPosition::*;
         match s {
             "auto" => Ok(Auto),
             "hidden" => Ok(Hidden),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -528,13 +528,13 @@ impl CreatePaymentLinkConsentCollectionPromotions {
 }
 
 impl std::str::FromStr for CreatePaymentLinkConsentCollectionPromotions {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentLinkConsentCollectionPromotions::*;
         match s {
             "auto" => Ok(Auto),
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -587,13 +587,13 @@ impl CreatePaymentLinkConsentCollectionTermsOfService {
 }
 
 impl std::str::FromStr for CreatePaymentLinkConsentCollectionTermsOfService {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentLinkConsentCollectionTermsOfService::*;
         match s {
             "none" => Ok(None),
             "required" => Ok(Required),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -692,12 +692,12 @@ impl CreatePaymentLinkCustomFieldsLabelType {
 }
 
 impl std::str::FromStr for CreatePaymentLinkCustomFieldsLabelType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentLinkCustomFieldsLabelType::*;
         match s {
             "custom" => Ok(Custom),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -779,14 +779,14 @@ impl CreatePaymentLinkCustomFieldsType {
 }
 
 impl std::str::FromStr for CreatePaymentLinkCustomFieldsType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentLinkCustomFieldsType::*;
         match s {
             "dropdown" => Ok(Dropdown),
             "numeric" => Ok(Numeric),
             "text" => Ok(Text),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -836,13 +836,13 @@ impl CreatePaymentLinkCustomerCreation {
 }
 
 impl std::str::FromStr for CreatePaymentLinkCustomerCreation {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentLinkCustomerCreation::*;
         match s {
             "always" => Ok(Always),
             "if_required" => Ok(IfRequired),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -956,13 +956,13 @@ impl CreatePaymentLinkInvoiceCreationInvoiceDataIssuerType {
 }
 
 impl std::str::FromStr for CreatePaymentLinkInvoiceCreationInvoiceDataIssuerType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentLinkInvoiceCreationInvoiceDataIssuerType::*;
         match s {
             "account" => Ok(Account),
             "self" => Ok(Self_),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1035,13 +1035,13 @@ impl CreatePaymentLinkInvoiceCreationInvoiceDataRenderingOptionsAmountTaxDisplay
 impl std::str::FromStr
     for CreatePaymentLinkInvoiceCreationInvoiceDataRenderingOptionsAmountTaxDisplay
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentLinkInvoiceCreationInvoiceDataRenderingOptionsAmountTaxDisplay::*;
         match s {
             "exclude_tax" => Ok(ExcludeTax),
             "include_inclusive_tax" => Ok(IncludeInclusiveTax),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1164,14 +1164,14 @@ impl CreatePaymentLinkPaymentIntentDataCaptureMethod {
 }
 
 impl std::str::FromStr for CreatePaymentLinkPaymentIntentDataCaptureMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentLinkPaymentIntentDataCaptureMethod::*;
         match s {
             "automatic" => Ok(Automatic),
             "automatic_async" => Ok(AutomaticAsync),
             "manual" => Ok(Manual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1234,13 +1234,13 @@ impl CreatePaymentLinkPaymentIntentDataSetupFutureUsage {
 }
 
 impl std::str::FromStr for CreatePaymentLinkPaymentIntentDataSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentLinkPaymentIntentDataSetupFutureUsage::*;
         match s {
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1297,13 +1297,13 @@ impl CreatePaymentLinkPaymentMethodCollection {
 }
 
 impl std::str::FromStr for CreatePaymentLinkPaymentMethodCollection {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentLinkPaymentMethodCollection::*;
         match s {
             "always" => Ok(Always),
             "if_required" => Ok(IfRequired),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1857,7 +1857,7 @@ impl CreatePaymentLinkShippingAddressCollectionAllowedCountries {
 }
 
 impl std::str::FromStr for CreatePaymentLinkShippingAddressCollectionAllowedCountries {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentLinkShippingAddressCollectionAllowedCountries::*;
         match s {
@@ -2098,7 +2098,7 @@ impl std::str::FromStr for CreatePaymentLinkShippingAddressCollectionAllowedCoun
             "ZM" => Ok(Zm),
             "ZW" => Ok(Zw),
             "ZZ" => Ok(Zz),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -2126,7 +2126,7 @@ impl<'de> serde::Deserialize<'de> for CreatePaymentLinkShippingAddressCollection
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// The shipping rate options to apply to [checkout sessions](https://stripe.com/docs/api/checkout/sessions) created by this payment link.
@@ -2216,13 +2216,13 @@ impl CreatePaymentLinkSubscriptionDataInvoiceSettingsIssuerType {
 }
 
 impl std::str::FromStr for CreatePaymentLinkSubscriptionDataInvoiceSettingsIssuerType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentLinkSubscriptionDataInvoiceSettingsIssuerType::*;
         match s {
             "account" => Ok(Account),
             "self" => Ok(Self_),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2303,14 +2303,14 @@ impl CreatePaymentLinkSubscriptionDataTrialSettingsEndBehaviorMissingPaymentMeth
 impl std::str::FromStr
     for CreatePaymentLinkSubscriptionDataTrialSettingsEndBehaviorMissingPaymentMethod
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentLinkSubscriptionDataTrialSettingsEndBehaviorMissingPaymentMethod::*;
         match s {
             "cancel" => Ok(Cancel),
             "create_invoice" => Ok(CreateInvoice),
             "pause" => Ok(Pause),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2498,13 +2498,13 @@ impl UpdatePaymentLinkAfterCompletionType {
 }
 
 impl std::str::FromStr for UpdatePaymentLinkAfterCompletionType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentLinkAfterCompletionType::*;
         match s {
             "hosted_confirmation" => Ok(HostedConfirmation),
             "redirect" => Ok(Redirect),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2587,13 +2587,13 @@ impl UpdatePaymentLinkAutomaticTaxLiabilityType {
 }
 
 impl std::str::FromStr for UpdatePaymentLinkAutomaticTaxLiabilityType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentLinkAutomaticTaxLiabilityType::*;
         match s {
             "account" => Ok(Account),
             "self" => Ok(Self_),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2690,12 +2690,12 @@ impl UpdatePaymentLinkCustomFieldsLabelType {
 }
 
 impl std::str::FromStr for UpdatePaymentLinkCustomFieldsLabelType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentLinkCustomFieldsLabelType::*;
         match s {
             "custom" => Ok(Custom),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2777,14 +2777,14 @@ impl UpdatePaymentLinkCustomFieldsType {
 }
 
 impl std::str::FromStr for UpdatePaymentLinkCustomFieldsType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentLinkCustomFieldsType::*;
         match s {
             "dropdown" => Ok(Dropdown),
             "numeric" => Ok(Numeric),
             "text" => Ok(Text),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2834,13 +2834,13 @@ impl UpdatePaymentLinkCustomerCreation {
 }
 
 impl std::str::FromStr for UpdatePaymentLinkCustomerCreation {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentLinkCustomerCreation::*;
         match s {
             "always" => Ok(Always),
             "if_required" => Ok(IfRequired),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2954,13 +2954,13 @@ impl UpdatePaymentLinkInvoiceCreationInvoiceDataIssuerType {
 }
 
 impl std::str::FromStr for UpdatePaymentLinkInvoiceCreationInvoiceDataIssuerType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentLinkInvoiceCreationInvoiceDataIssuerType::*;
         match s {
             "account" => Ok(Account),
             "self" => Ok(Self_),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3033,13 +3033,13 @@ impl UpdatePaymentLinkInvoiceCreationInvoiceDataRenderingOptionsAmountTaxDisplay
 impl std::str::FromStr
     for UpdatePaymentLinkInvoiceCreationInvoiceDataRenderingOptionsAmountTaxDisplay
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentLinkInvoiceCreationInvoiceDataRenderingOptionsAmountTaxDisplay::*;
         match s {
             "exclude_tax" => Ok(ExcludeTax),
             "include_inclusive_tax" => Ok(IncludeInclusiveTax),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3149,13 +3149,13 @@ impl UpdatePaymentLinkPaymentMethodCollection {
 }
 
 impl std::str::FromStr for UpdatePaymentLinkPaymentMethodCollection {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentLinkPaymentMethodCollection::*;
         match s {
             "always" => Ok(Always),
             "if_required" => Ok(IfRequired),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3696,7 +3696,7 @@ impl UpdatePaymentLinkShippingAddressCollectionAllowedCountries {
 }
 
 impl std::str::FromStr for UpdatePaymentLinkShippingAddressCollectionAllowedCountries {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentLinkShippingAddressCollectionAllowedCountries::*;
         match s {
@@ -3937,7 +3937,7 @@ impl std::str::FromStr for UpdatePaymentLinkShippingAddressCollectionAllowedCoun
             "ZM" => Ok(Zm),
             "ZW" => Ok(Zw),
             "ZZ" => Ok(Zz),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -3965,7 +3965,7 @@ impl<'de> serde::Deserialize<'de> for UpdatePaymentLinkShippingAddressCollection
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// When creating a subscription, the specified configuration data will be used.
@@ -4035,13 +4035,13 @@ impl UpdatePaymentLinkSubscriptionDataInvoiceSettingsIssuerType {
 }
 
 impl std::str::FromStr for UpdatePaymentLinkSubscriptionDataInvoiceSettingsIssuerType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentLinkSubscriptionDataInvoiceSettingsIssuerType::*;
         match s {
             "account" => Ok(Account),
             "self" => Ok(Self_),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4122,14 +4122,14 @@ impl UpdatePaymentLinkSubscriptionDataTrialSettingsEndBehaviorMissingPaymentMeth
 impl std::str::FromStr
     for UpdatePaymentLinkSubscriptionDataTrialSettingsEndBehaviorMissingPaymentMethod
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentLinkSubscriptionDataTrialSettingsEndBehaviorMissingPaymentMethod::*;
         match s {
             "cancel" => Ok(Cancel),
             "create_invoice" => Ok(CreateInvoice),
             "pause" => Ok(Pause),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_payment/src/payment_method/requests.rs
+++ b/generated/stripe_payment/src/payment_method/requests.rs
@@ -117,7 +117,7 @@ impl ListPaymentMethodType {
 }
 
 impl std::str::FromStr for ListPaymentMethodType {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ListPaymentMethodType::*;
         match s {
@@ -154,7 +154,7 @@ impl std::str::FromStr for ListPaymentMethodType {
             "us_bank_account" => Ok(UsBankAccount),
             "wechat_pay" => Ok(WechatPay),
             "zip" => Ok(Zip),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -182,7 +182,7 @@ impl<'de> serde::Deserialize<'de> for ListPaymentMethodType {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 impl<'a> ListPaymentMethod<'a> {
@@ -572,7 +572,7 @@ impl CreatePaymentMethodEpsBank {
 }
 
 impl std::str::FromStr for CreatePaymentMethodEpsBank {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentMethodEpsBank::*;
         match s {
@@ -604,7 +604,7 @@ impl std::str::FromStr for CreatePaymentMethodEpsBank {
             "volksbank_gruppe" => Ok(VolksbankGruppe),
             "volkskreditbank_ag" => Ok(VolkskreditbankAg),
             "vr_bank_braunau" => Ok(VrBankBraunau),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -632,7 +632,7 @@ impl<'de> serde::Deserialize<'de> for CreatePaymentMethodEpsBank {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// If this is an `fpx` PaymentMethod, this hash contains details about the FPX payment method.
@@ -666,13 +666,13 @@ impl CreatePaymentMethodFpxAccountHolderType {
 }
 
 impl std::str::FromStr for CreatePaymentMethodFpxAccountHolderType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentMethodFpxAccountHolderType::*;
         match s {
             "company" => Ok(Company),
             "individual" => Ok(Individual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -766,7 +766,7 @@ impl CreatePaymentMethodFpxBank {
 }
 
 impl std::str::FromStr for CreatePaymentMethodFpxBank {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentMethodFpxBank::*;
         match s {
@@ -792,7 +792,7 @@ impl std::str::FromStr for CreatePaymentMethodFpxBank {
             "rhb" => Ok(Rhb),
             "standard_chartered" => Ok(StandardChartered),
             "uob" => Ok(Uob),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -820,7 +820,7 @@ impl<'de> serde::Deserialize<'de> for CreatePaymentMethodFpxBank {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// If this is an `ideal` PaymentMethod, this hash contains details about the iDEAL payment method.
@@ -884,7 +884,7 @@ impl CreatePaymentMethodIdealBank {
 }
 
 impl std::str::FromStr for CreatePaymentMethodIdealBank {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentMethodIdealBank::*;
         match s {
@@ -904,7 +904,7 @@ impl std::str::FromStr for CreatePaymentMethodIdealBank {
             "triodos_bank" => Ok(TriodosBank),
             "van_lanschot" => Ok(VanLanschot),
             "yoursafe" => Ok(Yoursafe),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -932,7 +932,7 @@ impl<'de> serde::Deserialize<'de> for CreatePaymentMethodIdealBank {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// If this is a `klarna` PaymentMethod, this hash contains details about the Klarna payment method.
@@ -1043,7 +1043,7 @@ impl CreatePaymentMethodP24Bank {
 }
 
 impl std::str::FromStr for CreatePaymentMethodP24Bank {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentMethodP24Bank::*;
         match s {
@@ -1073,7 +1073,7 @@ impl std::str::FromStr for CreatePaymentMethodP24Bank {
             "toyota_bank" => Ok(ToyotaBank),
             "velobank" => Ok(Velobank),
             "volkswagen_bank" => Ok(VolkswagenBank),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -1101,7 +1101,7 @@ impl<'de> serde::Deserialize<'de> for CreatePaymentMethodP24Bank {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// Options to configure Radar.
@@ -1164,7 +1164,7 @@ impl CreatePaymentMethodSofortCountry {
 }
 
 impl std::str::FromStr for CreatePaymentMethodSofortCountry {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentMethodSofortCountry::*;
         match s {
@@ -1174,7 +1174,7 @@ impl std::str::FromStr for CreatePaymentMethodSofortCountry {
             "ES" => Ok(Es),
             "IT" => Ok(It),
             "NL" => Ok(Nl),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1292,7 +1292,7 @@ impl CreatePaymentMethodType {
 }
 
 impl std::str::FromStr for CreatePaymentMethodType {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentMethodType::*;
         match s {
@@ -1329,7 +1329,7 @@ impl std::str::FromStr for CreatePaymentMethodType {
             "us_bank_account" => Ok(UsBankAccount),
             "wechat_pay" => Ok(WechatPay),
             "zip" => Ok(Zip),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -1357,7 +1357,7 @@ impl<'de> serde::Deserialize<'de> for CreatePaymentMethodType {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// If this is an `us_bank_account` PaymentMethod, this hash contains details about the US bank account payment method.
@@ -1401,13 +1401,13 @@ impl CreatePaymentMethodUsBankAccountAccountHolderType {
 }
 
 impl std::str::FromStr for CreatePaymentMethodUsBankAccountAccountHolderType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentMethodUsBankAccountAccountHolderType::*;
         match s {
             "company" => Ok(Company),
             "individual" => Ok(Individual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1459,13 +1459,13 @@ impl CreatePaymentMethodUsBankAccountAccountType {
 }
 
 impl std::str::FromStr for CreatePaymentMethodUsBankAccountAccountType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentMethodUsBankAccountAccountType::*;
         match s {
             "checking" => Ok(Checking),
             "savings" => Ok(Savings),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1586,13 +1586,13 @@ impl UpdatePaymentMethodUsBankAccountAccountHolderType {
 }
 
 impl std::str::FromStr for UpdatePaymentMethodUsBankAccountAccountHolderType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentMethodUsBankAccountAccountHolderType::*;
         match s {
             "company" => Ok(Company),
             "individual" => Ok(Individual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1644,13 +1644,13 @@ impl UpdatePaymentMethodUsBankAccountAccountType {
 }
 
 impl std::str::FromStr for UpdatePaymentMethodUsBankAccountAccountType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentMethodUsBankAccountAccountType::*;
         match s {
             "checking" => Ok(Checking),
             "savings" => Ok(Savings),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_payment/src/payment_method_config_resource_display_preference.rs
+++ b/generated/stripe_payment/src/payment_method_config_resource_display_preference.rs
@@ -129,14 +129,14 @@ impl PaymentMethodConfigResourceDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for PaymentMethodConfigResourceDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodConfigResourceDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -209,13 +209,13 @@ impl PaymentMethodConfigResourceDisplayPreferenceValue {
 }
 
 impl std::str::FromStr for PaymentMethodConfigResourceDisplayPreferenceValue {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodConfigResourceDisplayPreferenceValue::*;
         match s {
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_payment/src/payment_method_configuration/requests.rs
+++ b/generated/stripe_payment/src/payment_method_configuration/requests.rs
@@ -268,14 +268,14 @@ impl CreatePaymentMethodConfigurationAcssDebitDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for CreatePaymentMethodConfigurationAcssDebitDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentMethodConfigurationAcssDebitDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -353,14 +353,14 @@ impl CreatePaymentMethodConfigurationAffirmDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for CreatePaymentMethodConfigurationAffirmDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentMethodConfigurationAffirmDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -441,14 +441,14 @@ impl CreatePaymentMethodConfigurationAfterpayClearpayDisplayPreferencePreference
 impl std::str::FromStr
     for CreatePaymentMethodConfigurationAfterpayClearpayDisplayPreferencePreference
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentMethodConfigurationAfterpayClearpayDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -533,14 +533,14 @@ impl CreatePaymentMethodConfigurationAlipayDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for CreatePaymentMethodConfigurationAlipayDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentMethodConfigurationAlipayDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -618,14 +618,14 @@ impl CreatePaymentMethodConfigurationApplePayDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for CreatePaymentMethodConfigurationApplePayDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentMethodConfigurationApplePayDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -704,14 +704,14 @@ impl CreatePaymentMethodConfigurationApplePayLaterDisplayPreferencePreference {
 impl std::str::FromStr
     for CreatePaymentMethodConfigurationApplePayLaterDisplayPreferencePreference
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentMethodConfigurationApplePayLaterDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -790,14 +790,14 @@ impl CreatePaymentMethodConfigurationAuBecsDebitDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for CreatePaymentMethodConfigurationAuBecsDebitDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentMethodConfigurationAuBecsDebitDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -873,14 +873,14 @@ impl CreatePaymentMethodConfigurationBacsDebitDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for CreatePaymentMethodConfigurationBacsDebitDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentMethodConfigurationBacsDebitDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -958,14 +958,14 @@ impl CreatePaymentMethodConfigurationBancontactDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for CreatePaymentMethodConfigurationBancontactDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentMethodConfigurationBancontactDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1043,14 +1043,14 @@ impl CreatePaymentMethodConfigurationBlikDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for CreatePaymentMethodConfigurationBlikDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentMethodConfigurationBlikDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1131,14 +1131,14 @@ impl CreatePaymentMethodConfigurationBoletoDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for CreatePaymentMethodConfigurationBoletoDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentMethodConfigurationBoletoDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1215,14 +1215,14 @@ impl CreatePaymentMethodConfigurationCardDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for CreatePaymentMethodConfigurationCardDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentMethodConfigurationCardDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1308,14 +1308,14 @@ impl CreatePaymentMethodConfigurationCartesBancairesDisplayPreferencePreference 
 impl std::str::FromStr
     for CreatePaymentMethodConfigurationCartesBancairesDisplayPreferencePreference
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentMethodConfigurationCartesBancairesDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1398,14 +1398,14 @@ impl CreatePaymentMethodConfigurationCashappDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for CreatePaymentMethodConfigurationCashappDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentMethodConfigurationCashappDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1487,14 +1487,14 @@ impl CreatePaymentMethodConfigurationCustomerBalanceDisplayPreferencePreference 
 impl std::str::FromStr
     for CreatePaymentMethodConfigurationCustomerBalanceDisplayPreferencePreference
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentMethodConfigurationCustomerBalanceDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1578,14 +1578,14 @@ impl CreatePaymentMethodConfigurationEpsDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for CreatePaymentMethodConfigurationEpsDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentMethodConfigurationEpsDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1668,14 +1668,14 @@ impl CreatePaymentMethodConfigurationFpxDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for CreatePaymentMethodConfigurationFpxDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentMethodConfigurationFpxDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1759,14 +1759,14 @@ impl CreatePaymentMethodConfigurationGiropayDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for CreatePaymentMethodConfigurationGiropayDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentMethodConfigurationGiropayDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1844,14 +1844,14 @@ impl CreatePaymentMethodConfigurationGooglePayDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for CreatePaymentMethodConfigurationGooglePayDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentMethodConfigurationGooglePayDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1929,14 +1929,14 @@ impl CreatePaymentMethodConfigurationGrabpayDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for CreatePaymentMethodConfigurationGrabpayDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentMethodConfigurationGrabpayDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2014,14 +2014,14 @@ impl CreatePaymentMethodConfigurationIdealDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for CreatePaymentMethodConfigurationIdealDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentMethodConfigurationIdealDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2099,14 +2099,14 @@ impl CreatePaymentMethodConfigurationJcbDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for CreatePaymentMethodConfigurationJcbDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentMethodConfigurationJcbDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2189,14 +2189,14 @@ impl CreatePaymentMethodConfigurationKlarnaDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for CreatePaymentMethodConfigurationKlarnaDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentMethodConfigurationKlarnaDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2273,14 +2273,14 @@ impl CreatePaymentMethodConfigurationKonbiniDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for CreatePaymentMethodConfigurationKonbiniDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentMethodConfigurationKonbiniDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2357,14 +2357,14 @@ impl CreatePaymentMethodConfigurationLinkDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for CreatePaymentMethodConfigurationLinkDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentMethodConfigurationLinkDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2446,14 +2446,14 @@ impl CreatePaymentMethodConfigurationOxxoDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for CreatePaymentMethodConfigurationOxxoDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentMethodConfigurationOxxoDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2535,14 +2535,14 @@ impl CreatePaymentMethodConfigurationP24DisplayPreferencePreference {
 }
 
 impl std::str::FromStr for CreatePaymentMethodConfigurationP24DisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentMethodConfigurationP24DisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2623,14 +2623,14 @@ impl CreatePaymentMethodConfigurationPaynowDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for CreatePaymentMethodConfigurationPaynowDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentMethodConfigurationPaynowDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2707,14 +2707,14 @@ impl CreatePaymentMethodConfigurationPaypalDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for CreatePaymentMethodConfigurationPaypalDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentMethodConfigurationPaypalDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2791,14 +2791,14 @@ impl CreatePaymentMethodConfigurationPromptpayDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for CreatePaymentMethodConfigurationPromptpayDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentMethodConfigurationPromptpayDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2875,14 +2875,14 @@ impl CreatePaymentMethodConfigurationRevolutPayDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for CreatePaymentMethodConfigurationRevolutPayDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentMethodConfigurationRevolutPayDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -2959,14 +2959,14 @@ impl CreatePaymentMethodConfigurationSepaDebitDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for CreatePaymentMethodConfigurationSepaDebitDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentMethodConfigurationSepaDebitDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3043,14 +3043,14 @@ impl CreatePaymentMethodConfigurationSofortDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for CreatePaymentMethodConfigurationSofortDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentMethodConfigurationSofortDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3130,14 +3130,14 @@ impl CreatePaymentMethodConfigurationUsBankAccountDisplayPreferencePreference {
 impl std::str::FromStr
     for CreatePaymentMethodConfigurationUsBankAccountDisplayPreferencePreference
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentMethodConfigurationUsBankAccountDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3218,14 +3218,14 @@ impl CreatePaymentMethodConfigurationWechatPayDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for CreatePaymentMethodConfigurationWechatPayDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePaymentMethodConfigurationWechatPayDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3488,14 +3488,14 @@ impl UpdatePaymentMethodConfigurationAcssDebitDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for UpdatePaymentMethodConfigurationAcssDebitDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentMethodConfigurationAcssDebitDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3573,14 +3573,14 @@ impl UpdatePaymentMethodConfigurationAffirmDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for UpdatePaymentMethodConfigurationAffirmDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentMethodConfigurationAffirmDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3661,14 +3661,14 @@ impl UpdatePaymentMethodConfigurationAfterpayClearpayDisplayPreferencePreference
 impl std::str::FromStr
     for UpdatePaymentMethodConfigurationAfterpayClearpayDisplayPreferencePreference
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentMethodConfigurationAfterpayClearpayDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3753,14 +3753,14 @@ impl UpdatePaymentMethodConfigurationAlipayDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for UpdatePaymentMethodConfigurationAlipayDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentMethodConfigurationAlipayDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3838,14 +3838,14 @@ impl UpdatePaymentMethodConfigurationApplePayDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for UpdatePaymentMethodConfigurationApplePayDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentMethodConfigurationApplePayDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -3924,14 +3924,14 @@ impl UpdatePaymentMethodConfigurationApplePayLaterDisplayPreferencePreference {
 impl std::str::FromStr
     for UpdatePaymentMethodConfigurationApplePayLaterDisplayPreferencePreference
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentMethodConfigurationApplePayLaterDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4010,14 +4010,14 @@ impl UpdatePaymentMethodConfigurationAuBecsDebitDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for UpdatePaymentMethodConfigurationAuBecsDebitDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentMethodConfigurationAuBecsDebitDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4093,14 +4093,14 @@ impl UpdatePaymentMethodConfigurationBacsDebitDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for UpdatePaymentMethodConfigurationBacsDebitDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentMethodConfigurationBacsDebitDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4178,14 +4178,14 @@ impl UpdatePaymentMethodConfigurationBancontactDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for UpdatePaymentMethodConfigurationBancontactDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentMethodConfigurationBancontactDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4263,14 +4263,14 @@ impl UpdatePaymentMethodConfigurationBlikDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for UpdatePaymentMethodConfigurationBlikDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentMethodConfigurationBlikDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4351,14 +4351,14 @@ impl UpdatePaymentMethodConfigurationBoletoDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for UpdatePaymentMethodConfigurationBoletoDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentMethodConfigurationBoletoDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4435,14 +4435,14 @@ impl UpdatePaymentMethodConfigurationCardDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for UpdatePaymentMethodConfigurationCardDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentMethodConfigurationCardDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4528,14 +4528,14 @@ impl UpdatePaymentMethodConfigurationCartesBancairesDisplayPreferencePreference 
 impl std::str::FromStr
     for UpdatePaymentMethodConfigurationCartesBancairesDisplayPreferencePreference
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentMethodConfigurationCartesBancairesDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4618,14 +4618,14 @@ impl UpdatePaymentMethodConfigurationCashappDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for UpdatePaymentMethodConfigurationCashappDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentMethodConfigurationCashappDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4707,14 +4707,14 @@ impl UpdatePaymentMethodConfigurationCustomerBalanceDisplayPreferencePreference 
 impl std::str::FromStr
     for UpdatePaymentMethodConfigurationCustomerBalanceDisplayPreferencePreference
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentMethodConfigurationCustomerBalanceDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4798,14 +4798,14 @@ impl UpdatePaymentMethodConfigurationEpsDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for UpdatePaymentMethodConfigurationEpsDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentMethodConfigurationEpsDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4888,14 +4888,14 @@ impl UpdatePaymentMethodConfigurationFpxDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for UpdatePaymentMethodConfigurationFpxDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentMethodConfigurationFpxDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -4979,14 +4979,14 @@ impl UpdatePaymentMethodConfigurationGiropayDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for UpdatePaymentMethodConfigurationGiropayDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentMethodConfigurationGiropayDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5064,14 +5064,14 @@ impl UpdatePaymentMethodConfigurationGooglePayDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for UpdatePaymentMethodConfigurationGooglePayDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentMethodConfigurationGooglePayDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5149,14 +5149,14 @@ impl UpdatePaymentMethodConfigurationGrabpayDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for UpdatePaymentMethodConfigurationGrabpayDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentMethodConfigurationGrabpayDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5234,14 +5234,14 @@ impl UpdatePaymentMethodConfigurationIdealDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for UpdatePaymentMethodConfigurationIdealDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentMethodConfigurationIdealDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5319,14 +5319,14 @@ impl UpdatePaymentMethodConfigurationJcbDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for UpdatePaymentMethodConfigurationJcbDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentMethodConfigurationJcbDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5409,14 +5409,14 @@ impl UpdatePaymentMethodConfigurationKlarnaDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for UpdatePaymentMethodConfigurationKlarnaDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentMethodConfigurationKlarnaDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5493,14 +5493,14 @@ impl UpdatePaymentMethodConfigurationKonbiniDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for UpdatePaymentMethodConfigurationKonbiniDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentMethodConfigurationKonbiniDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5577,14 +5577,14 @@ impl UpdatePaymentMethodConfigurationLinkDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for UpdatePaymentMethodConfigurationLinkDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentMethodConfigurationLinkDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5666,14 +5666,14 @@ impl UpdatePaymentMethodConfigurationOxxoDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for UpdatePaymentMethodConfigurationOxxoDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentMethodConfigurationOxxoDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5755,14 +5755,14 @@ impl UpdatePaymentMethodConfigurationP24DisplayPreferencePreference {
 }
 
 impl std::str::FromStr for UpdatePaymentMethodConfigurationP24DisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentMethodConfigurationP24DisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5843,14 +5843,14 @@ impl UpdatePaymentMethodConfigurationPaynowDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for UpdatePaymentMethodConfigurationPaynowDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentMethodConfigurationPaynowDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -5927,14 +5927,14 @@ impl UpdatePaymentMethodConfigurationPaypalDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for UpdatePaymentMethodConfigurationPaypalDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentMethodConfigurationPaypalDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -6011,14 +6011,14 @@ impl UpdatePaymentMethodConfigurationPromptpayDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for UpdatePaymentMethodConfigurationPromptpayDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentMethodConfigurationPromptpayDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -6095,14 +6095,14 @@ impl UpdatePaymentMethodConfigurationRevolutPayDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for UpdatePaymentMethodConfigurationRevolutPayDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentMethodConfigurationRevolutPayDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -6179,14 +6179,14 @@ impl UpdatePaymentMethodConfigurationSepaDebitDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for UpdatePaymentMethodConfigurationSepaDebitDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentMethodConfigurationSepaDebitDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -6263,14 +6263,14 @@ impl UpdatePaymentMethodConfigurationSofortDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for UpdatePaymentMethodConfigurationSofortDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentMethodConfigurationSofortDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -6350,14 +6350,14 @@ impl UpdatePaymentMethodConfigurationUsBankAccountDisplayPreferencePreference {
 impl std::str::FromStr
     for UpdatePaymentMethodConfigurationUsBankAccountDisplayPreferencePreference
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentMethodConfigurationUsBankAccountDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -6438,14 +6438,14 @@ impl UpdatePaymentMethodConfigurationWechatPayDisplayPreferencePreference {
 }
 
 impl std::str::FromStr for UpdatePaymentMethodConfigurationWechatPayDisplayPreferencePreference {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdatePaymentMethodConfigurationWechatPayDisplayPreferencePreference::*;
         match s {
             "none" => Ok(None),
             "off" => Ok(Off),
             "on" => Ok(On),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_payment/src/payment_method_domain_resource_payment_method_status.rs
+++ b/generated/stripe_payment/src/payment_method_domain_resource_payment_method_status.rs
@@ -115,13 +115,13 @@ impl PaymentMethodDomainResourcePaymentMethodStatusStatus {
 }
 
 impl std::str::FromStr for PaymentMethodDomainResourcePaymentMethodStatusStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodDomainResourcePaymentMethodStatusStatus::*;
         match s {
             "active" => Ok(Active),
             "inactive" => Ok(Inactive),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_payment/src/source/requests.rs
+++ b/generated/stripe_payment/src/source/requests.rs
@@ -264,7 +264,7 @@ impl CreateSourceFlow {
 }
 
 impl std::str::FromStr for CreateSourceFlow {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSourceFlow::*;
         match s {
@@ -272,7 +272,7 @@ impl std::str::FromStr for CreateSourceFlow {
             "none" => Ok(None),
             "receiver" => Ok(Receiver),
             "redirect" => Ok(Redirect),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -393,7 +393,7 @@ impl CreateSourceMandateAcceptanceStatus {
 }
 
 impl std::str::FromStr for CreateSourceMandateAcceptanceStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSourceMandateAcceptanceStatus::*;
         match s {
@@ -401,7 +401,7 @@ impl std::str::FromStr for CreateSourceMandateAcceptanceStatus {
             "pending" => Ok(Pending),
             "refused" => Ok(Refused),
             "revoked" => Ok(Revoked),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -451,13 +451,13 @@ impl CreateSourceMandateAcceptanceType {
 }
 
 impl std::str::FromStr for CreateSourceMandateAcceptanceType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSourceMandateAcceptanceType::*;
         match s {
             "offline" => Ok(Offline),
             "online" => Ok(Online),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -510,14 +510,14 @@ impl CreateSourceMandateInterval {
 }
 
 impl std::str::FromStr for CreateSourceMandateInterval {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSourceMandateInterval::*;
         match s {
             "one_time" => Ok(OneTime),
             "scheduled" => Ok(Scheduled),
             "variable" => Ok(Variable),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -573,7 +573,7 @@ impl CreateSourceMandateNotificationMethod {
 }
 
 impl std::str::FromStr for CreateSourceMandateNotificationMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSourceMandateNotificationMethod::*;
         match s {
@@ -582,7 +582,7 @@ impl std::str::FromStr for CreateSourceMandateNotificationMethod {
             "manual" => Ok(Manual),
             "none" => Ok(None),
             "stripe_email" => Ok(StripeEmail),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -651,14 +651,14 @@ impl CreateSourceReceiverRefundAttributesMethod {
 }
 
 impl std::str::FromStr for CreateSourceReceiverRefundAttributesMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSourceReceiverRefundAttributesMethod::*;
         match s {
             "email" => Ok(Email),
             "manual" => Ok(Manual),
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -766,7 +766,7 @@ impl CreateSourceSourceOrderItemsType {
 }
 
 impl std::str::FromStr for CreateSourceSourceOrderItemsType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSourceSourceOrderItemsType::*;
         match s {
@@ -774,7 +774,7 @@ impl std::str::FromStr for CreateSourceSourceOrderItemsType {
             "shipping" => Ok(Shipping),
             "sku" => Ok(Sku),
             "tax" => Ok(Tax),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -823,13 +823,13 @@ impl CreateSourceUsage {
 }
 
 impl std::str::FromStr for CreateSourceUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateSourceUsage::*;
         match s {
             "reusable" => Ok(Reusable),
             "single_use" => Ok(SingleUse),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -986,7 +986,7 @@ impl UpdateSourceMandateAcceptanceStatus {
 }
 
 impl std::str::FromStr for UpdateSourceMandateAcceptanceStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSourceMandateAcceptanceStatus::*;
         match s {
@@ -994,7 +994,7 @@ impl std::str::FromStr for UpdateSourceMandateAcceptanceStatus {
             "pending" => Ok(Pending),
             "refused" => Ok(Refused),
             "revoked" => Ok(Revoked),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1044,13 +1044,13 @@ impl UpdateSourceMandateAcceptanceType {
 }
 
 impl std::str::FromStr for UpdateSourceMandateAcceptanceType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSourceMandateAcceptanceType::*;
         match s {
             "offline" => Ok(Offline),
             "online" => Ok(Online),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1103,14 +1103,14 @@ impl UpdateSourceMandateInterval {
 }
 
 impl std::str::FromStr for UpdateSourceMandateInterval {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSourceMandateInterval::*;
         match s {
             "one_time" => Ok(OneTime),
             "scheduled" => Ok(Scheduled),
             "variable" => Ok(Variable),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1166,7 +1166,7 @@ impl UpdateSourceMandateNotificationMethod {
 }
 
 impl std::str::FromStr for UpdateSourceMandateNotificationMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSourceMandateNotificationMethod::*;
         match s {
@@ -1175,7 +1175,7 @@ impl std::str::FromStr for UpdateSourceMandateNotificationMethod {
             "manual" => Ok(Manual),
             "none" => Ok(None),
             "stripe_email" => Ok(StripeEmail),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1270,7 +1270,7 @@ impl UpdateSourceSourceOrderItemsType {
 }
 
 impl std::str::FromStr for UpdateSourceSourceOrderItemsType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateSourceSourceOrderItemsType::*;
         match s {
@@ -1278,7 +1278,7 @@ impl std::str::FromStr for UpdateSourceSourceOrderItemsType {
             "shipping" => Ok(Shipping),
             "sku" => Ok(Sku),
             "tax" => Ok(Tax),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_product/src/price/requests.rs
+++ b/generated/stripe_product/src/price/requests.rs
@@ -82,7 +82,7 @@ impl ListPriceRecurringInterval {
 }
 
 impl std::str::FromStr for ListPriceRecurringInterval {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ListPriceRecurringInterval::*;
         match s {
@@ -90,7 +90,7 @@ impl std::str::FromStr for ListPriceRecurringInterval {
             "month" => Ok(Month),
             "week" => Ok(Week),
             "year" => Ok(Year),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -139,13 +139,13 @@ impl ListPriceRecurringUsageType {
 }
 
 impl std::str::FromStr for ListPriceRecurringUsageType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ListPriceRecurringUsageType::*;
         match s {
             "licensed" => Ok(Licensed),
             "metered" => Ok(Metered),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -533,7 +533,7 @@ impl CreatePriceRecurringAggregateUsage {
 }
 
 impl std::str::FromStr for CreatePriceRecurringAggregateUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePriceRecurringAggregateUsage::*;
         match s {
@@ -541,7 +541,7 @@ impl std::str::FromStr for CreatePriceRecurringAggregateUsage {
             "last_ever" => Ok(LastEver),
             "max" => Ok(Max),
             "sum" => Ok(Sum),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -595,7 +595,7 @@ impl CreatePriceRecurringInterval {
 }
 
 impl std::str::FromStr for CreatePriceRecurringInterval {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePriceRecurringInterval::*;
         match s {
@@ -603,7 +603,7 @@ impl std::str::FromStr for CreatePriceRecurringInterval {
             "month" => Ok(Month),
             "week" => Ok(Week),
             "year" => Ok(Year),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -656,13 +656,13 @@ impl CreatePriceRecurringUsageType {
 }
 
 impl std::str::FromStr for CreatePriceRecurringUsageType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePriceRecurringUsageType::*;
         match s {
             "licensed" => Ok(Licensed),
             "metered" => Ok(Metered),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -770,13 +770,13 @@ impl CreatePriceTransformQuantityRound {
 }
 
 impl std::str::FromStr for CreatePriceTransformQuantityRound {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreatePriceTransformQuantityRound::*;
         match s {
             "down" => Ok(Down),
             "up" => Ok(Up),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_product/src/product/requests.rs
+++ b/generated/stripe_product/src/product/requests.rs
@@ -349,14 +349,14 @@ impl CreateProductDefaultPriceDataCurrencyOptionsTaxBehavior {
 }
 
 impl std::str::FromStr for CreateProductDefaultPriceDataCurrencyOptionsTaxBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateProductDefaultPriceDataCurrencyOptionsTaxBehavior::*;
         match s {
             "exclusive" => Ok(Exclusive),
             "inclusive" => Ok(Inclusive),
             "unspecified" => Ok(Unspecified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -472,7 +472,7 @@ impl CreateProductDefaultPriceDataRecurringInterval {
 }
 
 impl std::str::FromStr for CreateProductDefaultPriceDataRecurringInterval {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateProductDefaultPriceDataRecurringInterval::*;
         match s {
@@ -480,7 +480,7 @@ impl std::str::FromStr for CreateProductDefaultPriceDataRecurringInterval {
             "month" => Ok(Month),
             "week" => Ok(Week),
             "year" => Ok(Year),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -537,14 +537,14 @@ impl CreateProductDefaultPriceDataTaxBehavior {
 }
 
 impl std::str::FromStr for CreateProductDefaultPriceDataTaxBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateProductDefaultPriceDataTaxBehavior::*;
         match s {
             "exclusive" => Ok(Exclusive),
             "inclusive" => Ok(Inclusive),
             "unspecified" => Ok(Unspecified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_product/src/shipping_rate/requests.rs
+++ b/generated/stripe_product/src/shipping_rate/requests.rs
@@ -168,7 +168,7 @@ impl CreateShippingRateDeliveryEstimateMaximumUnit {
 }
 
 impl std::str::FromStr for CreateShippingRateDeliveryEstimateMaximumUnit {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateShippingRateDeliveryEstimateMaximumUnit::*;
         match s {
@@ -177,7 +177,7 @@ impl std::str::FromStr for CreateShippingRateDeliveryEstimateMaximumUnit {
             "hour" => Ok(Hour),
             "month" => Ok(Month),
             "week" => Ok(Week),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -248,7 +248,7 @@ impl CreateShippingRateDeliveryEstimateMinimumUnit {
 }
 
 impl std::str::FromStr for CreateShippingRateDeliveryEstimateMinimumUnit {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateShippingRateDeliveryEstimateMinimumUnit::*;
         match s {
@@ -257,7 +257,7 @@ impl std::str::FromStr for CreateShippingRateDeliveryEstimateMinimumUnit {
             "hour" => Ok(Hour),
             "month" => Ok(Month),
             "week" => Ok(Week),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/account.rs
+++ b/generated/stripe_shared/src/account.rs
@@ -303,7 +303,7 @@ impl AccountBusinessType {
 }
 
 impl std::str::FromStr for AccountBusinessType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use AccountBusinessType::*;
         match s {
@@ -311,7 +311,7 @@ impl std::str::FromStr for AccountBusinessType {
             "government_entity" => Ok(GovernmentEntity),
             "individual" => Ok(Individual),
             "non_profit" => Ok(NonProfit),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -376,14 +376,14 @@ impl AccountType {
 }
 
 impl std::str::FromStr for AccountType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use AccountType::*;
         match s {
             "custom" => Ok(Custom),
             "express" => Ok(Express),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/account_capabilities.rs
+++ b/generated/stripe_shared/src/account_capabilities.rs
@@ -410,14 +410,14 @@ impl AccountCapabilitiesStatus {
 }
 
 impl std::str::FromStr for AccountCapabilitiesStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use AccountCapabilitiesStatus::*;
         match s {
             "active" => Ok(Active),
             "inactive" => Ok(Inactive),
             "pending" => Ok(Pending),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/account_requirements_error.rs
+++ b/generated/stripe_shared/src/account_requirements_error.rs
@@ -332,7 +332,7 @@ impl AccountRequirementsErrorCode {
 }
 
 impl std::str::FromStr for AccountRequirementsErrorCode {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use AccountRequirementsErrorCode::*;
         match s {
@@ -457,7 +457,7 @@ impl std::str::FromStr for AccountRequirementsErrorCode {
             "verification_requires_additional_memorandum_of_associations" => {
                 Ok(VerificationRequiresAdditionalMemorandumOfAssociations)
             }
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -490,10 +490,7 @@ impl miniserde::Deserialize for AccountRequirementsErrorCode {
 impl miniserde::de::Visitor for crate::Place<AccountRequirementsErrorCode> {
     fn string(&mut self, s: &str) -> miniserde::Result<()> {
         use std::str::FromStr;
-        self.out = Some(
-            AccountRequirementsErrorCode::from_str(s)
-                .unwrap_or(AccountRequirementsErrorCode::Unknown),
-        );
+        self.out = Some(AccountRequirementsErrorCode::from_str(s).unwrap());
         Ok(())
     }
 }
@@ -504,6 +501,6 @@ impl<'de> serde::Deserialize<'de> for AccountRequirementsErrorCode {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }

--- a/generated/stripe_shared/src/account_unification_account_controller.rs
+++ b/generated/stripe_shared/src/account_unification_account_controller.rs
@@ -117,13 +117,13 @@ impl AccountUnificationAccountControllerType {
 }
 
 impl std::str::FromStr for AccountUnificationAccountControllerType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use AccountUnificationAccountControllerType::*;
         match s {
             "account" => Ok(Account),
             "application" => Ok(Application),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/api_errors.rs
+++ b/generated/stripe_shared/src/api_errors.rs
@@ -544,7 +544,7 @@ impl ApiErrorsCode {
 }
 
 impl std::str::FromStr for ApiErrorsCode {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ApiErrorsCode::*;
         match s {
@@ -737,7 +737,7 @@ impl std::str::FromStr for ApiErrorsCode {
             }
             "transfers_not_allowed" => Ok(TransfersNotAllowed),
             "url_invalid" => Ok(UrlInvalid),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -770,7 +770,7 @@ impl miniserde::Deserialize for ApiErrorsCode {
 impl miniserde::de::Visitor for crate::Place<ApiErrorsCode> {
     fn string(&mut self, s: &str) -> miniserde::Result<()> {
         use std::str::FromStr;
-        self.out = Some(ApiErrorsCode::from_str(s).unwrap_or(ApiErrorsCode::Unknown));
+        self.out = Some(ApiErrorsCode::from_str(s).unwrap());
         Ok(())
     }
 }
@@ -781,7 +781,7 @@ impl<'de> serde::Deserialize<'de> for ApiErrorsCode {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// The type of error returned.
@@ -806,7 +806,7 @@ impl ApiErrorsType {
 }
 
 impl std::str::FromStr for ApiErrorsType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ApiErrorsType::*;
         match s {
@@ -814,7 +814,7 @@ impl std::str::FromStr for ApiErrorsType {
             "card_error" => Ok(CardError),
             "idempotency_error" => Ok(IdempotencyError),
             "invalid_request_error" => Ok(InvalidRequestError),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/api_version.rs
+++ b/generated/stripe_shared/src/api_version.rs
@@ -214,7 +214,7 @@ impl ApiVersion {
 }
 
 impl std::str::FromStr for ApiVersion {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ApiVersion::*;
         match s {
@@ -318,7 +318,7 @@ impl std::str::FromStr for ApiVersion {
             "2022-11-15" => Ok(V2022_11_15),
             "2023-08-16" => Ok(V2023_08_16),
             "2023-10-16" => Ok(V2023_10_16),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -350,7 +350,7 @@ impl miniserde::Deserialize for ApiVersion {
 impl miniserde::de::Visitor for crate::Place<ApiVersion> {
     fn string(&mut self, s: &str) -> miniserde::Result<()> {
         use std::str::FromStr;
-        self.out = Some(ApiVersion::from_str(s).unwrap_or(ApiVersion::Unknown));
+        self.out = Some(ApiVersion::from_str(s).unwrap());
         Ok(())
     }
 }
@@ -361,6 +361,6 @@ impl<'de> serde::Deserialize<'de> for ApiVersion {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }

--- a/generated/stripe_shared/src/automatic_tax.rs
+++ b/generated/stripe_shared/src/automatic_tax.rs
@@ -131,14 +131,14 @@ impl AutomaticTaxStatus {
 }
 
 impl std::str::FromStr for AutomaticTaxStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use AutomaticTaxStatus::*;
         match s {
             "complete" => Ok(Complete),
             "failed" => Ok(Failed),
             "requires_location_inputs" => Ok(RequiresLocationInputs),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/balance_transaction.rs
+++ b/generated/stripe_shared/src/balance_transaction.rs
@@ -327,7 +327,7 @@ impl BalanceTransactionType {
 }
 
 impl std::str::FromStr for BalanceTransactionType {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use BalanceTransactionType::*;
         match s {
@@ -371,7 +371,7 @@ impl std::str::FromStr for BalanceTransactionType {
             "transfer_cancel" => Ok(TransferCancel),
             "transfer_failure" => Ok(TransferFailure),
             "transfer_refund" => Ok(TransferRefund),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -404,8 +404,7 @@ impl miniserde::Deserialize for BalanceTransactionType {
 impl miniserde::de::Visitor for crate::Place<BalanceTransactionType> {
     fn string(&mut self, s: &str) -> miniserde::Result<()> {
         use std::str::FromStr;
-        self.out =
-            Some(BalanceTransactionType::from_str(s).unwrap_or(BalanceTransactionType::Unknown));
+        self.out = Some(BalanceTransactionType::from_str(s).unwrap());
         Ok(())
     }
 }
@@ -416,7 +415,7 @@ impl<'de> serde::Deserialize<'de> for BalanceTransactionType {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 impl stripe_types::Object for BalanceTransaction {

--- a/generated/stripe_shared/src/bank_account.rs
+++ b/generated/stripe_shared/src/bank_account.rs
@@ -295,13 +295,13 @@ impl BankAccountAvailablePayoutMethods {
 }
 
 impl std::str::FromStr for BankAccountAvailablePayoutMethods {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use BankAccountAvailablePayoutMethods::*;
         match s {
             "instant" => Ok(Instant),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/cancellation_details.rs
+++ b/generated/stripe_shared/src/cancellation_details.rs
@@ -138,7 +138,7 @@ impl CancellationDetailsFeedback {
 }
 
 impl std::str::FromStr for CancellationDetailsFeedback {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CancellationDetailsFeedback::*;
         match s {
@@ -150,7 +150,7 @@ impl std::str::FromStr for CancellationDetailsFeedback {
             "too_complex" => Ok(TooComplex),
             "too_expensive" => Ok(TooExpensive),
             "unused" => Ok(Unused),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -217,14 +217,14 @@ impl CancellationDetailsReason {
 }
 
 impl std::str::FromStr for CancellationDetailsReason {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CancellationDetailsReason::*;
         match s {
             "cancellation_requested" => Ok(CancellationRequested),
             "payment_disputed" => Ok(PaymentDisputed),
             "payment_failed" => Ok(PaymentFailed),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/capability.rs
+++ b/generated/stripe_shared/src/capability.rs
@@ -181,7 +181,7 @@ impl CapabilityStatus {
 }
 
 impl std::str::FromStr for CapabilityStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CapabilityStatus::*;
         match s {
@@ -190,7 +190,7 @@ impl std::str::FromStr for CapabilityStatus {
             "inactive" => Ok(Inactive),
             "pending" => Ok(Pending),
             "unrequested" => Ok(Unrequested),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/card.rs
+++ b/generated/stripe_shared/src/card.rs
@@ -389,13 +389,13 @@ impl CardAvailablePayoutMethods {
 }
 
 impl std::str::FromStr for CardAvailablePayoutMethods {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CardAvailablePayoutMethods::*;
         match s {
             "instant" => Ok(Instant),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/charge.rs
+++ b/generated/stripe_shared/src/charge.rs
@@ -544,14 +544,14 @@ impl ChargeStatus {
 }
 
 impl std::str::FromStr for ChargeStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ChargeStatus::*;
         match s {
             "failed" => Ok(Failed),
             "pending" => Ok(Pending),
             "succeeded" => Ok(Succeeded),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/connect_account_reference.rs
+++ b/generated/stripe_shared/src/connect_account_reference.rs
@@ -114,13 +114,13 @@ impl ConnectAccountReferenceType {
 }
 
 impl std::str::FromStr for ConnectAccountReferenceType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ConnectAccountReferenceType::*;
         match s {
             "account" => Ok(Account),
             "self" => Ok(Self_),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/coupon.rs
+++ b/generated/stripe_shared/src/coupon.rs
@@ -266,14 +266,14 @@ impl CouponDuration {
 }
 
 impl std::str::FromStr for CouponDuration {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CouponDuration::*;
         match s {
             "forever" => Ok(Forever),
             "once" => Ok(Once),
             "repeating" => Ok(Repeating),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/credit_note.rs
+++ b/generated/stripe_shared/src/credit_note.rs
@@ -372,13 +372,13 @@ impl CreditNoteStatus {
 }
 
 impl std::str::FromStr for CreditNoteStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreditNoteStatus::*;
         match s {
             "issued" => Ok(Issued),
             "void" => Ok(Void),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -445,13 +445,13 @@ impl CreditNoteType {
 }
 
 impl std::str::FromStr for CreditNoteType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreditNoteType::*;
         match s {
             "post_payment" => Ok(PostPayment),
             "pre_payment" => Ok(PrePayment),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -525,7 +525,7 @@ impl CreditNoteReason {
 }
 
 impl std::str::FromStr for CreditNoteReason {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreditNoteReason::*;
         match s {
@@ -533,7 +533,7 @@ impl std::str::FromStr for CreditNoteReason {
             "fraudulent" => Ok(Fraudulent),
             "order_change" => Ok(OrderChange),
             "product_unsatisfactory" => Ok(ProductUnsatisfactory),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/credit_note_line_item.rs
+++ b/generated/stripe_shared/src/credit_note_line_item.rs
@@ -248,13 +248,13 @@ impl CreditNoteLineItemType {
 }
 
 impl std::str::FromStr for CreditNoteLineItemType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreditNoteLineItemType::*;
         match s {
             "custom_line_item" => Ok(CustomLineItem),
             "invoice_line_item" => Ok(InvoiceLineItem),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/credit_note_tax_amount.rs
+++ b/generated/stripe_shared/src/credit_note_tax_amount.rs
@@ -172,7 +172,7 @@ impl CreditNoteTaxAmountTaxabilityReason {
 }
 
 impl std::str::FromStr for CreditNoteTaxAmountTaxabilityReason {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreditNoteTaxAmountTaxabilityReason::*;
         match s {
@@ -191,7 +191,7 @@ impl std::str::FromStr for CreditNoteTaxAmountTaxabilityReason {
             "standard_rated" => Ok(StandardRated),
             "taxable_basis_reduced" => Ok(TaxableBasisReduced),
             "zero_rated" => Ok(ZeroRated),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -224,10 +224,7 @@ impl miniserde::Deserialize for CreditNoteTaxAmountTaxabilityReason {
 impl miniserde::de::Visitor for crate::Place<CreditNoteTaxAmountTaxabilityReason> {
     fn string(&mut self, s: &str) -> miniserde::Result<()> {
         use std::str::FromStr;
-        self.out = Some(
-            CreditNoteTaxAmountTaxabilityReason::from_str(s)
-                .unwrap_or(CreditNoteTaxAmountTaxabilityReason::Unknown),
-        );
+        self.out = Some(CreditNoteTaxAmountTaxabilityReason::from_str(s).unwrap());
         Ok(())
     }
 }
@@ -238,6 +235,6 @@ impl<'de> serde::Deserialize<'de> for CreditNoteTaxAmountTaxabilityReason {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }

--- a/generated/stripe_shared/src/currency_option.rs
+++ b/generated/stripe_shared/src/currency_option.rs
@@ -156,14 +156,14 @@ impl CurrencyOptionTaxBehavior {
 }
 
 impl std::str::FromStr for CurrencyOptionTaxBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CurrencyOptionTaxBehavior::*;
         match s {
             "exclusive" => Ok(Exclusive),
             "inclusive" => Ok(Inclusive),
             "unspecified" => Ok(Unspecified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/customer.rs
+++ b/generated/stripe_shared/src/customer.rs
@@ -366,14 +366,14 @@ impl CustomerTaxExempt {
 }
 
 impl std::str::FromStr for CustomerTaxExempt {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CustomerTaxExempt::*;
         match s {
             "exempt" => Ok(Exempt),
             "none" => Ok(None),
             "reverse" => Ok(Reverse),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/customer_acceptance.rs
+++ b/generated/stripe_shared/src/customer_acceptance.rs
@@ -132,13 +132,13 @@ impl CustomerAcceptanceType {
 }
 
 impl std::str::FromStr for CustomerAcceptanceType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CustomerAcceptanceType::*;
         match s {
             "offline" => Ok(Offline),
             "online" => Ok(Online),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/customer_balance_customer_balance_settings.rs
+++ b/generated/stripe_shared/src/customer_balance_customer_balance_settings.rs
@@ -123,13 +123,13 @@ impl CustomerBalanceCustomerBalanceSettingsReconciliationMode {
 }
 
 impl std::str::FromStr for CustomerBalanceCustomerBalanceSettingsReconciliationMode {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CustomerBalanceCustomerBalanceSettingsReconciliationMode::*;
         match s {
             "automatic" => Ok(Automatic),
             "manual" => Ok(Manual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/customer_balance_resource_cash_balance_transaction_resource_funded_transaction_resource_bank_transfer.rs
+++ b/generated/stripe_shared/src/customer_balance_resource_cash_balance_transaction_resource_funded_transaction_resource_bank_transfer.rs
@@ -157,7 +157,7 @@ impl
 }
 
 impl std::str::FromStr for CustomerBalanceResourceCashBalanceTransactionResourceFundedTransactionResourceBankTransferType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CustomerBalanceResourceCashBalanceTransactionResourceFundedTransactionResourceBankTransferType::*;
         match s {
@@ -166,7 +166,7 @@ impl std::str::FromStr for CustomerBalanceResourceCashBalanceTransactionResource
 "jp_bank_transfer" => Ok(JpBankTransfer),
 "mx_bank_transfer" => Ok(MxBankTransfer),
 "us_bank_transfer" => Ok(UsBankTransfer),
-_ => Err(())
+_ => Err(stripe_types::StripeParseError)
 
         }
     }

--- a/generated/stripe_shared/src/customer_balance_resource_cash_balance_transaction_resource_funded_transaction_resource_bank_transfer_resource_us_bank_transfer.rs
+++ b/generated/stripe_shared/src/customer_balance_resource_cash_balance_transaction_resource_funded_transaction_resource_bank_transfer_resource_us_bank_transfer.rs
@@ -125,14 +125,14 @@ Swift => "swift",
 }
 
 impl std::str::FromStr for CustomerBalanceResourceCashBalanceTransactionResourceFundedTransactionResourceBankTransferResourceUsBankTransferNetwork {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CustomerBalanceResourceCashBalanceTransactionResourceFundedTransactionResourceBankTransferResourceUsBankTransferNetwork::*;
         match s {
     "ach" => Ok(Ach),
 "domestic_wire_us" => Ok(DomesticWireUs),
 "swift" => Ok(Swift),
-_ => Err(())
+_ => Err(stripe_types::StripeParseError)
 
         }
     }

--- a/generated/stripe_shared/src/customer_balance_transaction.rs
+++ b/generated/stripe_shared/src/customer_balance_transaction.rs
@@ -242,7 +242,7 @@ impl CustomerBalanceTransactionType {
 }
 
 impl std::str::FromStr for CustomerBalanceTransactionType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CustomerBalanceTransactionType::*;
         match s {
@@ -256,7 +256,7 @@ impl std::str::FromStr for CustomerBalanceTransactionType {
             "migration" => Ok(Migration),
             "unapplied_from_invoice" => Ok(UnappliedFromInvoice),
             "unspent_receiver_credit" => Ok(UnspentReceiverCredit),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/customer_cash_balance_transaction.rs
+++ b/generated/stripe_shared/src/customer_cash_balance_transaction.rs
@@ -262,7 +262,7 @@ impl CustomerCashBalanceTransactionType {
 }
 
 impl std::str::FromStr for CustomerCashBalanceTransactionType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CustomerCashBalanceTransactionType::*;
         match s {
@@ -275,7 +275,7 @@ impl std::str::FromStr for CustomerCashBalanceTransactionType {
             "return_initiated" => Ok(ReturnInitiated),
             "transferred_to_balance" => Ok(TransferredToBalance),
             "unapplied_from_payment" => Ok(UnappliedFromPayment),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/customer_tax.rs
+++ b/generated/stripe_shared/src/customer_tax.rs
@@ -130,7 +130,7 @@ impl CustomerTaxAutomaticTax {
 }
 
 impl std::str::FromStr for CustomerTaxAutomaticTax {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CustomerTaxAutomaticTax::*;
         match s {
@@ -138,7 +138,7 @@ impl std::str::FromStr for CustomerTaxAutomaticTax {
             "not_collecting" => Ok(NotCollecting),
             "supported" => Ok(Supported),
             "unrecognized_location" => Ok(UnrecognizedLocation),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/customer_tax_location.rs
+++ b/generated/stripe_shared/src/customer_tax_location.rs
@@ -130,7 +130,7 @@ impl CustomerTaxLocationSource {
 }
 
 impl std::str::FromStr for CustomerTaxLocationSource {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CustomerTaxLocationSource::*;
         match s {
@@ -138,7 +138,7 @@ impl std::str::FromStr for CustomerTaxLocationSource {
             "ip_address" => Ok(IpAddress),
             "payment_method" => Ok(PaymentMethod),
             "shipping_destination" => Ok(ShippingDestination),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/dispute.rs
+++ b/generated/stripe_shared/src/dispute.rs
@@ -269,7 +269,7 @@ impl DisputeStatus {
 }
 
 impl std::str::FromStr for DisputeStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use DisputeStatus::*;
         match s {
@@ -280,7 +280,7 @@ impl std::str::FromStr for DisputeStatus {
             "warning_needs_response" => Ok(WarningNeedsResponse),
             "warning_under_review" => Ok(WarningUnderReview),
             "won" => Ok(Won),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/dispute_payment_method_details.rs
+++ b/generated/stripe_shared/src/dispute_payment_method_details.rs
@@ -112,12 +112,12 @@ impl DisputePaymentMethodDetailsType {
 }
 
 impl std::str::FromStr for DisputePaymentMethodDetailsType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use DisputePaymentMethodDetailsType::*;
         match s {
             "card" => Ok(Card),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/event.rs
+++ b/generated/stripe_shared/src/event.rs
@@ -684,7 +684,7 @@ impl EventType {
 }
 
 impl std::str::FromStr for EventType {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use EventType::*;
         match s {
@@ -939,7 +939,7 @@ impl std::str::FromStr for EventType {
             "treasury.received_credit.failed" => Ok(TreasuryReceivedCreditFailed),
             "treasury.received_credit.succeeded" => Ok(TreasuryReceivedCreditSucceeded),
             "treasury.received_debit.created" => Ok(TreasuryReceivedDebitCreated),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -972,7 +972,7 @@ impl miniserde::Deserialize for EventType {
 impl miniserde::de::Visitor for crate::Place<EventType> {
     fn string(&mut self, s: &str) -> miniserde::Result<()> {
         use std::str::FromStr;
-        self.out = Some(EventType::from_str(s).unwrap_or(EventType::Unknown));
+        self.out = Some(EventType::from_str(s).unwrap());
         Ok(())
     }
 }
@@ -983,7 +983,7 @@ impl<'de> serde::Deserialize<'de> for EventType {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 impl stripe_types::Object for Event {

--- a/generated/stripe_shared/src/file.rs
+++ b/generated/stripe_shared/src/file.rs
@@ -237,7 +237,7 @@ impl FilePurpose {
 }
 
 impl std::str::FromStr for FilePurpose {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use FilePurpose::*;
         match s {
@@ -256,7 +256,7 @@ impl std::str::FromStr for FilePurpose {
             "sigma_scheduled_query" => Ok(SigmaScheduledQuery),
             "tax_document_user_upload" => Ok(TaxDocumentUserUpload),
             "terminal_reader_splashscreen" => Ok(TerminalReaderSplashscreen),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -288,7 +288,7 @@ impl miniserde::Deserialize for FilePurpose {
 impl miniserde::de::Visitor for crate::Place<FilePurpose> {
     fn string(&mut self, s: &str) -> miniserde::Result<()> {
         use std::str::FromStr;
-        self.out = Some(FilePurpose::from_str(s).unwrap_or(FilePurpose::Unknown));
+        self.out = Some(FilePurpose::from_str(s).unwrap());
         Ok(())
     }
 }
@@ -299,6 +299,6 @@ impl<'de> serde::Deserialize<'de> for FilePurpose {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }

--- a/generated/stripe_shared/src/funding_instructions.rs
+++ b/generated/stripe_shared/src/funding_instructions.rs
@@ -149,12 +149,12 @@ impl FundingInstructionsFundingType {
 }
 
 impl std::str::FromStr for FundingInstructionsFundingType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use FundingInstructionsFundingType::*;
         match s {
             "bank_transfer" => Ok(BankTransfer),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/funding_instructions_bank_transfer.rs
+++ b/generated/stripe_shared/src/funding_instructions_bank_transfer.rs
@@ -130,13 +130,13 @@ impl FundingInstructionsBankTransferType {
 }
 
 impl std::str::FromStr for FundingInstructionsBankTransferType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use FundingInstructionsBankTransferType::*;
         match s {
             "eu_bank_transfer" => Ok(EuBankTransfer),
             "jp_bank_transfer" => Ok(JpBankTransfer),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/funding_instructions_bank_transfer_financial_address.rs
+++ b/generated/stripe_shared/src/funding_instructions_bank_transfer_financial_address.rs
@@ -173,7 +173,7 @@ impl FundingInstructionsBankTransferFinancialAddressSupportedNetworks {
 }
 
 impl std::str::FromStr for FundingInstructionsBankTransferFinancialAddressSupportedNetworks {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use FundingInstructionsBankTransferFinancialAddressSupportedNetworks::*;
         match s {
@@ -185,7 +185,7 @@ impl std::str::FromStr for FundingInstructionsBankTransferFinancialAddressSuppor
             "spei" => Ok(Spei),
             "swift" => Ok(Swift),
             "zengin" => Ok(Zengin),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -266,7 +266,7 @@ impl FundingInstructionsBankTransferFinancialAddressType {
 }
 
 impl std::str::FromStr for FundingInstructionsBankTransferFinancialAddressType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use FundingInstructionsBankTransferFinancialAddressType::*;
         match s {
@@ -276,7 +276,7 @@ impl std::str::FromStr for FundingInstructionsBankTransferFinancialAddressType {
             "spei" => Ok(Spei),
             "swift" => Ok(Swift),
             "zengin" => Ok(Zengin),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/invoice.rs
+++ b/generated/stripe_shared/src/invoice.rs
@@ -935,7 +935,7 @@ impl InvoiceBillingReason {
 }
 
 impl std::str::FromStr for InvoiceBillingReason {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use InvoiceBillingReason::*;
         match s {
@@ -948,7 +948,7 @@ impl std::str::FromStr for InvoiceBillingReason {
             "subscription_threshold" => Ok(SubscriptionThreshold),
             "subscription_update" => Ok(SubscriptionUpdate),
             "upcoming" => Ok(Upcoming),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1017,14 +1017,14 @@ impl InvoiceCustomerTaxExempt {
 }
 
 impl std::str::FromStr for InvoiceCustomerTaxExempt {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use InvoiceCustomerTaxExempt::*;
         match s {
             "exempt" => Ok(Exempt),
             "none" => Ok(None),
             "reverse" => Ok(Reverse),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1095,13 +1095,13 @@ impl InvoiceCollectionMethod {
 }
 
 impl std::str::FromStr for InvoiceCollectionMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use InvoiceCollectionMethod::*;
         match s {
             "charge_automatically" => Ok(ChargeAutomatically),
             "send_invoice" => Ok(SendInvoice),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -1170,7 +1170,7 @@ impl InvoiceStatus {
 }
 
 impl std::str::FromStr for InvoiceStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use InvoiceStatus::*;
         match s {
@@ -1179,7 +1179,7 @@ impl std::str::FromStr for InvoiceStatus {
             "paid" => Ok(Paid),
             "uncollectible" => Ok(Uncollectible),
             "void" => Ok(Void),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/invoice_line_item.rs
+++ b/generated/stripe_shared/src/invoice_line_item.rs
@@ -310,13 +310,13 @@ impl InvoiceLineItemType {
 }
 
 impl std::str::FromStr for InvoiceLineItemType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use InvoiceLineItemType::*;
         match s {
             "invoiceitem" => Ok(Invoiceitem),
             "subscription" => Ok(Subscription),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/invoice_mandate_options_card.rs
+++ b/generated/stripe_shared/src/invoice_mandate_options_card.rs
@@ -130,13 +130,13 @@ impl InvoiceMandateOptionsCardAmountType {
 }
 
 impl std::str::FromStr for InvoiceMandateOptionsCardAmountType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use InvoiceMandateOptionsCardAmountType::*;
         match s {
             "fixed" => Ok(Fixed),
             "maximum" => Ok(Maximum),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/invoice_payment_method_options_acss_debit.rs
+++ b/generated/stripe_shared/src/invoice_payment_method_options_acss_debit.rs
@@ -123,14 +123,14 @@ impl InvoicePaymentMethodOptionsAcssDebitVerificationMethod {
 }
 
 impl std::str::FromStr for InvoicePaymentMethodOptionsAcssDebitVerificationMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use InvoicePaymentMethodOptionsAcssDebitVerificationMethod::*;
         match s {
             "automatic" => Ok(Automatic),
             "instant" => Ok(Instant),
             "microdeposits" => Ok(Microdeposits),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/invoice_payment_method_options_acss_debit_mandate_options.rs
+++ b/generated/stripe_shared/src/invoice_payment_method_options_acss_debit_mandate_options.rs
@@ -109,13 +109,13 @@ impl InvoicePaymentMethodOptionsAcssDebitMandateOptionsTransactionType {
 }
 
 impl std::str::FromStr for InvoicePaymentMethodOptionsAcssDebitMandateOptionsTransactionType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use InvoicePaymentMethodOptionsAcssDebitMandateOptionsTransactionType::*;
         match s {
             "business" => Ok(Business),
             "personal" => Ok(Personal),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/invoice_payment_method_options_bancontact.rs
+++ b/generated/stripe_shared/src/invoice_payment_method_options_bancontact.rs
@@ -114,7 +114,7 @@ impl InvoicePaymentMethodOptionsBancontactPreferredLanguage {
 }
 
 impl std::str::FromStr for InvoicePaymentMethodOptionsBancontactPreferredLanguage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use InvoicePaymentMethodOptionsBancontactPreferredLanguage::*;
         match s {
@@ -122,7 +122,7 @@ impl std::str::FromStr for InvoicePaymentMethodOptionsBancontactPreferredLanguag
             "en" => Ok(En),
             "fr" => Ok(Fr),
             "nl" => Ok(Nl),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/invoice_payment_method_options_card.rs
+++ b/generated/stripe_shared/src/invoice_payment_method_options_card.rs
@@ -126,14 +126,14 @@ impl InvoicePaymentMethodOptionsCardRequestThreeDSecure {
 }
 
 impl std::str::FromStr for InvoicePaymentMethodOptionsCardRequestThreeDSecure {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use InvoicePaymentMethodOptionsCardRequestThreeDSecure::*;
         match s {
             "any" => Ok(Any),
             "automatic" => Ok(Automatic),
             "challenge" => Ok(Challenge),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/invoice_payment_method_options_customer_balance.rs
+++ b/generated/stripe_shared/src/invoice_payment_method_options_customer_balance.rs
@@ -117,12 +117,12 @@ impl InvoicePaymentMethodOptionsCustomerBalanceFundingType {
 }
 
 impl std::str::FromStr for InvoicePaymentMethodOptionsCustomerBalanceFundingType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use InvoicePaymentMethodOptionsCustomerBalanceFundingType::*;
         match s {
             "bank_transfer" => Ok(BankTransfer),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/invoice_payment_method_options_customer_balance_bank_transfer_eu_bank_transfer.rs
+++ b/generated/stripe_shared/src/invoice_payment_method_options_customer_balance_bank_transfer_eu_bank_transfer.rs
@@ -120,7 +120,7 @@ impl InvoicePaymentMethodOptionsCustomerBalanceBankTransferEuBankTransferCountry
 impl std::str::FromStr
     for InvoicePaymentMethodOptionsCustomerBalanceBankTransferEuBankTransferCountry
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use InvoicePaymentMethodOptionsCustomerBalanceBankTransferEuBankTransferCountry::*;
         match s {
@@ -130,7 +130,7 @@ impl std::str::FromStr
             "FR" => Ok(Fr),
             "IE" => Ok(Ie),
             "NL" => Ok(Nl),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/invoice_payment_method_options_us_bank_account.rs
+++ b/generated/stripe_shared/src/invoice_payment_method_options_us_bank_account.rs
@@ -126,14 +126,14 @@ impl InvoicePaymentMethodOptionsUsBankAccountVerificationMethod {
 }
 
 impl std::str::FromStr for InvoicePaymentMethodOptionsUsBankAccountVerificationMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use InvoicePaymentMethodOptionsUsBankAccountVerificationMethod::*;
         match s {
             "automatic" => Ok(Automatic),
             "instant" => Ok(Instant),
             "microdeposits" => Ok(Microdeposits),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/invoice_payment_method_options_us_bank_account_linked_account_options.rs
+++ b/generated/stripe_shared/src/invoice_payment_method_options_us_bank_account_linked_account_options.rs
@@ -124,14 +124,14 @@ impl InvoicePaymentMethodOptionsUsBankAccountLinkedAccountOptionsPermissions {
 }
 
 impl std::str::FromStr for InvoicePaymentMethodOptionsUsBankAccountLinkedAccountOptionsPermissions {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use InvoicePaymentMethodOptionsUsBankAccountLinkedAccountOptionsPermissions::*;
         match s {
             "balances" => Ok(Balances),
             "payment_method" => Ok(PaymentMethod),
             "transactions" => Ok(Transactions),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -206,13 +206,13 @@ impl InvoicePaymentMethodOptionsUsBankAccountLinkedAccountOptionsPrefetch {
 }
 
 impl std::str::FromStr for InvoicePaymentMethodOptionsUsBankAccountLinkedAccountOptionsPrefetch {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use InvoicePaymentMethodOptionsUsBankAccountLinkedAccountOptionsPrefetch::*;
         match s {
             "balances" => Ok(Balances),
             "transactions" => Ok(Transactions),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/invoice_rendering_pdf.rs
+++ b/generated/stripe_shared/src/invoice_rendering_pdf.rs
@@ -114,14 +114,14 @@ impl InvoiceRenderingPdfPageSize {
 }
 
 impl std::str::FromStr for InvoiceRenderingPdfPageSize {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use InvoiceRenderingPdfPageSize::*;
         match s {
             "a4" => Ok(A4),
             "auto" => Ok(Auto),
             "letter" => Ok(Letter),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/invoice_tax_amount.rs
+++ b/generated/stripe_shared/src/invoice_tax_amount.rs
@@ -172,7 +172,7 @@ impl InvoiceTaxAmountTaxabilityReason {
 }
 
 impl std::str::FromStr for InvoiceTaxAmountTaxabilityReason {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use InvoiceTaxAmountTaxabilityReason::*;
         match s {
@@ -191,7 +191,7 @@ impl std::str::FromStr for InvoiceTaxAmountTaxabilityReason {
             "standard_rated" => Ok(StandardRated),
             "taxable_basis_reduced" => Ok(TaxableBasisReduced),
             "zero_rated" => Ok(ZeroRated),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -224,10 +224,7 @@ impl miniserde::Deserialize for InvoiceTaxAmountTaxabilityReason {
 impl miniserde::de::Visitor for crate::Place<InvoiceTaxAmountTaxabilityReason> {
     fn string(&mut self, s: &str) -> miniserde::Result<()> {
         use std::str::FromStr;
-        self.out = Some(
-            InvoiceTaxAmountTaxabilityReason::from_str(s)
-                .unwrap_or(InvoiceTaxAmountTaxabilityReason::Unknown),
-        );
+        self.out = Some(InvoiceTaxAmountTaxabilityReason::from_str(s).unwrap());
         Ok(())
     }
 }
@@ -238,6 +235,6 @@ impl<'de> serde::Deserialize<'de> for InvoiceTaxAmountTaxabilityReason {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }

--- a/generated/stripe_shared/src/invoices_payment_settings.rs
+++ b/generated/stripe_shared/src/invoices_payment_settings.rs
@@ -187,7 +187,7 @@ impl InvoicesPaymentSettingsPaymentMethodTypes {
 }
 
 impl std::str::FromStr for InvoicesPaymentSettingsPaymentMethodTypes {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use InvoicesPaymentSettingsPaymentMethodTypes::*;
         match s {
@@ -217,7 +217,7 @@ impl std::str::FromStr for InvoicesPaymentSettingsPaymentMethodTypes {
             "sofort" => Ok(Sofort),
             "us_bank_account" => Ok(UsBankAccount),
             "wechat_pay" => Ok(WechatPay),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -250,10 +250,7 @@ impl miniserde::Deserialize for InvoicesPaymentSettingsPaymentMethodTypes {
 impl miniserde::de::Visitor for crate::Place<InvoicesPaymentSettingsPaymentMethodTypes> {
     fn string(&mut self, s: &str) -> miniserde::Result<()> {
         use std::str::FromStr;
-        self.out = Some(
-            InvoicesPaymentSettingsPaymentMethodTypes::from_str(s)
-                .unwrap_or(InvoicesPaymentSettingsPaymentMethodTypes::Unknown),
-        );
+        self.out = Some(InvoicesPaymentSettingsPaymentMethodTypes::from_str(s).unwrap());
         Ok(())
     }
 }
@@ -264,6 +261,6 @@ impl<'de> serde::Deserialize<'de> for InvoicesPaymentSettingsPaymentMethodTypes 
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }

--- a/generated/stripe_shared/src/invoices_resource_invoice_tax_id.rs
+++ b/generated/stripe_shared/src/invoices_resource_invoice_tax_id.rs
@@ -244,7 +244,7 @@ impl InvoicesResourceInvoiceTaxIdType {
 }
 
 impl std::str::FromStr for InvoicesResourceInvoiceTaxIdType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use InvoicesResourceInvoiceTaxIdType::*;
         match s {
@@ -315,7 +315,7 @@ impl std::str::FromStr for InvoicesResourceInvoiceTaxIdType {
             "ve_rif" => Ok(VeRif),
             "vn_tin" => Ok(VnTin),
             "za_vat" => Ok(ZaVat),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/issuing_authorization.rs
+++ b/generated/stripe_shared/src/issuing_authorization.rs
@@ -346,7 +346,7 @@ impl IssuingAuthorizationAuthorizationMethod {
 }
 
 impl std::str::FromStr for IssuingAuthorizationAuthorizationMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingAuthorizationAuthorizationMethod::*;
         match s {
@@ -355,7 +355,7 @@ impl std::str::FromStr for IssuingAuthorizationAuthorizationMethod {
             "keyed_in" => Ok(KeyedIn),
             "online" => Ok(Online),
             "swipe" => Ok(Swipe),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -423,14 +423,14 @@ impl IssuingAuthorizationStatus {
 }
 
 impl std::str::FromStr for IssuingAuthorizationStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingAuthorizationStatus::*;
         match s {
             "closed" => Ok(Closed),
             "pending" => Ok(Pending),
             "reversed" => Ok(Reversed),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/issuing_authorization_authentication_exemption.rs
+++ b/generated/stripe_shared/src/issuing_authorization_authentication_exemption.rs
@@ -114,13 +114,13 @@ impl IssuingAuthorizationAuthenticationExemptionClaimedBy {
 }
 
 impl std::str::FromStr for IssuingAuthorizationAuthenticationExemptionClaimedBy {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingAuthorizationAuthenticationExemptionClaimedBy::*;
         match s {
             "acquirer" => Ok(Acquirer),
             "issuer" => Ok(Issuer),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -193,14 +193,14 @@ impl IssuingAuthorizationAuthenticationExemptionType {
 }
 
 impl std::str::FromStr for IssuingAuthorizationAuthenticationExemptionType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingAuthorizationAuthenticationExemptionType::*;
         match s {
             "low_value_transaction" => Ok(LowValueTransaction),
             "transaction_risk_analysis" => Ok(TransactionRiskAnalysis),
             "unknown" => Ok(Unknown),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/issuing_authorization_request.rs
+++ b/generated/stripe_shared/src/issuing_authorization_request.rs
@@ -232,7 +232,7 @@ impl IssuingAuthorizationRequestReason {
 }
 
 impl std::str::FromStr for IssuingAuthorizationRequestReason {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingAuthorizationRequestReason::*;
         match s {
@@ -250,7 +250,7 @@ impl std::str::FromStr for IssuingAuthorizationRequestReason {
             "webhook_declined" => Ok(WebhookDeclined),
             "webhook_error" => Ok(WebhookError),
             "webhook_timeout" => Ok(WebhookTimeout),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -283,10 +283,7 @@ impl miniserde::Deserialize for IssuingAuthorizationRequestReason {
 impl miniserde::de::Visitor for crate::Place<IssuingAuthorizationRequestReason> {
     fn string(&mut self, s: &str) -> miniserde::Result<()> {
         use std::str::FromStr;
-        self.out = Some(
-            IssuingAuthorizationRequestReason::from_str(s)
-                .unwrap_or(IssuingAuthorizationRequestReason::Unknown),
-        );
+        self.out = Some(IssuingAuthorizationRequestReason::from_str(s).unwrap());
         Ok(())
     }
 }
@@ -297,6 +294,6 @@ impl<'de> serde::Deserialize<'de> for IssuingAuthorizationRequestReason {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }

--- a/generated/stripe_shared/src/issuing_authorization_three_d_secure.rs
+++ b/generated/stripe_shared/src/issuing_authorization_three_d_secure.rs
@@ -112,7 +112,7 @@ impl IssuingAuthorizationThreeDSecureResult {
 }
 
 impl std::str::FromStr for IssuingAuthorizationThreeDSecureResult {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingAuthorizationThreeDSecureResult::*;
         match s {
@@ -120,7 +120,7 @@ impl std::str::FromStr for IssuingAuthorizationThreeDSecureResult {
             "authenticated" => Ok(Authenticated),
             "failed" => Ok(Failed),
             "required" => Ok(Required),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/issuing_authorization_verification_data.rs
+++ b/generated/stripe_shared/src/issuing_authorization_verification_data.rs
@@ -168,14 +168,14 @@ impl IssuingAuthorizationVerificationDataAddressLine1Check {
 }
 
 impl std::str::FromStr for IssuingAuthorizationVerificationDataAddressLine1Check {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingAuthorizationVerificationDataAddressLine1Check::*;
         match s {
             "match" => Ok(Match),
             "mismatch" => Ok(Mismatch),
             "not_provided" => Ok(NotProvided),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -250,14 +250,14 @@ impl IssuingAuthorizationVerificationDataAddressPostalCodeCheck {
 }
 
 impl std::str::FromStr for IssuingAuthorizationVerificationDataAddressPostalCodeCheck {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingAuthorizationVerificationDataAddressPostalCodeCheck::*;
         match s {
             "match" => Ok(Match),
             "mismatch" => Ok(Mismatch),
             "not_provided" => Ok(NotProvided),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -334,14 +334,14 @@ impl IssuingAuthorizationVerificationDataCvcCheck {
 }
 
 impl std::str::FromStr for IssuingAuthorizationVerificationDataCvcCheck {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingAuthorizationVerificationDataCvcCheck::*;
         match s {
             "match" => Ok(Match),
             "mismatch" => Ok(Mismatch),
             "not_provided" => Ok(NotProvided),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -414,14 +414,14 @@ impl IssuingAuthorizationVerificationDataExpiryCheck {
 }
 
 impl std::str::FromStr for IssuingAuthorizationVerificationDataExpiryCheck {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingAuthorizationVerificationDataExpiryCheck::*;
         match s {
             "match" => Ok(Match),
             "mismatch" => Ok(Mismatch),
             "not_provided" => Ok(NotProvided),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/issuing_card.rs
+++ b/generated/stripe_shared/src/issuing_card.rs
@@ -306,14 +306,14 @@ impl IssuingCardCancellationReason {
 }
 
 impl std::str::FromStr for IssuingCardCancellationReason {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingCardCancellationReason::*;
         match s {
             "design_rejected" => Ok(DesignRejected),
             "lost" => Ok(Lost),
             "stolen" => Ok(Stolen),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -389,7 +389,7 @@ impl IssuingCardReplacementReason {
 }
 
 impl std::str::FromStr for IssuingCardReplacementReason {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingCardReplacementReason::*;
         match s {
@@ -397,7 +397,7 @@ impl std::str::FromStr for IssuingCardReplacementReason {
             "expired" => Ok(Expired),
             "lost" => Ok(Lost),
             "stolen" => Ok(Stolen),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -462,14 +462,14 @@ impl IssuingCardStatus {
 }
 
 impl std::str::FromStr for IssuingCardStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingCardStatus::*;
         match s {
             "active" => Ok(Active),
             "canceled" => Ok(Canceled),
             "inactive" => Ok(Inactive),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -532,13 +532,13 @@ impl IssuingCardType {
 }
 
 impl std::str::FromStr for IssuingCardType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingCardType::*;
         match s {
             "physical" => Ok(Physical),
             "virtual" => Ok(Virtual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/issuing_card_apple_pay.rs
+++ b/generated/stripe_shared/src/issuing_card_apple_pay.rs
@@ -115,14 +115,14 @@ impl IssuingCardApplePayIneligibleReason {
 }
 
 impl std::str::FromStr for IssuingCardApplePayIneligibleReason {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingCardApplePayIneligibleReason::*;
         match s {
             "missing_agreement" => Ok(MissingAgreement),
             "missing_cardholder_contact" => Ok(MissingCardholderContact),
             "unsupported_region" => Ok(UnsupportedRegion),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/issuing_card_authorization_controls.rs
+++ b/generated/stripe_shared/src/issuing_card_authorization_controls.rs
@@ -781,7 +781,7 @@ impl IssuingCardAuthorizationControlsAllowedCategories {
 }
 
 impl std::str::FromStr for IssuingCardAuthorizationControlsAllowedCategories {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingCardAuthorizationControlsAllowedCategories::*;
         match s {
@@ -1128,7 +1128,7 @@ impl std::str::FromStr for IssuingCardAuthorizationControlsAllowedCategories {
             "womens_accessory_and_specialty_shops" => Ok(WomensAccessoryAndSpecialtyShops),
             "womens_ready_to_wear_stores" => Ok(WomensReadyToWearStores),
             "wrecking_and_salvage_yards" => Ok(WreckingAndSalvageYards),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -1161,10 +1161,7 @@ impl miniserde::Deserialize for IssuingCardAuthorizationControlsAllowedCategorie
 impl miniserde::de::Visitor for crate::Place<IssuingCardAuthorizationControlsAllowedCategories> {
     fn string(&mut self, s: &str) -> miniserde::Result<()> {
         use std::str::FromStr;
-        self.out = Some(
-            IssuingCardAuthorizationControlsAllowedCategories::from_str(s)
-                .unwrap_or(IssuingCardAuthorizationControlsAllowedCategories::Unknown),
-        );
+        self.out = Some(IssuingCardAuthorizationControlsAllowedCategories::from_str(s).unwrap());
         Ok(())
     }
 }
@@ -1175,7 +1172,7 @@ impl<'de> serde::Deserialize<'de> for IssuingCardAuthorizationControlsAllowedCat
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to decline.
@@ -1831,7 +1828,7 @@ impl IssuingCardAuthorizationControlsBlockedCategories {
 }
 
 impl std::str::FromStr for IssuingCardAuthorizationControlsBlockedCategories {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingCardAuthorizationControlsBlockedCategories::*;
         match s {
@@ -2178,7 +2175,7 @@ impl std::str::FromStr for IssuingCardAuthorizationControlsBlockedCategories {
             "womens_accessory_and_specialty_shops" => Ok(WomensAccessoryAndSpecialtyShops),
             "womens_ready_to_wear_stores" => Ok(WomensReadyToWearStores),
             "wrecking_and_salvage_yards" => Ok(WreckingAndSalvageYards),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -2211,10 +2208,7 @@ impl miniserde::Deserialize for IssuingCardAuthorizationControlsBlockedCategorie
 impl miniserde::de::Visitor for crate::Place<IssuingCardAuthorizationControlsBlockedCategories> {
     fn string(&mut self, s: &str) -> miniserde::Result<()> {
         use std::str::FromStr;
-        self.out = Some(
-            IssuingCardAuthorizationControlsBlockedCategories::from_str(s)
-                .unwrap_or(IssuingCardAuthorizationControlsBlockedCategories::Unknown),
-        );
+        self.out = Some(IssuingCardAuthorizationControlsBlockedCategories::from_str(s).unwrap());
         Ok(())
     }
 }
@@ -2225,6 +2219,6 @@ impl<'de> serde::Deserialize<'de> for IssuingCardAuthorizationControlsBlockedCat
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }

--- a/generated/stripe_shared/src/issuing_card_google_pay.rs
+++ b/generated/stripe_shared/src/issuing_card_google_pay.rs
@@ -115,14 +115,14 @@ impl IssuingCardGooglePayIneligibleReason {
 }
 
 impl std::str::FromStr for IssuingCardGooglePayIneligibleReason {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingCardGooglePayIneligibleReason::*;
         match s {
             "missing_agreement" => Ok(MissingAgreement),
             "missing_cardholder_contact" => Ok(MissingCardholderContact),
             "unsupported_region" => Ok(UnsupportedRegion),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/issuing_card_shipping.rs
+++ b/generated/stripe_shared/src/issuing_card_shipping.rs
@@ -198,7 +198,7 @@ impl IssuingCardShippingCarrier {
 }
 
 impl std::str::FromStr for IssuingCardShippingCarrier {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingCardShippingCarrier::*;
         match s {
@@ -206,7 +206,7 @@ impl std::str::FromStr for IssuingCardShippingCarrier {
             "fedex" => Ok(Fedex),
             "royal_mail" => Ok(RoyalMail),
             "usps" => Ok(Usps),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -273,14 +273,14 @@ impl IssuingCardShippingService {
 }
 
 impl std::str::FromStr for IssuingCardShippingService {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingCardShippingService::*;
         match s {
             "express" => Ok(Express),
             "priority" => Ok(Priority),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -353,7 +353,7 @@ impl IssuingCardShippingStatus {
 }
 
 impl std::str::FromStr for IssuingCardShippingStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingCardShippingStatus::*;
         match s {
@@ -363,7 +363,7 @@ impl std::str::FromStr for IssuingCardShippingStatus {
             "pending" => Ok(Pending),
             "returned" => Ok(Returned),
             "shipped" => Ok(Shipped),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -428,13 +428,13 @@ impl IssuingCardShippingType {
 }
 
 impl std::str::FromStr for IssuingCardShippingType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingCardShippingType::*;
         match s {
             "bulk" => Ok(Bulk),
             "individual" => Ok(Individual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/issuing_card_spending_limit.rs
+++ b/generated/stripe_shared/src/issuing_card_spending_limit.rs
@@ -763,7 +763,7 @@ impl IssuingCardSpendingLimitCategories {
 }
 
 impl std::str::FromStr for IssuingCardSpendingLimitCategories {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingCardSpendingLimitCategories::*;
         match s {
@@ -1110,7 +1110,7 @@ impl std::str::FromStr for IssuingCardSpendingLimitCategories {
             "womens_accessory_and_specialty_shops" => Ok(WomensAccessoryAndSpecialtyShops),
             "womens_ready_to_wear_stores" => Ok(WomensReadyToWearStores),
             "wrecking_and_salvage_yards" => Ok(WreckingAndSalvageYards),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -1143,10 +1143,7 @@ impl miniserde::Deserialize for IssuingCardSpendingLimitCategories {
 impl miniserde::de::Visitor for crate::Place<IssuingCardSpendingLimitCategories> {
     fn string(&mut self, s: &str) -> miniserde::Result<()> {
         use std::str::FromStr;
-        self.out = Some(
-            IssuingCardSpendingLimitCategories::from_str(s)
-                .unwrap_or(IssuingCardSpendingLimitCategories::Unknown),
-        );
+        self.out = Some(IssuingCardSpendingLimitCategories::from_str(s).unwrap());
         Ok(())
     }
 }
@@ -1157,7 +1154,7 @@ impl<'de> serde::Deserialize<'de> for IssuingCardSpendingLimitCategories {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// Interval (or event) to which the amount applies.
@@ -1185,7 +1182,7 @@ impl IssuingCardSpendingLimitInterval {
 }
 
 impl std::str::FromStr for IssuingCardSpendingLimitInterval {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingCardSpendingLimitInterval::*;
         match s {
@@ -1195,7 +1192,7 @@ impl std::str::FromStr for IssuingCardSpendingLimitInterval {
             "per_authorization" => Ok(PerAuthorization),
             "weekly" => Ok(Weekly),
             "yearly" => Ok(Yearly),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/issuing_cardholder.rs
+++ b/generated/stripe_shared/src/issuing_cardholder.rs
@@ -257,7 +257,7 @@ impl IssuingCardholderPreferredLocales {
 }
 
 impl std::str::FromStr for IssuingCardholderPreferredLocales {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingCardholderPreferredLocales::*;
         match s {
@@ -266,7 +266,7 @@ impl std::str::FromStr for IssuingCardholderPreferredLocales {
             "es" => Ok(Es),
             "fr" => Ok(Fr),
             "it" => Ok(It),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -333,14 +333,14 @@ impl IssuingCardholderStatus {
 }
 
 impl std::str::FromStr for IssuingCardholderStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingCardholderStatus::*;
         match s {
             "active" => Ok(Active),
             "blocked" => Ok(Blocked),
             "inactive" => Ok(Inactive),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -403,13 +403,13 @@ impl IssuingCardholderType {
 }
 
 impl std::str::FromStr for IssuingCardholderType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingCardholderType::*;
         match s {
             "company" => Ok(Company),
             "individual" => Ok(Individual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/issuing_cardholder_authorization_controls.rs
+++ b/generated/stripe_shared/src/issuing_cardholder_authorization_controls.rs
@@ -783,7 +783,7 @@ impl IssuingCardholderAuthorizationControlsAllowedCategories {
 }
 
 impl std::str::FromStr for IssuingCardholderAuthorizationControlsAllowedCategories {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingCardholderAuthorizationControlsAllowedCategories::*;
         match s {
@@ -1130,7 +1130,7 @@ impl std::str::FromStr for IssuingCardholderAuthorizationControlsAllowedCategori
             "womens_accessory_and_specialty_shops" => Ok(WomensAccessoryAndSpecialtyShops),
             "womens_ready_to_wear_stores" => Ok(WomensReadyToWearStores),
             "wrecking_and_salvage_yards" => Ok(WreckingAndSalvageYards),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -1165,10 +1165,8 @@ impl miniserde::de::Visitor
 {
     fn string(&mut self, s: &str) -> miniserde::Result<()> {
         use std::str::FromStr;
-        self.out = Some(
-            IssuingCardholderAuthorizationControlsAllowedCategories::from_str(s)
-                .unwrap_or(IssuingCardholderAuthorizationControlsAllowedCategories::Unknown),
-        );
+        self.out =
+            Some(IssuingCardholderAuthorizationControlsAllowedCategories::from_str(s).unwrap());
         Ok(())
     }
 }
@@ -1179,7 +1177,7 @@ impl<'de> serde::Deserialize<'de> for IssuingCardholderAuthorizationControlsAllo
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to decline.
@@ -1835,7 +1833,7 @@ impl IssuingCardholderAuthorizationControlsBlockedCategories {
 }
 
 impl std::str::FromStr for IssuingCardholderAuthorizationControlsBlockedCategories {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingCardholderAuthorizationControlsBlockedCategories::*;
         match s {
@@ -2182,7 +2180,7 @@ impl std::str::FromStr for IssuingCardholderAuthorizationControlsBlockedCategori
             "womens_accessory_and_specialty_shops" => Ok(WomensAccessoryAndSpecialtyShops),
             "womens_ready_to_wear_stores" => Ok(WomensReadyToWearStores),
             "wrecking_and_salvage_yards" => Ok(WreckingAndSalvageYards),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -2217,10 +2215,8 @@ impl miniserde::de::Visitor
 {
     fn string(&mut self, s: &str) -> miniserde::Result<()> {
         use std::str::FromStr;
-        self.out = Some(
-            IssuingCardholderAuthorizationControlsBlockedCategories::from_str(s)
-                .unwrap_or(IssuingCardholderAuthorizationControlsBlockedCategories::Unknown),
-        );
+        self.out =
+            Some(IssuingCardholderAuthorizationControlsBlockedCategories::from_str(s).unwrap());
         Ok(())
     }
 }
@@ -2231,6 +2227,6 @@ impl<'de> serde::Deserialize<'de> for IssuingCardholderAuthorizationControlsBloc
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }

--- a/generated/stripe_shared/src/issuing_cardholder_requirements.rs
+++ b/generated/stripe_shared/src/issuing_cardholder_requirements.rs
@@ -120,7 +120,7 @@ impl IssuingCardholderRequirementsDisabledReason {
 }
 
 impl std::str::FromStr for IssuingCardholderRequirementsDisabledReason {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingCardholderRequirementsDisabledReason::*;
         match s {
@@ -128,7 +128,7 @@ impl std::str::FromStr for IssuingCardholderRequirementsDisabledReason {
             "rejected.listed" => Ok(RejectedListed),
             "requirements.past_due" => Ok(RequirementsPastDue),
             "under_review" => Ok(UnderReview),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -217,7 +217,7 @@ impl IssuingCardholderRequirementsPastDue {
 }
 
 impl std::str::FromStr for IssuingCardholderRequirementsPastDue {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingCardholderRequirementsPastDue::*;
         match s {
@@ -234,7 +234,7 @@ impl std::str::FromStr for IssuingCardholderRequirementsPastDue {
             "individual.first_name" => Ok(IndividualFirstName),
             "individual.last_name" => Ok(IndividualLastName),
             "individual.verification.document" => Ok(IndividualVerificationDocument),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/issuing_cardholder_spending_limit.rs
+++ b/generated/stripe_shared/src/issuing_cardholder_spending_limit.rs
@@ -763,7 +763,7 @@ impl IssuingCardholderSpendingLimitCategories {
 }
 
 impl std::str::FromStr for IssuingCardholderSpendingLimitCategories {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingCardholderSpendingLimitCategories::*;
         match s {
@@ -1110,7 +1110,7 @@ impl std::str::FromStr for IssuingCardholderSpendingLimitCategories {
             "womens_accessory_and_specialty_shops" => Ok(WomensAccessoryAndSpecialtyShops),
             "womens_ready_to_wear_stores" => Ok(WomensReadyToWearStores),
             "wrecking_and_salvage_yards" => Ok(WreckingAndSalvageYards),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -1143,10 +1143,7 @@ impl miniserde::Deserialize for IssuingCardholderSpendingLimitCategories {
 impl miniserde::de::Visitor for crate::Place<IssuingCardholderSpendingLimitCategories> {
     fn string(&mut self, s: &str) -> miniserde::Result<()> {
         use std::str::FromStr;
-        self.out = Some(
-            IssuingCardholderSpendingLimitCategories::from_str(s)
-                .unwrap_or(IssuingCardholderSpendingLimitCategories::Unknown),
-        );
+        self.out = Some(IssuingCardholderSpendingLimitCategories::from_str(s).unwrap());
         Ok(())
     }
 }
@@ -1157,7 +1154,7 @@ impl<'de> serde::Deserialize<'de> for IssuingCardholderSpendingLimitCategories {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// Interval (or event) to which the amount applies.
@@ -1185,7 +1182,7 @@ impl IssuingCardholderSpendingLimitInterval {
 }
 
 impl std::str::FromStr for IssuingCardholderSpendingLimitInterval {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingCardholderSpendingLimitInterval::*;
         match s {
@@ -1195,7 +1192,7 @@ impl std::str::FromStr for IssuingCardholderSpendingLimitInterval {
             "per_authorization" => Ok(PerAuthorization),
             "weekly" => Ok(Weekly),
             "yearly" => Ok(Yearly),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/issuing_dispute.rs
+++ b/generated/stripe_shared/src/issuing_dispute.rs
@@ -222,7 +222,7 @@ impl IssuingDisputeStatus {
 }
 
 impl std::str::FromStr for IssuingDisputeStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingDisputeStatus::*;
         match s {
@@ -231,7 +231,7 @@ impl std::str::FromStr for IssuingDisputeStatus {
             "submitted" => Ok(Submitted),
             "unsubmitted" => Ok(Unsubmitted),
             "won" => Ok(Won),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/issuing_dispute_canceled_evidence.rs
+++ b/generated/stripe_shared/src/issuing_dispute_canceled_evidence.rs
@@ -187,13 +187,13 @@ impl IssuingDisputeCanceledEvidenceProductType {
 }
 
 impl std::str::FromStr for IssuingDisputeCanceledEvidenceProductType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingDisputeCanceledEvidenceProductType::*;
         match s {
             "merchandise" => Ok(Merchandise),
             "service" => Ok(Service),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -261,13 +261,13 @@ impl IssuingDisputeCanceledEvidenceReturnStatus {
 }
 
 impl std::str::FromStr for IssuingDisputeCanceledEvidenceReturnStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingDisputeCanceledEvidenceReturnStatus::*;
         match s {
             "merchant_rejected" => Ok(MerchantRejected),
             "successful" => Ok(Successful),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/issuing_dispute_evidence.rs
+++ b/generated/stripe_shared/src/issuing_dispute_evidence.rs
@@ -176,7 +176,7 @@ impl IssuingDisputeEvidenceReason {
 }
 
 impl std::str::FromStr for IssuingDisputeEvidenceReason {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingDisputeEvidenceReason::*;
         match s {
@@ -187,7 +187,7 @@ impl std::str::FromStr for IssuingDisputeEvidenceReason {
             "not_received" => Ok(NotReceived),
             "other" => Ok(Other),
             "service_not_as_described" => Ok(ServiceNotAsDescribed),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/issuing_dispute_merchandise_not_as_described_evidence.rs
+++ b/generated/stripe_shared/src/issuing_dispute_merchandise_not_as_described_evidence.rs
@@ -153,13 +153,13 @@ impl IssuingDisputeMerchandiseNotAsDescribedEvidenceReturnStatus {
 }
 
 impl std::str::FromStr for IssuingDisputeMerchandiseNotAsDescribedEvidenceReturnStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingDisputeMerchandiseNotAsDescribedEvidenceReturnStatus::*;
         match s {
             "merchant_rejected" => Ok(MerchantRejected),
             "successful" => Ok(Successful),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/issuing_dispute_not_received_evidence.rs
+++ b/generated/stripe_shared/src/issuing_dispute_not_received_evidence.rs
@@ -146,13 +146,13 @@ impl IssuingDisputeNotReceivedEvidenceProductType {
 }
 
 impl std::str::FromStr for IssuingDisputeNotReceivedEvidenceProductType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingDisputeNotReceivedEvidenceProductType::*;
         match s {
             "merchandise" => Ok(Merchandise),
             "service" => Ok(Service),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/issuing_dispute_other_evidence.rs
+++ b/generated/stripe_shared/src/issuing_dispute_other_evidence.rs
@@ -139,13 +139,13 @@ impl IssuingDisputeOtherEvidenceProductType {
 }
 
 impl std::str::FromStr for IssuingDisputeOtherEvidenceProductType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingDisputeOtherEvidenceProductType::*;
         match s {
             "merchandise" => Ok(Merchandise),
             "service" => Ok(Service),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/issuing_network_token_device.rs
+++ b/generated/stripe_shared/src/issuing_network_token_device.rs
@@ -153,14 +153,14 @@ impl IssuingNetworkTokenDeviceType {
 }
 
 impl std::str::FromStr for IssuingNetworkTokenDeviceType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingNetworkTokenDeviceType::*;
         match s {
             "other" => Ok(Other),
             "phone" => Ok(Phone),
             "watch" => Ok(Watch),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/issuing_network_token_network_data.rs
+++ b/generated/stripe_shared/src/issuing_network_token_network_data.rs
@@ -139,13 +139,13 @@ impl IssuingNetworkTokenNetworkDataType {
 }
 
 impl std::str::FromStr for IssuingNetworkTokenNetworkDataType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingNetworkTokenNetworkDataType::*;
         match s {
             "mastercard" => Ok(Mastercard),
             "visa" => Ok(Visa),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/issuing_network_token_wallet_provider.rs
+++ b/generated/stripe_shared/src/issuing_network_token_wallet_provider.rs
@@ -197,7 +197,7 @@ impl IssuingNetworkTokenWalletProviderCardNumberSource {
 }
 
 impl std::str::FromStr for IssuingNetworkTokenWalletProviderCardNumberSource {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingNetworkTokenWalletProviderCardNumberSource::*;
         match s {
@@ -205,7 +205,7 @@ impl std::str::FromStr for IssuingNetworkTokenWalletProviderCardNumberSource {
             "manual" => Ok(Manual),
             "on_file" => Ok(OnFile),
             "other" => Ok(Other),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -336,7 +336,7 @@ impl IssuingNetworkTokenWalletProviderReasonCodes {
 }
 
 impl std::str::FromStr for IssuingNetworkTokenWalletProviderReasonCodes {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingNetworkTokenWalletProviderReasonCodes::*;
         match s {
@@ -372,7 +372,7 @@ impl std::str::FromStr for IssuingNetworkTokenWalletProviderReasonCodes {
             "too_many_different_cardholders" => Ok(TooManyDifferentCardholders),
             "too_many_recent_attempts" => Ok(TooManyRecentAttempts),
             "too_many_recent_tokens" => Ok(TooManyRecentTokens),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -405,10 +405,7 @@ impl miniserde::Deserialize for IssuingNetworkTokenWalletProviderReasonCodes {
 impl miniserde::de::Visitor for crate::Place<IssuingNetworkTokenWalletProviderReasonCodes> {
     fn string(&mut self, s: &str) -> miniserde::Result<()> {
         use std::str::FromStr;
-        self.out = Some(
-            IssuingNetworkTokenWalletProviderReasonCodes::from_str(s)
-                .unwrap_or(IssuingNetworkTokenWalletProviderReasonCodes::Unknown),
-        );
+        self.out = Some(IssuingNetworkTokenWalletProviderReasonCodes::from_str(s).unwrap());
         Ok(())
     }
 }
@@ -419,7 +416,7 @@ impl<'de> serde::Deserialize<'de> for IssuingNetworkTokenWalletProviderReasonCod
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// The recommendation on responding to the tokenization request.
@@ -441,14 +438,14 @@ impl IssuingNetworkTokenWalletProviderSuggestedDecision {
 }
 
 impl std::str::FromStr for IssuingNetworkTokenWalletProviderSuggestedDecision {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingNetworkTokenWalletProviderSuggestedDecision::*;
         match s {
             "approve" => Ok(Approve),
             "decline" => Ok(Decline),
             "require_auth" => Ok(RequireAuth),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/issuing_token.rs
+++ b/generated/stripe_shared/src/issuing_token.rs
@@ -210,13 +210,13 @@ impl IssuingTokenNetwork {
 }
 
 impl std::str::FromStr for IssuingTokenNetwork {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingTokenNetwork::*;
         match s {
             "mastercard" => Ok(Mastercard),
             "visa" => Ok(Visa),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -283,14 +283,14 @@ impl IssuingTokenWalletProvider {
 }
 
 impl std::str::FromStr for IssuingTokenWalletProvider {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingTokenWalletProvider::*;
         match s {
             "apple_pay" => Ok(ApplePay),
             "google_pay" => Ok(GooglePay),
             "samsung_pay" => Ok(SamsungPay),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -365,7 +365,7 @@ impl IssuingTokenStatus {
 }
 
 impl std::str::FromStr for IssuingTokenStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingTokenStatus::*;
         match s {
@@ -373,7 +373,7 @@ impl std::str::FromStr for IssuingTokenStatus {
             "deleted" => Ok(Deleted),
             "requested" => Ok(Requested),
             "suspended" => Ok(Suspended),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/issuing_transaction.rs
+++ b/generated/stripe_shared/src/issuing_transaction.rs
@@ -300,14 +300,14 @@ impl IssuingTransactionWallet {
 }
 
 impl std::str::FromStr for IssuingTransactionWallet {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingTransactionWallet::*;
         match s {
             "apple_pay" => Ok(ApplePay),
             "google_pay" => Ok(GooglePay),
             "samsung_pay" => Ok(SamsungPay),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -378,13 +378,13 @@ impl IssuingTransactionType {
 }
 
 impl std::str::FromStr for IssuingTransactionType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use IssuingTransactionType::*;
         match s {
             "capture" => Ok(Capture),
             "refund" => Ok(Refund),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/legal_entity_company.rs
+++ b/generated/stripe_shared/src/legal_entity_company.rs
@@ -290,7 +290,7 @@ impl LegalEntityCompanyStructure {
 }
 
 impl std::str::FromStr for LegalEntityCompanyStructure {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use LegalEntityCompanyStructure::*;
         match s {
@@ -317,7 +317,7 @@ impl std::str::FromStr for LegalEntityCompanyStructure {
             "unincorporated_association" => Ok(UnincorporatedAssociation),
             "unincorporated_non_profit" => Ok(UnincorporatedNonProfit),
             "unincorporated_partnership" => Ok(UnincorporatedPartnership),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -350,10 +350,7 @@ impl miniserde::Deserialize for LegalEntityCompanyStructure {
 impl miniserde::de::Visitor for crate::Place<LegalEntityCompanyStructure> {
     fn string(&mut self, s: &str) -> miniserde::Result<()> {
         use std::str::FromStr;
-        self.out = Some(
-            LegalEntityCompanyStructure::from_str(s)
-                .unwrap_or(LegalEntityCompanyStructure::Unknown),
-        );
+        self.out = Some(LegalEntityCompanyStructure::from_str(s).unwrap());
         Ok(())
     }
 }
@@ -364,6 +361,6 @@ impl<'de> serde::Deserialize<'de> for LegalEntityCompanyStructure {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }

--- a/generated/stripe_shared/src/line_items_tax_amount.rs
+++ b/generated/stripe_shared/src/line_items_tax_amount.rs
@@ -164,7 +164,7 @@ impl LineItemsTaxAmountTaxabilityReason {
 }
 
 impl std::str::FromStr for LineItemsTaxAmountTaxabilityReason {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use LineItemsTaxAmountTaxabilityReason::*;
         match s {
@@ -183,7 +183,7 @@ impl std::str::FromStr for LineItemsTaxAmountTaxabilityReason {
             "standard_rated" => Ok(StandardRated),
             "taxable_basis_reduced" => Ok(TaxableBasisReduced),
             "zero_rated" => Ok(ZeroRated),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -216,10 +216,7 @@ impl miniserde::Deserialize for LineItemsTaxAmountTaxabilityReason {
 impl miniserde::de::Visitor for crate::Place<LineItemsTaxAmountTaxabilityReason> {
     fn string(&mut self, s: &str) -> miniserde::Result<()> {
         use std::str::FromStr;
-        self.out = Some(
-            LineItemsTaxAmountTaxabilityReason::from_str(s)
-                .unwrap_or(LineItemsTaxAmountTaxabilityReason::Unknown),
-        );
+        self.out = Some(LineItemsTaxAmountTaxabilityReason::from_str(s).unwrap());
         Ok(())
     }
 }
@@ -230,6 +227,6 @@ impl<'de> serde::Deserialize<'de> for LineItemsTaxAmountTaxabilityReason {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }

--- a/generated/stripe_shared/src/linked_account_options_us_bank_account.rs
+++ b/generated/stripe_shared/src/linked_account_options_us_bank_account.rs
@@ -131,7 +131,7 @@ impl LinkedAccountOptionsUsBankAccountPermissions {
 }
 
 impl std::str::FromStr for LinkedAccountOptionsUsBankAccountPermissions {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use LinkedAccountOptionsUsBankAccountPermissions::*;
         match s {
@@ -139,7 +139,7 @@ impl std::str::FromStr for LinkedAccountOptionsUsBankAccountPermissions {
             "ownership" => Ok(Ownership),
             "payment_method" => Ok(PaymentMethod),
             "transactions" => Ok(Transactions),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -210,13 +210,13 @@ impl LinkedAccountOptionsUsBankAccountPrefetch {
 }
 
 impl std::str::FromStr for LinkedAccountOptionsUsBankAccountPrefetch {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use LinkedAccountOptionsUsBankAccountPrefetch::*;
         match s {
             "balances" => Ok(Balances),
             "transactions" => Ok(Transactions),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/mandate.rs
+++ b/generated/stripe_shared/src/mandate.rs
@@ -197,14 +197,14 @@ impl MandateStatus {
 }
 
 impl std::str::FromStr for MandateStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use MandateStatus::*;
         match s {
             "active" => Ok(Active),
             "inactive" => Ok(Inactive),
             "pending" => Ok(Pending),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -268,13 +268,13 @@ impl MandateType {
 }
 
 impl std::str::FromStr for MandateType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use MandateType::*;
         match s {
             "multi_use" => Ok(MultiUse),
             "single_use" => Ok(SingleUse),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/mandate_acss_debit.rs
+++ b/generated/stripe_shared/src/mandate_acss_debit.rs
@@ -136,13 +136,13 @@ impl MandateAcssDebitDefaultFor {
 }
 
 impl std::str::FromStr for MandateAcssDebitDefaultFor {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use MandateAcssDebitDefaultFor::*;
         match s {
             "invoice" => Ok(Invoice),
             "subscription" => Ok(Subscription),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -209,14 +209,14 @@ impl MandateAcssDebitPaymentSchedule {
 }
 
 impl std::str::FromStr for MandateAcssDebitPaymentSchedule {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use MandateAcssDebitPaymentSchedule::*;
         match s {
             "combined" => Ok(Combined),
             "interval" => Ok(Interval),
             "sporadic" => Ok(Sporadic),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -283,13 +283,13 @@ impl MandateAcssDebitTransactionType {
 }
 
 impl std::str::FromStr for MandateAcssDebitTransactionType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use MandateAcssDebitTransactionType::*;
         match s {
             "business" => Ok(Business),
             "personal" => Ok(Personal),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/mandate_bacs_debit.rs
+++ b/generated/stripe_shared/src/mandate_bacs_debit.rs
@@ -139,7 +139,7 @@ impl MandateBacsDebitNetworkStatus {
 }
 
 impl std::str::FromStr for MandateBacsDebitNetworkStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use MandateBacsDebitNetworkStatus::*;
         match s {
@@ -147,7 +147,7 @@ impl std::str::FromStr for MandateBacsDebitNetworkStatus {
             "pending" => Ok(Pending),
             "refused" => Ok(Refused),
             "revoked" => Ok(Revoked),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -219,7 +219,7 @@ impl MandateBacsDebitRevocationReason {
 }
 
 impl std::str::FromStr for MandateBacsDebitRevocationReason {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use MandateBacsDebitRevocationReason::*;
         match s {
@@ -228,7 +228,7 @@ impl std::str::FromStr for MandateBacsDebitRevocationReason {
             "bank_ownership_changed" => Ok(BankOwnershipChanged),
             "could_not_process" => Ok(CouldNotProcess),
             "debit_not_authorized" => Ok(DebitNotAuthorized),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/mandate_us_bank_account.rs
+++ b/generated/stripe_shared/src/mandate_us_bank_account.rs
@@ -106,12 +106,12 @@ impl MandateUsBankAccountCollectionMethod {
 }
 
 impl std::str::FromStr for MandateUsBankAccountCollectionMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use MandateUsBankAccountCollectionMethod::*;
         match s {
             "paper" => Ok(Paper),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_flows_automatic_payment_methods_payment_intent.rs
+++ b/generated/stripe_shared/src/payment_flows_automatic_payment_methods_payment_intent.rs
@@ -119,13 +119,13 @@ impl PaymentFlowsAutomaticPaymentMethodsPaymentIntentAllowRedirects {
 }
 
 impl std::str::FromStr for PaymentFlowsAutomaticPaymentMethodsPaymentIntentAllowRedirects {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentFlowsAutomaticPaymentMethodsPaymentIntentAllowRedirects::*;
         match s {
             "always" => Ok(Always),
             "never" => Ok(Never),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_flows_automatic_payment_methods_setup_intent.rs
+++ b/generated/stripe_shared/src/payment_flows_automatic_payment_methods_setup_intent.rs
@@ -119,13 +119,13 @@ impl PaymentFlowsAutomaticPaymentMethodsSetupIntentAllowRedirects {
 }
 
 impl std::str::FromStr for PaymentFlowsAutomaticPaymentMethodsSetupIntentAllowRedirects {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentFlowsAutomaticPaymentMethodsSetupIntentAllowRedirects::*;
         match s {
             "always" => Ok(Always),
             "never" => Ok(Never),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_flows_private_payment_methods_card_details_api_resource_enterprise_features_extended_authorization_extended_authorization.rs
+++ b/generated/stripe_shared/src/payment_flows_private_payment_methods_card_details_api_resource_enterprise_features_extended_authorization_extended_authorization.rs
@@ -116,13 +116,13 @@ Enabled => "enabled",
 }
 
 impl std::str::FromStr for PaymentFlowsPrivatePaymentMethodsCardDetailsApiResourceEnterpriseFeaturesExtendedAuthorizationExtendedAuthorizationStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentFlowsPrivatePaymentMethodsCardDetailsApiResourceEnterpriseFeaturesExtendedAuthorizationExtendedAuthorizationStatus::*;
         match s {
     "disabled" => Ok(Disabled),
 "enabled" => Ok(Enabled),
-_ => Err(())
+_ => Err(stripe_types::StripeParseError)
 
         }
     }

--- a/generated/stripe_shared/src/payment_flows_private_payment_methods_card_details_api_resource_enterprise_features_incremental_authorization_incremental_authorization.rs
+++ b/generated/stripe_shared/src/payment_flows_private_payment_methods_card_details_api_resource_enterprise_features_incremental_authorization_incremental_authorization.rs
@@ -116,13 +116,13 @@ Unavailable => "unavailable",
 }
 
 impl std::str::FromStr for PaymentFlowsPrivatePaymentMethodsCardDetailsApiResourceEnterpriseFeaturesIncrementalAuthorizationIncrementalAuthorizationStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentFlowsPrivatePaymentMethodsCardDetailsApiResourceEnterpriseFeaturesIncrementalAuthorizationIncrementalAuthorizationStatus::*;
         match s {
     "available" => Ok(Available),
 "unavailable" => Ok(Unavailable),
-_ => Err(())
+_ => Err(stripe_types::StripeParseError)
 
         }
     }

--- a/generated/stripe_shared/src/payment_flows_private_payment_methods_card_details_api_resource_enterprise_features_overcapture_overcapture.rs
+++ b/generated/stripe_shared/src/payment_flows_private_payment_methods_card_details_api_resource_enterprise_features_overcapture_overcapture.rs
@@ -123,13 +123,13 @@ Unavailable => "unavailable",
 }
 
 impl std::str::FromStr for PaymentFlowsPrivatePaymentMethodsCardDetailsApiResourceEnterpriseFeaturesOvercaptureOvercaptureStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentFlowsPrivatePaymentMethodsCardDetailsApiResourceEnterpriseFeaturesOvercaptureOvercaptureStatus::*;
         match s {
     "available" => Ok(Available),
 "unavailable" => Ok(Unavailable),
-_ => Err(())
+_ => Err(stripe_types::StripeParseError)
 
         }
     }

--- a/generated/stripe_shared/src/payment_flows_private_payment_methods_card_details_api_resource_multicapture.rs
+++ b/generated/stripe_shared/src/payment_flows_private_payment_methods_card_details_api_resource_multicapture.rs
@@ -110,13 +110,13 @@ impl PaymentFlowsPrivatePaymentMethodsCardDetailsApiResourceMulticaptureStatus {
 impl std::str::FromStr
     for PaymentFlowsPrivatePaymentMethodsCardDetailsApiResourceMulticaptureStatus
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentFlowsPrivatePaymentMethodsCardDetailsApiResourceMulticaptureStatus::*;
         match s {
             "available" => Ok(Available),
             "unavailable" => Ok(Unavailable),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_intent.rs
+++ b/generated/stripe_shared/src/payment_intent.rs
@@ -520,7 +520,7 @@ impl PaymentIntentCancellationReason {
 }
 
 impl std::str::FromStr for PaymentIntentCancellationReason {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentIntentCancellationReason::*;
         match s {
@@ -531,7 +531,7 @@ impl std::str::FromStr for PaymentIntentCancellationReason {
             "fraudulent" => Ok(Fraudulent),
             "requested_by_customer" => Ok(RequestedByCustomer),
             "void_invoice" => Ok(VoidInvoice),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -609,7 +609,7 @@ impl PaymentIntentStatus {
 }
 
 impl std::str::FromStr for PaymentIntentStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentIntentStatus::*;
         match s {
@@ -620,7 +620,7 @@ impl std::str::FromStr for PaymentIntentStatus {
             "requires_confirmation" => Ok(RequiresConfirmation),
             "requires_payment_method" => Ok(RequiresPaymentMethod),
             "succeeded" => Ok(Succeeded),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -693,14 +693,14 @@ impl PaymentIntentCaptureMethod {
 }
 
 impl std::str::FromStr for PaymentIntentCaptureMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentIntentCaptureMethod::*;
         match s {
             "automatic" => Ok(Automatic),
             "automatic_async" => Ok(AutomaticAsync),
             "manual" => Ok(Manual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -763,13 +763,13 @@ impl PaymentIntentConfirmationMethod {
 }
 
 impl std::str::FromStr for PaymentIntentConfirmationMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentIntentConfirmationMethod::*;
         match s {
             "automatic" => Ok(Automatic),
             "manual" => Ok(Manual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -834,13 +834,13 @@ impl PaymentIntentSetupFutureUsage {
 }
 
 impl std::str::FromStr for PaymentIntentSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentIntentSetupFutureUsage::*;
         match s {
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_intent_next_action_display_bank_transfer_instructions.rs
+++ b/generated/stripe_shared/src/payment_intent_next_action_display_bank_transfer_instructions.rs
@@ -164,7 +164,7 @@ impl PaymentIntentNextActionDisplayBankTransferInstructionsType {
 }
 
 impl std::str::FromStr for PaymentIntentNextActionDisplayBankTransferInstructionsType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentIntentNextActionDisplayBankTransferInstructionsType::*;
         match s {
@@ -173,7 +173,7 @@ impl std::str::FromStr for PaymentIntentNextActionDisplayBankTransferInstruction
             "jp_bank_transfer" => Ok(JpBankTransfer),
             "mx_bank_transfer" => Ok(MxBankTransfer),
             "us_bank_transfer" => Ok(UsBankTransfer),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_intent_next_action_verify_with_microdeposits.rs
+++ b/generated/stripe_shared/src/payment_intent_next_action_verify_with_microdeposits.rs
@@ -131,13 +131,13 @@ impl PaymentIntentNextActionVerifyWithMicrodepositsMicrodepositType {
 }
 
 impl std::str::FromStr for PaymentIntentNextActionVerifyWithMicrodepositsMicrodepositType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentIntentNextActionVerifyWithMicrodepositsMicrodepositType::*;
         match s {
             "amounts" => Ok(Amounts),
             "descriptor_code" => Ok(DescriptorCode),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_intent_payment_method_options_acss_debit.rs
+++ b/generated/stripe_shared/src/payment_intent_payment_method_options_acss_debit.rs
@@ -144,14 +144,14 @@ impl PaymentIntentPaymentMethodOptionsAcssDebitSetupFutureUsage {
 }
 
 impl std::str::FromStr for PaymentIntentPaymentMethodOptionsAcssDebitSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentIntentPaymentMethodOptionsAcssDebitSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -228,14 +228,14 @@ impl PaymentIntentPaymentMethodOptionsAcssDebitVerificationMethod {
 }
 
 impl std::str::FromStr for PaymentIntentPaymentMethodOptionsAcssDebitVerificationMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentIntentPaymentMethodOptionsAcssDebitVerificationMethod::*;
         match s {
             "automatic" => Ok(Automatic),
             "instant" => Ok(Instant),
             "microdeposits" => Ok(Microdeposits),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_intent_payment_method_options_au_becs_debit.rs
+++ b/generated/stripe_shared/src/payment_intent_payment_method_options_au_becs_debit.rs
@@ -123,14 +123,14 @@ impl PaymentIntentPaymentMethodOptionsAuBecsDebitSetupFutureUsage {
 }
 
 impl std::str::FromStr for PaymentIntentPaymentMethodOptionsAuBecsDebitSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentIntentPaymentMethodOptionsAuBecsDebitSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_intent_payment_method_options_blik.rs
+++ b/generated/stripe_shared/src/payment_intent_payment_method_options_blik.rs
@@ -118,12 +118,12 @@ impl PaymentIntentPaymentMethodOptionsBlikSetupFutureUsage {
 }
 
 impl std::str::FromStr for PaymentIntentPaymentMethodOptionsBlikSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentIntentPaymentMethodOptionsBlikSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_intent_payment_method_options_card.rs
+++ b/generated/stripe_shared/src/payment_intent_payment_method_options_card.rs
@@ -246,12 +246,12 @@ impl PaymentIntentPaymentMethodOptionsCardCaptureMethod {
 }
 
 impl std::str::FromStr for PaymentIntentPaymentMethodOptionsCardCaptureMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentIntentPaymentMethodOptionsCardCaptureMethod::*;
         match s {
             "manual" => Ok(Manual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -342,7 +342,7 @@ impl PaymentIntentPaymentMethodOptionsCardNetwork {
 }
 
 impl std::str::FromStr for PaymentIntentPaymentMethodOptionsCardNetwork {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentIntentPaymentMethodOptionsCardNetwork::*;
         match s {
@@ -357,7 +357,7 @@ impl std::str::FromStr for PaymentIntentPaymentMethodOptionsCardNetwork {
             "unionpay" => Ok(Unionpay),
             "unknown" => Ok(Unknown),
             "visa" => Ok(Visa),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -428,13 +428,13 @@ impl PaymentIntentPaymentMethodOptionsCardRequestExtendedAuthorization {
 }
 
 impl std::str::FromStr for PaymentIntentPaymentMethodOptionsCardRequestExtendedAuthorization {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentIntentPaymentMethodOptionsCardRequestExtendedAuthorization::*;
         match s {
             "if_available" => Ok(IfAvailable),
             "never" => Ok(Never),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -507,13 +507,13 @@ impl PaymentIntentPaymentMethodOptionsCardRequestIncrementalAuthorization {
 }
 
 impl std::str::FromStr for PaymentIntentPaymentMethodOptionsCardRequestIncrementalAuthorization {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentIntentPaymentMethodOptionsCardRequestIncrementalAuthorization::*;
         match s {
             "if_available" => Ok(IfAvailable),
             "never" => Ok(Never),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -588,13 +588,13 @@ impl PaymentIntentPaymentMethodOptionsCardRequestMulticapture {
 }
 
 impl std::str::FromStr for PaymentIntentPaymentMethodOptionsCardRequestMulticapture {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentIntentPaymentMethodOptionsCardRequestMulticapture::*;
         match s {
             "if_available" => Ok(IfAvailable),
             "never" => Ok(Never),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -669,13 +669,13 @@ impl PaymentIntentPaymentMethodOptionsCardRequestOvercapture {
 }
 
 impl std::str::FromStr for PaymentIntentPaymentMethodOptionsCardRequestOvercapture {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentIntentPaymentMethodOptionsCardRequestOvercapture::*;
         match s {
             "if_available" => Ok(IfAvailable),
             "never" => Ok(Never),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -753,14 +753,14 @@ impl PaymentIntentPaymentMethodOptionsCardRequestThreeDSecure {
 }
 
 impl std::str::FromStr for PaymentIntentPaymentMethodOptionsCardRequestThreeDSecure {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentIntentPaymentMethodOptionsCardRequestThreeDSecure::*;
         match s {
             "any" => Ok(Any),
             "automatic" => Ok(Automatic),
             "challenge" => Ok(Challenge),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -842,14 +842,14 @@ impl PaymentIntentPaymentMethodOptionsCardSetupFutureUsage {
 }
 
 impl std::str::FromStr for PaymentIntentPaymentMethodOptionsCardSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentIntentPaymentMethodOptionsCardSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_intent_payment_method_options_eps.rs
+++ b/generated/stripe_shared/src/payment_intent_payment_method_options_eps.rs
@@ -118,12 +118,12 @@ impl PaymentIntentPaymentMethodOptionsEpsSetupFutureUsage {
 }
 
 impl std::str::FromStr for PaymentIntentPaymentMethodOptionsEpsSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentIntentPaymentMethodOptionsEpsSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_intent_payment_method_options_link.rs
+++ b/generated/stripe_shared/src/payment_intent_payment_method_options_link.rs
@@ -131,12 +131,12 @@ impl PaymentIntentPaymentMethodOptionsLinkCaptureMethod {
 }
 
 impl std::str::FromStr for PaymentIntentPaymentMethodOptionsLinkCaptureMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentIntentPaymentMethodOptionsLinkCaptureMethod::*;
         match s {
             "manual" => Ok(Manual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -212,13 +212,13 @@ impl PaymentIntentPaymentMethodOptionsLinkSetupFutureUsage {
 }
 
 impl std::str::FromStr for PaymentIntentPaymentMethodOptionsLinkSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentIntentPaymentMethodOptionsLinkSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_intent_payment_method_options_mandate_options_acss_debit.rs
+++ b/generated/stripe_shared/src/payment_intent_payment_method_options_mandate_options_acss_debit.rs
@@ -146,14 +146,14 @@ impl PaymentIntentPaymentMethodOptionsMandateOptionsAcssDebitPaymentSchedule {
 }
 
 impl std::str::FromStr for PaymentIntentPaymentMethodOptionsMandateOptionsAcssDebitPaymentSchedule {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentIntentPaymentMethodOptionsMandateOptionsAcssDebitPaymentSchedule::*;
         match s {
             "combined" => Ok(Combined),
             "interval" => Ok(Interval),
             "sporadic" => Ok(Sporadic),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -228,13 +228,13 @@ impl PaymentIntentPaymentMethodOptionsMandateOptionsAcssDebitTransactionType {
 }
 
 impl std::str::FromStr for PaymentIntentPaymentMethodOptionsMandateOptionsAcssDebitTransactionType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentIntentPaymentMethodOptionsMandateOptionsAcssDebitTransactionType::*;
         match s {
             "business" => Ok(Business),
             "personal" => Ok(Personal),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_intent_payment_method_options_sepa_debit.rs
+++ b/generated/stripe_shared/src/payment_intent_payment_method_options_sepa_debit.rs
@@ -134,14 +134,14 @@ impl PaymentIntentPaymentMethodOptionsSepaDebitSetupFutureUsage {
 }
 
 impl std::str::FromStr for PaymentIntentPaymentMethodOptionsSepaDebitSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentIntentPaymentMethodOptionsSepaDebitSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_intent_payment_method_options_swish.rs
+++ b/generated/stripe_shared/src/payment_intent_payment_method_options_swish.rs
@@ -126,12 +126,12 @@ impl PaymentIntentPaymentMethodOptionsSwishSetupFutureUsage {
 }
 
 impl std::str::FromStr for PaymentIntentPaymentMethodOptionsSwishSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentIntentPaymentMethodOptionsSwishSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_intent_payment_method_options_us_bank_account.rs
+++ b/generated/stripe_shared/src/payment_intent_payment_method_options_us_bank_account.rs
@@ -158,13 +158,13 @@ impl PaymentIntentPaymentMethodOptionsUsBankAccountPreferredSettlementSpeed {
 }
 
 impl std::str::FromStr for PaymentIntentPaymentMethodOptionsUsBankAccountPreferredSettlementSpeed {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentIntentPaymentMethodOptionsUsBankAccountPreferredSettlementSpeed::*;
         match s {
             "fastest" => Ok(Fastest),
             "standard" => Ok(Standard),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -246,14 +246,14 @@ impl PaymentIntentPaymentMethodOptionsUsBankAccountSetupFutureUsage {
 }
 
 impl std::str::FromStr for PaymentIntentPaymentMethodOptionsUsBankAccountSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentIntentPaymentMethodOptionsUsBankAccountSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -332,14 +332,14 @@ impl PaymentIntentPaymentMethodOptionsUsBankAccountVerificationMethod {
 }
 
 impl std::str::FromStr for PaymentIntentPaymentMethodOptionsUsBankAccountVerificationMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentIntentPaymentMethodOptionsUsBankAccountVerificationMethod::*;
         match s {
             "automatic" => Ok(Automatic),
             "instant" => Ok(Instant),
             "microdeposits" => Ok(Microdeposits),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_intent_processing.rs
+++ b/generated/stripe_shared/src/payment_intent_processing.rs
@@ -111,12 +111,12 @@ impl PaymentIntentProcessingType {
 }
 
 impl std::str::FromStr for PaymentIntentProcessingType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentIntentProcessingType::*;
         match s {
             "card" => Ok(Card),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_link.rs
+++ b/generated/stripe_shared/src/payment_link.rs
@@ -409,13 +409,13 @@ impl PaymentLinkCustomerCreation {
 }
 
 impl std::str::FromStr for PaymentLinkCustomerCreation {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentLinkCustomerCreation::*;
         match s {
             "always" => Ok(Always),
             "if_required" => Ok(IfRequired),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -480,13 +480,13 @@ impl PaymentLinkPaymentMethodCollection {
 }
 
 impl std::str::FromStr for PaymentLinkPaymentMethodCollection {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentLinkPaymentMethodCollection::*;
         match s {
             "always" => Ok(Always),
             "if_required" => Ok(IfRequired),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -559,13 +559,13 @@ impl PaymentLinkBillingAddressCollection {
 }
 
 impl std::str::FromStr for PaymentLinkBillingAddressCollection {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentLinkBillingAddressCollection::*;
         match s {
             "auto" => Ok(Auto),
             "required" => Ok(Required),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -688,7 +688,7 @@ impl PaymentLinkPaymentMethodTypes {
 }
 
 impl std::str::FromStr for PaymentLinkPaymentMethodTypes {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentLinkPaymentMethodTypes::*;
         match s {
@@ -721,7 +721,7 @@ impl std::str::FromStr for PaymentLinkPaymentMethodTypes {
             "swish" => Ok(Swish),
             "us_bank_account" => Ok(UsBankAccount),
             "wechat_pay" => Ok(WechatPay),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -753,10 +753,7 @@ impl miniserde::Deserialize for PaymentLinkPaymentMethodTypes {
 impl miniserde::de::Visitor for crate::Place<PaymentLinkPaymentMethodTypes> {
     fn string(&mut self, s: &str) -> miniserde::Result<()> {
         use std::str::FromStr;
-        self.out = Some(
-            PaymentLinkPaymentMethodTypes::from_str(s)
-                .unwrap_or(PaymentLinkPaymentMethodTypes::Unknown),
-        );
+        self.out = Some(PaymentLinkPaymentMethodTypes::from_str(s).unwrap());
         Ok(())
     }
 }
@@ -767,7 +764,7 @@ impl<'de> serde::Deserialize<'de> for PaymentLinkPaymentMethodTypes {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -790,7 +787,7 @@ impl PaymentLinkSubmitType {
 }
 
 impl std::str::FromStr for PaymentLinkSubmitType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentLinkSubmitType::*;
         match s {
@@ -798,7 +795,7 @@ impl std::str::FromStr for PaymentLinkSubmitType {
             "book" => Ok(Book),
             "donate" => Ok(Donate),
             "pay" => Ok(Pay),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_links_resource_after_completion.rs
+++ b/generated/stripe_shared/src/payment_links_resource_after_completion.rs
@@ -129,13 +129,13 @@ impl PaymentLinksResourceAfterCompletionType {
 }
 
 impl std::str::FromStr for PaymentLinksResourceAfterCompletionType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentLinksResourceAfterCompletionType::*;
         match s {
             "hosted_confirmation" => Ok(HostedConfirmation),
             "redirect" => Ok(Redirect),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_links_resource_consent_collection.rs
+++ b/generated/stripe_shared/src/payment_links_resource_consent_collection.rs
@@ -133,13 +133,13 @@ impl PaymentLinksResourceConsentCollectionPromotions {
 }
 
 impl std::str::FromStr for PaymentLinksResourceConsentCollectionPromotions {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentLinksResourceConsentCollectionPromotions::*;
         match s {
             "auto" => Ok(Auto),
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -211,13 +211,13 @@ impl PaymentLinksResourceConsentCollectionTermsOfService {
 }
 
 impl std::str::FromStr for PaymentLinksResourceConsentCollectionTermsOfService {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentLinksResourceConsentCollectionTermsOfService::*;
         match s {
             "none" => Ok(None),
             "required" => Ok(Required),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_links_resource_custom_fields.rs
+++ b/generated/stripe_shared/src/payment_links_resource_custom_fields.rs
@@ -155,14 +155,14 @@ impl PaymentLinksResourceCustomFieldsType {
 }
 
 impl std::str::FromStr for PaymentLinksResourceCustomFieldsType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentLinksResourceCustomFieldsType::*;
         match s {
             "dropdown" => Ok(Dropdown),
             "numeric" => Ok(Numeric),
             "text" => Ok(Text),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_links_resource_custom_fields_label.rs
+++ b/generated/stripe_shared/src/payment_links_resource_custom_fields_label.rs
@@ -112,12 +112,12 @@ impl PaymentLinksResourceCustomFieldsLabelType {
 }
 
 impl std::str::FromStr for PaymentLinksResourceCustomFieldsLabelType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentLinksResourceCustomFieldsLabelType::*;
         match s {
             "custom" => Ok(Custom),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_links_resource_payment_intent_data.rs
+++ b/generated/stripe_shared/src/payment_links_resource_payment_intent_data.rs
@@ -168,14 +168,14 @@ impl PaymentLinksResourcePaymentIntentDataCaptureMethod {
 }
 
 impl std::str::FromStr for PaymentLinksResourcePaymentIntentDataCaptureMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentLinksResourcePaymentIntentDataCaptureMethod::*;
         match s {
             "automatic" => Ok(Automatic),
             "automatic_async" => Ok(AutomaticAsync),
             "manual" => Ok(Manual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -246,13 +246,13 @@ impl PaymentLinksResourcePaymentIntentDataSetupFutureUsage {
 }
 
 impl std::str::FromStr for PaymentLinksResourcePaymentIntentDataSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentLinksResourcePaymentIntentDataSetupFutureUsage::*;
         match s {
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_links_resource_payment_method_reuse_agreement.rs
+++ b/generated/stripe_shared/src/payment_links_resource_payment_method_reuse_agreement.rs
@@ -114,13 +114,13 @@ impl PaymentLinksResourcePaymentMethodReuseAgreementPosition {
 }
 
 impl std::str::FromStr for PaymentLinksResourcePaymentMethodReuseAgreementPosition {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentLinksResourcePaymentMethodReuseAgreementPosition::*;
         match s {
             "auto" => Ok(Auto),
             "hidden" => Ok(Hidden),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_links_resource_shipping_address_collection.rs
+++ b/generated/stripe_shared/src/payment_links_resource_shipping_address_collection.rs
@@ -584,7 +584,7 @@ impl PaymentLinksResourceShippingAddressCollectionAllowedCountries {
 }
 
 impl std::str::FromStr for PaymentLinksResourceShippingAddressCollectionAllowedCountries {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentLinksResourceShippingAddressCollectionAllowedCountries::*;
         match s {
@@ -825,7 +825,7 @@ impl std::str::FromStr for PaymentLinksResourceShippingAddressCollectionAllowedC
             "ZM" => Ok(Zm),
             "ZW" => Ok(Zw),
             "ZZ" => Ok(Zz),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -861,8 +861,7 @@ impl miniserde::de::Visitor
     fn string(&mut self, s: &str) -> miniserde::Result<()> {
         use std::str::FromStr;
         self.out = Some(
-            PaymentLinksResourceShippingAddressCollectionAllowedCountries::from_str(s)
-                .unwrap_or(PaymentLinksResourceShippingAddressCollectionAllowedCountries::Unknown),
+            PaymentLinksResourceShippingAddressCollectionAllowedCountries::from_str(s).unwrap(),
         );
         Ok(())
     }
@@ -878,6 +877,6 @@ impl<'de> serde::Deserialize<'de>
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }

--- a/generated/stripe_shared/src/payment_method.rs
+++ b/generated/stripe_shared/src/payment_method.rs
@@ -505,7 +505,7 @@ impl PaymentMethodType {
 }
 
 impl std::str::FromStr for PaymentMethodType {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodType::*;
         match s {
@@ -544,7 +544,7 @@ impl std::str::FromStr for PaymentMethodType {
             "us_bank_account" => Ok(UsBankAccount),
             "wechat_pay" => Ok(WechatPay),
             "zip" => Ok(Zip),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -577,7 +577,7 @@ impl miniserde::Deserialize for PaymentMethodType {
 impl miniserde::de::Visitor for crate::Place<PaymentMethodType> {
     fn string(&mut self, s: &str) -> miniserde::Result<()> {
         use std::str::FromStr;
-        self.out = Some(PaymentMethodType::from_str(s).unwrap_or(PaymentMethodType::Unknown));
+        self.out = Some(PaymentMethodType::from_str(s).unwrap());
         Ok(())
     }
 }
@@ -588,7 +588,7 @@ impl<'de> serde::Deserialize<'de> for PaymentMethodType {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 impl stripe_types::Object for PaymentMethod {

--- a/generated/stripe_shared/src/payment_method_card_present.rs
+++ b/generated/stripe_shared/src/payment_method_card_present.rs
@@ -214,7 +214,7 @@ impl PaymentMethodCardPresentReadMethod {
 }
 
 impl std::str::FromStr for PaymentMethodCardPresentReadMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodCardPresentReadMethod::*;
         match s {
@@ -223,7 +223,7 @@ impl std::str::FromStr for PaymentMethodCardPresentReadMethod {
             "contactless_magstripe_mode" => Ok(ContactlessMagstripeMode),
             "magnetic_stripe_fallback" => Ok(MagneticStripeFallback),
             "magnetic_stripe_track2" => Ok(MagneticStripeTrack2),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_method_card_wallet.rs
+++ b/generated/stripe_shared/src/payment_method_card_wallet.rs
@@ -179,7 +179,7 @@ impl PaymentMethodCardWalletType {
 }
 
 impl std::str::FromStr for PaymentMethodCardWalletType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodCardWalletType::*;
         match s {
@@ -190,7 +190,7 @@ impl std::str::FromStr for PaymentMethodCardWalletType {
             "masterpass" => Ok(Masterpass),
             "samsung_pay" => Ok(SamsungPay),
             "visa_checkout" => Ok(VisaCheckout),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_method_details_ach_debit.rs
+++ b/generated/stripe_shared/src/payment_method_details_ach_debit.rs
@@ -150,13 +150,13 @@ impl PaymentMethodDetailsAchDebitAccountHolderType {
 }
 
 impl std::str::FromStr for PaymentMethodDetailsAchDebitAccountHolderType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodDetailsAchDebitAccountHolderType::*;
         match s {
             "company" => Ok(Company),
             "individual" => Ok(Individual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_method_details_bancontact.rs
+++ b/generated/stripe_shared/src/payment_method_details_bancontact.rs
@@ -176,7 +176,7 @@ impl PaymentMethodDetailsBancontactPreferredLanguage {
 }
 
 impl std::str::FromStr for PaymentMethodDetailsBancontactPreferredLanguage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodDetailsBancontactPreferredLanguage::*;
         match s {
@@ -184,7 +184,7 @@ impl std::str::FromStr for PaymentMethodDetailsBancontactPreferredLanguage {
             "en" => Ok(En),
             "fr" => Ok(Fr),
             "nl" => Ok(Nl),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_method_details_card_installments_plan.rs
+++ b/generated/stripe_shared/src/payment_method_details_card_installments_plan.rs
@@ -123,12 +123,12 @@ impl PaymentMethodDetailsCardInstallmentsPlanInterval {
 }
 
 impl std::str::FromStr for PaymentMethodDetailsCardInstallmentsPlanInterval {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodDetailsCardInstallmentsPlanInterval::*;
         match s {
             "month" => Ok(Month),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -197,12 +197,12 @@ impl PaymentMethodDetailsCardInstallmentsPlanType {
 }
 
 impl std::str::FromStr for PaymentMethodDetailsCardInstallmentsPlanType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodDetailsCardInstallmentsPlanType::*;
         match s {
             "fixed_count" => Ok(FixedCount),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_method_details_card_present.rs
+++ b/generated/stripe_shared/src/payment_method_details_card_present.rs
@@ -279,7 +279,7 @@ impl PaymentMethodDetailsCardPresentReadMethod {
 }
 
 impl std::str::FromStr for PaymentMethodDetailsCardPresentReadMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodDetailsCardPresentReadMethod::*;
         match s {
@@ -288,7 +288,7 @@ impl std::str::FromStr for PaymentMethodDetailsCardPresentReadMethod {
             "contactless_magstripe_mode" => Ok(ContactlessMagstripeMode),
             "magnetic_stripe_fallback" => Ok(MagneticStripeFallback),
             "magnetic_stripe_track2" => Ok(MagneticStripeTrack2),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_method_details_card_present_receipt.rs
+++ b/generated/stripe_shared/src/payment_method_details_card_present_receipt.rs
@@ -198,7 +198,7 @@ impl PaymentMethodDetailsCardPresentReceiptAccountType {
 }
 
 impl std::str::FromStr for PaymentMethodDetailsCardPresentReceiptAccountType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodDetailsCardPresentReceiptAccountType::*;
         match s {
@@ -206,7 +206,7 @@ impl std::str::FromStr for PaymentMethodDetailsCardPresentReceiptAccountType {
             "credit" => Ok(Credit),
             "prepaid" => Ok(Prepaid),
             "unknown" => Ok(Unknown),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_method_details_card_wallet.rs
+++ b/generated/stripe_shared/src/payment_method_details_card_wallet.rs
@@ -180,7 +180,7 @@ impl PaymentMethodDetailsCardWalletType {
 }
 
 impl std::str::FromStr for PaymentMethodDetailsCardWalletType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodDetailsCardWalletType::*;
         match s {
@@ -191,7 +191,7 @@ impl std::str::FromStr for PaymentMethodDetailsCardWalletType {
             "masterpass" => Ok(Masterpass),
             "samsung_pay" => Ok(SamsungPay),
             "visa_checkout" => Ok(VisaCheckout),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_method_details_eps.rs
+++ b/generated/stripe_shared/src/payment_method_details_eps.rs
@@ -173,7 +173,7 @@ impl PaymentMethodDetailsEpsBank {
 }
 
 impl std::str::FromStr for PaymentMethodDetailsEpsBank {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodDetailsEpsBank::*;
         match s {
@@ -205,7 +205,7 @@ impl std::str::FromStr for PaymentMethodDetailsEpsBank {
             "volksbank_gruppe" => Ok(VolksbankGruppe),
             "volkskreditbank_ag" => Ok(VolkskreditbankAg),
             "vr_bank_braunau" => Ok(VrBankBraunau),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -238,10 +238,7 @@ impl miniserde::Deserialize for PaymentMethodDetailsEpsBank {
 impl miniserde::de::Visitor for crate::Place<PaymentMethodDetailsEpsBank> {
     fn string(&mut self, s: &str) -> miniserde::Result<()> {
         use std::str::FromStr;
-        self.out = Some(
-            PaymentMethodDetailsEpsBank::from_str(s)
-                .unwrap_or(PaymentMethodDetailsEpsBank::Unknown),
-        );
+        self.out = Some(PaymentMethodDetailsEpsBank::from_str(s).unwrap());
         Ok(())
     }
 }
@@ -252,6 +249,6 @@ impl<'de> serde::Deserialize<'de> for PaymentMethodDetailsEpsBank {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }

--- a/generated/stripe_shared/src/payment_method_details_fpx.rs
+++ b/generated/stripe_shared/src/payment_method_details_fpx.rs
@@ -129,13 +129,13 @@ impl PaymentMethodDetailsFpxAccountHolderType {
 }
 
 impl std::str::FromStr for PaymentMethodDetailsFpxAccountHolderType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodDetailsFpxAccountHolderType::*;
         match s {
             "company" => Ok(Company),
             "individual" => Ok(Individual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -248,7 +248,7 @@ impl PaymentMethodDetailsFpxBank {
 }
 
 impl std::str::FromStr for PaymentMethodDetailsFpxBank {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodDetailsFpxBank::*;
         match s {
@@ -274,7 +274,7 @@ impl std::str::FromStr for PaymentMethodDetailsFpxBank {
             "rhb" => Ok(Rhb),
             "standard_chartered" => Ok(StandardChartered),
             "uob" => Ok(Uob),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -307,10 +307,7 @@ impl miniserde::Deserialize for PaymentMethodDetailsFpxBank {
 impl miniserde::de::Visitor for crate::Place<PaymentMethodDetailsFpxBank> {
     fn string(&mut self, s: &str) -> miniserde::Result<()> {
         use std::str::FromStr;
-        self.out = Some(
-            PaymentMethodDetailsFpxBank::from_str(s)
-                .unwrap_or(PaymentMethodDetailsFpxBank::Unknown),
-        );
+        self.out = Some(PaymentMethodDetailsFpxBank::from_str(s).unwrap());
         Ok(())
     }
 }
@@ -321,6 +318,6 @@ impl<'de> serde::Deserialize<'de> for PaymentMethodDetailsFpxBank {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }

--- a/generated/stripe_shared/src/payment_method_details_ideal.rs
+++ b/generated/stripe_shared/src/payment_method_details_ideal.rs
@@ -188,7 +188,7 @@ impl PaymentMethodDetailsIdealBank {
 }
 
 impl std::str::FromStr for PaymentMethodDetailsIdealBank {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodDetailsIdealBank::*;
         match s {
@@ -208,7 +208,7 @@ impl std::str::FromStr for PaymentMethodDetailsIdealBank {
             "triodos_bank" => Ok(TriodosBank),
             "van_lanschot" => Ok(VanLanschot),
             "yoursafe" => Ok(Yoursafe),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -241,10 +241,7 @@ impl miniserde::Deserialize for PaymentMethodDetailsIdealBank {
 impl miniserde::de::Visitor for crate::Place<PaymentMethodDetailsIdealBank> {
     fn string(&mut self, s: &str) -> miniserde::Result<()> {
         use std::str::FromStr;
-        self.out = Some(
-            PaymentMethodDetailsIdealBank::from_str(s)
-                .unwrap_or(PaymentMethodDetailsIdealBank::Unknown),
-        );
+        self.out = Some(PaymentMethodDetailsIdealBank::from_str(s).unwrap());
         Ok(())
     }
 }
@@ -255,7 +252,7 @@ impl<'de> serde::Deserialize<'de> for PaymentMethodDetailsIdealBank {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// The Bank Identifier Code of the customer's bank.
@@ -309,7 +306,7 @@ impl PaymentMethodDetailsIdealBic {
 }
 
 impl std::str::FromStr for PaymentMethodDetailsIdealBic {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodDetailsIdealBic::*;
         match s {
@@ -330,7 +327,7 @@ impl std::str::FromStr for PaymentMethodDetailsIdealBic {
             "REVOLT21" => Ok(Revolt21),
             "SNSBNL2A" => Ok(Snsbnl2a),
             "TRIONL2U" => Ok(Trionl2u),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -363,10 +360,7 @@ impl miniserde::Deserialize for PaymentMethodDetailsIdealBic {
 impl miniserde::de::Visitor for crate::Place<PaymentMethodDetailsIdealBic> {
     fn string(&mut self, s: &str) -> miniserde::Result<()> {
         use std::str::FromStr;
-        self.out = Some(
-            PaymentMethodDetailsIdealBic::from_str(s)
-                .unwrap_or(PaymentMethodDetailsIdealBic::Unknown),
-        );
+        self.out = Some(PaymentMethodDetailsIdealBic::from_str(s).unwrap());
         Ok(())
     }
 }
@@ -377,6 +371,6 @@ impl<'de> serde::Deserialize<'de> for PaymentMethodDetailsIdealBic {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }

--- a/generated/stripe_shared/src/payment_method_details_interac_present.rs
+++ b/generated/stripe_shared/src/payment_method_details_interac_present.rs
@@ -243,7 +243,7 @@ impl PaymentMethodDetailsInteracPresentReadMethod {
 }
 
 impl std::str::FromStr for PaymentMethodDetailsInteracPresentReadMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodDetailsInteracPresentReadMethod::*;
         match s {
@@ -252,7 +252,7 @@ impl std::str::FromStr for PaymentMethodDetailsInteracPresentReadMethod {
             "contactless_magstripe_mode" => Ok(ContactlessMagstripeMode),
             "magnetic_stripe_fallback" => Ok(MagneticStripeFallback),
             "magnetic_stripe_track2" => Ok(MagneticStripeTrack2),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_method_details_interac_present_receipt.rs
+++ b/generated/stripe_shared/src/payment_method_details_interac_present_receipt.rs
@@ -196,14 +196,14 @@ impl PaymentMethodDetailsInteracPresentReceiptAccountType {
 }
 
 impl std::str::FromStr for PaymentMethodDetailsInteracPresentReceiptAccountType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodDetailsInteracPresentReceiptAccountType::*;
         match s {
             "checking" => Ok(Checking),
             "savings" => Ok(Savings),
             "unknown" => Ok(Unknown),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_method_details_konbini_store.rs
+++ b/generated/stripe_shared/src/payment_method_details_konbini_store.rs
@@ -112,7 +112,7 @@ impl PaymentMethodDetailsKonbiniStoreChain {
 }
 
 impl std::str::FromStr for PaymentMethodDetailsKonbiniStoreChain {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodDetailsKonbiniStoreChain::*;
         match s {
@@ -120,7 +120,7 @@ impl std::str::FromStr for PaymentMethodDetailsKonbiniStoreChain {
             "lawson" => Ok(Lawson),
             "ministop" => Ok(Ministop),
             "seicomart" => Ok(Seicomart),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_method_details_p24.rs
+++ b/generated/stripe_shared/src/payment_method_details_p24.rs
@@ -182,7 +182,7 @@ impl PaymentMethodDetailsP24Bank {
 }
 
 impl std::str::FromStr for PaymentMethodDetailsP24Bank {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodDetailsP24Bank::*;
         match s {
@@ -212,7 +212,7 @@ impl std::str::FromStr for PaymentMethodDetailsP24Bank {
             "toyota_bank" => Ok(ToyotaBank),
             "velobank" => Ok(Velobank),
             "volkswagen_bank" => Ok(VolkswagenBank),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -245,10 +245,7 @@ impl miniserde::Deserialize for PaymentMethodDetailsP24Bank {
 impl miniserde::de::Visitor for crate::Place<PaymentMethodDetailsP24Bank> {
     fn string(&mut self, s: &str) -> miniserde::Result<()> {
         use std::str::FromStr;
-        self.out = Some(
-            PaymentMethodDetailsP24Bank::from_str(s)
-                .unwrap_or(PaymentMethodDetailsP24Bank::Unknown),
-        );
+        self.out = Some(PaymentMethodDetailsP24Bank::from_str(s).unwrap());
         Ok(())
     }
 }
@@ -259,6 +256,6 @@ impl<'de> serde::Deserialize<'de> for PaymentMethodDetailsP24Bank {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }

--- a/generated/stripe_shared/src/payment_method_details_sofort.rs
+++ b/generated/stripe_shared/src/payment_method_details_sofort.rs
@@ -189,7 +189,7 @@ impl PaymentMethodDetailsSofortPreferredLanguage {
 }
 
 impl std::str::FromStr for PaymentMethodDetailsSofortPreferredLanguage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodDetailsSofortPreferredLanguage::*;
         match s {
@@ -200,7 +200,7 @@ impl std::str::FromStr for PaymentMethodDetailsSofortPreferredLanguage {
             "it" => Ok(It),
             "nl" => Ok(Nl),
             "pl" => Ok(Pl),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_method_details_us_bank_account.rs
+++ b/generated/stripe_shared/src/payment_method_details_us_bank_account.rs
@@ -150,13 +150,13 @@ impl PaymentMethodDetailsUsBankAccountAccountHolderType {
 }
 
 impl std::str::FromStr for PaymentMethodDetailsUsBankAccountAccountHolderType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodDetailsUsBankAccountAccountHolderType::*;
         match s {
             "company" => Ok(Company),
             "individual" => Ok(Individual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -227,13 +227,13 @@ impl PaymentMethodDetailsUsBankAccountAccountType {
 }
 
 impl std::str::FromStr for PaymentMethodDetailsUsBankAccountAccountType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodDetailsUsBankAccountAccountType::*;
         match s {
             "checking" => Ok(Checking),
             "savings" => Ok(Savings),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_method_eps.rs
+++ b/generated/stripe_shared/src/payment_method_eps.rs
@@ -166,7 +166,7 @@ impl PaymentMethodEpsBank {
 }
 
 impl std::str::FromStr for PaymentMethodEpsBank {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodEpsBank::*;
         match s {
@@ -198,7 +198,7 @@ impl std::str::FromStr for PaymentMethodEpsBank {
             "volksbank_gruppe" => Ok(VolksbankGruppe),
             "volkskreditbank_ag" => Ok(VolkskreditbankAg),
             "vr_bank_braunau" => Ok(VrBankBraunau),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -231,7 +231,7 @@ impl miniserde::Deserialize for PaymentMethodEpsBank {
 impl miniserde::de::Visitor for crate::Place<PaymentMethodEpsBank> {
     fn string(&mut self, s: &str) -> miniserde::Result<()> {
         use std::str::FromStr;
-        self.out = Some(PaymentMethodEpsBank::from_str(s).unwrap_or(PaymentMethodEpsBank::Unknown));
+        self.out = Some(PaymentMethodEpsBank::from_str(s).unwrap());
         Ok(())
     }
 }
@@ -242,6 +242,6 @@ impl<'de> serde::Deserialize<'de> for PaymentMethodEpsBank {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }

--- a/generated/stripe_shared/src/payment_method_fpx.rs
+++ b/generated/stripe_shared/src/payment_method_fpx.rs
@@ -116,13 +116,13 @@ impl PaymentMethodFpxAccountHolderType {
 }
 
 impl std::str::FromStr for PaymentMethodFpxAccountHolderType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodFpxAccountHolderType::*;
         match s {
             "company" => Ok(Company),
             "individual" => Ok(Individual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -234,7 +234,7 @@ impl PaymentMethodFpxBank {
 }
 
 impl std::str::FromStr for PaymentMethodFpxBank {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodFpxBank::*;
         match s {
@@ -260,7 +260,7 @@ impl std::str::FromStr for PaymentMethodFpxBank {
             "rhb" => Ok(Rhb),
             "standard_chartered" => Ok(StandardChartered),
             "uob" => Ok(Uob),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -293,7 +293,7 @@ impl miniserde::Deserialize for PaymentMethodFpxBank {
 impl miniserde::de::Visitor for crate::Place<PaymentMethodFpxBank> {
     fn string(&mut self, s: &str) -> miniserde::Result<()> {
         use std::str::FromStr;
-        self.out = Some(PaymentMethodFpxBank::from_str(s).unwrap_or(PaymentMethodFpxBank::Unknown));
+        self.out = Some(PaymentMethodFpxBank::from_str(s).unwrap());
         Ok(())
     }
 }
@@ -304,6 +304,6 @@ impl<'de> serde::Deserialize<'de> for PaymentMethodFpxBank {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }

--- a/generated/stripe_shared/src/payment_method_ideal.rs
+++ b/generated/stripe_shared/src/payment_method_ideal.rs
@@ -147,7 +147,7 @@ impl PaymentMethodIdealBank {
 }
 
 impl std::str::FromStr for PaymentMethodIdealBank {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodIdealBank::*;
         match s {
@@ -167,7 +167,7 @@ impl std::str::FromStr for PaymentMethodIdealBank {
             "triodos_bank" => Ok(TriodosBank),
             "van_lanschot" => Ok(VanLanschot),
             "yoursafe" => Ok(Yoursafe),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -200,8 +200,7 @@ impl miniserde::Deserialize for PaymentMethodIdealBank {
 impl miniserde::de::Visitor for crate::Place<PaymentMethodIdealBank> {
     fn string(&mut self, s: &str) -> miniserde::Result<()> {
         use std::str::FromStr;
-        self.out =
-            Some(PaymentMethodIdealBank::from_str(s).unwrap_or(PaymentMethodIdealBank::Unknown));
+        self.out = Some(PaymentMethodIdealBank::from_str(s).unwrap());
         Ok(())
     }
 }
@@ -212,7 +211,7 @@ impl<'de> serde::Deserialize<'de> for PaymentMethodIdealBank {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// The Bank Identifier Code of the customer's bank, if the bank was provided.
@@ -266,7 +265,7 @@ impl PaymentMethodIdealBic {
 }
 
 impl std::str::FromStr for PaymentMethodIdealBic {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodIdealBic::*;
         match s {
@@ -287,7 +286,7 @@ impl std::str::FromStr for PaymentMethodIdealBic {
             "REVOLT21" => Ok(Revolt21),
             "SNSBNL2A" => Ok(Snsbnl2a),
             "TRIONL2U" => Ok(Trionl2u),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -320,8 +319,7 @@ impl miniserde::Deserialize for PaymentMethodIdealBic {
 impl miniserde::de::Visitor for crate::Place<PaymentMethodIdealBic> {
     fn string(&mut self, s: &str) -> miniserde::Result<()> {
         use std::str::FromStr;
-        self.out =
-            Some(PaymentMethodIdealBic::from_str(s).unwrap_or(PaymentMethodIdealBic::Unknown));
+        self.out = Some(PaymentMethodIdealBic::from_str(s).unwrap());
         Ok(())
     }
 }
@@ -332,6 +330,6 @@ impl<'de> serde::Deserialize<'de> for PaymentMethodIdealBic {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }

--- a/generated/stripe_shared/src/payment_method_interac_present.rs
+++ b/generated/stripe_shared/src/payment_method_interac_present.rs
@@ -220,7 +220,7 @@ impl PaymentMethodInteracPresentReadMethod {
 }
 
 impl std::str::FromStr for PaymentMethodInteracPresentReadMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodInteracPresentReadMethod::*;
         match s {
@@ -229,7 +229,7 @@ impl std::str::FromStr for PaymentMethodInteracPresentReadMethod {
             "contactless_magstripe_mode" => Ok(ContactlessMagstripeMode),
             "magnetic_stripe_fallback" => Ok(MagneticStripeFallback),
             "magnetic_stripe_track2" => Ok(MagneticStripeTrack2),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_method_options_affirm.rs
+++ b/generated/stripe_shared/src/payment_method_options_affirm.rs
@@ -131,12 +131,12 @@ impl PaymentMethodOptionsAffirmCaptureMethod {
 }
 
 impl std::str::FromStr for PaymentMethodOptionsAffirmCaptureMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodOptionsAffirmCaptureMethod::*;
         match s {
             "manual" => Ok(Manual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -207,12 +207,12 @@ impl PaymentMethodOptionsAffirmSetupFutureUsage {
 }
 
 impl std::str::FromStr for PaymentMethodOptionsAffirmSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodOptionsAffirmSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_method_options_afterpay_clearpay.rs
+++ b/generated/stripe_shared/src/payment_method_options_afterpay_clearpay.rs
@@ -133,12 +133,12 @@ impl PaymentMethodOptionsAfterpayClearpayCaptureMethod {
 }
 
 impl std::str::FromStr for PaymentMethodOptionsAfterpayClearpayCaptureMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodOptionsAfterpayClearpayCaptureMethod::*;
         match s {
             "manual" => Ok(Manual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -212,12 +212,12 @@ impl PaymentMethodOptionsAfterpayClearpaySetupFutureUsage {
 }
 
 impl std::str::FromStr for PaymentMethodOptionsAfterpayClearpaySetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodOptionsAfterpayClearpaySetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_method_options_alipay.rs
+++ b/generated/stripe_shared/src/payment_method_options_alipay.rs
@@ -120,13 +120,13 @@ impl PaymentMethodOptionsAlipaySetupFutureUsage {
 }
 
 impl std::str::FromStr for PaymentMethodOptionsAlipaySetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodOptionsAlipaySetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_method_options_bacs_debit.rs
+++ b/generated/stripe_shared/src/payment_method_options_bacs_debit.rs
@@ -122,14 +122,14 @@ impl PaymentMethodOptionsBacsDebitSetupFutureUsage {
 }
 
 impl std::str::FromStr for PaymentMethodOptionsBacsDebitSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodOptionsBacsDebitSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_method_options_bancontact.rs
+++ b/generated/stripe_shared/src/payment_method_options_bancontact.rs
@@ -132,7 +132,7 @@ impl PaymentMethodOptionsBancontactPreferredLanguage {
 }
 
 impl std::str::FromStr for PaymentMethodOptionsBancontactPreferredLanguage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodOptionsBancontactPreferredLanguage::*;
         match s {
@@ -140,7 +140,7 @@ impl std::str::FromStr for PaymentMethodOptionsBancontactPreferredLanguage {
             "en" => Ok(En),
             "fr" => Ok(Fr),
             "nl" => Ok(Nl),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -216,13 +216,13 @@ impl PaymentMethodOptionsBancontactSetupFutureUsage {
 }
 
 impl std::str::FromStr for PaymentMethodOptionsBancontactSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodOptionsBancontactSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_method_options_boleto.rs
+++ b/generated/stripe_shared/src/payment_method_options_boleto.rs
@@ -136,14 +136,14 @@ impl PaymentMethodOptionsBoletoSetupFutureUsage {
 }
 
 impl std::str::FromStr for PaymentMethodOptionsBoletoSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodOptionsBoletoSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_method_options_card_mandate_options.rs
+++ b/generated/stripe_shared/src/payment_method_options_card_mandate_options.rs
@@ -177,13 +177,13 @@ impl PaymentMethodOptionsCardMandateOptionsAmountType {
 }
 
 impl std::str::FromStr for PaymentMethodOptionsCardMandateOptionsAmountType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodOptionsCardMandateOptionsAmountType::*;
         match s {
             "fixed" => Ok(Fixed),
             "maximum" => Ok(Maximum),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -260,7 +260,7 @@ impl PaymentMethodOptionsCardMandateOptionsInterval {
 }
 
 impl std::str::FromStr for PaymentMethodOptionsCardMandateOptionsInterval {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodOptionsCardMandateOptionsInterval::*;
         match s {
@@ -269,7 +269,7 @@ impl std::str::FromStr for PaymentMethodOptionsCardMandateOptionsInterval {
             "sporadic" => Ok(Sporadic),
             "week" => Ok(Week),
             "year" => Ok(Year),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -338,12 +338,12 @@ impl PaymentMethodOptionsCardMandateOptionsSupportedTypes {
 }
 
 impl std::str::FromStr for PaymentMethodOptionsCardMandateOptionsSupportedTypes {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodOptionsCardMandateOptionsSupportedTypes::*;
         match s {
             "india" => Ok(India),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_method_options_cashapp.rs
+++ b/generated/stripe_shared/src/payment_method_options_cashapp.rs
@@ -124,12 +124,12 @@ impl PaymentMethodOptionsCashappCaptureMethod {
 }
 
 impl std::str::FromStr for PaymentMethodOptionsCashappCaptureMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodOptionsCashappCaptureMethod::*;
         match s {
             "manual" => Ok(Manual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -204,14 +204,14 @@ impl PaymentMethodOptionsCashappSetupFutureUsage {
 }
 
 impl std::str::FromStr for PaymentMethodOptionsCashappSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodOptionsCashappSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
             "on_session" => Ok(OnSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_method_options_customer_balance.rs
+++ b/generated/stripe_shared/src/payment_method_options_customer_balance.rs
@@ -132,12 +132,12 @@ impl PaymentMethodOptionsCustomerBalanceFundingType {
 }
 
 impl std::str::FromStr for PaymentMethodOptionsCustomerBalanceFundingType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodOptionsCustomerBalanceFundingType::*;
         match s {
             "bank_transfer" => Ok(BankTransfer),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -211,12 +211,12 @@ impl PaymentMethodOptionsCustomerBalanceSetupFutureUsage {
 }
 
 impl std::str::FromStr for PaymentMethodOptionsCustomerBalanceSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodOptionsCustomerBalanceSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_method_options_customer_balance_bank_transfer.rs
+++ b/generated/stripe_shared/src/payment_method_options_customer_balance_bank_transfer.rs
@@ -147,7 +147,7 @@ impl PaymentMethodOptionsCustomerBalanceBankTransferRequestedAddressTypes {
 }
 
 impl std::str::FromStr for PaymentMethodOptionsCustomerBalanceBankTransferRequestedAddressTypes {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodOptionsCustomerBalanceBankTransferRequestedAddressTypes::*;
         match s {
@@ -158,7 +158,7 @@ impl std::str::FromStr for PaymentMethodOptionsCustomerBalanceBankTransferReques
             "spei" => Ok(Spei),
             "swift" => Ok(Swift),
             "zengin" => Ok(Zengin),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -239,7 +239,7 @@ impl PaymentMethodOptionsCustomerBalanceBankTransferType {
 }
 
 impl std::str::FromStr for PaymentMethodOptionsCustomerBalanceBankTransferType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodOptionsCustomerBalanceBankTransferType::*;
         match s {
@@ -248,7 +248,7 @@ impl std::str::FromStr for PaymentMethodOptionsCustomerBalanceBankTransferType {
             "jp_bank_transfer" => Ok(JpBankTransfer),
             "mx_bank_transfer" => Ok(MxBankTransfer),
             "us_bank_transfer" => Ok(UsBankTransfer),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_method_options_customer_balance_eu_bank_account.rs
+++ b/generated/stripe_shared/src/payment_method_options_customer_balance_eu_bank_account.rs
@@ -118,7 +118,7 @@ impl PaymentMethodOptionsCustomerBalanceEuBankAccountCountry {
 }
 
 impl std::str::FromStr for PaymentMethodOptionsCustomerBalanceEuBankAccountCountry {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodOptionsCustomerBalanceEuBankAccountCountry::*;
         match s {
@@ -128,7 +128,7 @@ impl std::str::FromStr for PaymentMethodOptionsCustomerBalanceEuBankAccountCount
             "FR" => Ok(Fr),
             "IE" => Ok(Ie),
             "NL" => Ok(Nl),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_method_options_fpx.rs
+++ b/generated/stripe_shared/src/payment_method_options_fpx.rs
@@ -118,12 +118,12 @@ impl PaymentMethodOptionsFpxSetupFutureUsage {
 }
 
 impl std::str::FromStr for PaymentMethodOptionsFpxSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodOptionsFpxSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_method_options_giropay.rs
+++ b/generated/stripe_shared/src/payment_method_options_giropay.rs
@@ -118,12 +118,12 @@ impl PaymentMethodOptionsGiropaySetupFutureUsage {
 }
 
 impl std::str::FromStr for PaymentMethodOptionsGiropaySetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodOptionsGiropaySetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_method_options_grabpay.rs
+++ b/generated/stripe_shared/src/payment_method_options_grabpay.rs
@@ -118,12 +118,12 @@ impl PaymentMethodOptionsGrabpaySetupFutureUsage {
 }
 
 impl std::str::FromStr for PaymentMethodOptionsGrabpaySetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodOptionsGrabpaySetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_method_options_ideal.rs
+++ b/generated/stripe_shared/src/payment_method_options_ideal.rs
@@ -120,13 +120,13 @@ impl PaymentMethodOptionsIdealSetupFutureUsage {
 }
 
 impl std::str::FromStr for PaymentMethodOptionsIdealSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodOptionsIdealSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_method_options_klarna.rs
+++ b/generated/stripe_shared/src/payment_method_options_klarna.rs
@@ -131,12 +131,12 @@ impl PaymentMethodOptionsKlarnaCaptureMethod {
 }
 
 impl std::str::FromStr for PaymentMethodOptionsKlarnaCaptureMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodOptionsKlarnaCaptureMethod::*;
         match s {
             "manual" => Ok(Manual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -207,12 +207,12 @@ impl PaymentMethodOptionsKlarnaSetupFutureUsage {
 }
 
 impl std::str::FromStr for PaymentMethodOptionsKlarnaSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodOptionsKlarnaSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_method_options_konbini.rs
+++ b/generated/stripe_shared/src/payment_method_options_konbini.rs
@@ -158,12 +158,12 @@ impl PaymentMethodOptionsKonbiniSetupFutureUsage {
 }
 
 impl std::str::FromStr for PaymentMethodOptionsKonbiniSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodOptionsKonbiniSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_method_options_oxxo.rs
+++ b/generated/stripe_shared/src/payment_method_options_oxxo.rs
@@ -132,12 +132,12 @@ impl PaymentMethodOptionsOxxoSetupFutureUsage {
 }
 
 impl std::str::FromStr for PaymentMethodOptionsOxxoSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodOptionsOxxoSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_method_options_p24.rs
+++ b/generated/stripe_shared/src/payment_method_options_p24.rs
@@ -118,12 +118,12 @@ impl PaymentMethodOptionsP24SetupFutureUsage {
 }
 
 impl std::str::FromStr for PaymentMethodOptionsP24SetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodOptionsP24SetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_method_options_paynow.rs
+++ b/generated/stripe_shared/src/payment_method_options_paynow.rs
@@ -118,12 +118,12 @@ impl PaymentMethodOptionsPaynowSetupFutureUsage {
 }
 
 impl std::str::FromStr for PaymentMethodOptionsPaynowSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodOptionsPaynowSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_method_options_paypal.rs
+++ b/generated/stripe_shared/src/payment_method_options_paypal.rs
@@ -139,12 +139,12 @@ impl PaymentMethodOptionsPaypalCaptureMethod {
 }
 
 impl std::str::FromStr for PaymentMethodOptionsPaypalCaptureMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodOptionsPaypalCaptureMethod::*;
         match s {
             "manual" => Ok(Manual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -217,13 +217,13 @@ impl PaymentMethodOptionsPaypalSetupFutureUsage {
 }
 
 impl std::str::FromStr for PaymentMethodOptionsPaypalSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodOptionsPaypalSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_method_options_pix.rs
+++ b/generated/stripe_shared/src/payment_method_options_pix.rs
@@ -138,12 +138,12 @@ impl PaymentMethodOptionsPixSetupFutureUsage {
 }
 
 impl std::str::FromStr for PaymentMethodOptionsPixSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodOptionsPixSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_method_options_promptpay.rs
+++ b/generated/stripe_shared/src/payment_method_options_promptpay.rs
@@ -118,12 +118,12 @@ impl PaymentMethodOptionsPromptpaySetupFutureUsage {
 }
 
 impl std::str::FromStr for PaymentMethodOptionsPromptpaySetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodOptionsPromptpaySetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_method_options_sofort.rs
+++ b/generated/stripe_shared/src/payment_method_options_sofort.rs
@@ -138,7 +138,7 @@ impl PaymentMethodOptionsSofortPreferredLanguage {
 }
 
 impl std::str::FromStr for PaymentMethodOptionsSofortPreferredLanguage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodOptionsSofortPreferredLanguage::*;
         match s {
@@ -149,7 +149,7 @@ impl std::str::FromStr for PaymentMethodOptionsSofortPreferredLanguage {
             "it" => Ok(It),
             "nl" => Ok(Nl),
             "pl" => Ok(Pl),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -225,13 +225,13 @@ impl PaymentMethodOptionsSofortSetupFutureUsage {
 }
 
 impl std::str::FromStr for PaymentMethodOptionsSofortSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodOptionsSofortSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
             "off_session" => Ok(OffSession),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_method_options_us_bank_account_mandate_options.rs
+++ b/generated/stripe_shared/src/payment_method_options_us_bank_account_mandate_options.rs
@@ -107,12 +107,12 @@ impl PaymentMethodOptionsUsBankAccountMandateOptionsCollectionMethod {
 }
 
 impl std::str::FromStr for PaymentMethodOptionsUsBankAccountMandateOptionsCollectionMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodOptionsUsBankAccountMandateOptionsCollectionMethod::*;
         match s {
             "paper" => Ok(Paper),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_method_options_wechat_pay.rs
+++ b/generated/stripe_shared/src/payment_method_options_wechat_pay.rs
@@ -135,14 +135,14 @@ impl PaymentMethodOptionsWechatPayClient {
 }
 
 impl std::str::FromStr for PaymentMethodOptionsWechatPayClient {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodOptionsWechatPayClient::*;
         match s {
             "android" => Ok(Android),
             "ios" => Ok(Ios),
             "web" => Ok(Web),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -212,12 +212,12 @@ impl PaymentMethodOptionsWechatPaySetupFutureUsage {
 }
 
 impl std::str::FromStr for PaymentMethodOptionsWechatPaySetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodOptionsWechatPaySetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_method_options_zip.rs
+++ b/generated/stripe_shared/src/payment_method_options_zip.rs
@@ -118,12 +118,12 @@ impl PaymentMethodOptionsZipSetupFutureUsage {
 }
 
 impl std::str::FromStr for PaymentMethodOptionsZipSetupFutureUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodOptionsZipSetupFutureUsage::*;
         match s {
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_method_p24.rs
+++ b/generated/stripe_shared/src/payment_method_p24.rs
@@ -160,7 +160,7 @@ impl PaymentMethodP24Bank {
 }
 
 impl std::str::FromStr for PaymentMethodP24Bank {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodP24Bank::*;
         match s {
@@ -190,7 +190,7 @@ impl std::str::FromStr for PaymentMethodP24Bank {
             "toyota_bank" => Ok(ToyotaBank),
             "velobank" => Ok(Velobank),
             "volkswagen_bank" => Ok(VolkswagenBank),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -223,7 +223,7 @@ impl miniserde::Deserialize for PaymentMethodP24Bank {
 impl miniserde::de::Visitor for crate::Place<PaymentMethodP24Bank> {
     fn string(&mut self, s: &str) -> miniserde::Result<()> {
         use std::str::FromStr;
-        self.out = Some(PaymentMethodP24Bank::from_str(s).unwrap_or(PaymentMethodP24Bank::Unknown));
+        self.out = Some(PaymentMethodP24Bank::from_str(s).unwrap());
         Ok(())
     }
 }
@@ -234,6 +234,6 @@ impl<'de> serde::Deserialize<'de> for PaymentMethodP24Bank {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }

--- a/generated/stripe_shared/src/payment_method_us_bank_account.rs
+++ b/generated/stripe_shared/src/payment_method_us_bank_account.rs
@@ -175,13 +175,13 @@ impl PaymentMethodUsBankAccountAccountHolderType {
 }
 
 impl std::str::FromStr for PaymentMethodUsBankAccountAccountHolderType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodUsBankAccountAccountHolderType::*;
         match s {
             "company" => Ok(Company),
             "individual" => Ok(Individual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -252,13 +252,13 @@ impl PaymentMethodUsBankAccountAccountType {
 }
 
 impl std::str::FromStr for PaymentMethodUsBankAccountAccountType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodUsBankAccountAccountType::*;
         match s {
             "checking" => Ok(Checking),
             "savings" => Ok(Savings),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payment_method_us_bank_account_blocked.rs
+++ b/generated/stripe_shared/src/payment_method_us_bank_account_blocked.rs
@@ -133,7 +133,7 @@ impl PaymentMethodUsBankAccountBlockedNetworkCode {
 }
 
 impl std::str::FromStr for PaymentMethodUsBankAccountBlockedNetworkCode {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodUsBankAccountBlockedNetworkCode::*;
         match s {
@@ -149,7 +149,7 @@ impl std::str::FromStr for PaymentMethodUsBankAccountBlockedNetworkCode {
             "R20" => Ok(R20),
             "R29" => Ok(R29),
             "R31" => Ok(R31),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -228,7 +228,7 @@ impl PaymentMethodUsBankAccountBlockedReason {
 }
 
 impl std::str::FromStr for PaymentMethodUsBankAccountBlockedReason {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaymentMethodUsBankAccountBlockedReason::*;
         match s {
@@ -238,7 +238,7 @@ impl std::str::FromStr for PaymentMethodUsBankAccountBlockedReason {
             "bank_account_restricted" => Ok(BankAccountRestricted),
             "bank_account_unusable" => Ok(BankAccountUnusable),
             "debit_not_authorized" => Ok(DebitNotAuthorized),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/payout.rs
+++ b/generated/stripe_shared/src/payout.rs
@@ -322,14 +322,14 @@ impl PayoutReconciliationStatus {
 }
 
 impl std::str::FromStr for PayoutReconciliationStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PayoutReconciliationStatus::*;
         match s {
             "completed" => Ok(Completed),
             "in_progress" => Ok(InProgress),
             "not_applicable" => Ok(NotApplicable),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -394,13 +394,13 @@ impl PayoutType {
 }
 
 impl std::str::FromStr for PayoutType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PayoutType::*;
         match s {
             "bank_account" => Ok(BankAccount),
             "card" => Ok(Card),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/paypal_seller_protection.rs
+++ b/generated/stripe_shared/src/paypal_seller_protection.rs
@@ -118,13 +118,13 @@ impl PaypalSellerProtectionDisputeCategories {
 }
 
 impl std::str::FromStr for PaypalSellerProtectionDisputeCategories {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaypalSellerProtectionDisputeCategories::*;
         match s {
             "fraudulent" => Ok(Fraudulent),
             "product_not_received" => Ok(ProductNotReceived),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -194,14 +194,14 @@ impl PaypalSellerProtectionStatus {
 }
 
 impl std::str::FromStr for PaypalSellerProtectionStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PaypalSellerProtectionStatus::*;
         match s {
             "eligible" => Ok(Eligible),
             "not_eligible" => Ok(NotEligible),
             "partially_eligible" => Ok(PartiallyEligible),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/person.rs
+++ b/generated/stripe_shared/src/person.rs
@@ -374,13 +374,13 @@ impl PersonPoliticalExposure {
 }
 
 impl std::str::FromStr for PersonPoliticalExposure {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PersonPoliticalExposure::*;
         match s {
             "existing" => Ok(Existing),
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/plan.rs
+++ b/generated/stripe_shared/src/plan.rs
@@ -305,7 +305,7 @@ impl PlanAggregateUsage {
 }
 
 impl std::str::FromStr for PlanAggregateUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PlanAggregateUsage::*;
         match s {
@@ -313,7 +313,7 @@ impl std::str::FromStr for PlanAggregateUsage {
             "last_ever" => Ok(LastEver),
             "max" => Ok(Max),
             "sum" => Ok(Sum),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -376,13 +376,13 @@ impl PlanBillingScheme {
 }
 
 impl std::str::FromStr for PlanBillingScheme {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PlanBillingScheme::*;
         match s {
             "per_unit" => Ok(PerUnit),
             "tiered" => Ok(Tiered),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -449,7 +449,7 @@ impl PlanInterval {
 }
 
 impl std::str::FromStr for PlanInterval {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PlanInterval::*;
         match s {
@@ -457,7 +457,7 @@ impl std::str::FromStr for PlanInterval {
             "month" => Ok(Month),
             "week" => Ok(Week),
             "year" => Ok(Year),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -519,13 +519,13 @@ impl PlanTiersMode {
 }
 
 impl std::str::FromStr for PlanTiersMode {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PlanTiersMode::*;
         match s {
             "graduated" => Ok(Graduated),
             "volume" => Ok(Volume),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -587,13 +587,13 @@ impl PlanUsageType {
 }
 
 impl std::str::FromStr for PlanUsageType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PlanUsageType::*;
         match s {
             "licensed" => Ok(Licensed),
             "metered" => Ok(Metered),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/price.rs
+++ b/generated/stripe_shared/src/price.rs
@@ -314,13 +314,13 @@ impl PriceBillingScheme {
 }
 
 impl std::str::FromStr for PriceBillingScheme {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PriceBillingScheme::*;
         match s {
             "per_unit" => Ok(PerUnit),
             "tiered" => Ok(Tiered),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -385,14 +385,14 @@ impl PriceTaxBehavior {
 }
 
 impl std::str::FromStr for PriceTaxBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PriceTaxBehavior::*;
         match s {
             "exclusive" => Ok(Exclusive),
             "inclusive" => Ok(Inclusive),
             "unspecified" => Ok(Unspecified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -455,13 +455,13 @@ impl PriceTiersMode {
 }
 
 impl std::str::FromStr for PriceTiersMode {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PriceTiersMode::*;
         match s {
             "graduated" => Ok(Graduated),
             "volume" => Ok(Volume),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -523,13 +523,13 @@ impl PriceType {
 }
 
 impl std::str::FromStr for PriceType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PriceType::*;
         match s {
             "one_time" => Ok(OneTime),
             "recurring" => Ok(Recurring),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/product.rs
+++ b/generated/stripe_shared/src/product.rs
@@ -282,13 +282,13 @@ impl ProductType {
 }
 
 impl std::str::FromStr for ProductType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ProductType::*;
         match s {
             "good" => Ok(Good),
             "service" => Ok(Service),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/quote.rs
+++ b/generated/stripe_shared/src/quote.rs
@@ -411,13 +411,13 @@ impl QuoteCollectionMethod {
 }
 
 impl std::str::FromStr for QuoteCollectionMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use QuoteCollectionMethod::*;
         match s {
             "charge_automatically" => Ok(ChargeAutomatically),
             "send_invoice" => Ok(SendInvoice),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -484,7 +484,7 @@ impl QuoteStatus {
 }
 
 impl std::str::FromStr for QuoteStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use QuoteStatus::*;
         match s {
@@ -492,7 +492,7 @@ impl std::str::FromStr for QuoteStatus {
             "canceled" => Ok(Canceled),
             "draft" => Ok(Draft),
             "open" => Ok(Open),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/quotes_resource_automatic_tax.rs
+++ b/generated/stripe_shared/src/quotes_resource_automatic_tax.rs
@@ -130,14 +130,14 @@ impl QuotesResourceAutomaticTaxStatus {
 }
 
 impl std::str::FromStr for QuotesResourceAutomaticTaxStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use QuotesResourceAutomaticTaxStatus::*;
         match s {
             "complete" => Ok(Complete),
             "failed" => Ok(Failed),
             "requires_location_inputs" => Ok(RequiresLocationInputs),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/quotes_resource_recurring.rs
+++ b/generated/stripe_shared/src/quotes_resource_recurring.rs
@@ -144,7 +144,7 @@ impl QuotesResourceRecurringInterval {
 }
 
 impl std::str::FromStr for QuotesResourceRecurringInterval {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use QuotesResourceRecurringInterval::*;
         match s {
@@ -152,7 +152,7 @@ impl std::str::FromStr for QuotesResourceRecurringInterval {
             "month" => Ok(Month),
             "week" => Ok(Week),
             "year" => Ok(Year),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/recurring.rs
+++ b/generated/stripe_shared/src/recurring.rs
@@ -146,7 +146,7 @@ impl RecurringAggregateUsage {
 }
 
 impl std::str::FromStr for RecurringAggregateUsage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use RecurringAggregateUsage::*;
         match s {
@@ -154,7 +154,7 @@ impl std::str::FromStr for RecurringAggregateUsage {
             "last_ever" => Ok(LastEver),
             "max" => Ok(Max),
             "sum" => Ok(Sum),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -223,7 +223,7 @@ impl RecurringInterval {
 }
 
 impl std::str::FromStr for RecurringInterval {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use RecurringInterval::*;
         match s {
@@ -231,7 +231,7 @@ impl std::str::FromStr for RecurringInterval {
             "month" => Ok(Month),
             "week" => Ok(Week),
             "year" => Ok(Year),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -300,13 +300,13 @@ impl RecurringUsageType {
 }
 
 impl std::str::FromStr for RecurringUsageType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use RecurringUsageType::*;
         match s {
             "licensed" => Ok(Licensed),
             "metered" => Ok(Metered),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/refund.rs
+++ b/generated/stripe_shared/src/refund.rs
@@ -298,7 +298,7 @@ impl RefundReason {
 }
 
 impl std::str::FromStr for RefundReason {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use RefundReason::*;
         match s {
@@ -306,7 +306,7 @@ impl std::str::FromStr for RefundReason {
             "expired_uncaptured_charge" => Ok(ExpiredUncapturedCharge),
             "fraudulent" => Ok(Fraudulent),
             "requested_by_customer" => Ok(RequestedByCustomer),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/refund_destination_details_card.rs
+++ b/generated/stripe_shared/src/refund_destination_details_card.rs
@@ -136,14 +136,14 @@ impl RefundDestinationDetailsCardType {
 }
 
 impl std::str::FromStr for RefundDestinationDetailsCardType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use RefundDestinationDetailsCardType::*;
         match s {
             "pending" => Ok(Pending),
             "refund" => Ok(Refund),
             "reversal" => Ok(Reversal),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/review.rs
+++ b/generated/stripe_shared/src/review.rs
@@ -233,7 +233,7 @@ impl ReviewClosedReason {
 }
 
 impl std::str::FromStr for ReviewClosedReason {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ReviewClosedReason::*;
         match s {
@@ -242,7 +242,7 @@ impl std::str::FromStr for ReviewClosedReason {
             "redacted" => Ok(Redacted),
             "refunded" => Ok(Refunded),
             "refunded_as_fraud" => Ok(RefundedAsFraud),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -307,13 +307,13 @@ impl ReviewOpenedReason {
 }
 
 impl std::str::FromStr for ReviewOpenedReason {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ReviewOpenedReason::*;
         match s {
             "manual" => Ok(Manual),
             "rule" => Ok(Rule),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/setup_attempt.rs
+++ b/generated/stripe_shared/src/setup_attempt.rs
@@ -244,13 +244,13 @@ impl SetupAttemptFlowDirections {
 }
 
 impl std::str::FromStr for SetupAttemptFlowDirections {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use SetupAttemptFlowDirections::*;
         match s {
             "inbound" => Ok(Inbound),
             "outbound" => Ok(Outbound),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/setup_attempt_payment_method_details_bancontact.rs
+++ b/generated/stripe_shared/src/setup_attempt_payment_method_details_bancontact.rs
@@ -176,7 +176,7 @@ impl SetupAttemptPaymentMethodDetailsBancontactPreferredLanguage {
 }
 
 impl std::str::FromStr for SetupAttemptPaymentMethodDetailsBancontactPreferredLanguage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use SetupAttemptPaymentMethodDetailsBancontactPreferredLanguage::*;
         match s {
@@ -184,7 +184,7 @@ impl std::str::FromStr for SetupAttemptPaymentMethodDetailsBancontactPreferredLa
             "en" => Ok(En),
             "fr" => Ok(Fr),
             "nl" => Ok(Nl),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/setup_attempt_payment_method_details_card_wallet.rs
+++ b/generated/stripe_shared/src/setup_attempt_payment_method_details_card_wallet.rs
@@ -131,14 +131,14 @@ impl SetupAttemptPaymentMethodDetailsCardWalletType {
 }
 
 impl std::str::FromStr for SetupAttemptPaymentMethodDetailsCardWalletType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use SetupAttemptPaymentMethodDetailsCardWalletType::*;
         match s {
             "apple_pay" => Ok(ApplePay),
             "google_pay" => Ok(GooglePay),
             "link" => Ok(Link),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/setup_attempt_payment_method_details_ideal.rs
+++ b/generated/stripe_shared/src/setup_attempt_payment_method_details_ideal.rs
@@ -188,7 +188,7 @@ impl SetupAttemptPaymentMethodDetailsIdealBank {
 }
 
 impl std::str::FromStr for SetupAttemptPaymentMethodDetailsIdealBank {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use SetupAttemptPaymentMethodDetailsIdealBank::*;
         match s {
@@ -208,7 +208,7 @@ impl std::str::FromStr for SetupAttemptPaymentMethodDetailsIdealBank {
             "triodos_bank" => Ok(TriodosBank),
             "van_lanschot" => Ok(VanLanschot),
             "yoursafe" => Ok(Yoursafe),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -241,10 +241,7 @@ impl miniserde::Deserialize for SetupAttemptPaymentMethodDetailsIdealBank {
 impl miniserde::de::Visitor for crate::Place<SetupAttemptPaymentMethodDetailsIdealBank> {
     fn string(&mut self, s: &str) -> miniserde::Result<()> {
         use std::str::FromStr;
-        self.out = Some(
-            SetupAttemptPaymentMethodDetailsIdealBank::from_str(s)
-                .unwrap_or(SetupAttemptPaymentMethodDetailsIdealBank::Unknown),
-        );
+        self.out = Some(SetupAttemptPaymentMethodDetailsIdealBank::from_str(s).unwrap());
         Ok(())
     }
 }
@@ -255,7 +252,7 @@ impl<'de> serde::Deserialize<'de> for SetupAttemptPaymentMethodDetailsIdealBank 
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// The Bank Identifier Code of the customer's bank.
@@ -309,7 +306,7 @@ impl SetupAttemptPaymentMethodDetailsIdealBic {
 }
 
 impl std::str::FromStr for SetupAttemptPaymentMethodDetailsIdealBic {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use SetupAttemptPaymentMethodDetailsIdealBic::*;
         match s {
@@ -330,7 +327,7 @@ impl std::str::FromStr for SetupAttemptPaymentMethodDetailsIdealBic {
             "REVOLT21" => Ok(Revolt21),
             "SNSBNL2A" => Ok(Snsbnl2a),
             "TRIONL2U" => Ok(Trionl2u),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -363,10 +360,7 @@ impl miniserde::Deserialize for SetupAttemptPaymentMethodDetailsIdealBic {
 impl miniserde::de::Visitor for crate::Place<SetupAttemptPaymentMethodDetailsIdealBic> {
     fn string(&mut self, s: &str) -> miniserde::Result<()> {
         use std::str::FromStr;
-        self.out = Some(
-            SetupAttemptPaymentMethodDetailsIdealBic::from_str(s)
-                .unwrap_or(SetupAttemptPaymentMethodDetailsIdealBic::Unknown),
-        );
+        self.out = Some(SetupAttemptPaymentMethodDetailsIdealBic::from_str(s).unwrap());
         Ok(())
     }
 }
@@ -377,6 +371,6 @@ impl<'de> serde::Deserialize<'de> for SetupAttemptPaymentMethodDetailsIdealBic {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }

--- a/generated/stripe_shared/src/setup_attempt_payment_method_details_sofort.rs
+++ b/generated/stripe_shared/src/setup_attempt_payment_method_details_sofort.rs
@@ -176,7 +176,7 @@ impl SetupAttemptPaymentMethodDetailsSofortPreferredLanguage {
 }
 
 impl std::str::FromStr for SetupAttemptPaymentMethodDetailsSofortPreferredLanguage {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use SetupAttemptPaymentMethodDetailsSofortPreferredLanguage::*;
         match s {
@@ -184,7 +184,7 @@ impl std::str::FromStr for SetupAttemptPaymentMethodDetailsSofortPreferredLangua
             "en" => Ok(En),
             "fr" => Ok(Fr),
             "nl" => Ok(Nl),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/setup_intent.rs
+++ b/generated/stripe_shared/src/setup_intent.rs
@@ -381,7 +381,7 @@ impl SetupIntentStatus {
 }
 
 impl std::str::FromStr for SetupIntentStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use SetupIntentStatus::*;
         match s {
@@ -391,7 +391,7 @@ impl std::str::FromStr for SetupIntentStatus {
             "requires_confirmation" => Ok(RequiresConfirmation),
             "requires_payment_method" => Ok(RequiresPaymentMethod),
             "succeeded" => Ok(Succeeded),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -464,14 +464,14 @@ impl SetupIntentCancellationReason {
 }
 
 impl std::str::FromStr for SetupIntentCancellationReason {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use SetupIntentCancellationReason::*;
         match s {
             "abandoned" => Ok(Abandoned),
             "duplicate" => Ok(Duplicate),
             "requested_by_customer" => Ok(RequestedByCustomer),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -535,13 +535,13 @@ impl SetupIntentFlowDirections {
 }
 
 impl std::str::FromStr for SetupIntentFlowDirections {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use SetupIntentFlowDirections::*;
         match s {
             "inbound" => Ok(Inbound),
             "outbound" => Ok(Outbound),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/setup_intent_next_action_verify_with_microdeposits.rs
+++ b/generated/stripe_shared/src/setup_intent_next_action_verify_with_microdeposits.rs
@@ -130,13 +130,13 @@ impl SetupIntentNextActionVerifyWithMicrodepositsMicrodepositType {
 }
 
 impl std::str::FromStr for SetupIntentNextActionVerifyWithMicrodepositsMicrodepositType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use SetupIntentNextActionVerifyWithMicrodepositsMicrodepositType::*;
         match s {
             "amounts" => Ok(Amounts),
             "descriptor_code" => Ok(DescriptorCode),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/setup_intent_payment_method_options_acss_debit.rs
+++ b/generated/stripe_shared/src/setup_intent_payment_method_options_acss_debit.rs
@@ -129,13 +129,13 @@ impl SetupIntentPaymentMethodOptionsAcssDebitCurrency {
 }
 
 impl std::str::FromStr for SetupIntentPaymentMethodOptionsAcssDebitCurrency {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use SetupIntentPaymentMethodOptionsAcssDebitCurrency::*;
         match s {
             "cad" => Ok(Cad),
             "usd" => Ok(Usd),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -208,14 +208,14 @@ impl SetupIntentPaymentMethodOptionsAcssDebitVerificationMethod {
 }
 
 impl std::str::FromStr for SetupIntentPaymentMethodOptionsAcssDebitVerificationMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use SetupIntentPaymentMethodOptionsAcssDebitVerificationMethod::*;
         match s {
             "automatic" => Ok(Automatic),
             "instant" => Ok(Instant),
             "microdeposits" => Ok(Microdeposits),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/setup_intent_payment_method_options_card.rs
+++ b/generated/stripe_shared/src/setup_intent_payment_method_options_card.rs
@@ -154,7 +154,7 @@ impl SetupIntentPaymentMethodOptionsCardNetwork {
 }
 
 impl std::str::FromStr for SetupIntentPaymentMethodOptionsCardNetwork {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use SetupIntentPaymentMethodOptionsCardNetwork::*;
         match s {
@@ -169,7 +169,7 @@ impl std::str::FromStr for SetupIntentPaymentMethodOptionsCardNetwork {
             "unionpay" => Ok(Unionpay),
             "unknown" => Ok(Unknown),
             "visa" => Ok(Visa),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -243,14 +243,14 @@ impl SetupIntentPaymentMethodOptionsCardRequestThreeDSecure {
 }
 
 impl std::str::FromStr for SetupIntentPaymentMethodOptionsCardRequestThreeDSecure {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use SetupIntentPaymentMethodOptionsCardRequestThreeDSecure::*;
         match s {
             "any" => Ok(Any),
             "automatic" => Ok(Automatic),
             "challenge" => Ok(Challenge),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/setup_intent_payment_method_options_card_mandate_options.rs
+++ b/generated/stripe_shared/src/setup_intent_payment_method_options_card_mandate_options.rs
@@ -187,13 +187,13 @@ impl SetupIntentPaymentMethodOptionsCardMandateOptionsAmountType {
 }
 
 impl std::str::FromStr for SetupIntentPaymentMethodOptionsCardMandateOptionsAmountType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use SetupIntentPaymentMethodOptionsCardMandateOptionsAmountType::*;
         match s {
             "fixed" => Ok(Fixed),
             "maximum" => Ok(Maximum),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -274,7 +274,7 @@ impl SetupIntentPaymentMethodOptionsCardMandateOptionsInterval {
 }
 
 impl std::str::FromStr for SetupIntentPaymentMethodOptionsCardMandateOptionsInterval {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use SetupIntentPaymentMethodOptionsCardMandateOptionsInterval::*;
         match s {
@@ -283,7 +283,7 @@ impl std::str::FromStr for SetupIntentPaymentMethodOptionsCardMandateOptionsInte
             "sporadic" => Ok(Sporadic),
             "week" => Ok(Week),
             "year" => Ok(Year),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -356,12 +356,12 @@ impl SetupIntentPaymentMethodOptionsCardMandateOptionsSupportedTypes {
 }
 
 impl std::str::FromStr for SetupIntentPaymentMethodOptionsCardMandateOptionsSupportedTypes {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use SetupIntentPaymentMethodOptionsCardMandateOptionsSupportedTypes::*;
         match s {
             "india" => Ok(India),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/setup_intent_payment_method_options_mandate_options_acss_debit.rs
+++ b/generated/stripe_shared/src/setup_intent_payment_method_options_mandate_options_acss_debit.rs
@@ -152,13 +152,13 @@ impl SetupIntentPaymentMethodOptionsMandateOptionsAcssDebitDefaultFor {
 }
 
 impl std::str::FromStr for SetupIntentPaymentMethodOptionsMandateOptionsAcssDebitDefaultFor {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use SetupIntentPaymentMethodOptionsMandateOptionsAcssDebitDefaultFor::*;
         match s {
             "invoice" => Ok(Invoice),
             "subscription" => Ok(Subscription),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -233,14 +233,14 @@ impl SetupIntentPaymentMethodOptionsMandateOptionsAcssDebitPaymentSchedule {
 }
 
 impl std::str::FromStr for SetupIntentPaymentMethodOptionsMandateOptionsAcssDebitPaymentSchedule {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use SetupIntentPaymentMethodOptionsMandateOptionsAcssDebitPaymentSchedule::*;
         match s {
             "combined" => Ok(Combined),
             "interval" => Ok(Interval),
             "sporadic" => Ok(Sporadic),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -315,13 +315,13 @@ impl SetupIntentPaymentMethodOptionsMandateOptionsAcssDebitTransactionType {
 }
 
 impl std::str::FromStr for SetupIntentPaymentMethodOptionsMandateOptionsAcssDebitTransactionType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use SetupIntentPaymentMethodOptionsMandateOptionsAcssDebitTransactionType::*;
         match s {
             "business" => Ok(Business),
             "personal" => Ok(Personal),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/setup_intent_payment_method_options_us_bank_account.rs
+++ b/generated/stripe_shared/src/setup_intent_payment_method_options_us_bank_account.rs
@@ -131,14 +131,14 @@ impl SetupIntentPaymentMethodOptionsUsBankAccountVerificationMethod {
 }
 
 impl std::str::FromStr for SetupIntentPaymentMethodOptionsUsBankAccountVerificationMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use SetupIntentPaymentMethodOptionsUsBankAccountVerificationMethod::*;
         match s {
             "automatic" => Ok(Automatic),
             "instant" => Ok(Instant),
             "microdeposits" => Ok(Microdeposits),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/shipping_rate.rs
+++ b/generated/stripe_shared/src/shipping_rate.rs
@@ -220,14 +220,14 @@ impl ShippingRateTaxBehavior {
 }
 
 impl std::str::FromStr for ShippingRateTaxBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ShippingRateTaxBehavior::*;
         match s {
             "exclusive" => Ok(Exclusive),
             "inclusive" => Ok(Inclusive),
             "unspecified" => Ok(Unspecified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -288,12 +288,12 @@ impl ShippingRateType {
 }
 
 impl std::str::FromStr for ShippingRateType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ShippingRateType::*;
         match s {
             "fixed_amount" => Ok(FixedAmount),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/shipping_rate_currency_option.rs
+++ b/generated/stripe_shared/src/shipping_rate_currency_option.rs
@@ -117,14 +117,14 @@ impl ShippingRateCurrencyOptionTaxBehavior {
 }
 
 impl std::str::FromStr for ShippingRateCurrencyOptionTaxBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ShippingRateCurrencyOptionTaxBehavior::*;
         match s {
             "exclusive" => Ok(Exclusive),
             "inclusive" => Ok(Inclusive),
             "unspecified" => Ok(Unspecified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/shipping_rate_delivery_estimate_bound.rs
+++ b/generated/stripe_shared/src/shipping_rate_delivery_estimate_bound.rs
@@ -119,7 +119,7 @@ impl ShippingRateDeliveryEstimateBoundUnit {
 }
 
 impl std::str::FromStr for ShippingRateDeliveryEstimateBoundUnit {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ShippingRateDeliveryEstimateBoundUnit::*;
         match s {
@@ -128,7 +128,7 @@ impl std::str::FromStr for ShippingRateDeliveryEstimateBoundUnit {
             "hour" => Ok(Hour),
             "month" => Ok(Month),
             "week" => Ok(Week),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/source.rs
+++ b/generated/stripe_shared/src/source.rs
@@ -459,7 +459,7 @@ impl SourceType {
 }
 
 impl std::str::FromStr for SourceType {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use SourceType::*;
         match s {
@@ -482,7 +482,7 @@ impl std::str::FromStr for SourceType {
             "sofort" => Ok(Sofort),
             "three_d_secure" => Ok(ThreeDSecure),
             "wechat" => Ok(Wechat),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -515,7 +515,7 @@ impl miniserde::Deserialize for SourceType {
 impl miniserde::de::Visitor for crate::Place<SourceType> {
     fn string(&mut self, s: &str) -> miniserde::Result<()> {
         use std::str::FromStr;
-        self.out = Some(SourceType::from_str(s).unwrap_or(SourceType::Unknown));
+        self.out = Some(SourceType::from_str(s).unwrap());
         Ok(())
     }
 }
@@ -526,7 +526,7 @@ impl<'de> serde::Deserialize<'de> for SourceType {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 impl stripe_types::Object for Source {

--- a/generated/stripe_shared/src/source_transaction.rs
+++ b/generated/stripe_shared/src/source_transaction.rs
@@ -259,7 +259,7 @@ impl SourceTransactionType {
 }
 
 impl std::str::FromStr for SourceTransactionType {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use SourceTransactionType::*;
         match s {
@@ -279,7 +279,7 @@ impl std::str::FromStr for SourceTransactionType {
             "sofort" => Ok(Sofort),
             "three_d_secure" => Ok(ThreeDSecure),
             "wechat" => Ok(Wechat),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -312,8 +312,7 @@ impl miniserde::Deserialize for SourceTransactionType {
 impl miniserde::de::Visitor for crate::Place<SourceTransactionType> {
     fn string(&mut self, s: &str) -> miniserde::Result<()> {
         use std::str::FromStr;
-        self.out =
-            Some(SourceTransactionType::from_str(s).unwrap_or(SourceTransactionType::Unknown));
+        self.out = Some(SourceTransactionType::from_str(s).unwrap());
         Ok(())
     }
 }
@@ -324,7 +323,7 @@ impl<'de> serde::Deserialize<'de> for SourceTransactionType {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 impl stripe_types::Object for SourceTransaction {

--- a/generated/stripe_shared/src/subscription.rs
+++ b/generated/stripe_shared/src/subscription.rs
@@ -573,7 +573,7 @@ impl SubscriptionStatus {
 }
 
 impl std::str::FromStr for SubscriptionStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use SubscriptionStatus::*;
         match s {
@@ -585,7 +585,7 @@ impl std::str::FromStr for SubscriptionStatus {
             "paused" => Ok(Paused),
             "trialing" => Ok(Trialing),
             "unpaid" => Ok(Unpaid),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -656,13 +656,13 @@ impl SubscriptionCollectionMethod {
 }
 
 impl std::str::FromStr for SubscriptionCollectionMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use SubscriptionCollectionMethod::*;
         match s {
             "charge_automatically" => Ok(ChargeAutomatically),
             "send_invoice" => Ok(SendInvoice),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/subscription_payment_method_options_card.rs
+++ b/generated/stripe_shared/src/subscription_payment_method_options_card.rs
@@ -151,7 +151,7 @@ impl SubscriptionPaymentMethodOptionsCardNetwork {
 }
 
 impl std::str::FromStr for SubscriptionPaymentMethodOptionsCardNetwork {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use SubscriptionPaymentMethodOptionsCardNetwork::*;
         match s {
@@ -166,7 +166,7 @@ impl std::str::FromStr for SubscriptionPaymentMethodOptionsCardNetwork {
             "unionpay" => Ok(Unionpay),
             "unknown" => Ok(Unknown),
             "visa" => Ok(Visa),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -241,14 +241,14 @@ impl SubscriptionPaymentMethodOptionsCardRequestThreeDSecure {
 }
 
 impl std::str::FromStr for SubscriptionPaymentMethodOptionsCardRequestThreeDSecure {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use SubscriptionPaymentMethodOptionsCardRequestThreeDSecure::*;
         match s {
             "any" => Ok(Any),
             "automatic" => Ok(Automatic),
             "challenge" => Ok(Challenge),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/subscription_pending_invoice_item_interval.rs
+++ b/generated/stripe_shared/src/subscription_pending_invoice_item_interval.rs
@@ -119,7 +119,7 @@ impl SubscriptionPendingInvoiceItemIntervalInterval {
 }
 
 impl std::str::FromStr for SubscriptionPendingInvoiceItemIntervalInterval {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use SubscriptionPendingInvoiceItemIntervalInterval::*;
         match s {
@@ -127,7 +127,7 @@ impl std::str::FromStr for SubscriptionPendingInvoiceItemIntervalInterval {
             "month" => Ok(Month),
             "week" => Ok(Week),
             "year" => Ok(Year),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/subscription_schedule.rs
+++ b/generated/stripe_shared/src/subscription_schedule.rs
@@ -270,7 +270,7 @@ impl SubscriptionScheduleStatus {
 }
 
 impl std::str::FromStr for SubscriptionScheduleStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use SubscriptionScheduleStatus::*;
         match s {
@@ -279,7 +279,7 @@ impl std::str::FromStr for SubscriptionScheduleStatus {
             "completed" => Ok(Completed),
             "not_started" => Ok(NotStarted),
             "released" => Ok(Released),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -354,7 +354,7 @@ impl SubscriptionScheduleEndBehavior {
 }
 
 impl std::str::FromStr for SubscriptionScheduleEndBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use SubscriptionScheduleEndBehavior::*;
         match s {
@@ -362,7 +362,7 @@ impl std::str::FromStr for SubscriptionScheduleEndBehavior {
             "none" => Ok(None),
             "release" => Ok(Release),
             "renew" => Ok(Renew),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/subscription_schedule_phase_configuration.rs
+++ b/generated/stripe_shared/src/subscription_schedule_phase_configuration.rs
@@ -272,13 +272,13 @@ impl SubscriptionSchedulePhaseConfigurationBillingCycleAnchor {
 }
 
 impl std::str::FromStr for SubscriptionSchedulePhaseConfigurationBillingCycleAnchor {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use SubscriptionSchedulePhaseConfigurationBillingCycleAnchor::*;
         match s {
             "automatic" => Ok(Automatic),
             "phase_start" => Ok(PhaseStart),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -355,13 +355,13 @@ impl SubscriptionSchedulePhaseConfigurationCollectionMethod {
 }
 
 impl std::str::FromStr for SubscriptionSchedulePhaseConfigurationCollectionMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use SubscriptionSchedulePhaseConfigurationCollectionMethod::*;
         match s {
             "charge_automatically" => Ok(ChargeAutomatically),
             "send_invoice" => Ok(SendInvoice),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -437,14 +437,14 @@ impl SubscriptionSchedulePhaseConfigurationProrationBehavior {
 }
 
 impl std::str::FromStr for SubscriptionSchedulePhaseConfigurationProrationBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use SubscriptionSchedulePhaseConfigurationProrationBehavior::*;
         match s {
             "always_invoice" => Ok(AlwaysInvoice),
             "create_prorations" => Ok(CreateProrations),
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/subscription_schedules_resource_default_settings.rs
+++ b/generated/stripe_shared/src/subscription_schedules_resource_default_settings.rs
@@ -195,13 +195,13 @@ impl SubscriptionSchedulesResourceDefaultSettingsBillingCycleAnchor {
 }
 
 impl std::str::FromStr for SubscriptionSchedulesResourceDefaultSettingsBillingCycleAnchor {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use SubscriptionSchedulesResourceDefaultSettingsBillingCycleAnchor::*;
         match s {
             "automatic" => Ok(Automatic),
             "phase_start" => Ok(PhaseStart),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -280,13 +280,13 @@ impl SubscriptionSchedulesResourceDefaultSettingsCollectionMethod {
 }
 
 impl std::str::FromStr for SubscriptionSchedulesResourceDefaultSettingsCollectionMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use SubscriptionSchedulesResourceDefaultSettingsCollectionMethod::*;
         match s {
             "charge_automatically" => Ok(ChargeAutomatically),
             "send_invoice" => Ok(SendInvoice),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/subscriptions_resource_pause_collection.rs
+++ b/generated/stripe_shared/src/subscriptions_resource_pause_collection.rs
@@ -119,14 +119,14 @@ impl SubscriptionsResourcePauseCollectionBehavior {
 }
 
 impl std::str::FromStr for SubscriptionsResourcePauseCollectionBehavior {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use SubscriptionsResourcePauseCollectionBehavior::*;
         match s {
             "keep_as_draft" => Ok(KeepAsDraft),
             "mark_uncollectible" => Ok(MarkUncollectible),
             "void" => Ok(Void),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/subscriptions_resource_payment_settings.rs
+++ b/generated/stripe_shared/src/subscriptions_resource_payment_settings.rs
@@ -193,7 +193,7 @@ impl SubscriptionsResourcePaymentSettingsPaymentMethodTypes {
 }
 
 impl std::str::FromStr for SubscriptionsResourcePaymentSettingsPaymentMethodTypes {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use SubscriptionsResourcePaymentSettingsPaymentMethodTypes::*;
         match s {
@@ -223,7 +223,7 @@ impl std::str::FromStr for SubscriptionsResourcePaymentSettingsPaymentMethodType
             "sofort" => Ok(Sofort),
             "us_bank_account" => Ok(UsBankAccount),
             "wechat_pay" => Ok(WechatPay),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -258,10 +258,8 @@ impl miniserde::de::Visitor
 {
     fn string(&mut self, s: &str) -> miniserde::Result<()> {
         use std::str::FromStr;
-        self.out = Some(
-            SubscriptionsResourcePaymentSettingsPaymentMethodTypes::from_str(s)
-                .unwrap_or(SubscriptionsResourcePaymentSettingsPaymentMethodTypes::Unknown),
-        );
+        self.out =
+            Some(SubscriptionsResourcePaymentSettingsPaymentMethodTypes::from_str(s).unwrap());
         Ok(())
     }
 }
@@ -272,7 +270,7 @@ impl<'de> serde::Deserialize<'de> for SubscriptionsResourcePaymentSettingsPaymen
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 /// Either `off`, or `on_subscription`.
@@ -293,13 +291,13 @@ impl SubscriptionsResourcePaymentSettingsSaveDefaultPaymentMethod {
 }
 
 impl std::str::FromStr for SubscriptionsResourcePaymentSettingsSaveDefaultPaymentMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use SubscriptionsResourcePaymentSettingsSaveDefaultPaymentMethod::*;
         match s {
             "off" => Ok(Off),
             "on_subscription" => Ok(OnSubscription),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/subscriptions_trials_resource_end_behavior.rs
+++ b/generated/stripe_shared/src/subscriptions_trials_resource_end_behavior.rs
@@ -113,14 +113,14 @@ impl SubscriptionsTrialsResourceEndBehaviorMissingPaymentMethod {
 }
 
 impl std::str::FromStr for SubscriptionsTrialsResourceEndBehaviorMissingPaymentMethod {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use SubscriptionsTrialsResourceEndBehaviorMissingPaymentMethod::*;
         match s {
             "cancel" => Ok(Cancel),
             "create_invoice" => Ok(CreateInvoice),
             "pause" => Ok(Pause),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/tax_i_ds_owner.rs
+++ b/generated/stripe_shared/src/tax_i_ds_owner.rs
@@ -138,7 +138,7 @@ impl TaxIDsOwnerType {
 }
 
 impl std::str::FromStr for TaxIDsOwnerType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TaxIDsOwnerType::*;
         match s {
@@ -146,7 +146,7 @@ impl std::str::FromStr for TaxIDsOwnerType {
             "application" => Ok(Application),
             "customer" => Ok(Customer),
             "self" => Ok(Self_),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/tax_id.rs
+++ b/generated/stripe_shared/src/tax_id.rs
@@ -322,7 +322,7 @@ impl TaxIdType {
 }
 
 impl std::str::FromStr for TaxIdType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TaxIdType::*;
         match s {
@@ -393,7 +393,7 @@ impl std::str::FromStr for TaxIdType {
             "ve_rif" => Ok(VeRif),
             "vn_tin" => Ok(VnTin),
             "za_vat" => Ok(ZaVat),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/tax_id_verification.rs
+++ b/generated/stripe_shared/src/tax_id_verification.rs
@@ -130,7 +130,7 @@ impl TaxIdVerificationStatus {
 }
 
 impl std::str::FromStr for TaxIdVerificationStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TaxIdVerificationStatus::*;
         match s {
@@ -138,7 +138,7 @@ impl std::str::FromStr for TaxIdVerificationStatus {
             "unavailable" => Ok(Unavailable),
             "unverified" => Ok(Unverified),
             "verified" => Ok(Verified),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/tax_rate.rs
+++ b/generated/stripe_shared/src/tax_rate.rs
@@ -260,7 +260,7 @@ impl TaxRateJurisdictionLevel {
 }
 
 impl std::str::FromStr for TaxRateJurisdictionLevel {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TaxRateJurisdictionLevel::*;
         match s {
@@ -270,7 +270,7 @@ impl std::str::FromStr for TaxRateJurisdictionLevel {
             "district" => Ok(District),
             "multiple" => Ok(Multiple),
             "state" => Ok(State),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -367,7 +367,7 @@ impl TaxRateTaxType {
 }
 
 impl std::str::FromStr for TaxRateTaxType {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TaxRateTaxType::*;
         match s {
@@ -384,7 +384,7 @@ impl std::str::FromStr for TaxRateTaxType {
             "sales_tax" => Ok(SalesTax),
             "service_tax" => Ok(ServiceTax),
             "vat" => Ok(Vat),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -416,7 +416,7 @@ impl miniserde::Deserialize for TaxRateTaxType {
 impl miniserde::de::Visitor for crate::Place<TaxRateTaxType> {
     fn string(&mut self, s: &str) -> miniserde::Result<()> {
         use std::str::FromStr;
-        self.out = Some(TaxRateTaxType::from_str(s).unwrap_or(TaxRateTaxType::Unknown));
+        self.out = Some(TaxRateTaxType::from_str(s).unwrap());
         Ok(())
     }
 }
@@ -427,6 +427,6 @@ impl<'de> serde::Deserialize<'de> for TaxRateTaxType {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }

--- a/generated/stripe_shared/src/test_helpers_test_clock.rs
+++ b/generated/stripe_shared/src/test_helpers_test_clock.rs
@@ -177,14 +177,14 @@ impl TestHelpersTestClockStatus {
 }
 
 impl std::str::FromStr for TestHelpersTestClockStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TestHelpersTestClockStatus::*;
         match s {
             "advancing" => Ok(Advancing),
             "internal_failure" => Ok(InternalFailure),
             "ready" => Ok(Ready),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/three_d_secure_details.rs
+++ b/generated/stripe_shared/src/three_d_secure_details.rs
@@ -158,13 +158,13 @@ impl ThreeDSecureDetailsAuthenticationFlow {
 }
 
 impl std::str::FromStr for ThreeDSecureDetailsAuthenticationFlow {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ThreeDSecureDetailsAuthenticationFlow::*;
         match s {
             "challenge" => Ok(Challenge),
             "frictionless" => Ok(Frictionless),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -238,7 +238,7 @@ impl ThreeDSecureDetailsElectronicCommerceIndicator {
 }
 
 impl std::str::FromStr for ThreeDSecureDetailsElectronicCommerceIndicator {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ThreeDSecureDetailsElectronicCommerceIndicator::*;
         match s {
@@ -247,7 +247,7 @@ impl std::str::FromStr for ThreeDSecureDetailsElectronicCommerceIndicator {
             "05" => Ok(V05),
             "06" => Ok(V06),
             "07" => Ok(V07),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -326,7 +326,7 @@ impl ThreeDSecureDetailsResult {
 }
 
 impl std::str::FromStr for ThreeDSecureDetailsResult {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ThreeDSecureDetailsResult::*;
         match s {
@@ -336,7 +336,7 @@ impl std::str::FromStr for ThreeDSecureDetailsResult {
             "failed" => Ok(Failed),
             "not_supported" => Ok(NotSupported),
             "processing_error" => Ok(ProcessingError),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -412,7 +412,7 @@ impl ThreeDSecureDetailsResultReason {
 }
 
 impl std::str::FromStr for ThreeDSecureDetailsResultReason {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ThreeDSecureDetailsResultReason::*;
         match s {
@@ -423,7 +423,7 @@ impl std::str::FromStr for ThreeDSecureDetailsResultReason {
             "network_not_supported" => Ok(NetworkNotSupported),
             "protocol_error" => Ok(ProtocolError),
             "rejected" => Ok(Rejected),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -492,14 +492,14 @@ impl ThreeDSecureDetailsVersion {
 }
 
 impl std::str::FromStr for ThreeDSecureDetailsVersion {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ThreeDSecureDetailsVersion::*;
         match s {
             "1.0.2" => Ok(V1_0_2),
             "2.1.0" => Ok(V2_1_0),
             "2.2.0" => Ok(V2_2_0),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/three_d_secure_details_charge.rs
+++ b/generated/stripe_shared/src/three_d_secure_details_charge.rs
@@ -180,13 +180,13 @@ impl ThreeDSecureDetailsChargeAuthenticationFlow {
 }
 
 impl std::str::FromStr for ThreeDSecureDetailsChargeAuthenticationFlow {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ThreeDSecureDetailsChargeAuthenticationFlow::*;
         match s {
             "challenge" => Ok(Challenge),
             "frictionless" => Ok(Frictionless),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -264,7 +264,7 @@ impl ThreeDSecureDetailsChargeElectronicCommerceIndicator {
 }
 
 impl std::str::FromStr for ThreeDSecureDetailsChargeElectronicCommerceIndicator {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ThreeDSecureDetailsChargeElectronicCommerceIndicator::*;
         match s {
@@ -273,7 +273,7 @@ impl std::str::FromStr for ThreeDSecureDetailsChargeElectronicCommerceIndicator 
             "05" => Ok(V05),
             "06" => Ok(V06),
             "07" => Ok(V07),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -344,13 +344,13 @@ impl ThreeDSecureDetailsChargeExemptionIndicator {
 }
 
 impl std::str::FromStr for ThreeDSecureDetailsChargeExemptionIndicator {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ThreeDSecureDetailsChargeExemptionIndicator::*;
         match s {
             "low_risk" => Ok(LowRisk),
             "none" => Ok(None),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -429,7 +429,7 @@ impl ThreeDSecureDetailsChargeResult {
 }
 
 impl std::str::FromStr for ThreeDSecureDetailsChargeResult {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ThreeDSecureDetailsChargeResult::*;
         match s {
@@ -439,7 +439,7 @@ impl std::str::FromStr for ThreeDSecureDetailsChargeResult {
             "failed" => Ok(Failed),
             "not_supported" => Ok(NotSupported),
             "processing_error" => Ok(ProcessingError),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -517,7 +517,7 @@ impl ThreeDSecureDetailsChargeResultReason {
 }
 
 impl std::str::FromStr for ThreeDSecureDetailsChargeResultReason {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ThreeDSecureDetailsChargeResultReason::*;
         match s {
@@ -528,7 +528,7 @@ impl std::str::FromStr for ThreeDSecureDetailsChargeResultReason {
             "network_not_supported" => Ok(NetworkNotSupported),
             "protocol_error" => Ok(ProtocolError),
             "rejected" => Ok(Rejected),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -597,14 +597,14 @@ impl ThreeDSecureDetailsChargeVersion {
 }
 
 impl std::str::FromStr for ThreeDSecureDetailsChargeVersion {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ThreeDSecureDetailsChargeVersion::*;
         match s {
             "1.0.2" => Ok(V1_0_2),
             "2.1.0" => Ok(V2_1_0),
             "2.2.0" => Ok(V2_2_0),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/topup.rs
+++ b/generated/stripe_shared/src/topup.rs
@@ -260,7 +260,7 @@ impl TopupStatus {
 }
 
 impl std::str::FromStr for TopupStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TopupStatus::*;
         match s {
@@ -269,7 +269,7 @@ impl std::str::FromStr for TopupStatus {
             "pending" => Ok(Pending),
             "reversed" => Ok(Reversed),
             "succeeded" => Ok(Succeeded),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/transform_quantity.rs
+++ b/generated/stripe_shared/src/transform_quantity.rs
@@ -113,13 +113,13 @@ impl TransformQuantityRound {
 }
 
 impl std::str::FromStr for TransformQuantityRound {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TransformQuantityRound::*;
         match s {
             "down" => Ok(Down),
             "up" => Ok(Up),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/transform_usage.rs
+++ b/generated/stripe_shared/src/transform_usage.rs
@@ -113,13 +113,13 @@ impl TransformUsageRound {
 }
 
 impl std::str::FromStr for TransformUsageRound {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TransformUsageRound::*;
         match s {
             "down" => Ok(Down),
             "up" => Ok(Up),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_shared/src/us_bank_account_networks.rs
+++ b/generated/stripe_shared/src/us_bank_account_networks.rs
@@ -113,13 +113,13 @@ impl UsBankAccountNetworksSupported {
 }
 
 impl std::str::FromStr for UsBankAccountNetworksSupported {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UsBankAccountNetworksSupported::*;
         match s {
             "ach" => Ok(Ach),
             "us_domestic_wire" => Ok(UsDomesticWire),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_terminal/src/terminal_reader/requests.rs
+++ b/generated/stripe_terminal/src/terminal_reader/requests.rs
@@ -554,12 +554,12 @@ impl SetReaderDisplayTerminalReaderType {
 }
 
 impl std::str::FromStr for SetReaderDisplayTerminalReaderType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use SetReaderDisplayTerminalReaderType::*;
         match s {
             "cart" => Ok(Cart),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -671,13 +671,13 @@ impl PresentPaymentMethodTerminalReaderType {
 }
 
 impl std::str::FromStr for PresentPaymentMethodTerminalReaderType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use PresentPaymentMethodTerminalReaderType::*;
         match s {
             "card_present" => Ok(CardPresent),
             "interac_present" => Ok(InteracPresent),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_terminal/src/terminal_reader/types.rs
+++ b/generated/stripe_terminal/src/terminal_reader/types.rs
@@ -222,7 +222,7 @@ impl TerminalReaderDeviceType {
 }
 
 impl std::str::FromStr for TerminalReaderDeviceType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TerminalReaderDeviceType::*;
         match s {
@@ -232,7 +232,7 @@ impl std::str::FromStr for TerminalReaderDeviceType {
             "simulated_wisepos_e" => Ok(SimulatedWiseposE),
             "stripe_m2" => Ok(StripeM2),
             "verifone_P400" => Ok(VerifoneP400),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -295,13 +295,13 @@ impl TerminalReaderStatus {
 }
 
 impl std::str::FromStr for TerminalReaderStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TerminalReaderStatus::*;
         match s {
             "offline" => Ok(Offline),
             "online" => Ok(Online),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_terminal/src/terminal_reader_reader_resource_reader_action.rs
+++ b/generated/stripe_terminal/src/terminal_reader_reader_resource_reader_action.rs
@@ -174,14 +174,14 @@ impl TerminalReaderReaderResourceReaderActionStatus {
 }
 
 impl std::str::FromStr for TerminalReaderReaderResourceReaderActionStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TerminalReaderReaderResourceReaderActionStatus::*;
         match s {
             "failed" => Ok(Failed),
             "in_progress" => Ok(InProgress),
             "succeeded" => Ok(Succeeded),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -256,7 +256,7 @@ impl TerminalReaderReaderResourceReaderActionType {
 }
 
 impl std::str::FromStr for TerminalReaderReaderResourceReaderActionType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TerminalReaderReaderResourceReaderActionType::*;
         match s {
@@ -264,7 +264,7 @@ impl std::str::FromStr for TerminalReaderReaderResourceReaderActionType {
             "process_setup_intent" => Ok(ProcessSetupIntent),
             "refund_payment" => Ok(RefundPayment),
             "set_reader_display" => Ok(SetReaderDisplay),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_terminal/src/terminal_reader_reader_resource_refund_payment_action.rs
+++ b/generated/stripe_terminal/src/terminal_reader_reader_resource_refund_payment_action.rs
@@ -172,14 +172,14 @@ impl TerminalReaderReaderResourceRefundPaymentActionReason {
 }
 
 impl std::str::FromStr for TerminalReaderReaderResourceRefundPaymentActionReason {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TerminalReaderReaderResourceRefundPaymentActionReason::*;
         match s {
             "duplicate" => Ok(Duplicate),
             "fraudulent" => Ok(Fraudulent),
             "requested_by_customer" => Ok(RequestedByCustomer),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_terminal/src/terminal_reader_reader_resource_set_reader_display_action.rs
+++ b/generated/stripe_terminal/src/terminal_reader_reader_resource_set_reader_display_action.rs
@@ -113,12 +113,12 @@ impl TerminalReaderReaderResourceSetReaderDisplayActionType {
 }
 
 impl std::str::FromStr for TerminalReaderReaderResourceSetReaderDisplayActionType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TerminalReaderReaderResourceSetReaderDisplayActionType::*;
         match s {
             "cart" => Ok(Cart),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_treasury/src/inbound_transfers.rs
+++ b/generated/stripe_treasury/src/inbound_transfers.rs
@@ -125,12 +125,12 @@ impl InboundTransfersType {
 }
 
 impl std::str::FromStr for InboundTransfersType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use InboundTransfersType::*;
         match s {
             "us_bank_account" => Ok(UsBankAccount),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_treasury/src/inbound_transfers_payment_method_details_us_bank_account.rs
+++ b/generated/stripe_treasury/src/inbound_transfers_payment_method_details_us_bank_account.rs
@@ -159,13 +159,13 @@ impl InboundTransfersPaymentMethodDetailsUsBankAccountAccountHolderType {
 }
 
 impl std::str::FromStr for InboundTransfersPaymentMethodDetailsUsBankAccountAccountHolderType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use InboundTransfersPaymentMethodDetailsUsBankAccountAccountHolderType::*;
         match s {
             "company" => Ok(Company),
             "individual" => Ok(Individual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -238,13 +238,13 @@ impl InboundTransfersPaymentMethodDetailsUsBankAccountAccountType {
 }
 
 impl std::str::FromStr for InboundTransfersPaymentMethodDetailsUsBankAccountAccountType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use InboundTransfersPaymentMethodDetailsUsBankAccountAccountType::*;
         match s {
             "checking" => Ok(Checking),
             "savings" => Ok(Savings),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -317,12 +317,12 @@ impl InboundTransfersPaymentMethodDetailsUsBankAccountNetwork {
 }
 
 impl std::str::FromStr for InboundTransfersPaymentMethodDetailsUsBankAccountNetwork {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use InboundTransfersPaymentMethodDetailsUsBankAccountNetwork::*;
         match s {
             "ach" => Ok(Ach),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_treasury/src/outbound_payments_payment_method_details.rs
+++ b/generated/stripe_treasury/src/outbound_payments_payment_method_details.rs
@@ -134,13 +134,13 @@ impl OutboundPaymentsPaymentMethodDetailsType {
 }
 
 impl std::str::FromStr for OutboundPaymentsPaymentMethodDetailsType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use OutboundPaymentsPaymentMethodDetailsType::*;
         match s {
             "financial_account" => Ok(FinancialAccount),
             "us_bank_account" => Ok(UsBankAccount),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_treasury/src/outbound_payments_payment_method_details_financial_account.rs
+++ b/generated/stripe_treasury/src/outbound_payments_payment_method_details_financial_account.rs
@@ -113,12 +113,12 @@ impl OutboundPaymentsPaymentMethodDetailsFinancialAccountNetwork {
 }
 
 impl std::str::FromStr for OutboundPaymentsPaymentMethodDetailsFinancialAccountNetwork {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use OutboundPaymentsPaymentMethodDetailsFinancialAccountNetwork::*;
         match s {
             "stripe" => Ok(Stripe),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_treasury/src/outbound_payments_payment_method_details_us_bank_account.rs
+++ b/generated/stripe_treasury/src/outbound_payments_payment_method_details_us_bank_account.rs
@@ -159,13 +159,13 @@ impl OutboundPaymentsPaymentMethodDetailsUsBankAccountAccountHolderType {
 }
 
 impl std::str::FromStr for OutboundPaymentsPaymentMethodDetailsUsBankAccountAccountHolderType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use OutboundPaymentsPaymentMethodDetailsUsBankAccountAccountHolderType::*;
         match s {
             "company" => Ok(Company),
             "individual" => Ok(Individual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -238,13 +238,13 @@ impl OutboundPaymentsPaymentMethodDetailsUsBankAccountAccountType {
 }
 
 impl std::str::FromStr for OutboundPaymentsPaymentMethodDetailsUsBankAccountAccountType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use OutboundPaymentsPaymentMethodDetailsUsBankAccountAccountType::*;
         match s {
             "checking" => Ok(Checking),
             "savings" => Ok(Savings),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -319,13 +319,13 @@ impl OutboundPaymentsPaymentMethodDetailsUsBankAccountNetwork {
 }
 
 impl std::str::FromStr for OutboundPaymentsPaymentMethodDetailsUsBankAccountNetwork {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use OutboundPaymentsPaymentMethodDetailsUsBankAccountNetwork::*;
         match s {
             "ach" => Ok(Ach),
             "us_domestic_wire" => Ok(UsDomesticWire),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_treasury/src/outbound_transfers_payment_method_details.rs
+++ b/generated/stripe_treasury/src/outbound_transfers_payment_method_details.rs
@@ -125,12 +125,12 @@ impl OutboundTransfersPaymentMethodDetailsType {
 }
 
 impl std::str::FromStr for OutboundTransfersPaymentMethodDetailsType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use OutboundTransfersPaymentMethodDetailsType::*;
         match s {
             "us_bank_account" => Ok(UsBankAccount),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_treasury/src/outbound_transfers_payment_method_details_us_bank_account.rs
+++ b/generated/stripe_treasury/src/outbound_transfers_payment_method_details_us_bank_account.rs
@@ -159,13 +159,13 @@ impl OutboundTransfersPaymentMethodDetailsUsBankAccountAccountHolderType {
 }
 
 impl std::str::FromStr for OutboundTransfersPaymentMethodDetailsUsBankAccountAccountHolderType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use OutboundTransfersPaymentMethodDetailsUsBankAccountAccountHolderType::*;
         match s {
             "company" => Ok(Company),
             "individual" => Ok(Individual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -240,13 +240,13 @@ impl OutboundTransfersPaymentMethodDetailsUsBankAccountAccountType {
 }
 
 impl std::str::FromStr for OutboundTransfersPaymentMethodDetailsUsBankAccountAccountType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use OutboundTransfersPaymentMethodDetailsUsBankAccountAccountType::*;
         match s {
             "checking" => Ok(Checking),
             "savings" => Ok(Savings),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -323,13 +323,13 @@ impl OutboundTransfersPaymentMethodDetailsUsBankAccountNetwork {
 }
 
 impl std::str::FromStr for OutboundTransfersPaymentMethodDetailsUsBankAccountNetwork {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use OutboundTransfersPaymentMethodDetailsUsBankAccountNetwork::*;
         match s {
             "ach" => Ok(Ach),
             "us_domestic_wire" => Ok(UsDomesticWire),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_treasury/src/received_payment_method_details_financial_account.rs
+++ b/generated/stripe_treasury/src/received_payment_method_details_financial_account.rs
@@ -111,12 +111,12 @@ impl ReceivedPaymentMethodDetailsFinancialAccountNetwork {
 }
 
 impl std::str::FromStr for ReceivedPaymentMethodDetailsFinancialAccountNetwork {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ReceivedPaymentMethodDetailsFinancialAccountNetwork::*;
         match s {
             "stripe" => Ok(Stripe),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_treasury/src/treasury_credit_reversal/types.rs
+++ b/generated/stripe_treasury/src/treasury_credit_reversal/types.rs
@@ -227,13 +227,13 @@ impl TreasuryCreditReversalNetwork {
 }
 
 impl std::str::FromStr for TreasuryCreditReversalNetwork {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TreasuryCreditReversalNetwork::*;
         match s {
             "ach" => Ok(Ach),
             "stripe" => Ok(Stripe),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -307,14 +307,14 @@ impl TreasuryCreditReversalStatus {
 }
 
 impl std::str::FromStr for TreasuryCreditReversalStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TreasuryCreditReversalStatus::*;
         match s {
             "canceled" => Ok(Canceled),
             "posted" => Ok(Posted),
             "processing" => Ok(Processing),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_treasury/src/treasury_debit_reversal/requests.rs
+++ b/generated/stripe_treasury/src/treasury_debit_reversal/requests.rs
@@ -60,13 +60,13 @@ impl ListTreasuryDebitReversalResolution {
 }
 
 impl std::str::FromStr for ListTreasuryDebitReversalResolution {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ListTreasuryDebitReversalResolution::*;
         match s {
             "lost" => Ok(Lost),
             "won" => Ok(Won),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -118,14 +118,14 @@ impl ListTreasuryDebitReversalStatus {
 }
 
 impl std::str::FromStr for ListTreasuryDebitReversalStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ListTreasuryDebitReversalStatus::*;
         match s {
             "canceled" => Ok(Canceled),
             "completed" => Ok(Completed),
             "processing" => Ok(Processing),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_treasury/src/treasury_debit_reversal/types.rs
+++ b/generated/stripe_treasury/src/treasury_debit_reversal/types.rs
@@ -237,13 +237,13 @@ impl TreasuryDebitReversalNetwork {
 }
 
 impl std::str::FromStr for TreasuryDebitReversalNetwork {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TreasuryDebitReversalNetwork::*;
         match s {
             "ach" => Ok(Ach),
             "card" => Ok(Card),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -310,14 +310,14 @@ impl TreasuryDebitReversalStatus {
 }
 
 impl std::str::FromStr for TreasuryDebitReversalStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TreasuryDebitReversalStatus::*;
         match s {
             "failed" => Ok(Failed),
             "processing" => Ok(Processing),
             "succeeded" => Ok(Succeeded),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_treasury/src/treasury_financial_account/requests.rs
+++ b/generated/stripe_treasury/src/treasury_financial_account/requests.rs
@@ -329,13 +329,13 @@ impl CreateTreasuryFinancialAccountPlatformRestrictionsInboundFlows {
 }
 
 impl std::str::FromStr for CreateTreasuryFinancialAccountPlatformRestrictionsInboundFlows {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTreasuryFinancialAccountPlatformRestrictionsInboundFlows::*;
         match s {
             "restricted" => Ok(Restricted),
             "unrestricted" => Ok(Unrestricted),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -389,13 +389,13 @@ impl CreateTreasuryFinancialAccountPlatformRestrictionsOutboundFlows {
 }
 
 impl std::str::FromStr for CreateTreasuryFinancialAccountPlatformRestrictionsOutboundFlows {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTreasuryFinancialAccountPlatformRestrictionsOutboundFlows::*;
         match s {
             "restricted" => Ok(Restricted),
             "unrestricted" => Ok(Unrestricted),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -685,13 +685,13 @@ impl UpdateTreasuryFinancialAccountPlatformRestrictionsInboundFlows {
 }
 
 impl std::str::FromStr for UpdateTreasuryFinancialAccountPlatformRestrictionsInboundFlows {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateTreasuryFinancialAccountPlatformRestrictionsInboundFlows::*;
         match s {
             "restricted" => Ok(Restricted),
             "unrestricted" => Ok(Unrestricted),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -745,13 +745,13 @@ impl UpdateTreasuryFinancialAccountPlatformRestrictionsOutboundFlows {
 }
 
 impl std::str::FromStr for UpdateTreasuryFinancialAccountPlatformRestrictionsOutboundFlows {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use UpdateTreasuryFinancialAccountPlatformRestrictionsOutboundFlows::*;
         match s {
             "restricted" => Ok(Restricted),
             "unrestricted" => Ok(Unrestricted),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_treasury/src/treasury_financial_account/types.rs
+++ b/generated/stripe_treasury/src/treasury_financial_account/types.rs
@@ -247,13 +247,13 @@ impl TreasuryFinancialAccountStatus {
 }
 
 impl std::str::FromStr for TreasuryFinancialAccountStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TreasuryFinancialAccountStatus::*;
         match s {
             "closed" => Ok(Closed),
             "open" => Ok(Open),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -341,7 +341,7 @@ impl TreasuryFinancialAccountArray {
 }
 
 impl std::str::FromStr for TreasuryFinancialAccountArray {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TreasuryFinancialAccountArray::*;
         match s {
@@ -355,7 +355,7 @@ impl std::str::FromStr for TreasuryFinancialAccountArray {
             "outbound_transfers.ach" => Ok(OutboundTransfersAch),
             "outbound_transfers.us_domestic_wire" => Ok(OutboundTransfersUsDomesticWire),
             "remote_deposit_capture" => Ok(RemoteDepositCapture),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_treasury/src/treasury_financial_accounts_resource_aba_toggle_settings.rs
+++ b/generated/stripe_treasury/src/treasury_financial_accounts_resource_aba_toggle_settings.rs
@@ -131,14 +131,14 @@ impl TreasuryFinancialAccountsResourceAbaToggleSettingsStatus {
 }
 
 impl std::str::FromStr for TreasuryFinancialAccountsResourceAbaToggleSettingsStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TreasuryFinancialAccountsResourceAbaToggleSettingsStatus::*;
         match s {
             "active" => Ok(Active),
             "pending" => Ok(Pending),
             "restricted" => Ok(Restricted),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_treasury/src/treasury_financial_accounts_resource_ach_toggle_settings.rs
+++ b/generated/stripe_treasury/src/treasury_financial_accounts_resource_ach_toggle_settings.rs
@@ -131,14 +131,14 @@ impl TreasuryFinancialAccountsResourceAchToggleSettingsStatus {
 }
 
 impl std::str::FromStr for TreasuryFinancialAccountsResourceAchToggleSettingsStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TreasuryFinancialAccountsResourceAchToggleSettingsStatus::*;
         match s {
             "active" => Ok(Active),
             "pending" => Ok(Pending),
             "restricted" => Ok(Restricted),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_treasury/src/treasury_financial_accounts_resource_closed_status_details.rs
+++ b/generated/stripe_treasury/src/treasury_financial_accounts_resource_closed_status_details.rs
@@ -112,14 +112,14 @@ impl TreasuryFinancialAccountsResourceClosedStatusDetailsReasons {
 }
 
 impl std::str::FromStr for TreasuryFinancialAccountsResourceClosedStatusDetailsReasons {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TreasuryFinancialAccountsResourceClosedStatusDetailsReasons::*;
         match s {
             "account_rejected" => Ok(AccountRejected),
             "closed_by_platform" => Ok(ClosedByPlatform),
             "other" => Ok(Other),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_treasury/src/treasury_financial_accounts_resource_financial_address.rs
+++ b/generated/stripe_treasury/src/treasury_financial_accounts_resource_financial_address.rs
@@ -131,13 +131,13 @@ impl TreasuryFinancialAccountsResourceFinancialAddressSupportedNetworks {
 }
 
 impl std::str::FromStr for TreasuryFinancialAccountsResourceFinancialAddressSupportedNetworks {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TreasuryFinancialAccountsResourceFinancialAddressSupportedNetworks::*;
         match s {
             "ach" => Ok(Ach),
             "us_domestic_wire" => Ok(UsDomesticWire),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -208,12 +208,12 @@ impl TreasuryFinancialAccountsResourceFinancialAddressType {
 }
 
 impl std::str::FromStr for TreasuryFinancialAccountsResourceFinancialAddressType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TreasuryFinancialAccountsResourceFinancialAddressType::*;
         match s {
             "aba" => Ok(Aba),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_treasury/src/treasury_financial_accounts_resource_platform_restrictions.rs
+++ b/generated/stripe_treasury/src/treasury_financial_accounts_resource_platform_restrictions.rs
@@ -121,13 +121,13 @@ impl TreasuryFinancialAccountsResourcePlatformRestrictionsInboundFlows {
 }
 
 impl std::str::FromStr for TreasuryFinancialAccountsResourcePlatformRestrictionsInboundFlows {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TreasuryFinancialAccountsResourcePlatformRestrictionsInboundFlows::*;
         match s {
             "restricted" => Ok(Restricted),
             "unrestricted" => Ok(Unrestricted),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -200,13 +200,13 @@ impl TreasuryFinancialAccountsResourcePlatformRestrictionsOutboundFlows {
 }
 
 impl std::str::FromStr for TreasuryFinancialAccountsResourcePlatformRestrictionsOutboundFlows {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TreasuryFinancialAccountsResourcePlatformRestrictionsOutboundFlows::*;
         match s {
             "restricted" => Ok(Restricted),
             "unrestricted" => Ok(Unrestricted),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_treasury/src/treasury_financial_accounts_resource_toggle_settings.rs
+++ b/generated/stripe_treasury/src/treasury_financial_accounts_resource_toggle_settings.rs
@@ -131,14 +131,14 @@ impl TreasuryFinancialAccountsResourceToggleSettingsStatus {
 }
 
 impl std::str::FromStr for TreasuryFinancialAccountsResourceToggleSettingsStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TreasuryFinancialAccountsResourceToggleSettingsStatus::*;
         match s {
             "active" => Ok(Active),
             "pending" => Ok(Pending),
             "restricted" => Ok(Restricted),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_treasury/src/treasury_financial_accounts_resource_toggles_setting_status_details.rs
+++ b/generated/stripe_treasury/src/treasury_financial_accounts_resource_toggles_setting_status_details.rs
@@ -146,7 +146,7 @@ impl TreasuryFinancialAccountsResourceTogglesSettingStatusDetailsCode {
 }
 
 impl std::str::FromStr for TreasuryFinancialAccountsResourceTogglesSettingStatusDetailsCode {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TreasuryFinancialAccountsResourceTogglesSettingStatusDetailsCode::*;
         match s {
@@ -159,7 +159,7 @@ impl std::str::FromStr for TreasuryFinancialAccountsResourceTogglesSettingStatus
             "requirements_pending_verification" => Ok(RequirementsPendingVerification),
             "restricted_by_platform" => Ok(RestrictedByPlatform),
             "restricted_other" => Ok(RestrictedOther),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -234,14 +234,14 @@ impl TreasuryFinancialAccountsResourceTogglesSettingStatusDetailsResolution {
 }
 
 impl std::str::FromStr for TreasuryFinancialAccountsResourceTogglesSettingStatusDetailsResolution {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TreasuryFinancialAccountsResourceTogglesSettingStatusDetailsResolution::*;
         match s {
             "contact_stripe" => Ok(ContactStripe),
             "provide_information" => Ok(ProvideInformation),
             "remove_restriction" => Ok(RemoveRestriction),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -316,13 +316,13 @@ impl TreasuryFinancialAccountsResourceTogglesSettingStatusDetailsRestriction {
 }
 
 impl std::str::FromStr for TreasuryFinancialAccountsResourceTogglesSettingStatusDetailsRestriction {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TreasuryFinancialAccountsResourceTogglesSettingStatusDetailsRestriction::*;
         match s {
             "inbound_flows" => Ok(InboundFlows),
             "outbound_flows" => Ok(OutboundFlows),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_treasury/src/treasury_inbound_transfer/requests.rs
+++ b/generated/stripe_treasury/src/treasury_inbound_transfer/requests.rs
@@ -139,7 +139,7 @@ impl FailTreasuryInboundTransferFailureDetailsCode {
 }
 
 impl std::str::FromStr for FailTreasuryInboundTransferFailureDetailsCode {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use FailTreasuryInboundTransferFailureDetailsCode::*;
         match s {
@@ -156,7 +156,7 @@ impl std::str::FromStr for FailTreasuryInboundTransferFailureDetailsCode {
             "invalid_currency" => Ok(InvalidCurrency),
             "no_account" => Ok(NoAccount),
             "other" => Ok(Other),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -184,7 +184,7 @@ impl<'de> serde::Deserialize<'de> for FailTreasuryInboundTransferFailureDetailsC
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 impl<'a> FailTreasuryInboundTransfer<'a> {

--- a/generated/stripe_treasury/src/treasury_inbound_transfer/types.rs
+++ b/generated/stripe_treasury/src/treasury_inbound_transfer/types.rs
@@ -302,7 +302,7 @@ impl TreasuryInboundTransferStatus {
 }
 
 impl std::str::FromStr for TreasuryInboundTransferStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TreasuryInboundTransferStatus::*;
         match s {
@@ -310,7 +310,7 @@ impl std::str::FromStr for TreasuryInboundTransferStatus {
             "failed" => Ok(Failed),
             "processing" => Ok(Processing),
             "succeeded" => Ok(Succeeded),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_treasury/src/treasury_inbound_transfers_resource_failure_details.rs
+++ b/generated/stripe_treasury/src/treasury_inbound_transfers_resource_failure_details.rs
@@ -134,7 +134,7 @@ impl TreasuryInboundTransfersResourceFailureDetailsCode {
 }
 
 impl std::str::FromStr for TreasuryInboundTransfersResourceFailureDetailsCode {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TreasuryInboundTransfersResourceFailureDetailsCode::*;
         match s {
@@ -151,7 +151,7 @@ impl std::str::FromStr for TreasuryInboundTransfersResourceFailureDetailsCode {
             "invalid_currency" => Ok(InvalidCurrency),
             "no_account" => Ok(NoAccount),
             "other" => Ok(Other),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -184,10 +184,7 @@ impl miniserde::Deserialize for TreasuryInboundTransfersResourceFailureDetailsCo
 impl miniserde::de::Visitor for crate::Place<TreasuryInboundTransfersResourceFailureDetailsCode> {
     fn string(&mut self, s: &str) -> miniserde::Result<()> {
         use std::str::FromStr;
-        self.out = Some(
-            TreasuryInboundTransfersResourceFailureDetailsCode::from_str(s)
-                .unwrap_or(TreasuryInboundTransfersResourceFailureDetailsCode::Unknown),
-        );
+        self.out = Some(TreasuryInboundTransfersResourceFailureDetailsCode::from_str(s).unwrap());
         Ok(())
     }
 }
@@ -198,6 +195,6 @@ impl<'de> serde::Deserialize<'de> for TreasuryInboundTransfersResourceFailureDet
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }

--- a/generated/stripe_treasury/src/treasury_outbound_payment/requests.rs
+++ b/generated/stripe_treasury/src/treasury_outbound_payment/requests.rs
@@ -185,7 +185,7 @@ impl ReturnOutboundPaymentTreasuryOutboundPaymentReturnedDetailsCode {
 }
 
 impl std::str::FromStr for ReturnOutboundPaymentTreasuryOutboundPaymentReturnedDetailsCode {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ReturnOutboundPaymentTreasuryOutboundPaymentReturnedDetailsCode::*;
         match s {
@@ -199,7 +199,7 @@ impl std::str::FromStr for ReturnOutboundPaymentTreasuryOutboundPaymentReturnedD
             "invalid_currency" => Ok(InvalidCurrency),
             "no_account" => Ok(NoAccount),
             "other" => Ok(Other),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -422,13 +422,13 @@ impl CreateTreasuryOutboundPaymentDestinationPaymentMethodDataType {
 }
 
 impl std::str::FromStr for CreateTreasuryOutboundPaymentDestinationPaymentMethodDataType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTreasuryOutboundPaymentDestinationPaymentMethodDataType::*;
         match s {
             "financial_account" => Ok(FinancialAccount),
             "us_bank_account" => Ok(UsBankAccount),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -511,13 +511,13 @@ impl CreateTreasuryOutboundPaymentDestinationPaymentMethodDataUsBankAccountAccou
 impl std::str::FromStr
     for CreateTreasuryOutboundPaymentDestinationPaymentMethodDataUsBankAccountAccountHolderType
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTreasuryOutboundPaymentDestinationPaymentMethodDataUsBankAccountAccountHolderType::*;
         match s {
             "company" => Ok(Company),
             "individual" => Ok(Individual),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -575,13 +575,13 @@ impl CreateTreasuryOutboundPaymentDestinationPaymentMethodDataUsBankAccountAccou
 impl std::str::FromStr
     for CreateTreasuryOutboundPaymentDestinationPaymentMethodDataUsBankAccountAccountType
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTreasuryOutboundPaymentDestinationPaymentMethodDataUsBankAccountAccountType::*;
         match s {
             "checking" => Ok(Checking),
             "savings" => Ok(Savings),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -667,13 +667,13 @@ impl CreateTreasuryOutboundPaymentDestinationPaymentMethodOptionsUsBankAccountNe
 impl std::str::FromStr
     for CreateTreasuryOutboundPaymentDestinationPaymentMethodOptionsUsBankAccountNetwork
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTreasuryOutboundPaymentDestinationPaymentMethodOptionsUsBankAccountNetwork::*;
         match s {
             "ach" => Ok(Ach),
             "us_domestic_wire" => Ok(UsDomesticWire),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_treasury/src/treasury_outbound_payment/types.rs
+++ b/generated/stripe_treasury/src/treasury_outbound_payment/types.rs
@@ -331,7 +331,7 @@ impl TreasuryOutboundPaymentStatus {
 }
 
 impl std::str::FromStr for TreasuryOutboundPaymentStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TreasuryOutboundPaymentStatus::*;
         match s {
@@ -340,7 +340,7 @@ impl std::str::FromStr for TreasuryOutboundPaymentStatus {
             "posted" => Ok(Posted),
             "processing" => Ok(Processing),
             "returned" => Ok(Returned),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_treasury/src/treasury_outbound_payments_resource_returned_status.rs
+++ b/generated/stripe_treasury/src/treasury_outbound_payments_resource_returned_status.rs
@@ -129,7 +129,7 @@ impl TreasuryOutboundPaymentsResourceReturnedStatusCode {
 }
 
 impl std::str::FromStr for TreasuryOutboundPaymentsResourceReturnedStatusCode {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TreasuryOutboundPaymentsResourceReturnedStatusCode::*;
         match s {
@@ -143,7 +143,7 @@ impl std::str::FromStr for TreasuryOutboundPaymentsResourceReturnedStatusCode {
             "invalid_currency" => Ok(InvalidCurrency),
             "no_account" => Ok(NoAccount),
             "other" => Ok(Other),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_treasury/src/treasury_outbound_transfer/requests.rs
+++ b/generated/stripe_treasury/src/treasury_outbound_transfer/requests.rs
@@ -181,7 +181,7 @@ impl ReturnOutboundTransferTreasuryOutboundTransferReturnedDetailsCode {
 }
 
 impl std::str::FromStr for ReturnOutboundTransferTreasuryOutboundTransferReturnedDetailsCode {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ReturnOutboundTransferTreasuryOutboundTransferReturnedDetailsCode::*;
         match s {
@@ -195,7 +195,7 @@ impl std::str::FromStr for ReturnOutboundTransferTreasuryOutboundTransferReturne
             "invalid_currency" => Ok(InvalidCurrency),
             "no_account" => Ok(NoAccount),
             "other" => Ok(Other),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -337,13 +337,13 @@ impl CreateTreasuryOutboundTransferDestinationPaymentMethodOptionsUsBankAccountN
 impl std::str::FromStr
     for CreateTreasuryOutboundTransferDestinationPaymentMethodOptionsUsBankAccountNetwork
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTreasuryOutboundTransferDestinationPaymentMethodOptionsUsBankAccountNetwork::*;
         match s {
             "ach" => Ok(Ach),
             "us_domestic_wire" => Ok(UsDomesticWire),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_treasury/src/treasury_outbound_transfer/types.rs
+++ b/generated/stripe_treasury/src/treasury_outbound_transfer/types.rs
@@ -304,7 +304,7 @@ impl TreasuryOutboundTransferStatus {
 }
 
 impl std::str::FromStr for TreasuryOutboundTransferStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TreasuryOutboundTransferStatus::*;
         match s {
@@ -313,7 +313,7 @@ impl std::str::FromStr for TreasuryOutboundTransferStatus {
             "posted" => Ok(Posted),
             "processing" => Ok(Processing),
             "returned" => Ok(Returned),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_treasury/src/treasury_outbound_transfers_resource_returned_details.rs
+++ b/generated/stripe_treasury/src/treasury_outbound_transfers_resource_returned_details.rs
@@ -129,7 +129,7 @@ impl TreasuryOutboundTransfersResourceReturnedDetailsCode {
 }
 
 impl std::str::FromStr for TreasuryOutboundTransfersResourceReturnedDetailsCode {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TreasuryOutboundTransfersResourceReturnedDetailsCode::*;
         match s {
@@ -143,7 +143,7 @@ impl std::str::FromStr for TreasuryOutboundTransfersResourceReturnedDetailsCode 
             "invalid_currency" => Ok(InvalidCurrency),
             "no_account" => Ok(NoAccount),
             "other" => Ok(Other),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_treasury/src/treasury_received_credit/requests.rs
+++ b/generated/stripe_treasury/src/treasury_received_credit/requests.rs
@@ -71,7 +71,7 @@ impl ListTreasuryReceivedCreditLinkedFlowsSourceFlowType {
 }
 
 impl std::str::FromStr for ListTreasuryReceivedCreditLinkedFlowsSourceFlowType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ListTreasuryReceivedCreditLinkedFlowsSourceFlowType::*;
         match s {
@@ -79,7 +79,7 @@ impl std::str::FromStr for ListTreasuryReceivedCreditLinkedFlowsSourceFlowType {
             "other" => Ok(Other),
             "outbound_payment" => Ok(OutboundPayment),
             "payout" => Ok(Payout),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -220,12 +220,12 @@ impl CreateTreasuryReceivedCreditInitiatingPaymentMethodDetailsType {
 }
 
 impl std::str::FromStr for CreateTreasuryReceivedCreditInitiatingPaymentMethodDetailsType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTreasuryReceivedCreditInitiatingPaymentMethodDetailsType::*;
         match s {
             "us_bank_account" => Ok(UsBankAccount),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -297,13 +297,13 @@ impl CreateTreasuryReceivedCreditNetwork {
 }
 
 impl std::str::FromStr for CreateTreasuryReceivedCreditNetwork {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTreasuryReceivedCreditNetwork::*;
         match s {
             "ach" => Ok(Ach),
             "us_domestic_wire" => Ok(UsDomesticWire),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_treasury/src/treasury_received_credit/types.rs
+++ b/generated/stripe_treasury/src/treasury_received_credit/types.rs
@@ -254,14 +254,14 @@ impl TreasuryReceivedCreditFailureCode {
 }
 
 impl std::str::FromStr for TreasuryReceivedCreditFailureCode {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TreasuryReceivedCreditFailureCode::*;
         match s {
             "account_closed" => Ok(AccountClosed),
             "account_frozen" => Ok(AccountFrozen),
             "other" => Ok(Other),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -332,7 +332,7 @@ impl TreasuryReceivedCreditNetwork {
 }
 
 impl std::str::FromStr for TreasuryReceivedCreditNetwork {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TreasuryReceivedCreditNetwork::*;
         match s {
@@ -340,7 +340,7 @@ impl std::str::FromStr for TreasuryReceivedCreditNetwork {
             "card" => Ok(Card),
             "stripe" => Ok(Stripe),
             "us_domestic_wire" => Ok(UsDomesticWire),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -412,13 +412,13 @@ impl TreasuryReceivedCreditStatus {
 }
 
 impl std::str::FromStr for TreasuryReceivedCreditStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TreasuryReceivedCreditStatus::*;
         match s {
             "failed" => Ok(Failed),
             "succeeded" => Ok(Succeeded),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_treasury/src/treasury_received_credits_resource_reversal_details.rs
+++ b/generated/stripe_treasury/src/treasury_received_credits_resource_reversal_details.rs
@@ -120,7 +120,7 @@ impl TreasuryReceivedCreditsResourceReversalDetailsRestrictedReason {
 }
 
 impl std::str::FromStr for TreasuryReceivedCreditsResourceReversalDetailsRestrictedReason {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TreasuryReceivedCreditsResourceReversalDetailsRestrictedReason::*;
         match s {
@@ -129,7 +129,7 @@ impl std::str::FromStr for TreasuryReceivedCreditsResourceReversalDetailsRestric
             "network_restricted" => Ok(NetworkRestricted),
             "other" => Ok(Other),
             "source_flow_restricted" => Ok(SourceFlowRestricted),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_treasury/src/treasury_received_credits_resource_source_flows_details.rs
+++ b/generated/stripe_treasury/src/treasury_received_credits_resource_source_flows_details.rs
@@ -135,7 +135,7 @@ impl TreasuryReceivedCreditsResourceSourceFlowsDetailsType {
 }
 
 impl std::str::FromStr for TreasuryReceivedCreditsResourceSourceFlowsDetailsType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TreasuryReceivedCreditsResourceSourceFlowsDetailsType::*;
         match s {
@@ -143,7 +143,7 @@ impl std::str::FromStr for TreasuryReceivedCreditsResourceSourceFlowsDetailsType
             "other" => Ok(Other),
             "outbound_payment" => Ok(OutboundPayment),
             "payout" => Ok(Payout),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_treasury/src/treasury_received_debit/requests.rs
+++ b/generated/stripe_treasury/src/treasury_received_debit/requests.rs
@@ -141,12 +141,12 @@ impl CreateTreasuryReceivedDebitInitiatingPaymentMethodDetailsType {
 }
 
 impl std::str::FromStr for CreateTreasuryReceivedDebitInitiatingPaymentMethodDetailsType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTreasuryReceivedDebitInitiatingPaymentMethodDetailsType::*;
         match s {
             "us_bank_account" => Ok(UsBankAccount),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -216,12 +216,12 @@ impl CreateTreasuryReceivedDebitNetwork {
 }
 
 impl std::str::FromStr for CreateTreasuryReceivedDebitNetwork {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use CreateTreasuryReceivedDebitNetwork::*;
         match s {
             "ach" => Ok(Ach),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_treasury/src/treasury_received_debit/types.rs
+++ b/generated/stripe_treasury/src/treasury_received_debit/types.rs
@@ -256,7 +256,7 @@ impl TreasuryReceivedDebitFailureCode {
 }
 
 impl std::str::FromStr for TreasuryReceivedDebitFailureCode {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TreasuryReceivedDebitFailureCode::*;
         match s {
@@ -264,7 +264,7 @@ impl std::str::FromStr for TreasuryReceivedDebitFailureCode {
             "account_frozen" => Ok(AccountFrozen),
             "insufficient_funds" => Ok(InsufficientFunds),
             "other" => Ok(Other),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -333,14 +333,14 @@ impl TreasuryReceivedDebitNetwork {
 }
 
 impl std::str::FromStr for TreasuryReceivedDebitNetwork {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TreasuryReceivedDebitNetwork::*;
         match s {
             "ach" => Ok(Ach),
             "card" => Ok(Card),
             "stripe" => Ok(Stripe),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -411,13 +411,13 @@ impl TreasuryReceivedDebitStatus {
 }
 
 impl std::str::FromStr for TreasuryReceivedDebitStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TreasuryReceivedDebitStatus::*;
         match s {
             "failed" => Ok(Failed),
             "succeeded" => Ok(Succeeded),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_treasury/src/treasury_received_debits_resource_reversal_details.rs
+++ b/generated/stripe_treasury/src/treasury_received_debits_resource_reversal_details.rs
@@ -120,7 +120,7 @@ impl TreasuryReceivedDebitsResourceReversalDetailsRestrictedReason {
 }
 
 impl std::str::FromStr for TreasuryReceivedDebitsResourceReversalDetailsRestrictedReason {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TreasuryReceivedDebitsResourceReversalDetailsRestrictedReason::*;
         match s {
@@ -129,7 +129,7 @@ impl std::str::FromStr for TreasuryReceivedDebitsResourceReversalDetailsRestrict
             "network_restricted" => Ok(NetworkRestricted),
             "other" => Ok(Other),
             "source_flow_restricted" => Ok(SourceFlowRestricted),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_treasury/src/treasury_shared_resource_initiating_payment_method_details_initiating_payment_method_details.rs
+++ b/generated/stripe_treasury/src/treasury_shared_resource_initiating_payment_method_details_initiating_payment_method_details.rs
@@ -162,12 +162,12 @@ impl TreasurySharedResourceInitiatingPaymentMethodDetailsInitiatingPaymentMethod
 impl std::str::FromStr
     for TreasurySharedResourceInitiatingPaymentMethodDetailsInitiatingPaymentMethodDetailsBalance
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TreasurySharedResourceInitiatingPaymentMethodDetailsInitiatingPaymentMethodDetailsBalance::*;
         match s {
             "payments" => Ok(Payments),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -256,7 +256,7 @@ impl TreasurySharedResourceInitiatingPaymentMethodDetailsInitiatingPaymentMethod
 impl std::str::FromStr
     for TreasurySharedResourceInitiatingPaymentMethodDetailsInitiatingPaymentMethodDetailsType
 {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TreasurySharedResourceInitiatingPaymentMethodDetailsInitiatingPaymentMethodDetailsType::*;
         match s {
@@ -265,7 +265,7 @@ impl std::str::FromStr
             "issuing_card" => Ok(IssuingCard),
             "stripe" => Ok(Stripe),
             "us_bank_account" => Ok(UsBankAccount),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_treasury/src/treasury_transaction/requests.rs
+++ b/generated/stripe_treasury/src/treasury_transaction/requests.rs
@@ -66,13 +66,13 @@ impl ListTreasuryTransactionOrderBy {
 }
 
 impl std::str::FromStr for ListTreasuryTransactionOrderBy {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ListTreasuryTransactionOrderBy::*;
         match s {
             "created" => Ok(Created),
             "posted_at" => Ok(PostedAt),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_treasury/src/treasury_transaction/types.rs
+++ b/generated/stripe_treasury/src/treasury_transaction/types.rs
@@ -246,7 +246,7 @@ impl TreasuryTransactionFlowType {
 }
 
 impl std::str::FromStr for TreasuryTransactionFlowType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TreasuryTransactionFlowType::*;
         match s {
@@ -259,7 +259,7 @@ impl std::str::FromStr for TreasuryTransactionFlowType {
             "outbound_transfer" => Ok(OutboundTransfer),
             "received_credit" => Ok(ReceivedCredit),
             "received_debit" => Ok(ReceivedDebit),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -332,14 +332,14 @@ impl TreasuryTransactionStatus {
 }
 
 impl std::str::FromStr for TreasuryTransactionStatus {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TreasuryTransactionStatus::*;
         match s {
             "open" => Ok(Open),
             "posted" => Ok(Posted),
             "void" => Ok(Void),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_treasury/src/treasury_transaction_entry/requests.rs
+++ b/generated/stripe_treasury/src/treasury_transaction_entry/requests.rs
@@ -64,13 +64,13 @@ impl ListTreasuryTransactionEntryOrderBy {
 }
 
 impl std::str::FromStr for ListTreasuryTransactionEntryOrderBy {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use ListTreasuryTransactionEntryOrderBy::*;
         match s {
             "created" => Ok(Created),
             "effective_at" => Ok(EffectiveAt),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/generated/stripe_treasury/src/treasury_transaction_entry/types.rs
+++ b/generated/stripe_treasury/src/treasury_transaction_entry/types.rs
@@ -226,7 +226,7 @@ impl TreasuryTransactionEntryFlowType {
 }
 
 impl std::str::FromStr for TreasuryTransactionEntryFlowType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TreasuryTransactionEntryFlowType::*;
         match s {
@@ -239,7 +239,7 @@ impl std::str::FromStr for TreasuryTransactionEntryFlowType {
             "outbound_transfer" => Ok(OutboundTransfer),
             "received_credit" => Ok(ReceivedCredit),
             "received_debit" => Ok(ReceivedDebit),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }
@@ -346,7 +346,7 @@ impl TreasuryTransactionEntryType {
 }
 
 impl std::str::FromStr for TreasuryTransactionEntryType {
-    type Err = ();
+    type Err = std::convert::Infallible;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TreasuryTransactionEntryType::*;
         match s {
@@ -370,7 +370,7 @@ impl std::str::FromStr for TreasuryTransactionEntryType {
             "outbound_transfer_return" => Ok(OutboundTransferReturn),
             "received_credit" => Ok(ReceivedCredit),
             "received_debit" => Ok(ReceivedDebit),
-            _ => Err(()),
+            _ => Ok(Self::Unknown),
         }
     }
 }
@@ -403,10 +403,7 @@ impl miniserde::Deserialize for TreasuryTransactionEntryType {
 impl miniserde::de::Visitor for crate::Place<TreasuryTransactionEntryType> {
     fn string(&mut self, s: &str) -> miniserde::Result<()> {
         use std::str::FromStr;
-        self.out = Some(
-            TreasuryTransactionEntryType::from_str(s)
-                .unwrap_or(TreasuryTransactionEntryType::Unknown),
-        );
+        self.out = Some(TreasuryTransactionEntryType::from_str(s).unwrap());
         Ok(())
     }
 }
@@ -417,7 +414,7 @@ impl<'de> serde::Deserialize<'de> for TreasuryTransactionEntryType {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         use std::str::FromStr;
         let s: std::borrow::Cow<'de, str> = serde::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap_or(Self::Unknown))
+        Ok(Self::from_str(&s).unwrap())
     }
 }
 impl stripe_types::Object for TreasuryTransactionEntry {

--- a/generated/stripe_treasury/src/treasury_transactions_resource_flow_details.rs
+++ b/generated/stripe_treasury/src/treasury_transactions_resource_flow_details.rs
@@ -177,7 +177,7 @@ impl TreasuryTransactionsResourceFlowDetailsType {
 }
 
 impl std::str::FromStr for TreasuryTransactionsResourceFlowDetailsType {
-    type Err = ();
+    type Err = stripe_types::StripeParseError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         use TreasuryTransactionsResourceFlowDetailsType::*;
         match s {
@@ -190,7 +190,7 @@ impl std::str::FromStr for TreasuryTransactionsResourceFlowDetailsType {
             "outbound_transfer" => Ok(OutboundTransfer),
             "received_credit" => Ok(ReceivedCredit),
             "received_debit" => Ok(ReceivedDebit),
-            _ => Err(()),
+            _ => Err(stripe_types::StripeParseError),
         }
     }
 }

--- a/stripe_types/src/error.rs
+++ b/stripe_types/src/error.rs
@@ -1,0 +1,12 @@
+use std::fmt::{Display, Formatter};
+
+#[derive(Debug)]
+pub struct StripeParseError;
+
+impl Display for StripeParseError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str("unrecognized enum variant")
+    }
+}
+
+impl std::error::Error for StripeParseError {}

--- a/stripe_types/src/lib.rs
+++ b/stripe_types/src/lib.rs
@@ -1,12 +1,14 @@
 //! This crate provides Rust bindings for core types to the Stripe HTTP API.
 
 mod currency;
+mod error;
 mod expandable;
 mod ids;
 mod pagination;
 mod params;
 
 pub use currency::{Currency, ParseCurrencyError};
+pub use error::StripeParseError;
 pub use expandable::*;
 pub use pagination::*;
 pub use params::*;

--- a/tests/tests/it/enums.rs
+++ b/tests/tests/it/enums.rs
@@ -1,0 +1,32 @@
+use std::str::FromStr;
+
+use stripe_connect::AccountType;
+use stripe_core::EventType;
+
+#[test]
+fn enums_basic() {
+    assert_eq!(AccountType::Express, AccountType::from_str("express").unwrap());
+    assert_eq!(AccountType::Express.as_str(), "express");
+    assert_eq!(serde_json::to_string(&AccountType::Express).unwrap(), r#""express""#);
+    assert_eq!(
+        miniserde::json::from_str::<AccountType>(r#""express""#).unwrap(),
+        AccountType::Express
+    );
+    assert_eq!(serde_json::from_str::<AccountType>(r#""express""#).unwrap(), AccountType::Express);
+    assert_eq!(AccountType::Express.to_string(), "express");
+    assert!(AccountType::from_str("unknown").is_err());
+}
+
+#[test]
+fn from_str_and_deser_behavior_match_on_unknown_variant() {
+    let acct_authorized = "account.application.authorized";
+    assert_eq!(
+        EventType::AccountApplicationAuthorized,
+        EventType::from_str(acct_authorized).unwrap()
+    );
+    assert_eq!(EventType::AccountApplicationAuthorized.as_str(), acct_authorized);
+
+    assert_eq!(EventType::Unknown, EventType::from_str("acct").unwrap());
+    assert_eq!(miniserde::json::from_str::<EventType>(r#""acct""#).unwrap(), EventType::Unknown);
+    assert_eq!(serde_json::from_str::<EventType>(r#""acct""#).unwrap(), EventType::Unknown);
+}

--- a/tests/tests/it/main.rs
+++ b/tests/tests/it/main.rs
@@ -1,6 +1,7 @@
 // Needed for `json!` usage in tests
 #![recursion_limit = "256"]
 mod deser;
+mod enums;
 pub mod generated;
 mod mock;
 mod price;


### PR DESCRIPTION
After using this, I realized a couple issues
- Writing `from_str(s)?` reminded me `()` as the error type for `FromStr` is terrible since it doesn't impl `Error` or `Display`.
- Enums which fallback to `Unknown` can have an infallible `FromStr`.
- Fallback behavior for `from_str` and deserialization did not match.

There's another question which doesn't need to be answered here around usage of `Unknown` as a fallback so that added enum variants are not a breaking change for parsing. 

The `openapi` code currently uses the completely unscientific value of `12` variants for determining when `Unknown` should be inserted - there's probably an argument for using `Unknown` on smaller enums than that (or always, but that might start to hurt ergonomics for pretty stable enums).