### PR TITLE
feat(setup_intent): add mandate_data for confirm

### DIFF
--- a/src/resources/customer_ext.rs
+++ b/src/resources/customer_ext.rs
@@ -9,39 +9,40 @@ use crate::resources::{
 
 #[derive(Clone, Debug, Serialize, Eq, PartialEq)]
 pub struct CustomerPaymentMethodRetrieval<'a> {
-    ///A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list.
+    /// A cursor for use in pagination. `ending_before` is an object ID that defines your place in the list.
     ///For instance, if you make a list request and receive 100 objects, starting with `obj_bar`,
     ///your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ending_before: Option<String>,
 
-    ///Specifies which fields in the response should be expanded.
+    /// Specifies which fields in the response should be expanded.
     #[serde(skip_serializing_if = "Expand::is_empty")]
     pub expand: &'a [&'a str],
 
-    ///A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10.
+    /// A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub limit: Option<i32>,
 
-    ///A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list.
+    /// A cursor for use in pagination. `starting_after` is an object ID that defines your place in the list.
     ///For instance, if you make a list request and receive 100 objects, ending with `obj_foo`,
     ///your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub starting_after: Option<String>,
 
-    ///A required filter on the list, based on the object `type` field.
+    /// An optional filter on the list, based on the object type field. Without the filter, the list includes all current and future payment method types. If your integration expects only one type of payment method in the response, make sure to provide a type value in the request.
     #[serde(rename = "type")]
-    pub type_: CustomerPaymentMethodRetrievalType,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub type_: Option<CustomerPaymentMethodRetrievalType>,
 }
 
 impl<'a> CustomerPaymentMethodRetrieval<'a> {
-    pub fn new(the_type: CustomerPaymentMethodRetrievalType) -> Self {
+    pub fn new() -> Self {
         CustomerPaymentMethodRetrieval {
             ending_before: None,
             expand: &[],
             limit: None,
             starting_after: None,
-            type_: the_type,
+            type_: None,
         }
     }
 }

--- a/src/resources/setup_intent_ext.rs
+++ b/src/resources/setup_intent_ext.rs
@@ -2,26 +2,40 @@ use serde::Serialize;
 
 use crate::client::{Client, Response};
 use crate::resources::SetupIntent;
-use crate::{SetupIntentCancellationReason, SetupIntentId};
+use crate::{PaymentMethodId, SetupIntentCancellationReason, SetupIntentId};
 
 /// The set of parameters that can be used when confirming a setup_intent object.
 ///
 /// For more details see <https://stripe.com/docs/api/setup_intents/confirm>
 #[derive(Clone, Debug, Serialize)]
 pub struct ConfirmSetupIntent {
-    /// The client secret if on the client side
+    /// ID of the payment method (a PaymentMethod, Card, or saved Source object) to attach to this SetupIntent.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub client_secret: Option<String>,
+    pub payment_method: Option<PaymentMethodId>,
 
-    /// Specifies which payment method
+    /// This hash contains details about the mandate to create
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub payment_method: Option<String>,
+    pub mandate_data: Option<MandateData>,
 
-    // Mandate data and payment method options not implemented.  If you want
-    // something better, create an issue and lets fix
+    /// When included, this hash creates a PaymentMethod that is set as the payment_method value in the SetupIntent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payment_method_data: Option<crate::UpdatePaymentIntentPaymentMethodData>,
+
+    /// Payment method-specific configuration for this SetupIntent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payment_method_options: Option<crate::UpdatePaymentIntentPaymentMethodOptions>,
+
     /// The URL to redirect your customer back to after they authenticate on the payment method’s app or site.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub return_url: Option<String>,
+
+    /// Set to `true` when confirming server-side and using Stripe.js, iOS, or Android client-side SDKs to handle the next actions.
+    pub use_stripe_sdk: bool,
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct MandateData {
+    pub customer_acceptance: crate::CustomerAcceptance,
 }
 
 /// The set of parameters that can be used when canceling a setup_intent object.


### PR DESCRIPTION
# Summary

Adds a field for confirming a setup intent and providing the mandate that the customer used to confirm. 

Adds a new method for verifying a setup intent created as a us_bank_account with microdeposits.

Fixes a parameter to be optional when querying for all customer payment methods.

### Checklist

- [x] ran `cargo make fmt`
- [x] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features