### PR TITLE
Public api

### DIFF
--- a/.github/workflows/async-stripe.yml
+++ b/.github/workflows/async-stripe.yml
@@ -147,7 +147,7 @@ jobs:
       #     name: code-coverage-report
       #     path: lcov.info
 
-  public-api:
+  generate-public-api:
     continue-on-error: true
     runs-on: ubuntu-20.04
     steps:
@@ -162,31 +162,21 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-public-api
+      - name: Save PR number
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const fs = require('fs');
+            const util = require('util');
+            fs.mkdirSync("./public-api", { recursive: true });
+            const payload = context.payload;
+            const number = (payload.issue || payload.pull_request || payload).number;
+            const text = number === undefined ? "" : String(number);
+            core.info("Pr number is " + number + ", writing \"" + text + "\"");
+            fs.writeFileSync("./public-api/pr_number", text);
       - name: Compare with latest version published on crates.io
-        run: |
-          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-          echo "diff<<$EOF" >> $GITHUB_OUTPUT
-          echo "$(cargo public-api diff latest --features runtime-tokio-hyper)" >> $GITHUB_OUTPUT
-          echo "$EOF" >> $GITHUB_OUTPUT
-        id: diff
-      - name: Find Comment
-        uses: peter-evans/find-comment@v1
-        id: fc
+        run: cargo public-api diff latest --features runtime-tokio-hyper >> "public-api/diff"
+      - uses: actions/upload-artifact@v3
         with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: "github-actions[bot]"
-          body-includes: Removed items from the public API
-      - name: Create comment
-        if: steps.fc.outputs.comment-id == ''
-        uses: peter-evans/create-or-update-comment@v1
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            ${{ steps.diff.outputs.diff }}
-      - name: Update comment
-        if: steps.fc.outputs.comment-id != ''
-        uses: peter-evans/create-or-update-comment@v1
-        with:
-          comment-id: ${{ steps.fc.outputs.comment-id }}
-          body: |
-            ${{ steps.diff.outputs.diff }}
+          name: public-api
+          path: public-api/

--- a/.github/workflows/async-stripe.yml
+++ b/.github/workflows/async-stripe.yml
@@ -146,3 +146,21 @@ jobs:
       #   with:
       #     name: code-coverage-report
       #     path: lcov.info
+
+  public-api:
+    continue-on-error: true
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: nightly 
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+      - name: Install cargo-public-api
+        uses: baptiste0928/cargo-install@v3
+        with:
+           crate: cargo-public-api
+      - name: Compare with latest version published on crates.io
+        run: cargo public-api diff latest --features runtime-tokio-hyper

--- a/.github/workflows/async-stripe.yml
+++ b/.github/workflows/async-stripe.yml
@@ -154,13 +154,39 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: nightly 
+          toolchain: nightly
       - uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: stable
       - name: Install cargo-public-api
         uses: baptiste0928/cargo-install@v3
         with:
-           crate: cargo-public-api
+          crate: cargo-public-api
       - name: Compare with latest version published on crates.io
-        run: cargo public-api diff latest --features runtime-tokio-hyper
+        run: |
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "diff<<$EOF" >> $GITHUB_OUTPUT
+          echo "$(cargo public-api diff latest --features runtime-tokio-hyper)" >> $GITHUB_OUTPUT
+          echo "$EOF" >> $GITHUB_OUTPUT
+        id: diff
+      - name: Find Comment
+        uses: peter-evans/find-comment@v1
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: "github-actions[bot]"
+          body-includes: Removed items from the public API
+      - name: Create comment
+        if: steps.fc.outputs.comment-id == ''
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ${{ steps.diff.outputs.diff }}
+      - name: Update comment
+        if: steps.fc.outputs.comment-id != ''
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          body: |
+            ${{ steps.diff.outputs.diff }}

--- a/.github/workflows/public-api.yml
+++ b/.github/workflows/public-api.yml
@@ -1,0 +1,84 @@
+name: Cargo-public-api comment
+
+on:
+  workflow_run:
+    workflows: [Tests]
+    types:
+      - completed
+
+# taken from https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#using-data-from-the-triggering-workflow
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Download artifact'
+        id: da
+        uses: actions/github-script@v6
+        with:
+          script: |
+            if (context.payload.workflow_run === undefined) {
+                core.setFailed("No workflow run found");
+            }
+            const allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            
+            const theArtifact = allArtifacts.data.artifacts.find((artifact) => {
+               return artifact.name == "public-api"
+            });
+            if (theArtifact !== undefined) {
+               core.info("Found pr-number artifact id: " + theArtifact.id); 
+               let download = await github.rest.actions.downloadArtifact({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  artifact_id: theArtifact.id,
+                  archive_format: 'zip',
+               });
+               let fs = require('fs');
+               fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/public_api.zip`, Buffer.from(download.data));
+            } else {
+               core.setFailed("Artifact public-api was not found");
+            }
+
+      - name: 'Unzip artifact'
+        run: unzip public_api.zip
+
+      - name: 'Read artifact'
+        id: ra
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            let fs = require('fs');
+            let issue_number_text = fs.readFileSync('./pr_number', 'uft8');
+            core.info("Found pr number \"" + issue_number_text + "\"");
+            core.setOutput("pr-number", issue_number_text === "" ? "" : Number(issue_number_text));
+            
+            let diff = fs.readFileSync('./diff', 'uft8');
+            core.setOutput("diff", diff);
+
+      - name: Find Comment
+        uses: peter-evans/find-comment@v1
+        id: fc
+        with:
+          issue-number: ${{ steps.ra.outputs.pr-number  }}
+          comment-author: "github-actions[bot]"
+          body-includes: Removed items from the public API
+
+      - name: Create comment
+        if: steps.fc.outputs.comment-id == ''
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          issue-number: ${{ steps.ra.outputs.pr-number  }}
+          body: |
+            ${{ steps.ra.outputs.diff }}
+
+      - name: Update comment
+        if: steps.fc.outputs.comment-id != ''
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          body: |
+            ${{ steps.ra.outputs.diff }}


### PR DESCRIPTION
Observations:
* I omitted auto derived impls and blanket impls, which brought down the api json file from 25mb to 7mb
* `cargo public-api diff` does not work, I couldn't get features to be passed to diff (opened an issue for this)
* The test workflow would work, however, the output is not diffed and the file is 7mb. So this file would have to be diffed manually and the pipeline would always just report "not the same". Maybe there is some nice diff tool that can be used to generate a diff in the pipeline. 

Open questions:
* Does public-api exposes some api to generate the diff programatically?
* Which features do we want to use to check this? 
    * With diff we could check the whole matrix
    * With the test approach every combination of features will need a dedicated file which adds up quickly in repo size

Update: 
`cargo public-api diff` should work after they release a new version on crates.io. This is also what I would use. However, how would we use this? As an optional check just to at least see that something changed?
