### PR TITLE
feat: add support for voiding invoices

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 
 [package]
 name = "async-stripe"
-version = "0.37.1"
+version = "0.38.1"
 description = "API bindings for the Stripe HTTP API"
 rust-version = "1.74.0"
 authors = [

--- a/src/resources/generated/invoice.rs
+++ b/src/resources/generated/invoice.rs
@@ -496,6 +496,13 @@ impl Invoice {
     pub fn delete(client: &Client, id: &InvoiceId) -> Response<Deleted<InvoiceId>> {
         client.delete(&format!("/invoices/{}", id))
     }
+
+    /// Void an invoice that's already been finalized.
+    ///
+    /// This cannot be undone.
+    pub fn void(client: &Client, id: &InvoiceId) -> Response<Invoice> {
+        client.post(&format!("/invoices/{}/void", id))
+    }
 }
 
 impl Object for Invoice {


### PR DESCRIPTION
# Summary

Add support for [`/api/invoices/void`](https://docs.stripe.com/api/invoices/void).

### Checklist

- [x] ran `cargo make fmt`
- [x] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features
  <!--
  EXAMPLES:
  feat: you can now add and remove principals from a project
  fix: fixes an issue where the combobox was displaying incorrect values
  -->
