### PR TITLE
fix(client-core): add tracing dependency 

### DIFF
--- a/async-stripe-client-core/Cargo.toml
+++ b/async-stripe-client-core/Cargo.toml
@@ -26,3 +26,4 @@ bytes = "1.6.0"
 miniserde.workspace = true
 futures-util = "0.3.28"
 uuid = { version = "1.6.1", optional = true, features = ["v4"] }
+tracing = "0.1.40"

--- a/openapi/Cargo.toml
+++ b/openapi/Cargo.toml
@@ -17,7 +17,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8.8"
 anyhow = "1.0.34"
-tracing = "0.1.36"
+tracing = "0.1.40"
 openapiv3 = "2"
 indexmap = "2.2.5"
 tracing-subscriber = "0.3.15"


### PR DESCRIPTION
# Summary
A call to tracing:: was added on https://github.com/arlyon/async-stripe/pull/576 but the dependency seems to be missing, which causes the branch to not compile at the moment.

https://github.com/arlyon/async-stripe/blob/2b918fe596fd01f183bb944df59650ad9128342b/async-stripe-client-core/src/config.rs#L42-L44

---

Also bumped bump tracing from `0.1.36` to `0.1.40` on `openapi`.
