### PR TITLE
fix(next): linting issues from Rust 1.80

### DIFF
--- a/async-stripe-webhook/Cargo.toml
+++ b/async-stripe-webhook/Cargo.toml
@@ -24,13 +24,34 @@ chrono = { version = "0.4", default-features = false, features = ["clock"] }
 thiserror = "1.0.24"
 miniserde.workspace = true
 serde.workspace = true
+serde_json = { workspace = true, optional = true }
 
-async-stripe-core = { path = "../generated/async-stripe-core", optional = true }
-async-stripe-checkout = { path = "../generated/async-stripe-checkout", optional = true }
 async-stripe-billing = { path = "../generated/async-stripe-billing", optional = true }
+async-stripe-checkout = { path = "../generated/async-stripe-checkout", optional = true }
+async-stripe-core = { path = "../generated/async-stripe-core", optional = true }
+async-stripe-fraud = { path = "../generated/async-stripe-fraud", optional = true }
+async-stripe-misc = { path = "../generated/async-stripe-misc", optional = true }
+async-stripe-payment = { path = "../generated/async-stripe-payment", optional = true }
+async-stripe-terminal = { path = "../generated/async-stripe-terminal", optional = true }
+async-stripe-treasury = { path = "../generated/async-stripe-treasury", optional = true }
 
 [dev-dependencies]
 serde_json.workspace = true
 
+[features]
+serialize = ["async-stripe-types/serialize", "async-stripe-shared/serialize"]
+deserialize = ["async-stripe-types/deserialize", "async-stripe-shared/deserialize", "dep:serde_json"]
+
+full = [
+    "async-stripe-billing",
+    "async-stripe-checkout",
+    "async-stripe-core",
+    "async-stripe-fraud",
+    "async-stripe-misc",
+    "async-stripe-payment",
+    "async-stripe-terminal",
+    "async-stripe-treasury",
+]
+
 [package.metadata.docs.rs]
-features = ["async-stripe-core", "async-stripe-checkout", "async-stripe-billing"]
+features = ["full"]

--- a/async-stripe-webhook/src/webhook.rs
+++ b/async-stripe-webhook/src/webhook.rs
@@ -279,7 +279,7 @@ mod tests {
         assert_eq!(invoice.quantity, 3);
     }
 
-    #[cfg(feature = "stripe_billing")]
+    #[cfg(feature = "async-stripe-billing")]
     #[test]
     // https://github.com/arlyon/async-stripe/issues/455
     fn test_billing_portal_session() {

--- a/async-stripe/src/lib.rs
+++ b/async-stripe/src/lib.rs
@@ -29,9 +29,9 @@
 //! to determine which fields are required for either request.
 //!
 //! > **Note:** We have an extensive collection of examples which are interspersed in
-//!   the documentation. Any time an API is used in an example it is highlighted in the
-//!   docs for that item. You can also find all the raw examples in the `examples` directory.
-//!   Please have a look at those for inspiration or ideas on how to get started.
+//! > the documentation. Any time an API is used in an example it is highlighted in the
+//! > docs for that item. You can also find all the raw examples in the `examples` directory.
+//! > Please have a look at those for inspiration or ideas on how to get started.
 //!
 //! ## Idempotency / Request Strategies
 //!
@@ -51,7 +51,7 @@
 //!                                            generated automatically and is stable across retries.
 //!
 //! > Want to implement your own? If it is a common strategy, please consider opening a PR to add it to the library.
-//!   Otherwise, we are open to turning this into an open trait so that you can implement your own strategy.
+//! > Otherwise, we are open to turning this into an open trait so that you can implement your own strategy.
 
 #![warn(clippy::missing_errors_doc, clippy::missing_panics_doc)]
 #![deny(missing_docs, missing_debug_implementations)]

--- a/generated/async-stripe-shared/src/invoice.rs
+++ b/generated/async-stripe-shared/src/invoice.rs
@@ -71,7 +71,7 @@ pub struct Invoice {
     ///
     /// * `manual`: Unrelated to a subscription, for example, created via the invoice editor.
     /// * `subscription`: No longer in use.
-    /// Applies to subscriptions from before May 2018 where no distinction was made between updates, cycles, and thresholds.
+    ///   Applies to subscriptions from before May 2018 where no distinction was made between updates, cycles, and thresholds.
     /// * `subscription_create`: A new subscription was created.
     /// * `subscription_cycle`: A subscription advanced into a new period.
     /// * `subscription_threshold`: A subscription reached a billing threshold.
@@ -893,7 +893,7 @@ impl serde::Serialize for Invoice {
 ///
 /// * `manual`: Unrelated to a subscription, for example, created via the invoice editor.
 /// * `subscription`: No longer in use.
-/// Applies to subscriptions from before May 2018 where no distinction was made between updates, cycles, and thresholds.
+///   Applies to subscriptions from before May 2018 where no distinction was made between updates, cycles, and thresholds.
 /// * `subscription_create`: A new subscription was created.
 /// * `subscription_cycle`: A subscription advanced into a new period.
 /// * `subscription_threshold`: A subscription reached a billing threshold.

--- a/openapi/src/templates/utils.rs
+++ b/openapi/src/templates/utils.rs
@@ -184,12 +184,20 @@ pub fn write_doc_comment(description: &str, depth: u8) -> String {
             out.push_str(line);
             // If an unreasonable line, inject newlines after each sentence
         } else {
+            let is_list_item = line.starts_with("* ");
+
             for (i, part) in PERIOD_THEN_WHITESPACE.split(line).enumerate() {
                 if i > 0 {
                     out.push('\n');
                 }
                 print_indent(&mut out, depth);
-                out.push_str("/// ");
+
+                if is_list_item && i > 0 {
+                    out.push_str("///   ");
+                } else {
+                    out.push_str("/// ");
+                }
+
                 out.push_str(part.trim());
                 if !part.is_empty() && !out.ends_with('.') {
                     out.push('.');


### PR DESCRIPTION
# Summary
This applies fixes for issues that are introduced by the new version of Rust: [1.80](https://blog.rust-lang.org/2024/07/25/Rust-1.80.0.html).
These are the following:
- [Lazy doc continuation](https://rust-lang.github.io/rust-clippy/master/index.html#/doc_lazy_continuation): 
  > In CommonMark Markdown, the language used to write doc comments, a paragraph nested within a list or block quote does not need any line after the first one to be indented or marked. The specification calls this a “lazy paragraph continuation.”

  To avoid confusion, this means that multilines now need to be explicit. The two cases where that is the case today is for the docs on the [`async-stripe/src/lib.rs`](https://github.com/arlyon/async-stripe/blob/54553bf596a06d08c52973410c01bb9999b1401a/async-stripe/src/lib.rs#L53-L54) where we use `>`, and when generating doc comments.
  The doc comments specifically, we break the line if is too long. But we don't verify that we are breaking a list item. These should be indented differently. Check bebd57e94b3db9f281a0e75e73b83ad6515818d2 and 20f3cebed317ac0f1237b980220c8ecc435f23c0.

  For example, on [`generated/async-stripe-shared/src/invoice.rs`](https://github.com/arlyon/async-stripe/blob/54553bf596a06d08c52973410c01bb9999b1401a/generated/async-stripe-shared/src/invoice.rs#L70-L79) it there is this example that should be different on 1.80:
  ```diff
  /// Indicates the reason why the invoice was created.
  ///
  /// * `manual`: Unrelated to a subscription, for example, created via the invoice editor.
  /// * `subscription`: No longer in use.
  - /// Applies to subscriptions from before May 2018 where no distinction was made between updates, cycles, and thresholds.
  + ///   Applies to subscriptions from before May 2018 where no distinction was made between updates, cycles, and thresholds.
  /// * `subscription_create`: A new subscription was created.
  ```

- [Checked cfg names:](https://blog.rust-lang.org/2024/07/25/Rust-1.80.0.html#checked-cfg-names-and-values) Now Rust verify that the used `cfg` are defined in the Cargo.toml. Which is not the case for multiple ones on `async-stripe-webhook`. Check c94b754ea32b8f87632a1de0c23488dd5d430979

⚠️ Note: ~This still needs #581 so that it can be compiled.~ Merged! ✅ 
⚠️ Note 2: ~I did not run the openapi generation (seems like there are quite a few changes since the latest version available) that will fix the formatting of the docs comments. Not sure if the run of it should be part of this PR or if is fine to run afterwards.~ Nvm 😅 Just noticed that could run for the `current` version. So only `invoice.rs` has changed. Check https://github.com/arlyon/async-stripe/pull/582/commits/74cfc031a50ee878ac69bd43a8eef5befe157376.

### Checklist

- [x] ran `cargo make fmt`
- [x] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features
