### PR TITLE
fix(master): linting issue from Rust 1.80

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,9 +28,9 @@
 //! to determine which fields are required for either request.
 //!
 //! > **Note:** We have an extensive collection of examples which are interspersed in
-//!   the documentation. Any time an API is used in an example it is highlighted in the
-//!   docs for that item. You can also find all the raw examples in the `examples` directory.
-//!   Please have a look at those for inspiration or ideas on how to get started.
+//! > the documentation. Any time an API is used in an example it is highlighted in the
+//! > docs for that item. You can also find all the raw examples in the `examples` directory.
+//! > Please have a look at those for inspiration or ideas on how to get started.
 //!
 //! ## Idempotency / Request Strategies
 //!
@@ -50,7 +50,7 @@
 //!                                            generated automatically and is stable across retries.
 //!
 //! > Want to implement your own? If it is a common strategy, please consider opening a PR to add it to the library.
-//!   Otherwise, we are open to turning this into an open trait so that you can implement your own strategy.
+//! > Otherwise, we are open to turning this into an open trait so that you can implement your own strategy.
 
 #![allow(clippy::large_enum_variant)]
 #![warn(clippy::missing_panics_doc)]


### PR DESCRIPTION
# Summary
Similar to the work done for the [`next`](https://github.com/arlyon/async-stripe/tree/next) branch on https://github.com/arlyon/async-stripe/pull/582, this fixed the Clippy warning about [lazy doc continuation](https://rust-lang.github.io/rust-clippy/master/index.html#/doc_lazy_continuation).
This should fix issues with the pipeline for other PR's, like this one: https://github.com/arlyon/async-stripe/actions/runs/10114673863/job/27973827484

### Checklist

- [x] ran `cargo make fmt`
- [x] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features
