### PR TITLE
Enable rustdoc cfg feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,7 @@
 #![forbid(unsafe_code)]
 // Workaround
 #![allow(ambiguous_glob_reexports)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 // Give a clear error when a required runtime error is not present. Would be better for this
 // to be a fatal error preventing emission of further compile errors relating to lack of


### PR DESCRIPTION
I wasn't sure which features we want to add to `package.metadata.docs.rs` in `Cargo.toml` since the key already exists and only includes `runtime-tokio-hyper`.