### PR TITLE
feat(next): owned types on requests

### DIFF
--- a/async-stripe-types/src/ids.rs
+++ b/async-stripe-types/src/ids.rs
@@ -106,6 +106,34 @@ macro_rules! def_id {
             }
         }
 
+        impl From<&str> for $struct_name {
+            #[inline]
+            fn from(text: &str) -> Self {
+                Self(smol_str::SmolStr::from(text))
+            }
+        }
+
+        impl From<$struct_name> for String {
+            #[inline]
+            fn from(id: $struct_name) -> Self {
+                id.0.to_string()
+            }
+        }
+
+        impl From<&$struct_name> for String {
+            #[inline]
+            fn from(id: &$struct_name) -> Self {
+                id.0.to_string()
+            }
+        }
+
+        impl From<&$struct_name> for $struct_name {
+            #[inline]
+            fn from(id: &$struct_name) -> Self {
+                id.clone()
+            }
+        }
+
         #[cfg(feature = "deserialize")]
         impl<'de> serde::Deserialize<'de> for $struct_name {
             fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>

--- a/examples/endpoints/src/connect.rs
+++ b/examples/endpoints/src/connect.rs
@@ -28,7 +28,7 @@ pub async fn run_connect_example(client: &stripe::Client) -> Result<(), StripeEr
         .send(client)
         .await?;
 
-    let link = CreateAccountLink::new(&account.id, CreateAccountLinkType::AccountOnboarding)
+    let link = CreateAccountLink::new(account.id, CreateAccountLinkType::AccountOnboarding)
         .refresh_url("https://test.com/refresh")
         .return_url("https://test.com/return")
         .send(client)

--- a/examples/endpoints/src/customer.rs
+++ b/examples/endpoints/src/customer.rs
@@ -11,13 +11,11 @@ use stripe::{Client, StripeError};
 use stripe_core::customer::{CreateCustomer, ListCustomer};
 
 pub async fn run_customer_example(client: &Client) -> Result<(), StripeError> {
-    let meta =
-        std::collections::HashMap::from([(String::from("async-stripe"), String::from("true"))]);
     let customer = CreateCustomer::new()
         .name("Alexander Lyon")
         .email("test@async-stripe.com")
         .description("A fake customer that is used to illustrate the examples in async-stripe.")
-        .metadata(&meta)
+        .metadata([(String::from("async-stripe"), String::from("true"))])
         .send(client)
         .await?;
 
@@ -27,7 +25,7 @@ pub async fn run_customer_example(client: &Client) -> Result<(), StripeError> {
         .name("Someone Else")
         .email("test@async-stripe.com")
         .description("A fake customer that is used to illustrate the examples in async-stripe.")
-        .metadata(&meta)
+        .metadata([(String::from("async-stripe"), String::from("true"))])
         .send(client)
         .await?;
 

--- a/examples/endpoints/src/payment_link.rs
+++ b/examples/endpoints/src/payment_link.rs
@@ -15,16 +15,17 @@ use stripe_types::Currency;
 
 pub async fn run_payment_link_example(client: &Client) -> Result<(), StripeError> {
     // create a new example project
-    let meta =
-        std::collections::HashMap::from([(String::from("async-stripe"), String::from("true"))]);
-    let product = CreateProduct::new("T-Shirt").metadata(&meta).send(client).await?;
+    let product = CreateProduct::new("T-Shirt")
+        .metadata([(String::from("async-stripe"), String::from("true"))])
+        .send(client)
+        .await?;
 
     // and add a price for it in USD
     let price = CreatePrice::new(Currency::USD)
         .product(product.id.as_str())
-        .metadata(&meta)
+        .metadata([(String::from("async-stripe"), String::from("true"))])
         .unit_amount(1000)
-        .expand(&["product"])
+        .expand([String::from("product")])
         .send(client)
         .await?;
 
@@ -38,7 +39,7 @@ pub async fn run_payment_link_example(client: &Client) -> Result<(), StripeError
     let payment_link = CreatePaymentLink::new(&[CreatePaymentLinkLineItems {
         adjustable_quantity: None,
         quantity: 3,
-        price: &price.id,
+        price: price.id.to_string(),
     }])
     .send(client)
     .await?;

--- a/generated/async-stripe-billing/src/billing_meter/requests.rs
+++ b/generated/async-stripe-billing/src/billing_meter/requests.rs
@@ -2,30 +2,30 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListBillingMeterBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListBillingMeterBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     status: Option<stripe_billing::BillingMeterStatus>,
 }
-impl<'a> ListBillingMeterBuilder<'a> {
+impl ListBillingMeterBuilder {
     fn new() -> Self {
         Self { ending_before: None, expand: None, limit: None, starting_after: None, status: None }
     }
 }
 /// Retrieve a list of billing meters.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListBillingMeter<'a> {
-    inner: ListBillingMeterBuilder<'a>,
+pub struct ListBillingMeter {
+    inner: ListBillingMeterBuilder,
 }
-impl<'a> ListBillingMeter<'a> {
+impl ListBillingMeter {
     /// Construct a new `ListBillingMeter`.
     pub fn new() -> Self {
         Self { inner: ListBillingMeterBuilder::new() }
@@ -33,40 +33,40 @@ impl<'a> ListBillingMeter<'a> {
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
     /// Filter results to only include meters with the given status.
-    pub fn status(mut self, status: stripe_billing::BillingMeterStatus) -> Self {
-        self.inner.status = Some(status);
+    pub fn status(mut self, status: impl Into<stripe_billing::BillingMeterStatus>) -> Self {
+        self.inner.status = Some(status.into());
         self
     }
 }
-impl<'a> Default for ListBillingMeter<'a> {
+impl Default for ListBillingMeter {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListBillingMeter<'_> {
+impl ListBillingMeter {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -86,45 +86,45 @@ impl ListBillingMeter<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_billing::BillingMeter>> {
-        stripe_client_core::ListPaginator::new_list("/billing/meters", self.inner)
+        stripe_client_core::ListPaginator::new_list("/billing/meters", &self.inner)
     }
 }
 
-impl StripeRequest for ListBillingMeter<'_> {
+impl StripeRequest for ListBillingMeter {
     type Output = stripe_types::List<stripe_billing::BillingMeter>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/billing/meters").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveBillingMeterBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveBillingMeterBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveBillingMeterBuilder<'a> {
+impl RetrieveBillingMeterBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves a billing meter given an ID
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveBillingMeter<'a> {
-    inner: RetrieveBillingMeterBuilder<'a>,
-    id: &'a stripe_billing::BillingMeterId,
+pub struct RetrieveBillingMeter {
+    inner: RetrieveBillingMeterBuilder,
+    id: stripe_billing::BillingMeterId,
 }
-impl<'a> RetrieveBillingMeter<'a> {
+impl RetrieveBillingMeter {
     /// Construct a new `RetrieveBillingMeter`.
-    pub fn new(id: &'a stripe_billing::BillingMeterId) -> Self {
-        Self { id, inner: RetrieveBillingMeterBuilder::new() }
+    pub fn new(id: impl Into<stripe_billing::BillingMeterId>) -> Self {
+        Self { id: id.into(), inner: RetrieveBillingMeterBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveBillingMeter<'_> {
+impl RetrieveBillingMeter {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -142,39 +142,39 @@ impl RetrieveBillingMeter<'_> {
     }
 }
 
-impl StripeRequest for RetrieveBillingMeter<'_> {
+impl StripeRequest for RetrieveBillingMeter {
     type Output = stripe_billing::BillingMeter;
 
     fn build(&self) -> RequestBuilder {
-        let id = self.id;
+        let id = &self.id;
         RequestBuilder::new(StripeMethod::Get, format!("/billing/meters/{id}")).query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateBillingMeterBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateBillingMeterBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    customer_mapping: Option<CreateBillingMeterCustomerMapping<'a>>,
+    customer_mapping: Option<CreateBillingMeterCustomerMapping>,
     default_aggregation: CreateBillingMeterDefaultAggregation,
-    display_name: &'a str,
-    event_name: &'a str,
+    display_name: String,
+    event_name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     event_time_window: Option<stripe_billing::BillingMeterEventTimeWindow>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    value_settings: Option<CreateBillingMeterValueSettings<'a>>,
+    value_settings: Option<CreateBillingMeterValueSettings>,
 }
-impl<'a> CreateBillingMeterBuilder<'a> {
+impl CreateBillingMeterBuilder {
     fn new(
-        default_aggregation: CreateBillingMeterDefaultAggregation,
-        display_name: &'a str,
-        event_name: &'a str,
+        default_aggregation: impl Into<CreateBillingMeterDefaultAggregation>,
+        display_name: impl Into<String>,
+        event_name: impl Into<String>,
     ) -> Self {
         Self {
             customer_mapping: None,
-            default_aggregation,
-            display_name,
-            event_name,
+            default_aggregation: default_aggregation.into(),
+            display_name: display_name.into(),
+            event_name: event_name.into(),
             event_time_window: None,
             expand: None,
             value_settings: None,
@@ -182,17 +182,20 @@ impl<'a> CreateBillingMeterBuilder<'a> {
     }
 }
 /// Fields that specify how to map a meter event to a customer.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateBillingMeterCustomerMapping<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateBillingMeterCustomerMapping {
     /// The key in the usage event payload to use for mapping the event to a customer.
-    pub event_payload_key: &'a str,
+    pub event_payload_key: String,
     /// The method for mapping a meter event to a customer. Must be `by_id`.
     #[serde(rename = "type")]
     pub type_: CreateBillingMeterCustomerMappingType,
 }
-impl<'a> CreateBillingMeterCustomerMapping<'a> {
-    pub fn new(event_payload_key: &'a str, type_: CreateBillingMeterCustomerMappingType) -> Self {
-        Self { event_payload_key, type_ }
+impl CreateBillingMeterCustomerMapping {
+    pub fn new(
+        event_payload_key: impl Into<String>,
+        type_: impl Into<CreateBillingMeterCustomerMappingType>,
+    ) -> Self {
+        Self { event_payload_key: event_payload_key.into(), type_: type_.into() }
     }
 }
 /// The method for mapping a meter event to a customer. Must be `by_id`.
@@ -256,8 +259,8 @@ pub struct CreateBillingMeterDefaultAggregation {
     pub formula: CreateBillingMeterDefaultAggregationFormula,
 }
 impl CreateBillingMeterDefaultAggregation {
-    pub fn new(formula: CreateBillingMeterDefaultAggregationFormula) -> Self {
-        Self { formula }
+    pub fn new(formula: impl Into<CreateBillingMeterDefaultAggregationFormula>) -> Self {
+        Self { formula: formula.into() }
     }
 }
 /// Specifies how events are aggregated.
@@ -320,61 +323,68 @@ impl<'de> serde::Deserialize<'de> for CreateBillingMeterDefaultAggregationFormul
     }
 }
 /// Fields that specify how to calculate a meter event's value.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateBillingMeterValueSettings<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateBillingMeterValueSettings {
     /// The key in the usage event payload to use as the value for this meter.
     /// For example, if the event payload contains usage on a `bytes_used` field, then set the event_payload_key to "bytes_used".
-    pub event_payload_key: &'a str,
+    pub event_payload_key: String,
 }
-impl<'a> CreateBillingMeterValueSettings<'a> {
-    pub fn new(event_payload_key: &'a str) -> Self {
-        Self { event_payload_key }
+impl CreateBillingMeterValueSettings {
+    pub fn new(event_payload_key: impl Into<String>) -> Self {
+        Self { event_payload_key: event_payload_key.into() }
     }
 }
 /// Creates a billing meter
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateBillingMeter<'a> {
-    inner: CreateBillingMeterBuilder<'a>,
+pub struct CreateBillingMeter {
+    inner: CreateBillingMeterBuilder,
 }
-impl<'a> CreateBillingMeter<'a> {
+impl CreateBillingMeter {
     /// Construct a new `CreateBillingMeter`.
     pub fn new(
-        default_aggregation: CreateBillingMeterDefaultAggregation,
-        display_name: &'a str,
-        event_name: &'a str,
+        default_aggregation: impl Into<CreateBillingMeterDefaultAggregation>,
+        display_name: impl Into<String>,
+        event_name: impl Into<String>,
     ) -> Self {
         Self {
-            inner: CreateBillingMeterBuilder::new(default_aggregation, display_name, event_name),
+            inner: CreateBillingMeterBuilder::new(
+                default_aggregation.into(),
+                display_name.into(),
+                event_name.into(),
+            ),
         }
     }
     /// Fields that specify how to map a meter event to a customer.
     pub fn customer_mapping(
         mut self,
-        customer_mapping: CreateBillingMeterCustomerMapping<'a>,
+        customer_mapping: impl Into<CreateBillingMeterCustomerMapping>,
     ) -> Self {
-        self.inner.customer_mapping = Some(customer_mapping);
+        self.inner.customer_mapping = Some(customer_mapping.into());
         self
     }
     /// The time window to pre-aggregate meter events for, if any.
     pub fn event_time_window(
         mut self,
-        event_time_window: stripe_billing::BillingMeterEventTimeWindow,
+        event_time_window: impl Into<stripe_billing::BillingMeterEventTimeWindow>,
     ) -> Self {
-        self.inner.event_time_window = Some(event_time_window);
+        self.inner.event_time_window = Some(event_time_window.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Fields that specify how to calculate a meter event's value.
-    pub fn value_settings(mut self, value_settings: CreateBillingMeterValueSettings<'a>) -> Self {
-        self.inner.value_settings = Some(value_settings);
+    pub fn value_settings(
+        mut self,
+        value_settings: impl Into<CreateBillingMeterValueSettings>,
+    ) -> Self {
+        self.inner.value_settings = Some(value_settings.into());
         self
     }
 }
-impl CreateBillingMeter<'_> {
+impl CreateBillingMeter {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -392,48 +402,48 @@ impl CreateBillingMeter<'_> {
     }
 }
 
-impl StripeRequest for CreateBillingMeter<'_> {
+impl StripeRequest for CreateBillingMeter {
     type Output = stripe_billing::BillingMeter;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Post, "/billing/meters").form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdateBillingMeterBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdateBillingMeterBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    display_name: Option<&'a str>,
+    display_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> UpdateBillingMeterBuilder<'a> {
+impl UpdateBillingMeterBuilder {
     fn new() -> Self {
         Self { display_name: None, expand: None }
     }
 }
 /// Updates a billing meter
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateBillingMeter<'a> {
-    inner: UpdateBillingMeterBuilder<'a>,
-    id: &'a stripe_billing::BillingMeterId,
+pub struct UpdateBillingMeter {
+    inner: UpdateBillingMeterBuilder,
+    id: stripe_billing::BillingMeterId,
 }
-impl<'a> UpdateBillingMeter<'a> {
+impl UpdateBillingMeter {
     /// Construct a new `UpdateBillingMeter`.
-    pub fn new(id: &'a stripe_billing::BillingMeterId) -> Self {
-        Self { id, inner: UpdateBillingMeterBuilder::new() }
+    pub fn new(id: impl Into<stripe_billing::BillingMeterId>) -> Self {
+        Self { id: id.into(), inner: UpdateBillingMeterBuilder::new() }
     }
     /// The meter's name.
-    pub fn display_name(mut self, display_name: &'a str) -> Self {
-        self.inner.display_name = Some(display_name);
+    pub fn display_name(mut self, display_name: impl Into<String>) -> Self {
+        self.inner.display_name = Some(display_name.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl UpdateBillingMeter<'_> {
+impl UpdateBillingMeter {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -451,42 +461,42 @@ impl UpdateBillingMeter<'_> {
     }
 }
 
-impl StripeRequest for UpdateBillingMeter<'_> {
+impl StripeRequest for UpdateBillingMeter {
     type Output = stripe_billing::BillingMeter;
 
     fn build(&self) -> RequestBuilder {
-        let id = self.id;
+        let id = &self.id;
         RequestBuilder::new(StripeMethod::Post, format!("/billing/meters/{id}")).form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct DeactivateBillingMeterBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct DeactivateBillingMeterBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> DeactivateBillingMeterBuilder<'a> {
+impl DeactivateBillingMeterBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Deactivates a billing meter
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct DeactivateBillingMeter<'a> {
-    inner: DeactivateBillingMeterBuilder<'a>,
-    id: &'a stripe_billing::BillingMeterId,
+pub struct DeactivateBillingMeter {
+    inner: DeactivateBillingMeterBuilder,
+    id: stripe_billing::BillingMeterId,
 }
-impl<'a> DeactivateBillingMeter<'a> {
+impl DeactivateBillingMeter {
     /// Construct a new `DeactivateBillingMeter`.
-    pub fn new(id: &'a stripe_billing::BillingMeterId) -> Self {
-        Self { id, inner: DeactivateBillingMeterBuilder::new() }
+    pub fn new(id: impl Into<stripe_billing::BillingMeterId>) -> Self {
+        Self { id: id.into(), inner: DeactivateBillingMeterBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl DeactivateBillingMeter<'_> {
+impl DeactivateBillingMeter {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -504,43 +514,43 @@ impl DeactivateBillingMeter<'_> {
     }
 }
 
-impl StripeRequest for DeactivateBillingMeter<'_> {
+impl StripeRequest for DeactivateBillingMeter {
     type Output = stripe_billing::BillingMeter;
 
     fn build(&self) -> RequestBuilder {
-        let id = self.id;
+        let id = &self.id;
         RequestBuilder::new(StripeMethod::Post, format!("/billing/meters/{id}/deactivate"))
             .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ReactivateBillingMeterBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ReactivateBillingMeterBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> ReactivateBillingMeterBuilder<'a> {
+impl ReactivateBillingMeterBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Reactivates a billing meter
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ReactivateBillingMeter<'a> {
-    inner: ReactivateBillingMeterBuilder<'a>,
-    id: &'a stripe_billing::BillingMeterId,
+pub struct ReactivateBillingMeter {
+    inner: ReactivateBillingMeterBuilder,
+    id: stripe_billing::BillingMeterId,
 }
-impl<'a> ReactivateBillingMeter<'a> {
+impl ReactivateBillingMeter {
     /// Construct a new `ReactivateBillingMeter`.
-    pub fn new(id: &'a stripe_billing::BillingMeterId) -> Self {
-        Self { id, inner: ReactivateBillingMeterBuilder::new() }
+    pub fn new(id: impl Into<stripe_billing::BillingMeterId>) -> Self {
+        Self { id: id.into(), inner: ReactivateBillingMeterBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl ReactivateBillingMeter<'_> {
+impl ReactivateBillingMeter {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -558,11 +568,11 @@ impl ReactivateBillingMeter<'_> {
     }
 }
 
-impl StripeRequest for ReactivateBillingMeter<'_> {
+impl StripeRequest for ReactivateBillingMeter {
     type Output = stripe_billing::BillingMeter;
 
     fn build(&self) -> RequestBuilder {
-        let id = self.id;
+        let id = &self.id;
         RequestBuilder::new(StripeMethod::Post, format!("/billing/meters/{id}/reactivate"))
             .form(&self.inner)
     }

--- a/generated/async-stripe-billing/src/billing_meter_event/requests.rs
+++ b/generated/async-stripe-billing/src/billing_meter_event/requests.rs
@@ -2,58 +2,67 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateBillingMeterEventBuilder<'a> {
-    event_name: &'a str,
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateBillingMeterEventBuilder {
+    event_name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    identifier: Option<&'a str>,
-    payload: &'a std::collections::HashMap<String, String>,
+    identifier: Option<String>,
+    payload: std::collections::HashMap<String, String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     timestamp: Option<stripe_types::Timestamp>,
 }
-impl<'a> CreateBillingMeterEventBuilder<'a> {
-    fn new(event_name: &'a str, payload: &'a std::collections::HashMap<String, String>) -> Self {
-        Self { event_name, expand: None, identifier: None, payload, timestamp: None }
+impl CreateBillingMeterEventBuilder {
+    fn new(
+        event_name: impl Into<String>,
+        payload: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        Self {
+            event_name: event_name.into(),
+            expand: None,
+            identifier: None,
+            payload: payload.into(),
+            timestamp: None,
+        }
     }
 }
 /// Creates a billing meter event
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateBillingMeterEvent<'a> {
-    inner: CreateBillingMeterEventBuilder<'a>,
+pub struct CreateBillingMeterEvent {
+    inner: CreateBillingMeterEventBuilder,
 }
-impl<'a> CreateBillingMeterEvent<'a> {
+impl CreateBillingMeterEvent {
     /// Construct a new `CreateBillingMeterEvent`.
     pub fn new(
-        event_name: &'a str,
-        payload: &'a std::collections::HashMap<String, String>,
+        event_name: impl Into<String>,
+        payload: impl Into<std::collections::HashMap<String, String>>,
     ) -> Self {
-        Self { inner: CreateBillingMeterEventBuilder::new(event_name, payload) }
+        Self { inner: CreateBillingMeterEventBuilder::new(event_name.into(), payload.into()) }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A unique identifier for the event.
     /// If not provided, one will be generated.
     /// We recommend using a globally unique identifier for this.
     /// We'll enforce uniqueness within a rolling 24 hour period.
-    pub fn identifier(mut self, identifier: &'a str) -> Self {
-        self.inner.identifier = Some(identifier);
+    pub fn identifier(mut self, identifier: impl Into<String>) -> Self {
+        self.inner.identifier = Some(identifier.into());
         self
     }
     /// The time of the event.
     /// Measured in seconds since the Unix epoch.
     /// Must be within the past 35 calendar days or up to 5 minutes in the future.
     /// Defaults to current timestamp if not specified.
-    pub fn timestamp(mut self, timestamp: stripe_types::Timestamp) -> Self {
-        self.inner.timestamp = Some(timestamp);
+    pub fn timestamp(mut self, timestamp: impl Into<stripe_types::Timestamp>) -> Self {
+        self.inner.timestamp = Some(timestamp.into());
         self
     }
 }
-impl CreateBillingMeterEvent<'_> {
+impl CreateBillingMeterEvent {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -71,7 +80,7 @@ impl CreateBillingMeterEvent<'_> {
     }
 }
 
-impl StripeRequest for CreateBillingMeterEvent<'_> {
+impl StripeRequest for CreateBillingMeterEvent {
     type Output = stripe_billing::BillingMeterEvent;
 
     fn build(&self) -> RequestBuilder {

--- a/generated/async-stripe-billing/src/billing_meter_event_adjustment/requests.rs
+++ b/generated/async-stripe-billing/src/billing_meter_event_adjustment/requests.rs
@@ -2,64 +2,69 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateBillingMeterEventAdjustmentBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateBillingMeterEventAdjustmentBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    cancel: Option<CreateBillingMeterEventAdjustmentCancel<'a>>,
-    event_name: &'a str,
+    cancel: Option<CreateBillingMeterEventAdjustmentCancel>,
+    event_name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(rename = "type")]
     type_: stripe_billing::BillingMeterEventAdjustmentType,
 }
-impl<'a> CreateBillingMeterEventAdjustmentBuilder<'a> {
-    fn new(event_name: &'a str, type_: stripe_billing::BillingMeterEventAdjustmentType) -> Self {
-        Self { cancel: None, event_name, expand: None, type_ }
+impl CreateBillingMeterEventAdjustmentBuilder {
+    fn new(
+        event_name: impl Into<String>,
+        type_: impl Into<stripe_billing::BillingMeterEventAdjustmentType>,
+    ) -> Self {
+        Self { cancel: None, event_name: event_name.into(), expand: None, type_: type_.into() }
     }
 }
 /// Specifies which event to cancel.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateBillingMeterEventAdjustmentCancel<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateBillingMeterEventAdjustmentCancel {
     /// Unique identifier for the event.
     /// You can only cancel events within 24 hours of Stripe receiving them.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub identifier: Option<&'a str>,
+    pub identifier: Option<String>,
 }
-impl<'a> CreateBillingMeterEventAdjustmentCancel<'a> {
+impl CreateBillingMeterEventAdjustmentCancel {
     pub fn new() -> Self {
         Self { identifier: None }
     }
 }
-impl<'a> Default for CreateBillingMeterEventAdjustmentCancel<'a> {
+impl Default for CreateBillingMeterEventAdjustmentCancel {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Creates a billing meter event adjustment
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateBillingMeterEventAdjustment<'a> {
-    inner: CreateBillingMeterEventAdjustmentBuilder<'a>,
+pub struct CreateBillingMeterEventAdjustment {
+    inner: CreateBillingMeterEventAdjustmentBuilder,
 }
-impl<'a> CreateBillingMeterEventAdjustment<'a> {
+impl CreateBillingMeterEventAdjustment {
     /// Construct a new `CreateBillingMeterEventAdjustment`.
     pub fn new(
-        event_name: &'a str,
-        type_: stripe_billing::BillingMeterEventAdjustmentType,
+        event_name: impl Into<String>,
+        type_: impl Into<stripe_billing::BillingMeterEventAdjustmentType>,
     ) -> Self {
-        Self { inner: CreateBillingMeterEventAdjustmentBuilder::new(event_name, type_) }
+        Self {
+            inner: CreateBillingMeterEventAdjustmentBuilder::new(event_name.into(), type_.into()),
+        }
     }
     /// Specifies which event to cancel.
-    pub fn cancel(mut self, cancel: CreateBillingMeterEventAdjustmentCancel<'a>) -> Self {
-        self.inner.cancel = Some(cancel);
+    pub fn cancel(mut self, cancel: impl Into<CreateBillingMeterEventAdjustmentCancel>) -> Self {
+        self.inner.cancel = Some(cancel.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl CreateBillingMeterEventAdjustment<'_> {
+impl CreateBillingMeterEventAdjustment {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -77,7 +82,7 @@ impl CreateBillingMeterEventAdjustment<'_> {
     }
 }
 
-impl StripeRequest for CreateBillingMeterEventAdjustment<'_> {
+impl StripeRequest for CreateBillingMeterEventAdjustment {
     type Output = stripe_billing::BillingMeterEventAdjustment;
 
     fn build(&self) -> RequestBuilder {

--- a/generated/async-stripe-billing/src/billing_meter_event_summary/requests.rs
+++ b/generated/async-stripe-billing/src/billing_meter_event_summary/requests.rs
@@ -2,35 +2,35 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListIdBillingMeterEventSummaryBuilder<'a> {
-    customer: &'a str,
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListIdBillingMeterEventSummaryBuilder {
+    customer: String,
     end_time: stripe_types::Timestamp,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     start_time: stripe_types::Timestamp,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     value_grouping_window: Option<ListIdBillingMeterEventSummaryValueGroupingWindow>,
 }
-impl<'a> ListIdBillingMeterEventSummaryBuilder<'a> {
+impl ListIdBillingMeterEventSummaryBuilder {
     fn new(
-        customer: &'a str,
-        end_time: stripe_types::Timestamp,
-        start_time: stripe_types::Timestamp,
+        customer: impl Into<String>,
+        end_time: impl Into<stripe_types::Timestamp>,
+        start_time: impl Into<stripe_types::Timestamp>,
     ) -> Self {
         Self {
-            customer,
-            end_time,
+            customer: customer.into(),
+            end_time: end_time.into(),
             ending_before: None,
             expand: None,
             limit: None,
-            start_time,
+            start_time: start_time.into(),
             starting_after: None,
             value_grouping_window: None,
         }
@@ -94,59 +94,63 @@ impl<'de> serde::Deserialize<'de> for ListIdBillingMeterEventSummaryValueGroupin
 }
 /// Retrieve a list of billing meter event summaries.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListIdBillingMeterEventSummary<'a> {
-    inner: ListIdBillingMeterEventSummaryBuilder<'a>,
-    id: &'a stripe_billing::BillingMeterId,
+pub struct ListIdBillingMeterEventSummary {
+    inner: ListIdBillingMeterEventSummaryBuilder,
+    id: stripe_billing::BillingMeterId,
 }
-impl<'a> ListIdBillingMeterEventSummary<'a> {
+impl ListIdBillingMeterEventSummary {
     /// Construct a new `ListIdBillingMeterEventSummary`.
     pub fn new(
-        id: &'a stripe_billing::BillingMeterId,
-        customer: &'a str,
-        end_time: stripe_types::Timestamp,
-        start_time: stripe_types::Timestamp,
+        id: impl Into<stripe_billing::BillingMeterId>,
+        customer: impl Into<String>,
+        end_time: impl Into<stripe_types::Timestamp>,
+        start_time: impl Into<stripe_types::Timestamp>,
     ) -> Self {
         Self {
-            id,
-            inner: ListIdBillingMeterEventSummaryBuilder::new(customer, end_time, start_time),
+            id: id.into(),
+            inner: ListIdBillingMeterEventSummaryBuilder::new(
+                customer.into(),
+                end_time.into(),
+                start_time.into(),
+            ),
         }
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
     /// Specifies what granularity to use when generating event summaries.
     /// If not specified, a single event summary would be returned for the specified time range.
     pub fn value_grouping_window(
         mut self,
-        value_grouping_window: ListIdBillingMeterEventSummaryValueGroupingWindow,
+        value_grouping_window: impl Into<ListIdBillingMeterEventSummaryValueGroupingWindow>,
     ) -> Self {
-        self.inner.value_grouping_window = Some(value_grouping_window);
+        self.inner.value_grouping_window = Some(value_grouping_window.into());
         self
     }
 }
-impl ListIdBillingMeterEventSummary<'_> {
+impl ListIdBillingMeterEventSummary {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -168,20 +172,20 @@ impl ListIdBillingMeterEventSummary<'_> {
     ) -> stripe_client_core::ListPaginator<
         stripe_types::List<stripe_billing::BillingMeterEventSummary>,
     > {
-        let id = self.id;
+        let id = &self.id;
 
         stripe_client_core::ListPaginator::new_list(
             format!("/billing/meters/{id}/event_summaries"),
-            self.inner,
+            &self.inner,
         )
     }
 }
 
-impl StripeRequest for ListIdBillingMeterEventSummary<'_> {
+impl StripeRequest for ListIdBillingMeterEventSummary {
     type Output = stripe_types::List<stripe_billing::BillingMeterEventSummary>;
 
     fn build(&self) -> RequestBuilder {
-        let id = self.id;
+        let id = &self.id;
         RequestBuilder::new(StripeMethod::Get, format!("/billing/meters/{id}/event_summaries"))
             .query(&self.inner)
     }

--- a/generated/async-stripe-billing/src/billing_portal_configuration/requests.rs
+++ b/generated/async-stripe-billing/src/billing_portal_configuration/requests.rs
@@ -2,22 +2,22 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListBillingPortalConfigurationBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListBillingPortalConfigurationBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     active: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     is_default: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListBillingPortalConfigurationBuilder<'a> {
+impl ListBillingPortalConfigurationBuilder {
     fn new() -> Self {
         Self {
             active: None,
@@ -31,56 +31,56 @@ impl<'a> ListBillingPortalConfigurationBuilder<'a> {
 }
 /// Returns a list of configurations that describe the functionality of the customer portal.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListBillingPortalConfiguration<'a> {
-    inner: ListBillingPortalConfigurationBuilder<'a>,
+pub struct ListBillingPortalConfiguration {
+    inner: ListBillingPortalConfigurationBuilder,
 }
-impl<'a> ListBillingPortalConfiguration<'a> {
+impl ListBillingPortalConfiguration {
     /// Construct a new `ListBillingPortalConfiguration`.
     pub fn new() -> Self {
         Self { inner: ListBillingPortalConfigurationBuilder::new() }
     }
     /// Only return configurations that are active or inactive (e.g., pass `true` to only list active configurations).
-    pub fn active(mut self, active: bool) -> Self {
-        self.inner.active = Some(active);
+    pub fn active(mut self, active: impl Into<bool>) -> Self {
+        self.inner.active = Some(active.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Only return the default or non-default configurations (e.g., pass `true` to only list the default configuration).
-    pub fn is_default(mut self, is_default: bool) -> Self {
-        self.inner.is_default = Some(is_default);
+    pub fn is_default(mut self, is_default: impl Into<bool>) -> Self {
+        self.inner.is_default = Some(is_default.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl<'a> Default for ListBillingPortalConfiguration<'a> {
+impl Default for ListBillingPortalConfiguration {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListBillingPortalConfiguration<'_> {
+impl ListBillingPortalConfiguration {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -102,45 +102,48 @@ impl ListBillingPortalConfiguration<'_> {
     ) -> stripe_client_core::ListPaginator<
         stripe_types::List<stripe_billing::BillingPortalConfiguration>,
     > {
-        stripe_client_core::ListPaginator::new_list("/billing_portal/configurations", self.inner)
+        stripe_client_core::ListPaginator::new_list("/billing_portal/configurations", &self.inner)
     }
 }
 
-impl StripeRequest for ListBillingPortalConfiguration<'_> {
+impl StripeRequest for ListBillingPortalConfiguration {
     type Output = stripe_types::List<stripe_billing::BillingPortalConfiguration>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/billing_portal/configurations").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveBillingPortalConfigurationBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveBillingPortalConfigurationBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveBillingPortalConfigurationBuilder<'a> {
+impl RetrieveBillingPortalConfigurationBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves a configuration that describes the functionality of the customer portal.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveBillingPortalConfiguration<'a> {
-    inner: RetrieveBillingPortalConfigurationBuilder<'a>,
-    configuration: &'a stripe_billing::BillingPortalConfigurationId,
+pub struct RetrieveBillingPortalConfiguration {
+    inner: RetrieveBillingPortalConfigurationBuilder,
+    configuration: stripe_billing::BillingPortalConfigurationId,
 }
-impl<'a> RetrieveBillingPortalConfiguration<'a> {
+impl RetrieveBillingPortalConfiguration {
     /// Construct a new `RetrieveBillingPortalConfiguration`.
-    pub fn new(configuration: &'a stripe_billing::BillingPortalConfigurationId) -> Self {
-        Self { configuration, inner: RetrieveBillingPortalConfigurationBuilder::new() }
+    pub fn new(configuration: impl Into<stripe_billing::BillingPortalConfigurationId>) -> Self {
+        Self {
+            configuration: configuration.into(),
+            inner: RetrieveBillingPortalConfigurationBuilder::new(),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveBillingPortalConfiguration<'_> {
+impl RetrieveBillingPortalConfiguration {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -158,11 +161,11 @@ impl RetrieveBillingPortalConfiguration<'_> {
     }
 }
 
-impl StripeRequest for RetrieveBillingPortalConfiguration<'_> {
+impl StripeRequest for RetrieveBillingPortalConfiguration {
     type Output = stripe_billing::BillingPortalConfiguration;
 
     fn build(&self) -> RequestBuilder {
-        let configuration = self.configuration;
+        let configuration = &self.configuration;
         RequestBuilder::new(
             StripeMethod::Get,
             format!("/billing_portal/configurations/{configuration}"),
@@ -170,63 +173,63 @@ impl StripeRequest for RetrieveBillingPortalConfiguration<'_> {
         .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateBillingPortalConfigurationBuilder<'a> {
-    business_profile: CreateBillingPortalConfigurationBusinessProfile<'a>,
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateBillingPortalConfigurationBuilder {
+    business_profile: CreateBillingPortalConfigurationBusinessProfile,
     #[serde(skip_serializing_if = "Option::is_none")]
-    default_return_url: Option<&'a str>,
+    default_return_url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
-    features: CreateBillingPortalConfigurationFeatures<'a>,
+    expand: Option<Vec<String>>,
+    features: CreateBillingPortalConfigurationFeatures,
     #[serde(skip_serializing_if = "Option::is_none")]
     login_page: Option<CreateBillingPortalConfigurationLoginPage>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
 }
-impl<'a> CreateBillingPortalConfigurationBuilder<'a> {
+impl CreateBillingPortalConfigurationBuilder {
     fn new(
-        business_profile: CreateBillingPortalConfigurationBusinessProfile<'a>,
-        features: CreateBillingPortalConfigurationFeatures<'a>,
+        business_profile: impl Into<CreateBillingPortalConfigurationBusinessProfile>,
+        features: impl Into<CreateBillingPortalConfigurationFeatures>,
     ) -> Self {
         Self {
-            business_profile,
+            business_profile: business_profile.into(),
             default_return_url: None,
             expand: None,
-            features,
+            features: features.into(),
             login_page: None,
             metadata: None,
         }
     }
 }
 /// The business information shown to customers in the portal.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateBillingPortalConfigurationBusinessProfile<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateBillingPortalConfigurationBusinessProfile {
     /// The messaging shown to customers in the portal.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub headline: Option<&'a str>,
+    pub headline: Option<String>,
     /// A link to the business’s publicly available privacy policy.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub privacy_policy_url: Option<&'a str>,
+    pub privacy_policy_url: Option<String>,
     /// A link to the business’s publicly available terms of service.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub terms_of_service_url: Option<&'a str>,
+    pub terms_of_service_url: Option<String>,
 }
-impl<'a> CreateBillingPortalConfigurationBusinessProfile<'a> {
+impl CreateBillingPortalConfigurationBusinessProfile {
     pub fn new() -> Self {
         Self { headline: None, privacy_policy_url: None, terms_of_service_url: None }
     }
 }
-impl<'a> Default for CreateBillingPortalConfigurationBusinessProfile<'a> {
+impl Default for CreateBillingPortalConfigurationBusinessProfile {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Information about the features available in the portal.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateBillingPortalConfigurationFeatures<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateBillingPortalConfigurationFeatures {
     /// Information about updating the customer details in the portal.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub customer_update: Option<CreateBillingPortalConfigurationFeaturesCustomerUpdate<'a>>,
+    pub customer_update: Option<CreateBillingPortalConfigurationFeaturesCustomerUpdate>,
     /// Information about showing the billing history in the portal.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub invoice_history: Option<CreateBillingPortalConfigurationFeaturesInvoiceHistory>,
@@ -235,12 +238,12 @@ pub struct CreateBillingPortalConfigurationFeatures<'a> {
     pub payment_method_update: Option<CreateBillingPortalConfigurationFeaturesPaymentMethodUpdate>,
     /// Information about canceling subscriptions in the portal.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub subscription_cancel: Option<CreateBillingPortalConfigurationFeaturesSubscriptionCancel<'a>>,
+    pub subscription_cancel: Option<CreateBillingPortalConfigurationFeaturesSubscriptionCancel>,
     /// Information about updating subscriptions in the portal.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub subscription_update: Option<CreateBillingPortalConfigurationFeaturesSubscriptionUpdate<'a>>,
+    pub subscription_update: Option<CreateBillingPortalConfigurationFeaturesSubscriptionUpdate>,
 }
-impl<'a> CreateBillingPortalConfigurationFeatures<'a> {
+impl CreateBillingPortalConfigurationFeatures {
     pub fn new() -> Self {
         Self {
             customer_update: None,
@@ -251,24 +254,24 @@ impl<'a> CreateBillingPortalConfigurationFeatures<'a> {
         }
     }
 }
-impl<'a> Default for CreateBillingPortalConfigurationFeatures<'a> {
+impl Default for CreateBillingPortalConfigurationFeatures {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Information about updating the customer details in the portal.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateBillingPortalConfigurationFeaturesCustomerUpdate<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateBillingPortalConfigurationFeaturesCustomerUpdate {
     /// The types of customer updates that are supported. When empty, customers are not updateable.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allowed_updates:
-        Option<&'a [CreateBillingPortalConfigurationFeaturesCustomerUpdateAllowedUpdates]>,
+        Option<Vec<CreateBillingPortalConfigurationFeaturesCustomerUpdateAllowedUpdates>>,
     /// Whether the feature is enabled.
     pub enabled: bool,
 }
-impl<'a> CreateBillingPortalConfigurationFeaturesCustomerUpdate<'a> {
-    pub fn new(enabled: bool) -> Self {
-        Self { allowed_updates: None, enabled }
+impl CreateBillingPortalConfigurationFeaturesCustomerUpdate {
+    pub fn new(enabled: impl Into<bool>) -> Self {
+        Self { allowed_updates: None, enabled: enabled.into() }
     }
 }
 /// The types of customer updates that are supported. When empty, customers are not updateable.
@@ -346,8 +349,8 @@ pub struct CreateBillingPortalConfigurationFeaturesInvoiceHistory {
     pub enabled: bool,
 }
 impl CreateBillingPortalConfigurationFeaturesInvoiceHistory {
-    pub fn new(enabled: bool) -> Self {
-        Self { enabled }
+    pub fn new(enabled: impl Into<bool>) -> Self {
+        Self { enabled: enabled.into() }
     }
 }
 /// Information about updating payment methods in the portal.
@@ -357,17 +360,17 @@ pub struct CreateBillingPortalConfigurationFeaturesPaymentMethodUpdate {
     pub enabled: bool,
 }
 impl CreateBillingPortalConfigurationFeaturesPaymentMethodUpdate {
-    pub fn new(enabled: bool) -> Self {
-        Self { enabled }
+    pub fn new(enabled: impl Into<bool>) -> Self {
+        Self { enabled: enabled.into() }
     }
 }
 /// Information about canceling subscriptions in the portal.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateBillingPortalConfigurationFeaturesSubscriptionCancel<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateBillingPortalConfigurationFeaturesSubscriptionCancel {
     /// Whether the cancellation reasons will be collected in the portal and which options are exposed to the customer.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cancellation_reason:
-        Option<CreateBillingPortalConfigurationFeaturesSubscriptionCancelCancellationReason<'a>>,
+        Option<CreateBillingPortalConfigurationFeaturesSubscriptionCancelCancellationReason>,
     /// Whether the feature is enabled.
     pub enabled: bool,
     /// Whether to cancel subscriptions immediately or at the end of the billing period.
@@ -380,26 +383,35 @@ pub struct CreateBillingPortalConfigurationFeaturesSubscriptionCancel<'a> {
     pub proration_behavior:
         Option<CreateBillingPortalConfigurationFeaturesSubscriptionCancelProrationBehavior>,
 }
-impl<'a> CreateBillingPortalConfigurationFeaturesSubscriptionCancel<'a> {
-    pub fn new(enabled: bool) -> Self {
-        Self { cancellation_reason: None, enabled, mode: None, proration_behavior: None }
+impl CreateBillingPortalConfigurationFeaturesSubscriptionCancel {
+    pub fn new(enabled: impl Into<bool>) -> Self {
+        Self {
+            cancellation_reason: None,
+            enabled: enabled.into(),
+            mode: None,
+            proration_behavior: None,
+        }
     }
 }
 /// Whether the cancellation reasons will be collected in the portal and which options are exposed to the customer.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateBillingPortalConfigurationFeaturesSubscriptionCancelCancellationReason<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateBillingPortalConfigurationFeaturesSubscriptionCancelCancellationReason {
     /// Whether the feature is enabled.
     pub enabled: bool,
     /// Which cancellation reasons will be given as options to the customer.
     pub options:
-        &'a [CreateBillingPortalConfigurationFeaturesSubscriptionCancelCancellationReasonOptions],
+        Vec<CreateBillingPortalConfigurationFeaturesSubscriptionCancelCancellationReasonOptions>,
 }
-impl<'a> CreateBillingPortalConfigurationFeaturesSubscriptionCancelCancellationReason<'a> {
+impl CreateBillingPortalConfigurationFeaturesSubscriptionCancelCancellationReason {
     pub fn new(
-        enabled: bool,
-        options: &'a [CreateBillingPortalConfigurationFeaturesSubscriptionCancelCancellationReasonOptions],
+        enabled: impl Into<bool>,
+        options: impl Into<
+            Vec<
+                CreateBillingPortalConfigurationFeaturesSubscriptionCancelCancellationReasonOptions,
+            >,
+        >,
     ) -> Self {
-        Self { enabled, options }
+        Self { enabled: enabled.into(), options: options.into() }
     }
 }
 /// Which cancellation reasons will be given as options to the customer.
@@ -614,28 +626,35 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// Information about updating subscriptions in the portal.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateBillingPortalConfigurationFeaturesSubscriptionUpdate<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateBillingPortalConfigurationFeaturesSubscriptionUpdate {
     /// The types of subscription updates that are supported. When empty, subscriptions are not updateable.
     pub default_allowed_updates:
-        &'a [CreateBillingPortalConfigurationFeaturesSubscriptionUpdateDefaultAllowedUpdates],
+        Vec<CreateBillingPortalConfigurationFeaturesSubscriptionUpdateDefaultAllowedUpdates>,
     /// Whether the feature is enabled.
     pub enabled: bool,
     /// The list of up to 10 products that support subscription updates.
-    pub products: &'a [SubscriptionUpdateProductParam<'a>],
+    pub products: Vec<SubscriptionUpdateProductParam>,
     /// Determines how to handle prorations resulting from subscription updates.
     /// Valid values are `none`, `create_prorations`, and `always_invoice`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub proration_behavior:
         Option<CreateBillingPortalConfigurationFeaturesSubscriptionUpdateProrationBehavior>,
 }
-impl<'a> CreateBillingPortalConfigurationFeaturesSubscriptionUpdate<'a> {
+impl CreateBillingPortalConfigurationFeaturesSubscriptionUpdate {
     pub fn new(
-        default_allowed_updates: &'a [CreateBillingPortalConfigurationFeaturesSubscriptionUpdateDefaultAllowedUpdates],
-        enabled: bool,
-        products: &'a [SubscriptionUpdateProductParam<'a>],
+        default_allowed_updates: impl Into<
+            Vec<CreateBillingPortalConfigurationFeaturesSubscriptionUpdateDefaultAllowedUpdates>,
+        >,
+        enabled: impl Into<bool>,
+        products: impl Into<Vec<SubscriptionUpdateProductParam>>,
     ) -> Self {
-        Self { default_allowed_updates, enabled, products, proration_behavior: None }
+        Self {
+            default_allowed_updates: default_allowed_updates.into(),
+            enabled: enabled.into(),
+            products: products.into(),
+            proration_behavior: None,
+        }
     }
 }
 /// The types of subscription updates that are supported. When empty, subscriptions are not updateable.
@@ -781,50 +800,61 @@ pub struct CreateBillingPortalConfigurationLoginPage {
     pub enabled: bool,
 }
 impl CreateBillingPortalConfigurationLoginPage {
-    pub fn new(enabled: bool) -> Self {
-        Self { enabled }
+    pub fn new(enabled: impl Into<bool>) -> Self {
+        Self { enabled: enabled.into() }
     }
 }
 /// Creates a configuration that describes the functionality and behavior of a PortalSession
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateBillingPortalConfiguration<'a> {
-    inner: CreateBillingPortalConfigurationBuilder<'a>,
+pub struct CreateBillingPortalConfiguration {
+    inner: CreateBillingPortalConfigurationBuilder,
 }
-impl<'a> CreateBillingPortalConfiguration<'a> {
+impl CreateBillingPortalConfiguration {
     /// Construct a new `CreateBillingPortalConfiguration`.
     pub fn new(
-        business_profile: CreateBillingPortalConfigurationBusinessProfile<'a>,
-        features: CreateBillingPortalConfigurationFeatures<'a>,
+        business_profile: impl Into<CreateBillingPortalConfigurationBusinessProfile>,
+        features: impl Into<CreateBillingPortalConfigurationFeatures>,
     ) -> Self {
-        Self { inner: CreateBillingPortalConfigurationBuilder::new(business_profile, features) }
+        Self {
+            inner: CreateBillingPortalConfigurationBuilder::new(
+                business_profile.into(),
+                features.into(),
+            ),
+        }
     }
     /// The default URL to redirect customers to when they click on the portal's link to return to your website.
     /// This can be [overriden](https://stripe.com/docs/api/customer_portal/sessions/create#create_portal_session-return_url) when creating the session.
-    pub fn default_return_url(mut self, default_return_url: &'a str) -> Self {
-        self.inner.default_return_url = Some(default_return_url);
+    pub fn default_return_url(mut self, default_return_url: impl Into<String>) -> Self {
+        self.inner.default_return_url = Some(default_return_url.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// The hosted login page for this configuration.
     /// Learn more about the portal login page in our [integration docs](https://stripe.com/docs/billing/subscriptions/integrating-customer-portal#share).
-    pub fn login_page(mut self, login_page: CreateBillingPortalConfigurationLoginPage) -> Self {
-        self.inner.login_page = Some(login_page);
+    pub fn login_page(
+        mut self,
+        login_page: impl Into<CreateBillingPortalConfigurationLoginPage>,
+    ) -> Self {
+        self.inner.login_page = Some(login_page.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
 }
-impl CreateBillingPortalConfiguration<'_> {
+impl CreateBillingPortalConfiguration {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -842,31 +872,31 @@ impl CreateBillingPortalConfiguration<'_> {
     }
 }
 
-impl StripeRequest for CreateBillingPortalConfiguration<'_> {
+impl StripeRequest for CreateBillingPortalConfiguration {
     type Output = stripe_billing::BillingPortalConfiguration;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Post, "/billing_portal/configurations").form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdateBillingPortalConfigurationBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdateBillingPortalConfigurationBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     active: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    business_profile: Option<UpdateBillingPortalConfigurationBusinessProfile<'a>>,
+    business_profile: Option<UpdateBillingPortalConfigurationBusinessProfile>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    default_return_url: Option<&'a str>,
+    default_return_url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    features: Option<UpdateBillingPortalConfigurationFeatures<'a>>,
+    features: Option<UpdateBillingPortalConfigurationFeatures>,
     #[serde(skip_serializing_if = "Option::is_none")]
     login_page: Option<UpdateBillingPortalConfigurationLoginPage>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
 }
-impl<'a> UpdateBillingPortalConfigurationBuilder<'a> {
+impl UpdateBillingPortalConfigurationBuilder {
     fn new() -> Self {
         Self {
             active: None,
@@ -880,34 +910,34 @@ impl<'a> UpdateBillingPortalConfigurationBuilder<'a> {
     }
 }
 /// The business information shown to customers in the portal.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateBillingPortalConfigurationBusinessProfile<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateBillingPortalConfigurationBusinessProfile {
     /// The messaging shown to customers in the portal.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub headline: Option<&'a str>,
+    pub headline: Option<String>,
     /// A link to the business’s publicly available privacy policy.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub privacy_policy_url: Option<&'a str>,
+    pub privacy_policy_url: Option<String>,
     /// A link to the business’s publicly available terms of service.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub terms_of_service_url: Option<&'a str>,
+    pub terms_of_service_url: Option<String>,
 }
-impl<'a> UpdateBillingPortalConfigurationBusinessProfile<'a> {
+impl UpdateBillingPortalConfigurationBusinessProfile {
     pub fn new() -> Self {
         Self { headline: None, privacy_policy_url: None, terms_of_service_url: None }
     }
 }
-impl<'a> Default for UpdateBillingPortalConfigurationBusinessProfile<'a> {
+impl Default for UpdateBillingPortalConfigurationBusinessProfile {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Information about the features available in the portal.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateBillingPortalConfigurationFeatures<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateBillingPortalConfigurationFeatures {
     /// Information about updating the customer details in the portal.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub customer_update: Option<UpdateBillingPortalConfigurationFeaturesCustomerUpdate<'a>>,
+    pub customer_update: Option<UpdateBillingPortalConfigurationFeaturesCustomerUpdate>,
     /// Information about showing the billing history in the portal.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub invoice_history: Option<UpdateBillingPortalConfigurationFeaturesInvoiceHistory>,
@@ -916,12 +946,12 @@ pub struct UpdateBillingPortalConfigurationFeatures<'a> {
     pub payment_method_update: Option<UpdateBillingPortalConfigurationFeaturesPaymentMethodUpdate>,
     /// Information about canceling subscriptions in the portal.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub subscription_cancel: Option<UpdateBillingPortalConfigurationFeaturesSubscriptionCancel<'a>>,
+    pub subscription_cancel: Option<UpdateBillingPortalConfigurationFeaturesSubscriptionCancel>,
     /// Information about updating subscriptions in the portal.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub subscription_update: Option<UpdateBillingPortalConfigurationFeaturesSubscriptionUpdate<'a>>,
+    pub subscription_update: Option<UpdateBillingPortalConfigurationFeaturesSubscriptionUpdate>,
 }
-impl<'a> UpdateBillingPortalConfigurationFeatures<'a> {
+impl UpdateBillingPortalConfigurationFeatures {
     pub fn new() -> Self {
         Self {
             customer_update: None,
@@ -932,28 +962,28 @@ impl<'a> UpdateBillingPortalConfigurationFeatures<'a> {
         }
     }
 }
-impl<'a> Default for UpdateBillingPortalConfigurationFeatures<'a> {
+impl Default for UpdateBillingPortalConfigurationFeatures {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Information about updating the customer details in the portal.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateBillingPortalConfigurationFeaturesCustomerUpdate<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateBillingPortalConfigurationFeaturesCustomerUpdate {
     /// The types of customer updates that are supported. When empty, customers are not updateable.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allowed_updates:
-        Option<&'a [UpdateBillingPortalConfigurationFeaturesCustomerUpdateAllowedUpdates]>,
+        Option<Vec<UpdateBillingPortalConfigurationFeaturesCustomerUpdateAllowedUpdates>>,
     /// Whether the feature is enabled.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enabled: Option<bool>,
 }
-impl<'a> UpdateBillingPortalConfigurationFeaturesCustomerUpdate<'a> {
+impl UpdateBillingPortalConfigurationFeaturesCustomerUpdate {
     pub fn new() -> Self {
         Self { allowed_updates: None, enabled: None }
     }
 }
-impl<'a> Default for UpdateBillingPortalConfigurationFeaturesCustomerUpdate<'a> {
+impl Default for UpdateBillingPortalConfigurationFeaturesCustomerUpdate {
     fn default() -> Self {
         Self::new()
     }
@@ -1033,8 +1063,8 @@ pub struct UpdateBillingPortalConfigurationFeaturesInvoiceHistory {
     pub enabled: bool,
 }
 impl UpdateBillingPortalConfigurationFeaturesInvoiceHistory {
-    pub fn new(enabled: bool) -> Self {
-        Self { enabled }
+    pub fn new(enabled: impl Into<bool>) -> Self {
+        Self { enabled: enabled.into() }
     }
 }
 /// Information about updating payment methods in the portal.
@@ -1044,17 +1074,17 @@ pub struct UpdateBillingPortalConfigurationFeaturesPaymentMethodUpdate {
     pub enabled: bool,
 }
 impl UpdateBillingPortalConfigurationFeaturesPaymentMethodUpdate {
-    pub fn new(enabled: bool) -> Self {
-        Self { enabled }
+    pub fn new(enabled: impl Into<bool>) -> Self {
+        Self { enabled: enabled.into() }
     }
 }
 /// Information about canceling subscriptions in the portal.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateBillingPortalConfigurationFeaturesSubscriptionCancel<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateBillingPortalConfigurationFeaturesSubscriptionCancel {
     /// Whether the cancellation reasons will be collected in the portal and which options are exposed to the customer.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cancellation_reason:
-        Option<UpdateBillingPortalConfigurationFeaturesSubscriptionCancelCancellationReason<'a>>,
+        Option<UpdateBillingPortalConfigurationFeaturesSubscriptionCancelCancellationReason>,
     /// Whether the feature is enabled.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enabled: Option<bool>,
@@ -1068,30 +1098,30 @@ pub struct UpdateBillingPortalConfigurationFeaturesSubscriptionCancel<'a> {
     pub proration_behavior:
         Option<UpdateBillingPortalConfigurationFeaturesSubscriptionCancelProrationBehavior>,
 }
-impl<'a> UpdateBillingPortalConfigurationFeaturesSubscriptionCancel<'a> {
+impl UpdateBillingPortalConfigurationFeaturesSubscriptionCancel {
     pub fn new() -> Self {
         Self { cancellation_reason: None, enabled: None, mode: None, proration_behavior: None }
     }
 }
-impl<'a> Default for UpdateBillingPortalConfigurationFeaturesSubscriptionCancel<'a> {
+impl Default for UpdateBillingPortalConfigurationFeaturesSubscriptionCancel {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Whether the cancellation reasons will be collected in the portal and which options are exposed to the customer.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateBillingPortalConfigurationFeaturesSubscriptionCancelCancellationReason<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateBillingPortalConfigurationFeaturesSubscriptionCancelCancellationReason {
     /// Whether the feature is enabled.
     pub enabled: bool,
     /// Which cancellation reasons will be given as options to the customer.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub options: Option<
-        &'a [UpdateBillingPortalConfigurationFeaturesSubscriptionCancelCancellationReasonOptions],
+        Vec<UpdateBillingPortalConfigurationFeaturesSubscriptionCancelCancellationReasonOptions>,
     >,
 }
-impl<'a> UpdateBillingPortalConfigurationFeaturesSubscriptionCancelCancellationReason<'a> {
-    pub fn new(enabled: bool) -> Self {
-        Self { enabled, options: None }
+impl UpdateBillingPortalConfigurationFeaturesSubscriptionCancelCancellationReason {
+    pub fn new(enabled: impl Into<bool>) -> Self {
+        Self { enabled: enabled.into(), options: None }
     }
 }
 /// Which cancellation reasons will be given as options to the customer.
@@ -1306,26 +1336,26 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// Information about updating subscriptions in the portal.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateBillingPortalConfigurationFeaturesSubscriptionUpdate<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateBillingPortalConfigurationFeaturesSubscriptionUpdate {
     /// The types of subscription updates that are supported. When empty, subscriptions are not updateable.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_allowed_updates: Option<
-        &'a [UpdateBillingPortalConfigurationFeaturesSubscriptionUpdateDefaultAllowedUpdates],
+        Vec<UpdateBillingPortalConfigurationFeaturesSubscriptionUpdateDefaultAllowedUpdates>,
     >,
     /// Whether the feature is enabled.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub enabled: Option<bool>,
     /// The list of up to 10 products that support subscription updates.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub products: Option<&'a [SubscriptionUpdateProductParam<'a>]>,
+    pub products: Option<Vec<SubscriptionUpdateProductParam>>,
     /// Determines how to handle prorations resulting from subscription updates.
     /// Valid values are `none`, `create_prorations`, and `always_invoice`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub proration_behavior:
         Option<UpdateBillingPortalConfigurationFeaturesSubscriptionUpdateProrationBehavior>,
 }
-impl<'a> UpdateBillingPortalConfigurationFeaturesSubscriptionUpdate<'a> {
+impl UpdateBillingPortalConfigurationFeaturesSubscriptionUpdate {
     pub fn new() -> Self {
         Self {
             default_allowed_updates: None,
@@ -1335,7 +1365,7 @@ impl<'a> UpdateBillingPortalConfigurationFeaturesSubscriptionUpdate<'a> {
         }
     }
 }
-impl<'a> Default for UpdateBillingPortalConfigurationFeaturesSubscriptionUpdate<'a> {
+impl Default for UpdateBillingPortalConfigurationFeaturesSubscriptionUpdate {
     fn default() -> Self {
         Self::new()
     }
@@ -1485,66 +1515,78 @@ pub struct UpdateBillingPortalConfigurationLoginPage {
     pub enabled: bool,
 }
 impl UpdateBillingPortalConfigurationLoginPage {
-    pub fn new(enabled: bool) -> Self {
-        Self { enabled }
+    pub fn new(enabled: impl Into<bool>) -> Self {
+        Self { enabled: enabled.into() }
     }
 }
 /// Updates a configuration that describes the functionality of the customer portal.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateBillingPortalConfiguration<'a> {
-    inner: UpdateBillingPortalConfigurationBuilder<'a>,
-    configuration: &'a stripe_billing::BillingPortalConfigurationId,
+pub struct UpdateBillingPortalConfiguration {
+    inner: UpdateBillingPortalConfigurationBuilder,
+    configuration: stripe_billing::BillingPortalConfigurationId,
 }
-impl<'a> UpdateBillingPortalConfiguration<'a> {
+impl UpdateBillingPortalConfiguration {
     /// Construct a new `UpdateBillingPortalConfiguration`.
-    pub fn new(configuration: &'a stripe_billing::BillingPortalConfigurationId) -> Self {
-        Self { configuration, inner: UpdateBillingPortalConfigurationBuilder::new() }
+    pub fn new(configuration: impl Into<stripe_billing::BillingPortalConfigurationId>) -> Self {
+        Self {
+            configuration: configuration.into(),
+            inner: UpdateBillingPortalConfigurationBuilder::new(),
+        }
     }
     /// Whether the configuration is active and can be used to create portal sessions.
-    pub fn active(mut self, active: bool) -> Self {
-        self.inner.active = Some(active);
+    pub fn active(mut self, active: impl Into<bool>) -> Self {
+        self.inner.active = Some(active.into());
         self
     }
     /// The business information shown to customers in the portal.
     pub fn business_profile(
         mut self,
-        business_profile: UpdateBillingPortalConfigurationBusinessProfile<'a>,
+        business_profile: impl Into<UpdateBillingPortalConfigurationBusinessProfile>,
     ) -> Self {
-        self.inner.business_profile = Some(business_profile);
+        self.inner.business_profile = Some(business_profile.into());
         self
     }
     /// The default URL to redirect customers to when they click on the portal's link to return to your website.
     /// This can be [overriden](https://stripe.com/docs/api/customer_portal/sessions/create#create_portal_session-return_url) when creating the session.
-    pub fn default_return_url(mut self, default_return_url: &'a str) -> Self {
-        self.inner.default_return_url = Some(default_return_url);
+    pub fn default_return_url(mut self, default_return_url: impl Into<String>) -> Self {
+        self.inner.default_return_url = Some(default_return_url.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Information about the features available in the portal.
-    pub fn features(mut self, features: UpdateBillingPortalConfigurationFeatures<'a>) -> Self {
-        self.inner.features = Some(features);
+    pub fn features(
+        mut self,
+        features: impl Into<UpdateBillingPortalConfigurationFeatures>,
+    ) -> Self {
+        self.inner.features = Some(features.into());
         self
     }
     /// The hosted login page for this configuration.
     /// Learn more about the portal login page in our [integration docs](https://stripe.com/docs/billing/subscriptions/integrating-customer-portal#share).
-    pub fn login_page(mut self, login_page: UpdateBillingPortalConfigurationLoginPage) -> Self {
-        self.inner.login_page = Some(login_page);
+    pub fn login_page(
+        mut self,
+        login_page: impl Into<UpdateBillingPortalConfigurationLoginPage>,
+    ) -> Self {
+        self.inner.login_page = Some(login_page.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
 }
-impl UpdateBillingPortalConfiguration<'_> {
+impl UpdateBillingPortalConfiguration {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -1562,11 +1604,11 @@ impl UpdateBillingPortalConfiguration<'_> {
     }
 }
 
-impl StripeRequest for UpdateBillingPortalConfiguration<'_> {
+impl StripeRequest for UpdateBillingPortalConfiguration {
     type Output = stripe_billing::BillingPortalConfiguration;
 
     fn build(&self) -> RequestBuilder {
-        let configuration = self.configuration;
+        let configuration = &self.configuration;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/billing_portal/configurations/{configuration}"),
@@ -1575,15 +1617,15 @@ impl StripeRequest for UpdateBillingPortalConfiguration<'_> {
     }
 }
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct SubscriptionUpdateProductParam<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct SubscriptionUpdateProductParam {
     /// The list of price IDs for the product that a subscription can be updated to.
-    pub prices: &'a [&'a str],
+    pub prices: Vec<String>,
     /// The product id.
-    pub product: &'a str,
+    pub product: String,
 }
-impl<'a> SubscriptionUpdateProductParam<'a> {
-    pub fn new(prices: &'a [&'a str], product: &'a str) -> Self {
-        Self { prices, product }
+impl SubscriptionUpdateProductParam {
+    pub fn new(prices: impl Into<Vec<String>>, product: impl Into<String>) -> Self {
+        Self { prices: prices.into(), product: product.into() }
     }
 }

--- a/generated/async-stripe-billing/src/billing_portal_session/requests.rs
+++ b/generated/async-stripe-billing/src/billing_portal_session/requests.rs
@@ -2,27 +2,27 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateBillingPortalSessionBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateBillingPortalSessionBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    configuration: Option<&'a str>,
-    customer: &'a str,
+    configuration: Option<String>,
+    customer: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    flow_data: Option<CreateBillingPortalSessionFlowData<'a>>,
+    flow_data: Option<CreateBillingPortalSessionFlowData>,
     #[serde(skip_serializing_if = "Option::is_none")]
     locale: Option<stripe_billing::BillingPortalSessionLocale>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    on_behalf_of: Option<&'a str>,
+    on_behalf_of: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    return_url: Option<&'a str>,
+    return_url: Option<String>,
 }
-impl<'a> CreateBillingPortalSessionBuilder<'a> {
-    fn new(customer: &'a str) -> Self {
+impl CreateBillingPortalSessionBuilder {
+    fn new(customer: impl Into<String>) -> Self {
         Self {
             configuration: None,
-            customer,
+            customer: customer.into(),
             expand: None,
             flow_data: None,
             locale: None,
@@ -33,81 +33,81 @@ impl<'a> CreateBillingPortalSessionBuilder<'a> {
 }
 /// Information about a specific flow for the customer to go through.
 /// See the [docs](https://stripe.com/docs/customer-management/portal-deep-links) to learn more about using customer portal deep links and flows.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateBillingPortalSessionFlowData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateBillingPortalSessionFlowData {
     /// Behavior after the flow is completed.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub after_completion: Option<CreateBillingPortalSessionFlowDataAfterCompletion<'a>>,
+    pub after_completion: Option<CreateBillingPortalSessionFlowDataAfterCompletion>,
     /// Configuration when `flow_data.type=subscription_cancel`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub subscription_cancel: Option<CreateBillingPortalSessionFlowDataSubscriptionCancel<'a>>,
+    pub subscription_cancel: Option<CreateBillingPortalSessionFlowDataSubscriptionCancel>,
     /// Configuration when `flow_data.type=subscription_update`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub subscription_update: Option<CreateBillingPortalSessionFlowDataSubscriptionUpdate<'a>>,
+    pub subscription_update: Option<CreateBillingPortalSessionFlowDataSubscriptionUpdate>,
     /// Configuration when `flow_data.type=subscription_update_confirm`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub subscription_update_confirm:
-        Option<CreateBillingPortalSessionFlowDataSubscriptionUpdateConfirm<'a>>,
+        Option<CreateBillingPortalSessionFlowDataSubscriptionUpdateConfirm>,
     /// Type of flow that the customer will go through.
     #[serde(rename = "type")]
     pub type_: CreateBillingPortalSessionFlowDataType,
 }
-impl<'a> CreateBillingPortalSessionFlowData<'a> {
-    pub fn new(type_: CreateBillingPortalSessionFlowDataType) -> Self {
+impl CreateBillingPortalSessionFlowData {
+    pub fn new(type_: impl Into<CreateBillingPortalSessionFlowDataType>) -> Self {
         Self {
             after_completion: None,
             subscription_cancel: None,
             subscription_update: None,
             subscription_update_confirm: None,
-            type_,
+            type_: type_.into(),
         }
     }
 }
 /// Behavior after the flow is completed.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateBillingPortalSessionFlowDataAfterCompletion<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateBillingPortalSessionFlowDataAfterCompletion {
     /// Configuration when `after_completion.type=hosted_confirmation`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hosted_confirmation:
-        Option<CreateBillingPortalSessionFlowDataAfterCompletionHostedConfirmation<'a>>,
+        Option<CreateBillingPortalSessionFlowDataAfterCompletionHostedConfirmation>,
     /// Configuration when `after_completion.type=redirect`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub redirect: Option<CreateBillingPortalSessionFlowDataAfterCompletionRedirect<'a>>,
+    pub redirect: Option<CreateBillingPortalSessionFlowDataAfterCompletionRedirect>,
     /// The specified behavior after the flow is completed.
     #[serde(rename = "type")]
     pub type_: CreateBillingPortalSessionFlowDataAfterCompletionType,
 }
-impl<'a> CreateBillingPortalSessionFlowDataAfterCompletion<'a> {
-    pub fn new(type_: CreateBillingPortalSessionFlowDataAfterCompletionType) -> Self {
-        Self { hosted_confirmation: None, redirect: None, type_ }
+impl CreateBillingPortalSessionFlowDataAfterCompletion {
+    pub fn new(type_: impl Into<CreateBillingPortalSessionFlowDataAfterCompletionType>) -> Self {
+        Self { hosted_confirmation: None, redirect: None, type_: type_.into() }
     }
 }
 /// Configuration when `after_completion.type=hosted_confirmation`.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateBillingPortalSessionFlowDataAfterCompletionHostedConfirmation<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateBillingPortalSessionFlowDataAfterCompletionHostedConfirmation {
     /// A custom message to display to the customer after the flow is completed.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub custom_message: Option<&'a str>,
+    pub custom_message: Option<String>,
 }
-impl<'a> CreateBillingPortalSessionFlowDataAfterCompletionHostedConfirmation<'a> {
+impl CreateBillingPortalSessionFlowDataAfterCompletionHostedConfirmation {
     pub fn new() -> Self {
         Self { custom_message: None }
     }
 }
-impl<'a> Default for CreateBillingPortalSessionFlowDataAfterCompletionHostedConfirmation<'a> {
+impl Default for CreateBillingPortalSessionFlowDataAfterCompletionHostedConfirmation {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Configuration when `after_completion.type=redirect`.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateBillingPortalSessionFlowDataAfterCompletionRedirect<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateBillingPortalSessionFlowDataAfterCompletionRedirect {
     /// The URL the customer will be redirected to after the flow is completed.
-    pub return_url: &'a str,
+    pub return_url: String,
 }
-impl<'a> CreateBillingPortalSessionFlowDataAfterCompletionRedirect<'a> {
-    pub fn new(return_url: &'a str) -> Self {
-        Self { return_url }
+impl CreateBillingPortalSessionFlowDataAfterCompletionRedirect {
+    pub fn new(return_url: impl Into<String>) -> Self {
+        Self { return_url: return_url.into() }
     }
 }
 /// The specified behavior after the flow is completed.
@@ -172,45 +172,47 @@ impl<'de> serde::Deserialize<'de> for CreateBillingPortalSessionFlowDataAfterCom
     }
 }
 /// Configuration when `flow_data.type=subscription_cancel`.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateBillingPortalSessionFlowDataSubscriptionCancel<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateBillingPortalSessionFlowDataSubscriptionCancel {
     /// Specify a retention strategy to be used in the cancellation flow.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub retention: Option<CreateBillingPortalSessionFlowDataSubscriptionCancelRetention<'a>>,
+    pub retention: Option<CreateBillingPortalSessionFlowDataSubscriptionCancelRetention>,
     /// The ID of the subscription to be canceled.
-    pub subscription: &'a str,
+    pub subscription: String,
 }
-impl<'a> CreateBillingPortalSessionFlowDataSubscriptionCancel<'a> {
-    pub fn new(subscription: &'a str) -> Self {
-        Self { retention: None, subscription }
+impl CreateBillingPortalSessionFlowDataSubscriptionCancel {
+    pub fn new(subscription: impl Into<String>) -> Self {
+        Self { retention: None, subscription: subscription.into() }
     }
 }
 /// Specify a retention strategy to be used in the cancellation flow.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateBillingPortalSessionFlowDataSubscriptionCancelRetention<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateBillingPortalSessionFlowDataSubscriptionCancelRetention {
     /// Configuration when `retention.type=coupon_offer`.
-    pub coupon_offer: CreateBillingPortalSessionFlowDataSubscriptionCancelRetentionCouponOffer<'a>,
+    pub coupon_offer: CreateBillingPortalSessionFlowDataSubscriptionCancelRetentionCouponOffer,
     /// Type of retention strategy to use with the customer.
     #[serde(rename = "type")]
     pub type_: CreateBillingPortalSessionFlowDataSubscriptionCancelRetentionType,
 }
-impl<'a> CreateBillingPortalSessionFlowDataSubscriptionCancelRetention<'a> {
+impl CreateBillingPortalSessionFlowDataSubscriptionCancelRetention {
     pub fn new(
-        coupon_offer: CreateBillingPortalSessionFlowDataSubscriptionCancelRetentionCouponOffer<'a>,
-        type_: CreateBillingPortalSessionFlowDataSubscriptionCancelRetentionType,
+        coupon_offer: impl Into<
+            CreateBillingPortalSessionFlowDataSubscriptionCancelRetentionCouponOffer,
+        >,
+        type_: impl Into<CreateBillingPortalSessionFlowDataSubscriptionCancelRetentionType>,
     ) -> Self {
-        Self { coupon_offer, type_ }
+        Self { coupon_offer: coupon_offer.into(), type_: type_.into() }
     }
 }
 /// Configuration when `retention.type=coupon_offer`.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateBillingPortalSessionFlowDataSubscriptionCancelRetentionCouponOffer<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateBillingPortalSessionFlowDataSubscriptionCancelRetentionCouponOffer {
     /// The ID of the coupon to be offered.
-    pub coupon: &'a str,
+    pub coupon: String,
 }
-impl<'a> CreateBillingPortalSessionFlowDataSubscriptionCancelRetentionCouponOffer<'a> {
-    pub fn new(coupon: &'a str) -> Self {
-        Self { coupon }
+impl CreateBillingPortalSessionFlowDataSubscriptionCancelRetentionCouponOffer {
+    pub fn new(coupon: impl Into<String>) -> Self {
+        Self { coupon: coupon.into() }
     }
 }
 /// Type of retention strategy to use with the customer.
@@ -267,76 +269,76 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// Configuration when `flow_data.type=subscription_update`.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateBillingPortalSessionFlowDataSubscriptionUpdate<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateBillingPortalSessionFlowDataSubscriptionUpdate {
     /// The ID of the subscription to be updated.
-    pub subscription: &'a str,
+    pub subscription: String,
 }
-impl<'a> CreateBillingPortalSessionFlowDataSubscriptionUpdate<'a> {
-    pub fn new(subscription: &'a str) -> Self {
-        Self { subscription }
+impl CreateBillingPortalSessionFlowDataSubscriptionUpdate {
+    pub fn new(subscription: impl Into<String>) -> Self {
+        Self { subscription: subscription.into() }
     }
 }
 /// Configuration when `flow_data.type=subscription_update_confirm`.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateBillingPortalSessionFlowDataSubscriptionUpdateConfirm<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateBillingPortalSessionFlowDataSubscriptionUpdateConfirm {
     /// The coupon or promotion code to apply to this subscription update.
     /// Currently, only up to one may be specified.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub discounts:
-        Option<&'a [CreateBillingPortalSessionFlowDataSubscriptionUpdateConfirmDiscounts<'a>]>,
+        Option<Vec<CreateBillingPortalSessionFlowDataSubscriptionUpdateConfirmDiscounts>>,
     /// The [subscription item](https://stripe.com/docs/api/subscription_items) to be updated through this flow.
     /// Currently, only up to one may be specified and subscriptions with multiple items are not updatable.
-    pub items: &'a [CreateBillingPortalSessionFlowDataSubscriptionUpdateConfirmItems<'a>],
+    pub items: Vec<CreateBillingPortalSessionFlowDataSubscriptionUpdateConfirmItems>,
     /// The ID of the subscription to be updated.
-    pub subscription: &'a str,
+    pub subscription: String,
 }
-impl<'a> CreateBillingPortalSessionFlowDataSubscriptionUpdateConfirm<'a> {
+impl CreateBillingPortalSessionFlowDataSubscriptionUpdateConfirm {
     pub fn new(
-        items: &'a [CreateBillingPortalSessionFlowDataSubscriptionUpdateConfirmItems<'a>],
-        subscription: &'a str,
+        items: impl Into<Vec<CreateBillingPortalSessionFlowDataSubscriptionUpdateConfirmItems>>,
+        subscription: impl Into<String>,
     ) -> Self {
-        Self { discounts: None, items, subscription }
+        Self { discounts: None, items: items.into(), subscription: subscription.into() }
     }
 }
 /// The coupon or promotion code to apply to this subscription update.
 /// Currently, only up to one may be specified.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateBillingPortalSessionFlowDataSubscriptionUpdateConfirmDiscounts<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateBillingPortalSessionFlowDataSubscriptionUpdateConfirmDiscounts {
     /// The ID of the coupon to apply to this subscription update.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub coupon: Option<&'a str>,
+    pub coupon: Option<String>,
     /// The ID of a promotion code to apply to this subscription update.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub promotion_code: Option<&'a str>,
+    pub promotion_code: Option<String>,
 }
-impl<'a> CreateBillingPortalSessionFlowDataSubscriptionUpdateConfirmDiscounts<'a> {
+impl CreateBillingPortalSessionFlowDataSubscriptionUpdateConfirmDiscounts {
     pub fn new() -> Self {
         Self { coupon: None, promotion_code: None }
     }
 }
-impl<'a> Default for CreateBillingPortalSessionFlowDataSubscriptionUpdateConfirmDiscounts<'a> {
+impl Default for CreateBillingPortalSessionFlowDataSubscriptionUpdateConfirmDiscounts {
     fn default() -> Self {
         Self::new()
     }
 }
 /// The [subscription item](https://stripe.com/docs/api/subscription_items) to be updated through this flow.
 /// Currently, only up to one may be specified and subscriptions with multiple items are not updatable.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateBillingPortalSessionFlowDataSubscriptionUpdateConfirmItems<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateBillingPortalSessionFlowDataSubscriptionUpdateConfirmItems {
     /// The ID of the [subscription item](https://stripe.com/docs/api/subscriptions/object#subscription_object-items-data-id) to be updated.
-    pub id: &'a str,
+    pub id: String,
     /// The price the customer should subscribe to through this flow.
     /// The price must also be included in the configuration's [`features.subscription_update.products`](https://stripe.com/docs/api/customer_portal/configuration#portal_configuration_object-features-subscription_update-products).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price: Option<&'a str>,
+    pub price: Option<String>,
     /// [Quantity](https://stripe.com/docs/subscriptions/quantities) for this item that the customer should subscribe to through this flow.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub quantity: Option<u64>,
 }
-impl<'a> CreateBillingPortalSessionFlowDataSubscriptionUpdateConfirmItems<'a> {
-    pub fn new(id: &'a str) -> Self {
-        Self { id, price: None, quantity: None }
+impl CreateBillingPortalSessionFlowDataSubscriptionUpdateConfirmItems {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self { id: id.into(), price: None, quantity: None }
     }
 }
 /// Type of flow that the customer will go through.
@@ -403,52 +405,52 @@ impl<'de> serde::Deserialize<'de> for CreateBillingPortalSessionFlowDataType {
 }
 /// Creates a session of the customer portal.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateBillingPortalSession<'a> {
-    inner: CreateBillingPortalSessionBuilder<'a>,
+pub struct CreateBillingPortalSession {
+    inner: CreateBillingPortalSessionBuilder,
 }
-impl<'a> CreateBillingPortalSession<'a> {
+impl CreateBillingPortalSession {
     /// Construct a new `CreateBillingPortalSession`.
-    pub fn new(customer: &'a str) -> Self {
-        Self { inner: CreateBillingPortalSessionBuilder::new(customer) }
+    pub fn new(customer: impl Into<String>) -> Self {
+        Self { inner: CreateBillingPortalSessionBuilder::new(customer.into()) }
     }
     /// The ID of an existing [configuration](https://stripe.com/docs/api/customer_portal/configuration) to use for this session, describing its functionality and features.
     /// If not specified, the session uses the default configuration.
-    pub fn configuration(mut self, configuration: &'a str) -> Self {
-        self.inner.configuration = Some(configuration);
+    pub fn configuration(mut self, configuration: impl Into<String>) -> Self {
+        self.inner.configuration = Some(configuration.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Information about a specific flow for the customer to go through.
     /// See the [docs](https://stripe.com/docs/customer-management/portal-deep-links) to learn more about using customer portal deep links and flows.
-    pub fn flow_data(mut self, flow_data: CreateBillingPortalSessionFlowData<'a>) -> Self {
-        self.inner.flow_data = Some(flow_data);
+    pub fn flow_data(mut self, flow_data: impl Into<CreateBillingPortalSessionFlowData>) -> Self {
+        self.inner.flow_data = Some(flow_data.into());
         self
     }
     /// The IETF language tag of the locale customer portal is displayed in.
     /// If blank or auto, the customer’s `preferred_locales` or browser’s locale is used.
-    pub fn locale(mut self, locale: stripe_billing::BillingPortalSessionLocale) -> Self {
-        self.inner.locale = Some(locale);
+    pub fn locale(mut self, locale: impl Into<stripe_billing::BillingPortalSessionLocale>) -> Self {
+        self.inner.locale = Some(locale.into());
         self
     }
     /// The `on_behalf_of` account to use for this session.
     /// When specified, only subscriptions and invoices with this `on_behalf_of` account appear in the portal.
     /// For more information, see the [docs](https://stripe.com/docs/connect/separate-charges-and-transfers#settlement-merchant).
     /// Use the [Accounts API](https://stripe.com/docs/api/accounts/object#account_object-settings-branding) to modify the `on_behalf_of` account's branding settings, which the portal displays.
-    pub fn on_behalf_of(mut self, on_behalf_of: &'a str) -> Self {
-        self.inner.on_behalf_of = Some(on_behalf_of);
+    pub fn on_behalf_of(mut self, on_behalf_of: impl Into<String>) -> Self {
+        self.inner.on_behalf_of = Some(on_behalf_of.into());
         self
     }
     /// The default URL to redirect customers to when they click on the portal's link to return to your website.
-    pub fn return_url(mut self, return_url: &'a str) -> Self {
-        self.inner.return_url = Some(return_url);
+    pub fn return_url(mut self, return_url: impl Into<String>) -> Self {
+        self.inner.return_url = Some(return_url.into());
         self
     }
 }
-impl CreateBillingPortalSession<'_> {
+impl CreateBillingPortalSession {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -466,7 +468,7 @@ impl CreateBillingPortalSession<'_> {
     }
 }
 
-impl StripeRequest for CreateBillingPortalSession<'_> {
+impl StripeRequest for CreateBillingPortalSession {
     type Output = stripe_billing::BillingPortalSession;
 
     fn build(&self) -> RequestBuilder {

--- a/generated/async-stripe-billing/src/credit_note/requests.rs
+++ b/generated/async-stripe-billing/src/credit_note/requests.rs
@@ -2,24 +2,24 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListCreditNoteBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListCreditNoteBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     created: Option<stripe_types::RangeQueryTs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    customer: Option<&'a str>,
+    customer: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    invoice: Option<&'a str>,
+    invoice: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListCreditNoteBuilder<'a> {
+impl ListCreditNoteBuilder {
     fn new() -> Self {
         Self {
             created: None,
@@ -34,61 +34,61 @@ impl<'a> ListCreditNoteBuilder<'a> {
 }
 /// Returns a list of credit notes.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListCreditNote<'a> {
-    inner: ListCreditNoteBuilder<'a>,
+pub struct ListCreditNote {
+    inner: ListCreditNoteBuilder,
 }
-impl<'a> ListCreditNote<'a> {
+impl ListCreditNote {
     /// Construct a new `ListCreditNote`.
     pub fn new() -> Self {
         Self { inner: ListCreditNoteBuilder::new() }
     }
     /// Only return credit notes that were created during the given date interval.
-    pub fn created(mut self, created: stripe_types::RangeQueryTs) -> Self {
-        self.inner.created = Some(created);
+    pub fn created(mut self, created: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.created = Some(created.into());
         self
     }
     /// Only return credit notes for the customer specified by this customer ID.
-    pub fn customer(mut self, customer: &'a str) -> Self {
-        self.inner.customer = Some(customer);
+    pub fn customer(mut self, customer: impl Into<String>) -> Self {
+        self.inner.customer = Some(customer.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Only return credit notes for the invoice specified by this invoice ID.
-    pub fn invoice(mut self, invoice: &'a str) -> Self {
-        self.inner.invoice = Some(invoice);
+    pub fn invoice(mut self, invoice: impl Into<String>) -> Self {
+        self.inner.invoice = Some(invoice.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl<'a> Default for ListCreditNote<'a> {
+impl Default for ListCreditNote {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListCreditNote<'_> {
+impl ListCreditNote {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -108,45 +108,45 @@ impl ListCreditNote<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::CreditNote>> {
-        stripe_client_core::ListPaginator::new_list("/credit_notes", self.inner)
+        stripe_client_core::ListPaginator::new_list("/credit_notes", &self.inner)
     }
 }
 
-impl StripeRequest for ListCreditNote<'_> {
+impl StripeRequest for ListCreditNote {
     type Output = stripe_types::List<stripe_shared::CreditNote>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/credit_notes").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveCreditNoteBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveCreditNoteBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveCreditNoteBuilder<'a> {
+impl RetrieveCreditNoteBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves the credit note object with the given identifier.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveCreditNote<'a> {
-    inner: RetrieveCreditNoteBuilder<'a>,
-    id: &'a stripe_shared::CreditNoteId,
+pub struct RetrieveCreditNote {
+    inner: RetrieveCreditNoteBuilder,
+    id: stripe_shared::CreditNoteId,
 }
-impl<'a> RetrieveCreditNote<'a> {
+impl RetrieveCreditNote {
     /// Construct a new `RetrieveCreditNote`.
-    pub fn new(id: &'a stripe_shared::CreditNoteId) -> Self {
-        Self { id, inner: RetrieveCreditNoteBuilder::new() }
+    pub fn new(id: impl Into<stripe_shared::CreditNoteId>) -> Self {
+        Self { id: id.into(), inner: RetrieveCreditNoteBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveCreditNote<'_> {
+impl RetrieveCreditNote {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -164,16 +164,16 @@ impl RetrieveCreditNote<'_> {
     }
 }
 
-impl StripeRequest for RetrieveCreditNote<'_> {
+impl StripeRequest for RetrieveCreditNote {
     type Output = stripe_shared::CreditNote;
 
     fn build(&self) -> RequestBuilder {
-        let id = self.id;
+        let id = &self.id;
         RequestBuilder::new(StripeMethod::Get, format!("/credit_notes/{id}")).query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct PreviewCreditNoteBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct PreviewCreditNoteBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     amount: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -181,33 +181,33 @@ struct PreviewCreditNoteBuilder<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     effective_at: Option<stripe_types::Timestamp>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
-    invoice: &'a str,
+    expand: Option<Vec<String>>,
+    invoice: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    lines: Option<&'a [PreviewCreditNoteLines<'a>]>,
+    lines: Option<Vec<PreviewCreditNoteLines>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    memo: Option<&'a str>,
+    memo: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     out_of_band_amount: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     reason: Option<stripe_shared::CreditNoteReason>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    refund: Option<&'a str>,
+    refund: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     refund_amount: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    shipping_cost: Option<CreditNoteShippingCost<'a>>,
+    shipping_cost: Option<CreditNoteShippingCost>,
 }
-impl<'a> PreviewCreditNoteBuilder<'a> {
-    fn new(invoice: &'a str) -> Self {
+impl PreviewCreditNoteBuilder {
+    fn new(invoice: impl Into<String>) -> Self {
         Self {
             amount: None,
             credit_amount: None,
             effective_at: None,
             expand: None,
-            invoice,
+            invoice: invoice.into(),
             lines: None,
             memo: None,
             metadata: None,
@@ -220,27 +220,27 @@ impl<'a> PreviewCreditNoteBuilder<'a> {
     }
 }
 /// Line items that make up the credit note.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct PreviewCreditNoteLines<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct PreviewCreditNoteLines {
     /// The line item amount to credit. Only valid when `type` is `invoice_line_item`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub amount: Option<i64>,
     /// The description of the credit note line item. Only valid when the `type` is `custom_line_item`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<&'a str>,
+    pub description: Option<String>,
     /// The invoice line item to credit. Only valid when the `type` is `invoice_line_item`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub invoice_line_item: Option<&'a str>,
+    pub invoice_line_item: Option<String>,
     /// The line item quantity to credit.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub quantity: Option<u64>,
     /// A list of up to 10 tax amounts for the credit note line item. Cannot be mixed with `tax_rates`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_amounts: Option<&'a [TaxAmountWithTaxRateParam<'a>]>,
+    pub tax_amounts: Option<Vec<TaxAmountWithTaxRateParam>>,
     /// The tax rates which apply to the credit note line item.
     /// Only valid when the `type` is `custom_line_item` and cannot be mixed with `tax_amounts`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_rates: Option<&'a [&'a str]>,
+    pub tax_rates: Option<Vec<String>>,
     /// Type of the credit note line item, one of `invoice_line_item` or `custom_line_item`
     #[serde(rename = "type")]
     pub type_: PreviewCreditNoteLinesType,
@@ -252,10 +252,10 @@ pub struct PreviewCreditNoteLines<'a> {
     /// Same as `unit_amount`, but accepts a decimal value in cents (or local equivalent) with at most 12 decimal places.
     /// Only one of `unit_amount` and `unit_amount_decimal` can be set.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub unit_amount_decimal: Option<&'a str>,
+    pub unit_amount_decimal: Option<String>,
 }
-impl<'a> PreviewCreditNoteLines<'a> {
-    pub fn new(type_: PreviewCreditNoteLinesType) -> Self {
+impl PreviewCreditNoteLines {
+    pub fn new(type_: impl Into<PreviewCreditNoteLinesType>) -> Self {
         Self {
             amount: None,
             description: None,
@@ -263,7 +263,7 @@ impl<'a> PreviewCreditNoteLines<'a> {
             quantity: None,
             tax_amounts: None,
             tax_rates: None,
-            type_,
+            type_: type_.into(),
             unit_amount: None,
             unit_amount_decimal: None,
         }
@@ -326,82 +326,85 @@ impl<'de> serde::Deserialize<'de> for PreviewCreditNoteLinesType {
 }
 /// Get a preview of a credit note without creating it.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct PreviewCreditNote<'a> {
-    inner: PreviewCreditNoteBuilder<'a>,
+pub struct PreviewCreditNote {
+    inner: PreviewCreditNoteBuilder,
 }
-impl<'a> PreviewCreditNote<'a> {
+impl PreviewCreditNote {
     /// Construct a new `PreviewCreditNote`.
-    pub fn new(invoice: &'a str) -> Self {
-        Self { inner: PreviewCreditNoteBuilder::new(invoice) }
+    pub fn new(invoice: impl Into<String>) -> Self {
+        Self { inner: PreviewCreditNoteBuilder::new(invoice.into()) }
     }
     /// The integer amount in cents (or local equivalent) representing the total amount of the credit note.
-    pub fn amount(mut self, amount: i64) -> Self {
-        self.inner.amount = Some(amount);
+    pub fn amount(mut self, amount: impl Into<i64>) -> Self {
+        self.inner.amount = Some(amount.into());
         self
     }
     /// The integer amount in cents (or local equivalent) representing the amount to credit the customer's balance, which will be automatically applied to their next invoice.
-    pub fn credit_amount(mut self, credit_amount: i64) -> Self {
-        self.inner.credit_amount = Some(credit_amount);
+    pub fn credit_amount(mut self, credit_amount: impl Into<i64>) -> Self {
+        self.inner.credit_amount = Some(credit_amount.into());
         self
     }
     /// The date when this credit note is in effect.
     /// Same as `created` unless overwritten.
     /// When defined, this value replaces the system-generated 'Date of issue' printed on the credit note PDF.
-    pub fn effective_at(mut self, effective_at: stripe_types::Timestamp) -> Self {
-        self.inner.effective_at = Some(effective_at);
+    pub fn effective_at(mut self, effective_at: impl Into<stripe_types::Timestamp>) -> Self {
+        self.inner.effective_at = Some(effective_at.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Line items that make up the credit note.
-    pub fn lines(mut self, lines: &'a [PreviewCreditNoteLines<'a>]) -> Self {
-        self.inner.lines = Some(lines);
+    pub fn lines(mut self, lines: impl Into<Vec<PreviewCreditNoteLines>>) -> Self {
+        self.inner.lines = Some(lines.into());
         self
     }
     /// The credit note's memo appears on the credit note PDF.
-    pub fn memo(mut self, memo: &'a str) -> Self {
-        self.inner.memo = Some(memo);
+    pub fn memo(mut self, memo: impl Into<String>) -> Self {
+        self.inner.memo = Some(memo.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// The integer amount in cents (or local equivalent) representing the amount that is credited outside of Stripe.
-    pub fn out_of_band_amount(mut self, out_of_band_amount: i64) -> Self {
-        self.inner.out_of_band_amount = Some(out_of_band_amount);
+    pub fn out_of_band_amount(mut self, out_of_band_amount: impl Into<i64>) -> Self {
+        self.inner.out_of_band_amount = Some(out_of_band_amount.into());
         self
     }
     /// Reason for issuing this credit note, one of `duplicate`, `fraudulent`, `order_change`, or `product_unsatisfactory`.
-    pub fn reason(mut self, reason: stripe_shared::CreditNoteReason) -> Self {
-        self.inner.reason = Some(reason);
+    pub fn reason(mut self, reason: impl Into<stripe_shared::CreditNoteReason>) -> Self {
+        self.inner.reason = Some(reason.into());
         self
     }
     /// ID of an existing refund to link this credit note to.
-    pub fn refund(mut self, refund: &'a str) -> Self {
-        self.inner.refund = Some(refund);
+    pub fn refund(mut self, refund: impl Into<String>) -> Self {
+        self.inner.refund = Some(refund.into());
         self
     }
     /// The integer amount in cents (or local equivalent) representing the amount to refund.
     /// If set, a refund will be created for the charge associated with the invoice.
-    pub fn refund_amount(mut self, refund_amount: i64) -> Self {
-        self.inner.refund_amount = Some(refund_amount);
+    pub fn refund_amount(mut self, refund_amount: impl Into<i64>) -> Self {
+        self.inner.refund_amount = Some(refund_amount.into());
         self
     }
     /// When shipping_cost contains the shipping_rate from the invoice, the shipping_cost is included in the credit note.
-    pub fn shipping_cost(mut self, shipping_cost: CreditNoteShippingCost<'a>) -> Self {
-        self.inner.shipping_cost = Some(shipping_cost);
+    pub fn shipping_cost(mut self, shipping_cost: impl Into<CreditNoteShippingCost>) -> Self {
+        self.inner.shipping_cost = Some(shipping_cost.into());
         self
     }
 }
-impl PreviewCreditNote<'_> {
+impl PreviewCreditNote {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -419,15 +422,15 @@ impl PreviewCreditNote<'_> {
     }
 }
 
-impl StripeRequest for PreviewCreditNote<'_> {
+impl StripeRequest for PreviewCreditNote {
     type Output = stripe_shared::CreditNote;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/credit_notes/preview").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct PreviewLinesCreditNoteBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct PreviewLinesCreditNoteBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     amount: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -435,40 +438,40 @@ struct PreviewLinesCreditNoteBuilder<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     effective_at: Option<stripe_types::Timestamp>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
-    invoice: &'a str,
+    expand: Option<Vec<String>>,
+    invoice: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    lines: Option<&'a [PreviewLinesCreditNoteLines<'a>]>,
+    lines: Option<Vec<PreviewLinesCreditNoteLines>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    memo: Option<&'a str>,
+    memo: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     out_of_band_amount: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     reason: Option<stripe_shared::CreditNoteReason>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    refund: Option<&'a str>,
+    refund: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     refund_amount: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    shipping_cost: Option<CreditNoteShippingCost<'a>>,
+    shipping_cost: Option<CreditNoteShippingCost>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> PreviewLinesCreditNoteBuilder<'a> {
-    fn new(invoice: &'a str) -> Self {
+impl PreviewLinesCreditNoteBuilder {
+    fn new(invoice: impl Into<String>) -> Self {
         Self {
             amount: None,
             credit_amount: None,
             effective_at: None,
             ending_before: None,
             expand: None,
-            invoice,
+            invoice: invoice.into(),
             limit: None,
             lines: None,
             memo: None,
@@ -483,27 +486,27 @@ impl<'a> PreviewLinesCreditNoteBuilder<'a> {
     }
 }
 /// Line items that make up the credit note.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct PreviewLinesCreditNoteLines<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct PreviewLinesCreditNoteLines {
     /// The line item amount to credit. Only valid when `type` is `invoice_line_item`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub amount: Option<i64>,
     /// The description of the credit note line item. Only valid when the `type` is `custom_line_item`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<&'a str>,
+    pub description: Option<String>,
     /// The invoice line item to credit. Only valid when the `type` is `invoice_line_item`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub invoice_line_item: Option<&'a str>,
+    pub invoice_line_item: Option<String>,
     /// The line item quantity to credit.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub quantity: Option<u64>,
     /// A list of up to 10 tax amounts for the credit note line item. Cannot be mixed with `tax_rates`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_amounts: Option<&'a [TaxAmountWithTaxRateParam<'a>]>,
+    pub tax_amounts: Option<Vec<TaxAmountWithTaxRateParam>>,
     /// The tax rates which apply to the credit note line item.
     /// Only valid when the `type` is `custom_line_item` and cannot be mixed with `tax_amounts`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_rates: Option<&'a [&'a str]>,
+    pub tax_rates: Option<Vec<String>>,
     /// Type of the credit note line item, one of `invoice_line_item` or `custom_line_item`
     #[serde(rename = "type")]
     pub type_: PreviewLinesCreditNoteLinesType,
@@ -515,10 +518,10 @@ pub struct PreviewLinesCreditNoteLines<'a> {
     /// Same as `unit_amount`, but accepts a decimal value in cents (or local equivalent) with at most 12 decimal places.
     /// Only one of `unit_amount` and `unit_amount_decimal` can be set.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub unit_amount_decimal: Option<&'a str>,
+    pub unit_amount_decimal: Option<String>,
 }
-impl<'a> PreviewLinesCreditNoteLines<'a> {
-    pub fn new(type_: PreviewLinesCreditNoteLinesType) -> Self {
+impl PreviewLinesCreditNoteLines {
+    pub fn new(type_: impl Into<PreviewLinesCreditNoteLinesType>) -> Self {
         Self {
             amount: None,
             description: None,
@@ -526,7 +529,7 @@ impl<'a> PreviewLinesCreditNoteLines<'a> {
             quantity: None,
             tax_amounts: None,
             tax_rates: None,
-            type_,
+            type_: type_.into(),
             unit_amount: None,
             unit_amount_decimal: None,
         }
@@ -591,102 +594,105 @@ impl<'de> serde::Deserialize<'de> for PreviewLinesCreditNoteLinesType {
 /// When retrieving a credit note preview, you’ll get a **lines** property containing the first handful of those items.
 /// This URL you can retrieve the full (paginated) list of line items.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct PreviewLinesCreditNote<'a> {
-    inner: PreviewLinesCreditNoteBuilder<'a>,
+pub struct PreviewLinesCreditNote {
+    inner: PreviewLinesCreditNoteBuilder,
 }
-impl<'a> PreviewLinesCreditNote<'a> {
+impl PreviewLinesCreditNote {
     /// Construct a new `PreviewLinesCreditNote`.
-    pub fn new(invoice: &'a str) -> Self {
-        Self { inner: PreviewLinesCreditNoteBuilder::new(invoice) }
+    pub fn new(invoice: impl Into<String>) -> Self {
+        Self { inner: PreviewLinesCreditNoteBuilder::new(invoice.into()) }
     }
     /// The integer amount in cents (or local equivalent) representing the total amount of the credit note.
-    pub fn amount(mut self, amount: i64) -> Self {
-        self.inner.amount = Some(amount);
+    pub fn amount(mut self, amount: impl Into<i64>) -> Self {
+        self.inner.amount = Some(amount.into());
         self
     }
     /// The integer amount in cents (or local equivalent) representing the amount to credit the customer's balance, which will be automatically applied to their next invoice.
-    pub fn credit_amount(mut self, credit_amount: i64) -> Self {
-        self.inner.credit_amount = Some(credit_amount);
+    pub fn credit_amount(mut self, credit_amount: impl Into<i64>) -> Self {
+        self.inner.credit_amount = Some(credit_amount.into());
         self
     }
     /// The date when this credit note is in effect.
     /// Same as `created` unless overwritten.
     /// When defined, this value replaces the system-generated 'Date of issue' printed on the credit note PDF.
-    pub fn effective_at(mut self, effective_at: stripe_types::Timestamp) -> Self {
-        self.inner.effective_at = Some(effective_at);
+    pub fn effective_at(mut self, effective_at: impl Into<stripe_types::Timestamp>) -> Self {
+        self.inner.effective_at = Some(effective_at.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// Line items that make up the credit note.
-    pub fn lines(mut self, lines: &'a [PreviewLinesCreditNoteLines<'a>]) -> Self {
-        self.inner.lines = Some(lines);
+    pub fn lines(mut self, lines: impl Into<Vec<PreviewLinesCreditNoteLines>>) -> Self {
+        self.inner.lines = Some(lines.into());
         self
     }
     /// The credit note's memo appears on the credit note PDF.
-    pub fn memo(mut self, memo: &'a str) -> Self {
-        self.inner.memo = Some(memo);
+    pub fn memo(mut self, memo: impl Into<String>) -> Self {
+        self.inner.memo = Some(memo.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// The integer amount in cents (or local equivalent) representing the amount that is credited outside of Stripe.
-    pub fn out_of_band_amount(mut self, out_of_band_amount: i64) -> Self {
-        self.inner.out_of_band_amount = Some(out_of_band_amount);
+    pub fn out_of_band_amount(mut self, out_of_band_amount: impl Into<i64>) -> Self {
+        self.inner.out_of_band_amount = Some(out_of_band_amount.into());
         self
     }
     /// Reason for issuing this credit note, one of `duplicate`, `fraudulent`, `order_change`, or `product_unsatisfactory`.
-    pub fn reason(mut self, reason: stripe_shared::CreditNoteReason) -> Self {
-        self.inner.reason = Some(reason);
+    pub fn reason(mut self, reason: impl Into<stripe_shared::CreditNoteReason>) -> Self {
+        self.inner.reason = Some(reason.into());
         self
     }
     /// ID of an existing refund to link this credit note to.
-    pub fn refund(mut self, refund: &'a str) -> Self {
-        self.inner.refund = Some(refund);
+    pub fn refund(mut self, refund: impl Into<String>) -> Self {
+        self.inner.refund = Some(refund.into());
         self
     }
     /// The integer amount in cents (or local equivalent) representing the amount to refund.
     /// If set, a refund will be created for the charge associated with the invoice.
-    pub fn refund_amount(mut self, refund_amount: i64) -> Self {
-        self.inner.refund_amount = Some(refund_amount);
+    pub fn refund_amount(mut self, refund_amount: impl Into<i64>) -> Self {
+        self.inner.refund_amount = Some(refund_amount.into());
         self
     }
     /// When shipping_cost contains the shipping_rate from the invoice, the shipping_cost is included in the credit note.
-    pub fn shipping_cost(mut self, shipping_cost: CreditNoteShippingCost<'a>) -> Self {
-        self.inner.shipping_cost = Some(shipping_cost);
+    pub fn shipping_cost(mut self, shipping_cost: impl Into<CreditNoteShippingCost>) -> Self {
+        self.inner.shipping_cost = Some(shipping_cost.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl PreviewLinesCreditNote<'_> {
+impl PreviewLinesCreditNote {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -707,19 +713,19 @@ impl PreviewLinesCreditNote<'_> {
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::CreditNoteLineItem>>
     {
-        stripe_client_core::ListPaginator::new_list("/credit_notes/preview/lines", self.inner)
+        stripe_client_core::ListPaginator::new_list("/credit_notes/preview/lines", &self.inner)
     }
 }
 
-impl StripeRequest for PreviewLinesCreditNote<'_> {
+impl StripeRequest for PreviewLinesCreditNote {
     type Output = stripe_types::List<stripe_shared::CreditNoteLineItem>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/credit_notes/preview/lines").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateCreditNoteBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateCreditNoteBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     amount: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -727,33 +733,33 @@ struct CreateCreditNoteBuilder<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     effective_at: Option<stripe_types::Timestamp>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
-    invoice: &'a str,
+    expand: Option<Vec<String>>,
+    invoice: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    lines: Option<&'a [CreateCreditNoteLines<'a>]>,
+    lines: Option<Vec<CreateCreditNoteLines>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    memo: Option<&'a str>,
+    memo: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     out_of_band_amount: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     reason: Option<stripe_shared::CreditNoteReason>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    refund: Option<&'a str>,
+    refund: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     refund_amount: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    shipping_cost: Option<CreditNoteShippingCost<'a>>,
+    shipping_cost: Option<CreditNoteShippingCost>,
 }
-impl<'a> CreateCreditNoteBuilder<'a> {
-    fn new(invoice: &'a str) -> Self {
+impl CreateCreditNoteBuilder {
+    fn new(invoice: impl Into<String>) -> Self {
         Self {
             amount: None,
             credit_amount: None,
             effective_at: None,
             expand: None,
-            invoice,
+            invoice: invoice.into(),
             lines: None,
             memo: None,
             metadata: None,
@@ -766,27 +772,27 @@ impl<'a> CreateCreditNoteBuilder<'a> {
     }
 }
 /// Line items that make up the credit note.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateCreditNoteLines<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateCreditNoteLines {
     /// The line item amount to credit. Only valid when `type` is `invoice_line_item`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub amount: Option<i64>,
     /// The description of the credit note line item. Only valid when the `type` is `custom_line_item`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<&'a str>,
+    pub description: Option<String>,
     /// The invoice line item to credit. Only valid when the `type` is `invoice_line_item`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub invoice_line_item: Option<&'a str>,
+    pub invoice_line_item: Option<String>,
     /// The line item quantity to credit.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub quantity: Option<u64>,
     /// A list of up to 10 tax amounts for the credit note line item. Cannot be mixed with `tax_rates`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_amounts: Option<&'a [TaxAmountWithTaxRateParam<'a>]>,
+    pub tax_amounts: Option<Vec<TaxAmountWithTaxRateParam>>,
     /// The tax rates which apply to the credit note line item.
     /// Only valid when the `type` is `custom_line_item` and cannot be mixed with `tax_amounts`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_rates: Option<&'a [&'a str]>,
+    pub tax_rates: Option<Vec<String>>,
     /// Type of the credit note line item, one of `invoice_line_item` or `custom_line_item`
     #[serde(rename = "type")]
     pub type_: CreateCreditNoteLinesType,
@@ -798,10 +804,10 @@ pub struct CreateCreditNoteLines<'a> {
     /// Same as `unit_amount`, but accepts a decimal value in cents (or local equivalent) with at most 12 decimal places.
     /// Only one of `unit_amount` and `unit_amount_decimal` can be set.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub unit_amount_decimal: Option<&'a str>,
+    pub unit_amount_decimal: Option<String>,
 }
-impl<'a> CreateCreditNoteLines<'a> {
-    pub fn new(type_: CreateCreditNoteLinesType) -> Self {
+impl CreateCreditNoteLines {
+    pub fn new(type_: impl Into<CreateCreditNoteLinesType>) -> Self {
         Self {
             amount: None,
             description: None,
@@ -809,7 +815,7 @@ impl<'a> CreateCreditNoteLines<'a> {
             quantity: None,
             tax_amounts: None,
             tax_rates: None,
-            type_,
+            type_: type_.into(),
             unit_amount: None,
             unit_amount_decimal: None,
         }
@@ -889,82 +895,85 @@ impl<'de> serde::Deserialize<'de> for CreateCreditNoteLinesType {
 /// Each credit note will increment the invoice’s `pre_payment_credit_notes_amount`.
 /// or `post_payment_credit_notes_amount` depending on its `status` at the time of credit note creation.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateCreditNote<'a> {
-    inner: CreateCreditNoteBuilder<'a>,
+pub struct CreateCreditNote {
+    inner: CreateCreditNoteBuilder,
 }
-impl<'a> CreateCreditNote<'a> {
+impl CreateCreditNote {
     /// Construct a new `CreateCreditNote`.
-    pub fn new(invoice: &'a str) -> Self {
-        Self { inner: CreateCreditNoteBuilder::new(invoice) }
+    pub fn new(invoice: impl Into<String>) -> Self {
+        Self { inner: CreateCreditNoteBuilder::new(invoice.into()) }
     }
     /// The integer amount in cents (or local equivalent) representing the total amount of the credit note.
-    pub fn amount(mut self, amount: i64) -> Self {
-        self.inner.amount = Some(amount);
+    pub fn amount(mut self, amount: impl Into<i64>) -> Self {
+        self.inner.amount = Some(amount.into());
         self
     }
     /// The integer amount in cents (or local equivalent) representing the amount to credit the customer's balance, which will be automatically applied to their next invoice.
-    pub fn credit_amount(mut self, credit_amount: i64) -> Self {
-        self.inner.credit_amount = Some(credit_amount);
+    pub fn credit_amount(mut self, credit_amount: impl Into<i64>) -> Self {
+        self.inner.credit_amount = Some(credit_amount.into());
         self
     }
     /// The date when this credit note is in effect.
     /// Same as `created` unless overwritten.
     /// When defined, this value replaces the system-generated 'Date of issue' printed on the credit note PDF.
-    pub fn effective_at(mut self, effective_at: stripe_types::Timestamp) -> Self {
-        self.inner.effective_at = Some(effective_at);
+    pub fn effective_at(mut self, effective_at: impl Into<stripe_types::Timestamp>) -> Self {
+        self.inner.effective_at = Some(effective_at.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Line items that make up the credit note.
-    pub fn lines(mut self, lines: &'a [CreateCreditNoteLines<'a>]) -> Self {
-        self.inner.lines = Some(lines);
+    pub fn lines(mut self, lines: impl Into<Vec<CreateCreditNoteLines>>) -> Self {
+        self.inner.lines = Some(lines.into());
         self
     }
     /// The credit note's memo appears on the credit note PDF.
-    pub fn memo(mut self, memo: &'a str) -> Self {
-        self.inner.memo = Some(memo);
+    pub fn memo(mut self, memo: impl Into<String>) -> Self {
+        self.inner.memo = Some(memo.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// The integer amount in cents (or local equivalent) representing the amount that is credited outside of Stripe.
-    pub fn out_of_band_amount(mut self, out_of_band_amount: i64) -> Self {
-        self.inner.out_of_band_amount = Some(out_of_band_amount);
+    pub fn out_of_band_amount(mut self, out_of_band_amount: impl Into<i64>) -> Self {
+        self.inner.out_of_band_amount = Some(out_of_band_amount.into());
         self
     }
     /// Reason for issuing this credit note, one of `duplicate`, `fraudulent`, `order_change`, or `product_unsatisfactory`.
-    pub fn reason(mut self, reason: stripe_shared::CreditNoteReason) -> Self {
-        self.inner.reason = Some(reason);
+    pub fn reason(mut self, reason: impl Into<stripe_shared::CreditNoteReason>) -> Self {
+        self.inner.reason = Some(reason.into());
         self
     }
     /// ID of an existing refund to link this credit note to.
-    pub fn refund(mut self, refund: &'a str) -> Self {
-        self.inner.refund = Some(refund);
+    pub fn refund(mut self, refund: impl Into<String>) -> Self {
+        self.inner.refund = Some(refund.into());
         self
     }
     /// The integer amount in cents (or local equivalent) representing the amount to refund.
     /// If set, a refund will be created for the charge associated with the invoice.
-    pub fn refund_amount(mut self, refund_amount: i64) -> Self {
-        self.inner.refund_amount = Some(refund_amount);
+    pub fn refund_amount(mut self, refund_amount: impl Into<i64>) -> Self {
+        self.inner.refund_amount = Some(refund_amount.into());
         self
     }
     /// When shipping_cost contains the shipping_rate from the invoice, the shipping_cost is included in the credit note.
-    pub fn shipping_cost(mut self, shipping_cost: CreditNoteShippingCost<'a>) -> Self {
-        self.inner.shipping_cost = Some(shipping_cost);
+    pub fn shipping_cost(mut self, shipping_cost: impl Into<CreditNoteShippingCost>) -> Self {
+        self.inner.shipping_cost = Some(shipping_cost.into());
         self
     }
 }
-impl CreateCreditNote<'_> {
+impl CreateCreditNote {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -982,58 +991,61 @@ impl CreateCreditNote<'_> {
     }
 }
 
-impl StripeRequest for CreateCreditNote<'_> {
+impl StripeRequest for CreateCreditNote {
     type Output = stripe_shared::CreditNote;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Post, "/credit_notes").form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdateCreditNoteBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdateCreditNoteBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    memo: Option<&'a str>,
+    memo: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
 }
-impl<'a> UpdateCreditNoteBuilder<'a> {
+impl UpdateCreditNoteBuilder {
     fn new() -> Self {
         Self { expand: None, memo: None, metadata: None }
     }
 }
 /// Updates an existing credit note.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateCreditNote<'a> {
-    inner: UpdateCreditNoteBuilder<'a>,
-    id: &'a stripe_shared::CreditNoteId,
+pub struct UpdateCreditNote {
+    inner: UpdateCreditNoteBuilder,
+    id: stripe_shared::CreditNoteId,
 }
-impl<'a> UpdateCreditNote<'a> {
+impl UpdateCreditNote {
     /// Construct a new `UpdateCreditNote`.
-    pub fn new(id: &'a stripe_shared::CreditNoteId) -> Self {
-        Self { id, inner: UpdateCreditNoteBuilder::new() }
+    pub fn new(id: impl Into<stripe_shared::CreditNoteId>) -> Self {
+        Self { id: id.into(), inner: UpdateCreditNoteBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Credit note memo.
-    pub fn memo(mut self, memo: &'a str) -> Self {
-        self.inner.memo = Some(memo);
+    pub fn memo(mut self, memo: impl Into<String>) -> Self {
+        self.inner.memo = Some(memo.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
 }
-impl UpdateCreditNote<'_> {
+impl UpdateCreditNote {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -1051,20 +1063,20 @@ impl UpdateCreditNote<'_> {
     }
 }
 
-impl StripeRequest for UpdateCreditNote<'_> {
+impl StripeRequest for UpdateCreditNote {
     type Output = stripe_shared::CreditNote;
 
     fn build(&self) -> RequestBuilder {
-        let id = self.id;
+        let id = &self.id;
         RequestBuilder::new(StripeMethod::Post, format!("/credit_notes/{id}")).form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct VoidCreditNoteCreditNoteBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct VoidCreditNoteCreditNoteBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> VoidCreditNoteCreditNoteBuilder<'a> {
+impl VoidCreditNoteCreditNoteBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
@@ -1072,22 +1084,22 @@ impl<'a> VoidCreditNoteCreditNoteBuilder<'a> {
 /// Marks a credit note as void.
 /// Learn more about [voiding credit notes](https://stripe.com/docs/billing/invoices/credit-notes#voiding).
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct VoidCreditNoteCreditNote<'a> {
-    inner: VoidCreditNoteCreditNoteBuilder<'a>,
-    id: &'a stripe_shared::CreditNoteId,
+pub struct VoidCreditNoteCreditNote {
+    inner: VoidCreditNoteCreditNoteBuilder,
+    id: stripe_shared::CreditNoteId,
 }
-impl<'a> VoidCreditNoteCreditNote<'a> {
+impl VoidCreditNoteCreditNote {
     /// Construct a new `VoidCreditNoteCreditNote`.
-    pub fn new(id: &'a stripe_shared::CreditNoteId) -> Self {
-        Self { id, inner: VoidCreditNoteCreditNoteBuilder::new() }
+    pub fn new(id: impl Into<stripe_shared::CreditNoteId>) -> Self {
+        Self { id: id.into(), inner: VoidCreditNoteCreditNoteBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl VoidCreditNoteCreditNote<'_> {
+impl VoidCreditNoteCreditNote {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -1105,43 +1117,51 @@ impl VoidCreditNoteCreditNote<'_> {
     }
 }
 
-impl StripeRequest for VoidCreditNoteCreditNote<'_> {
+impl StripeRequest for VoidCreditNoteCreditNote {
     type Output = stripe_shared::CreditNote;
 
     fn build(&self) -> RequestBuilder {
-        let id = self.id;
+        let id = &self.id;
         RequestBuilder::new(StripeMethod::Post, format!("/credit_notes/{id}/void"))
             .form(&self.inner)
     }
 }
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct TaxAmountWithTaxRateParam<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct TaxAmountWithTaxRateParam {
     /// The amount, in cents (or local equivalent), of the tax.
     pub amount: i64,
     /// The id of the tax rate for this tax amount.
     /// The tax rate must have been automatically created by Stripe.
-    pub tax_rate: &'a str,
+    pub tax_rate: String,
     /// The amount on which tax is calculated, in cents (or local equivalent).
     pub taxable_amount: i64,
 }
-impl<'a> TaxAmountWithTaxRateParam<'a> {
-    pub fn new(amount: i64, tax_rate: &'a str, taxable_amount: i64) -> Self {
-        Self { amount, tax_rate, taxable_amount }
+impl TaxAmountWithTaxRateParam {
+    pub fn new(
+        amount: impl Into<i64>,
+        tax_rate: impl Into<String>,
+        taxable_amount: impl Into<i64>,
+    ) -> Self {
+        Self {
+            amount: amount.into(),
+            tax_rate: tax_rate.into(),
+            taxable_amount: taxable_amount.into(),
+        }
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreditNoteShippingCost<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreditNoteShippingCost {
     /// The ID of the shipping rate to use for this order.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub shipping_rate: Option<&'a str>,
+    pub shipping_rate: Option<String>,
 }
-impl<'a> CreditNoteShippingCost<'a> {
+impl CreditNoteShippingCost {
     pub fn new() -> Self {
         Self { shipping_rate: None }
     }
 }
-impl<'a> Default for CreditNoteShippingCost<'a> {
+impl Default for CreditNoteShippingCost {
     fn default() -> Self {
         Self::new()
     }

--- a/generated/async-stripe-billing/src/credit_note_line_item/requests.rs
+++ b/generated/async-stripe-billing/src/credit_note_line_item/requests.rs
@@ -2,18 +2,18 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListCreditNoteCreditNoteLineItemBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListCreditNoteCreditNoteLineItemBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListCreditNoteCreditNoteLineItemBuilder<'a> {
+impl ListCreditNoteCreditNoteLineItemBuilder {
     fn new() -> Self {
         Self { ending_before: None, expand: None, limit: None, starting_after: None }
     }
@@ -21,42 +21,45 @@ impl<'a> ListCreditNoteCreditNoteLineItemBuilder<'a> {
 /// When retrieving a credit note, you’ll get a **lines** property containing the the first handful of those items.
 /// There is also a URL where you can retrieve the full (paginated) list of line items.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListCreditNoteCreditNoteLineItem<'a> {
-    inner: ListCreditNoteCreditNoteLineItemBuilder<'a>,
-    credit_note: &'a stripe_shared::CreditNoteId,
+pub struct ListCreditNoteCreditNoteLineItem {
+    inner: ListCreditNoteCreditNoteLineItemBuilder,
+    credit_note: stripe_shared::CreditNoteId,
 }
-impl<'a> ListCreditNoteCreditNoteLineItem<'a> {
+impl ListCreditNoteCreditNoteLineItem {
     /// Construct a new `ListCreditNoteCreditNoteLineItem`.
-    pub fn new(credit_note: &'a stripe_shared::CreditNoteId) -> Self {
-        Self { credit_note, inner: ListCreditNoteCreditNoteLineItemBuilder::new() }
+    pub fn new(credit_note: impl Into<stripe_shared::CreditNoteId>) -> Self {
+        Self {
+            credit_note: credit_note.into(),
+            inner: ListCreditNoteCreditNoteLineItemBuilder::new(),
+        }
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl ListCreditNoteCreditNoteLineItem<'_> {
+impl ListCreditNoteCreditNoteLineItem {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -77,20 +80,20 @@ impl ListCreditNoteCreditNoteLineItem<'_> {
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::CreditNoteLineItem>>
     {
-        let credit_note = self.credit_note;
+        let credit_note = &self.credit_note;
 
         stripe_client_core::ListPaginator::new_list(
             format!("/credit_notes/{credit_note}/lines"),
-            self.inner,
+            &self.inner,
         )
     }
 }
 
-impl StripeRequest for ListCreditNoteCreditNoteLineItem<'_> {
+impl StripeRequest for ListCreditNoteCreditNoteLineItem {
     type Output = stripe_types::List<stripe_shared::CreditNoteLineItem>;
 
     fn build(&self) -> RequestBuilder {
-        let credit_note = self.credit_note;
+        let credit_note = &self.credit_note;
         RequestBuilder::new(StripeMethod::Get, format!("/credit_notes/{credit_note}/lines"))
             .query(&self.inner)
     }

--- a/generated/async-stripe-billing/src/invoice/requests.rs
+++ b/generated/async-stripe-billing/src/invoice/requests.rs
@@ -6,16 +6,16 @@ use stripe_client_core::{
 /// This cannot be undone.
 /// Attempts to delete invoices that are no longer in a draft state will fail; once an invoice has been finalized or if an invoice is for a subscription, it must be [voided](https://stripe.com/docs/api#void_invoice).
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct DeleteInvoice<'a> {
-    invoice: &'a stripe_shared::InvoiceId,
+pub struct DeleteInvoice {
+    invoice: stripe_shared::InvoiceId,
 }
-impl<'a> DeleteInvoice<'a> {
+impl DeleteInvoice {
     /// Construct a new `DeleteInvoice`.
-    pub fn new(invoice: &'a stripe_shared::InvoiceId) -> Self {
-        Self { invoice }
+    pub fn new(invoice: impl Into<stripe_shared::InvoiceId>) -> Self {
+        Self { invoice: invoice.into() }
     }
 }
-impl DeleteInvoice<'_> {
+impl DeleteInvoice {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -33,38 +33,38 @@ impl DeleteInvoice<'_> {
     }
 }
 
-impl StripeRequest for DeleteInvoice<'_> {
+impl StripeRequest for DeleteInvoice {
     type Output = stripe_shared::DeletedInvoice;
 
     fn build(&self) -> RequestBuilder {
-        let invoice = self.invoice;
+        let invoice = &self.invoice;
         RequestBuilder::new(StripeMethod::Delete, format!("/invoices/{invoice}"))
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListInvoiceBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListInvoiceBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     collection_method: Option<stripe_shared::InvoiceCollectionMethod>,
     #[serde(skip_serializing_if = "Option::is_none")]
     created: Option<stripe_types::RangeQueryTs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    customer: Option<&'a str>,
+    customer: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     due_date: Option<stripe_types::RangeQueryTs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     status: Option<stripe_shared::InvoiceStatus>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    subscription: Option<&'a str>,
+    subscription: Option<String>,
 }
-impl<'a> ListInvoiceBuilder<'a> {
+impl ListInvoiceBuilder {
     fn new() -> Self {
         Self {
             collection_method: None,
@@ -83,10 +83,10 @@ impl<'a> ListInvoiceBuilder<'a> {
 /// You can list all invoices, or list the invoices for a specific customer.
 /// The invoices are returned sorted by creation date, with the most recently created invoices appearing first.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListInvoice<'a> {
-    inner: ListInvoiceBuilder<'a>,
+pub struct ListInvoice {
+    inner: ListInvoiceBuilder,
 }
-impl<'a> ListInvoice<'a> {
+impl ListInvoice {
     /// Construct a new `ListInvoice`.
     pub fn new() -> Self {
         Self { inner: ListInvoiceBuilder::new() }
@@ -94,68 +94,68 @@ impl<'a> ListInvoice<'a> {
     /// The collection method of the invoice to retrieve. Either `charge_automatically` or `send_invoice`.
     pub fn collection_method(
         mut self,
-        collection_method: stripe_shared::InvoiceCollectionMethod,
+        collection_method: impl Into<stripe_shared::InvoiceCollectionMethod>,
     ) -> Self {
-        self.inner.collection_method = Some(collection_method);
+        self.inner.collection_method = Some(collection_method.into());
         self
     }
     /// Only return invoices that were created during the given date interval.
-    pub fn created(mut self, created: stripe_types::RangeQueryTs) -> Self {
-        self.inner.created = Some(created);
+    pub fn created(mut self, created: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.created = Some(created.into());
         self
     }
     /// Only return invoices for the customer specified by this customer ID.
-    pub fn customer(mut self, customer: &'a str) -> Self {
-        self.inner.customer = Some(customer);
+    pub fn customer(mut self, customer: impl Into<String>) -> Self {
+        self.inner.customer = Some(customer.into());
         self
     }
-    pub fn due_date(mut self, due_date: stripe_types::RangeQueryTs) -> Self {
-        self.inner.due_date = Some(due_date);
+    pub fn due_date(mut self, due_date: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.due_date = Some(due_date.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
     /// The status of the invoice, one of `draft`, `open`, `paid`, `uncollectible`, or `void`.
     /// [Learn more](https://stripe.com/docs/billing/invoices/workflow#workflow-overview).
-    pub fn status(mut self, status: stripe_shared::InvoiceStatus) -> Self {
-        self.inner.status = Some(status);
+    pub fn status(mut self, status: impl Into<stripe_shared::InvoiceStatus>) -> Self {
+        self.inner.status = Some(status.into());
         self
     }
     /// Only return invoices for the subscription specified by this subscription ID.
-    pub fn subscription(mut self, subscription: &'a str) -> Self {
-        self.inner.subscription = Some(subscription);
+    pub fn subscription(mut self, subscription: impl Into<String>) -> Self {
+        self.inner.subscription = Some(subscription.into());
         self
     }
 }
-impl<'a> Default for ListInvoice<'a> {
+impl Default for ListInvoice {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListInvoice<'_> {
+impl ListInvoice {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -175,45 +175,45 @@ impl ListInvoice<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::Invoice>> {
-        stripe_client_core::ListPaginator::new_list("/invoices", self.inner)
+        stripe_client_core::ListPaginator::new_list("/invoices", &self.inner)
     }
 }
 
-impl StripeRequest for ListInvoice<'_> {
+impl StripeRequest for ListInvoice {
     type Output = stripe_types::List<stripe_shared::Invoice>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/invoices").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveInvoiceBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveInvoiceBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveInvoiceBuilder<'a> {
+impl RetrieveInvoiceBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves the invoice with the given ID.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveInvoice<'a> {
-    inner: RetrieveInvoiceBuilder<'a>,
-    invoice: &'a stripe_shared::InvoiceId,
+pub struct RetrieveInvoice {
+    inner: RetrieveInvoiceBuilder,
+    invoice: stripe_shared::InvoiceId,
 }
-impl<'a> RetrieveInvoice<'a> {
+impl RetrieveInvoice {
     /// Construct a new `RetrieveInvoice`.
-    pub fn new(invoice: &'a stripe_shared::InvoiceId) -> Self {
-        Self { invoice, inner: RetrieveInvoiceBuilder::new() }
+    pub fn new(invoice: impl Into<stripe_shared::InvoiceId>) -> Self {
+        Self { invoice: invoice.into(), inner: RetrieveInvoiceBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveInvoice<'_> {
+impl RetrieveInvoice {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -231,27 +231,27 @@ impl RetrieveInvoice<'_> {
     }
 }
 
-impl StripeRequest for RetrieveInvoice<'_> {
+impl StripeRequest for RetrieveInvoice {
     type Output = stripe_shared::Invoice;
 
     fn build(&self) -> RequestBuilder {
-        let invoice = self.invoice;
+        let invoice = &self.invoice;
         RequestBuilder::new(StripeMethod::Get, format!("/invoices/{invoice}")).query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct SearchInvoiceBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct SearchInvoiceBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    page: Option<&'a str>,
-    query: &'a str,
+    page: Option<String>,
+    query: String,
 }
-impl<'a> SearchInvoiceBuilder<'a> {
-    fn new(query: &'a str) -> Self {
-        Self { expand: None, limit: None, page: None, query }
+impl SearchInvoiceBuilder {
+    fn new(query: impl Into<String>) -> Self {
+        Self { expand: None, limit: None, page: None, query: query.into() }
     }
 }
 /// Search for invoices you’ve previously created using Stripe’s [Search Query Language](https://stripe.com/docs/search#search-query-language).
@@ -261,34 +261,34 @@ impl<'a> SearchInvoiceBuilder<'a> {
 /// Occasionally, propagation of new or updated data can be up.
 /// to an hour behind during outages. Search functionality is not available to merchants in India.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct SearchInvoice<'a> {
-    inner: SearchInvoiceBuilder<'a>,
+pub struct SearchInvoice {
+    inner: SearchInvoiceBuilder,
 }
-impl<'a> SearchInvoice<'a> {
+impl SearchInvoice {
     /// Construct a new `SearchInvoice`.
-    pub fn new(query: &'a str) -> Self {
-        Self { inner: SearchInvoiceBuilder::new(query) }
+    pub fn new(query: impl Into<String>) -> Self {
+        Self { inner: SearchInvoiceBuilder::new(query.into()) }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for pagination across multiple pages of results.
     /// Don't include this parameter on the first call.
     /// Use the next_page value returned in a previous response to request subsequent results.
-    pub fn page(mut self, page: &'a str) -> Self {
-        self.inner.page = Some(page);
+    pub fn page(mut self, page: impl Into<String>) -> Self {
+        self.inner.page = Some(page.into());
         self
     }
 }
-impl SearchInvoice<'_> {
+impl SearchInvoice {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -308,45 +308,45 @@ impl SearchInvoice<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::SearchList<stripe_shared::Invoice>> {
-        stripe_client_core::ListPaginator::new_search_list("/invoices/search", self.inner)
+        stripe_client_core::ListPaginator::new_search_list("/invoices/search", &self.inner)
     }
 }
 
-impl StripeRequest for SearchInvoice<'_> {
+impl StripeRequest for SearchInvoice {
     type Output = stripe_types::SearchList<stripe_shared::Invoice>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/invoices/search").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpcomingInvoiceBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpcomingInvoiceBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    automatic_tax: Option<UpcomingInvoiceAutomaticTax<'a>>,
+    automatic_tax: Option<UpcomingInvoiceAutomaticTax>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    coupon: Option<&'a str>,
+    coupon: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     currency: Option<stripe_types::Currency>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    customer: Option<&'a str>,
+    customer: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    customer_details: Option<UpcomingInvoiceCustomerDetails<'a>>,
+    customer_details: Option<UpcomingInvoiceCustomerDetails>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    discounts: Option<&'a [DiscountsDataParam<'a>]>,
+    discounts: Option<Vec<DiscountsDataParam>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    invoice_items: Option<&'a [UpcomingInvoiceInvoiceItems<'a>]>,
+    invoice_items: Option<Vec<UpcomingInvoiceInvoiceItems>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    issuer: Option<UpcomingInvoiceIssuer<'a>>,
+    issuer: Option<UpcomingInvoiceIssuer>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    on_behalf_of: Option<&'a str>,
+    on_behalf_of: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    schedule: Option<&'a str>,
+    schedule: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    schedule_details: Option<UpcomingInvoiceScheduleDetails<'a>>,
+    schedule_details: Option<UpcomingInvoiceScheduleDetails>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    subscription: Option<&'a str>,
+    subscription: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     subscription_billing_cycle_anchor: Option<UpcomingInvoiceSubscriptionBillingCycleAnchor>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -356,11 +356,11 @@ struct UpcomingInvoiceBuilder<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     subscription_cancel_now: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    subscription_default_tax_rates: Option<&'a [&'a str]>,
+    subscription_default_tax_rates: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    subscription_details: Option<UpcomingInvoiceSubscriptionDetails<'a>>,
+    subscription_details: Option<UpcomingInvoiceSubscriptionDetails>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    subscription_items: Option<&'a [UpcomingInvoiceSubscriptionItems<'a>]>,
+    subscription_items: Option<Vec<UpcomingInvoiceSubscriptionItems>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     subscription_proration_behavior: Option<UpcomingInvoiceSubscriptionProrationBehavior>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -374,7 +374,7 @@ struct UpcomingInvoiceBuilder<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     subscription_trial_from_plan: Option<bool>,
 }
-impl<'a> UpcomingInvoiceBuilder<'a> {
+impl UpcomingInvoiceBuilder {
     fn new() -> Self {
         Self {
             automatic_tax: None,
@@ -407,8 +407,8 @@ impl<'a> UpcomingInvoiceBuilder<'a> {
     }
 }
 /// Settings for automatic tax lookup for this invoice preview.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpcomingInvoiceAutomaticTax<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpcomingInvoiceAutomaticTax {
     /// Whether Stripe automatically computes tax on this invoice.
     /// Note that incompatible invoice items (invoice items with manually specified [tax rates](https://stripe.com/docs/api/tax_rates), negative amounts, or `tax_behavior=unspecified`) cannot be added to automatic tax invoices.
     pub enabled: bool,
@@ -416,28 +416,28 @@ pub struct UpcomingInvoiceAutomaticTax<'a> {
     /// If set, the business address and tax registrations required to perform the tax calculation are loaded from this account.
     /// The tax transaction is returned in the report of the connected account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub liability: Option<UpcomingInvoiceAutomaticTaxLiability<'a>>,
+    pub liability: Option<UpcomingInvoiceAutomaticTaxLiability>,
 }
-impl<'a> UpcomingInvoiceAutomaticTax<'a> {
-    pub fn new(enabled: bool) -> Self {
-        Self { enabled, liability: None }
+impl UpcomingInvoiceAutomaticTax {
+    pub fn new(enabled: impl Into<bool>) -> Self {
+        Self { enabled: enabled.into(), liability: None }
     }
 }
 /// The account that's liable for tax.
 /// If set, the business address and tax registrations required to perform the tax calculation are loaded from this account.
 /// The tax transaction is returned in the report of the connected account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpcomingInvoiceAutomaticTaxLiability<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpcomingInvoiceAutomaticTaxLiability {
     /// The connected account being referenced when `type` is `account`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account: Option<&'a str>,
+    pub account: Option<String>,
     /// Type of the account referenced in the request.
     #[serde(rename = "type")]
     pub type_: UpcomingInvoiceAutomaticTaxLiabilityType,
 }
-impl<'a> UpcomingInvoiceAutomaticTaxLiability<'a> {
-    pub fn new(type_: UpcomingInvoiceAutomaticTaxLiabilityType) -> Self {
-        Self { account: None, type_ }
+impl UpcomingInvoiceAutomaticTaxLiability {
+    pub fn new(type_: impl Into<UpcomingInvoiceAutomaticTaxLiabilityType>) -> Self {
+        Self { account: None, type_: type_.into() }
     }
 }
 /// Type of the account referenced in the request.
@@ -498,30 +498,30 @@ impl<'de> serde::Deserialize<'de> for UpcomingInvoiceAutomaticTaxLiabilityType {
 }
 /// Details about the customer you want to invoice or overrides for an existing customer.
 /// If `automatic_tax` is enabled then one of `customer`, `customer_details`, `subscription`, or `schedule` must be set.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpcomingInvoiceCustomerDetails<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpcomingInvoiceCustomerDetails {
     /// The customer's address.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub address: Option<OptionalFieldsAddress<'a>>,
+    pub address: Option<OptionalFieldsAddress>,
     /// The customer's shipping information. Appears on invoices emailed to this customer.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub shipping: Option<CustomerShipping<'a>>,
+    pub shipping: Option<CustomerShipping>,
     /// Tax details about the customer.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax: Option<TaxParam<'a>>,
+    pub tax: Option<TaxParam>,
     /// The customer's tax exemption. One of `none`, `exempt`, or `reverse`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tax_exempt: Option<UpcomingInvoiceCustomerDetailsTaxExempt>,
     /// The customer's tax IDs.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_ids: Option<&'a [UpcomingInvoiceCustomerDetailsTaxIds<'a>]>,
+    pub tax_ids: Option<Vec<UpcomingInvoiceCustomerDetailsTaxIds>>,
 }
-impl<'a> UpcomingInvoiceCustomerDetails<'a> {
+impl UpcomingInvoiceCustomerDetails {
     pub fn new() -> Self {
         Self { address: None, shipping: None, tax: None, tax_exempt: None, tax_ids: None }
     }
 }
-impl<'a> Default for UpcomingInvoiceCustomerDetails<'a> {
+impl Default for UpcomingInvoiceCustomerDetails {
     fn default() -> Self {
         Self::new()
     }
@@ -586,17 +586,20 @@ impl<'de> serde::Deserialize<'de> for UpcomingInvoiceCustomerDetailsTaxExempt {
     }
 }
 /// The customer's tax IDs.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpcomingInvoiceCustomerDetailsTaxIds<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpcomingInvoiceCustomerDetailsTaxIds {
     /// Type of the tax ID, one of `ad_nrt`, `ae_trn`, `ar_cuit`, `au_abn`, `au_arn`, `bg_uic`, `bh_vat`, `bo_tin`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `cn_tin`, `co_nit`, `cr_tin`, `do_rcn`, `ec_ruc`, `eg_tin`, `es_cif`, `eu_oss_vat`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `hu_tin`, `id_npwp`, `il_vat`, `in_gst`, `is_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `ke_pin`, `kr_brn`, `kz_bin`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `ng_tin`, `no_vat`, `no_voec`, `nz_gst`, `om_vat`, `pe_ruc`, `ph_tin`, `ro_tin`, `rs_pib`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `si_tin`, `sv_nit`, `th_vat`, `tr_tin`, `tw_vat`, `ua_vat`, `us_ein`, `uy_ruc`, `ve_rif`, `vn_tin`, or `za_vat`.
     #[serde(rename = "type")]
     pub type_: UpcomingInvoiceCustomerDetailsTaxIdsType,
     /// Value of the tax ID.
-    pub value: &'a str,
+    pub value: String,
 }
-impl<'a> UpcomingInvoiceCustomerDetailsTaxIds<'a> {
-    pub fn new(type_: UpcomingInvoiceCustomerDetailsTaxIdsType, value: &'a str) -> Self {
-        Self { type_, value }
+impl UpcomingInvoiceCustomerDetailsTaxIds {
+    pub fn new(
+        type_: impl Into<UpcomingInvoiceCustomerDetailsTaxIdsType>,
+        value: impl Into<String>,
+    ) -> Self {
+        Self { type_: type_.into(), value: value.into() }
     }
 }
 /// Type of the tax ID, one of `ad_nrt`, `ae_trn`, `ar_cuit`, `au_abn`, `au_arn`, `bg_uic`, `bh_vat`, `bo_tin`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `cn_tin`, `co_nit`, `cr_tin`, `do_rcn`, `ec_ruc`, `eg_tin`, `es_cif`, `eu_oss_vat`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `hu_tin`, `id_npwp`, `il_vat`, `in_gst`, `is_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `ke_pin`, `kr_brn`, `kz_bin`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `ng_tin`, `no_vat`, `no_voec`, `nz_gst`, `om_vat`, `pe_ruc`, `ph_tin`, `ro_tin`, `rs_pib`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `si_tin`, `sv_nit`, `th_vat`, `tr_tin`, `tw_vat`, `ua_vat`, `us_ein`, `uy_ruc`, `ve_rif`, `vn_tin`, or `za_vat`.
@@ -865,8 +868,8 @@ impl<'de> serde::Deserialize<'de> for UpcomingInvoiceCustomerDetailsTaxIdsType {
     }
 }
 /// List of invoice items to add or update in the upcoming invoice preview.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpcomingInvoiceInvoiceItems<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpcomingInvoiceInvoiceItems {
     /// The integer amount in cents (or local equivalent) of previewed invoice item.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub amount: Option<i64>,
@@ -878,24 +881,24 @@ pub struct UpcomingInvoiceInvoiceItems<'a> {
     /// An arbitrary string which you can attach to the invoice item.
     /// The description is displayed in the invoice for easy tracking.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<&'a str>,
+    pub description: Option<String>,
     /// Explicitly controls whether discounts apply to this invoice item.
     /// Defaults to true, except for negative invoice items.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub discountable: Option<bool>,
     /// The coupons to redeem into discounts for the invoice item in the preview.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub discounts: Option<&'a [DiscountsDataParam<'a>]>,
+    pub discounts: Option<Vec<DiscountsDataParam>>,
     /// The ID of the invoice item to update in preview.
     /// If not specified, a new invoice item will be added to the preview of the upcoming invoice.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub invoiceitem: Option<&'a str>,
+    pub invoiceitem: Option<String>,
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// The period associated with this invoice item.
     /// When set to different values, the period will be rendered on the invoice.
     /// If you have [Stripe Revenue Recognition](https://stripe.com/docs/revenue-recognition) enabled, the period will be used to recognize and defer revenue.
@@ -904,10 +907,10 @@ pub struct UpcomingInvoiceInvoiceItems<'a> {
     pub period: Option<Period>,
     /// The ID of the price object.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price: Option<&'a str>,
+    pub price: Option<String>,
     /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price_data: Option<UpcomingInvoiceInvoiceItemsPriceData<'a>>,
+    pub price_data: Option<UpcomingInvoiceInvoiceItemsPriceData>,
     /// Non-negative integer. The quantity of units for the invoice item.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub quantity: Option<u64>,
@@ -919,10 +922,10 @@ pub struct UpcomingInvoiceInvoiceItems<'a> {
     pub tax_behavior: Option<UpcomingInvoiceInvoiceItemsTaxBehavior>,
     /// A [tax code](https://stripe.com/docs/tax/tax-categories) ID.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_code: Option<&'a str>,
+    pub tax_code: Option<String>,
     /// The tax rates that apply to the item. When set, any `default_tax_rates` do not apply to this item.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_rates: Option<&'a [&'a str]>,
+    pub tax_rates: Option<Vec<String>>,
     /// The integer unit amount in cents (or local equivalent) of the charge to be applied to the upcoming invoice.
     /// This unit_amount will be multiplied by the quantity to get the full amount.
     /// If you want to apply a credit to the customer's account, pass a negative unit_amount.
@@ -931,9 +934,9 @@ pub struct UpcomingInvoiceInvoiceItems<'a> {
     /// Same as `unit_amount`, but accepts a decimal value in cents (or local equivalent) with at most 12 decimal places.
     /// Only one of `unit_amount` and `unit_amount_decimal` can be set.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub unit_amount_decimal: Option<&'a str>,
+    pub unit_amount_decimal: Option<String>,
 }
-impl<'a> UpcomingInvoiceInvoiceItems<'a> {
+impl UpcomingInvoiceInvoiceItems {
     pub fn new() -> Self {
         Self {
             amount: None,
@@ -955,19 +958,19 @@ impl<'a> UpcomingInvoiceInvoiceItems<'a> {
         }
     }
 }
-impl<'a> Default for UpcomingInvoiceInvoiceItems<'a> {
+impl Default for UpcomingInvoiceInvoiceItems {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpcomingInvoiceInvoiceItemsPriceData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpcomingInvoiceInvoiceItemsPriceData {
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     /// Must be a [supported currency](https://stripe.com/docs/currencies).
     pub currency: stripe_types::Currency,
     /// The ID of the product that this price will belong to.
-    pub product: &'a str,
+    pub product: String,
     /// Only required if a [default tax behavior](https://stripe.com/docs/tax/products-prices-tax-categories-tax-behavior#setting-a-default-tax-behavior-(recommended)) was not provided in the Stripe Tax settings.
     /// Specifies whether the price is considered inclusive of taxes or exclusive of taxes.
     /// One of `inclusive`, `exclusive`, or `unspecified`.
@@ -980,11 +983,17 @@ pub struct UpcomingInvoiceInvoiceItemsPriceData<'a> {
     /// Same as `unit_amount`, but accepts a decimal value in cents (or local equivalent) with at most 12 decimal places.
     /// Only one of `unit_amount` and `unit_amount_decimal` can be set.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub unit_amount_decimal: Option<&'a str>,
+    pub unit_amount_decimal: Option<String>,
 }
-impl<'a> UpcomingInvoiceInvoiceItemsPriceData<'a> {
-    pub fn new(currency: stripe_types::Currency, product: &'a str) -> Self {
-        Self { currency, product, tax_behavior: None, unit_amount: None, unit_amount_decimal: None }
+impl UpcomingInvoiceInvoiceItemsPriceData {
+    pub fn new(currency: impl Into<stripe_types::Currency>, product: impl Into<String>) -> Self {
+        Self {
+            currency: currency.into(),
+            product: product.into(),
+            tax_behavior: None,
+            unit_amount: None,
+            unit_amount_decimal: None,
+        }
     }
 }
 /// Only required if a [default tax behavior](https://stripe.com/docs/tax/products-prices-tax-categories-tax-behavior#setting-a-default-tax-behavior-(recommended)) was not provided in the Stripe Tax settings.
@@ -1115,18 +1124,18 @@ impl<'de> serde::Deserialize<'de> for UpcomingInvoiceInvoiceItemsTaxBehavior {
 }
 /// The connected account that issues the invoice.
 /// The invoice is presented with the branding and support information of the specified account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpcomingInvoiceIssuer<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpcomingInvoiceIssuer {
     /// The connected account being referenced when `type` is `account`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account: Option<&'a str>,
+    pub account: Option<String>,
     /// Type of the account referenced in the request.
     #[serde(rename = "type")]
     pub type_: UpcomingInvoiceIssuerType,
 }
-impl<'a> UpcomingInvoiceIssuer<'a> {
-    pub fn new(type_: UpcomingInvoiceIssuerType) -> Self {
-        Self { account: None, type_ }
+impl UpcomingInvoiceIssuer {
+    pub fn new(type_: impl Into<UpcomingInvoiceIssuerType>) -> Self {
+        Self { account: None, type_: type_.into() }
     }
 }
 /// Type of the account referenced in the request.
@@ -1186,8 +1195,8 @@ impl<'de> serde::Deserialize<'de> for UpcomingInvoiceIssuerType {
 }
 /// The schedule creation or modification params to apply as a preview.
 /// Cannot be used with `subscription` or `subscription_` prefixed fields.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpcomingInvoiceScheduleDetails<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpcomingInvoiceScheduleDetails {
     /// Behavior of the subscription schedule and underlying subscription when it ends.
     /// Possible values are `release` or `cancel` with the default being `release`.
     /// `release` will end the subscription schedule and keep the underlying subscription running.
@@ -1198,17 +1207,17 @@ pub struct UpcomingInvoiceScheduleDetails<'a> {
     /// Each phase can be customized to have different durations, plans, and coupons.
     /// If there are multiple phases, the `end_date` of one phase will always equal the `start_date` of the next phase.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub phases: Option<&'a [UpcomingInvoiceScheduleDetailsPhases<'a>]>,
+    pub phases: Option<Vec<UpcomingInvoiceScheduleDetailsPhases>>,
     /// In cases where the `schedule_details` params update the currently active phase, specifies if and how to prorate at the time of the request.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub proration_behavior: Option<UpcomingInvoiceScheduleDetailsProrationBehavior>,
 }
-impl<'a> UpcomingInvoiceScheduleDetails<'a> {
+impl UpcomingInvoiceScheduleDetails {
     pub fn new() -> Self {
         Self { end_behavior: None, phases: None, proration_behavior: None }
     }
 }
-impl<'a> Default for UpcomingInvoiceScheduleDetails<'a> {
+impl Default for UpcomingInvoiceScheduleDetails {
     fn default() -> Self {
         Self::new()
     }
@@ -1275,12 +1284,12 @@ impl<'de> serde::Deserialize<'de> for UpcomingInvoiceScheduleDetailsEndBehavior 
 /// List representing phases of the subscription schedule.
 /// Each phase can be customized to have different durations, plans, and coupons.
 /// If there are multiple phases, the `end_date` of one phase will always equal the `start_date` of the next phase.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpcomingInvoiceScheduleDetailsPhases<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpcomingInvoiceScheduleDetailsPhases {
     /// A list of prices and quantities that will generate invoice items appended to the next invoice for this phase.
     /// You may pass up to 20 items.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub add_invoice_items: Option<&'a [UpcomingInvoiceScheduleDetailsPhasesAddInvoiceItems<'a>]>,
+    pub add_invoice_items: Option<Vec<UpcomingInvoiceScheduleDetailsPhasesAddInvoiceItems>>,
     /// A non-negative decimal between 0 and 100, with at most two decimal places.
     /// This represents the percentage of the subscription invoice total that will be transferred to the application owner's Stripe account.
     /// The request must be made by a platform account on a connected account in order to set an application fee percentage.
@@ -1289,7 +1298,7 @@ pub struct UpcomingInvoiceScheduleDetailsPhases<'a> {
     pub application_fee_percent: Option<f64>,
     /// Automatic tax settings for this phase.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub automatic_tax: Option<UpcomingInvoiceScheduleDetailsPhasesAutomaticTax<'a>>,
+    pub automatic_tax: Option<UpcomingInvoiceScheduleDetailsPhasesAutomaticTax>,
     /// Can be set to `phase_start` to set the anchor to the start of the phase or `automatic` to automatically change it if needed.
     /// Cannot be set to `phase_start` if this phase specifies a trial.
     /// For more information, see the billing cycle [documentation](https://stripe.com/docs/billing/subscriptions/billing-cycle).
@@ -1309,7 +1318,7 @@ pub struct UpcomingInvoiceScheduleDetailsPhases<'a> {
     /// This field has been deprecated and will be removed in a future API version.
     /// Use `discounts` instead.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub coupon: Option<&'a str>,
+    pub coupon: Option<String>,
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     /// Must be a [supported currency](https://stripe.com/docs/currencies).
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1318,29 +1327,29 @@ pub struct UpcomingInvoiceScheduleDetailsPhases<'a> {
     /// It must belong to the customer associated with the subscription schedule.
     /// If not set, invoices will use the default payment method in the customer's invoice settings.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub default_payment_method: Option<&'a str>,
+    pub default_payment_method: Option<String>,
     /// A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids.
     /// These Tax Rates will set the Subscription's [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates), which means they will be the Invoice's [`default_tax_rates`](https://stripe.com/docs/api/invoices/create#create_invoice-default_tax_rates) for any Invoices issued by the Subscription during this Phase.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub default_tax_rates: Option<&'a [&'a str]>,
+    pub default_tax_rates: Option<Vec<String>>,
     /// Subscription description, meant to be displayable to the customer.
     /// Use this field to optionally store an explanation of the subscription for rendering in Stripe surfaces and certain local payment methods UIs.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<&'a str>,
+    pub description: Option<String>,
     /// The coupons to redeem into discounts for the schedule phase.
     /// If not specified, inherits the discount from the subscription's customer.
     /// Pass an empty string to avoid inheriting any discounts.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub discounts: Option<&'a [DiscountsDataParam<'a>]>,
+    pub discounts: Option<Vec<DiscountsDataParam>>,
     /// The date at which this phase of the subscription schedule ends.
     /// If set, `iterations` must not be set.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub end_date: Option<UpcomingInvoiceScheduleDetailsPhasesEndDate>,
     /// All invoices will be billed using the specified settings.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub invoice_settings: Option<UpcomingInvoiceScheduleDetailsPhasesInvoiceSettings<'a>>,
+    pub invoice_settings: Option<UpcomingInvoiceScheduleDetailsPhasesInvoiceSettings>,
     /// List of configuration items, each with an attached price, to apply during this phase of the subscription schedule.
-    pub items: &'a [UpcomingInvoiceScheduleDetailsPhasesItems<'a>],
+    pub items: Vec<UpcomingInvoiceScheduleDetailsPhasesItems>,
     /// Integer representing the multiplier applied to the price interval.
     /// For example, `iterations=2` applied to a price with `interval=month` and `interval_count=3` results in a phase of duration `2 * 3 months = 6 months`.
     /// If set, `end_date` must not be set.
@@ -1351,10 +1360,10 @@ pub struct UpcomingInvoiceScheduleDetailsPhases<'a> {
     /// Individual keys in the subscription's `metadata` can be unset by posting an empty value to them in the phase's `metadata`.
     /// To unset all keys in the subscription's `metadata`, update the subscription directly or unset every key individually from the phase's `metadata`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// The account on behalf of which to charge, for each of the associated subscription's invoices.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub on_behalf_of: Option<&'a str>,
+    pub on_behalf_of: Option<String>,
     /// Whether the subscription schedule will create [prorations](https://stripe.com/docs/billing/subscriptions/prorations) when transitioning to this phase.
     /// The default value is `create_prorations`.
     /// This setting controls prorations when a phase is started asynchronously and it is persisted as a field on the phase.
@@ -1367,7 +1376,7 @@ pub struct UpcomingInvoiceScheduleDetailsPhases<'a> {
     pub start_date: Option<UpcomingInvoiceScheduleDetailsPhasesStartDate>,
     /// The data with which to automatically create a Transfer for each of the associated subscription's invoices.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub transfer_data: Option<TransferDataSpecs<'a>>,
+    pub transfer_data: Option<TransferDataSpecs>,
     /// If set to true the entire phase is counted as a trial and the customer will not be charged for any fees.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub trial: Option<bool>,
@@ -1376,8 +1385,8 @@ pub struct UpcomingInvoiceScheduleDetailsPhases<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub trial_end: Option<UpcomingInvoiceScheduleDetailsPhasesTrialEnd>,
 }
-impl<'a> UpcomingInvoiceScheduleDetailsPhases<'a> {
-    pub fn new(items: &'a [UpcomingInvoiceScheduleDetailsPhasesItems<'a>]) -> Self {
+impl UpcomingInvoiceScheduleDetailsPhases {
+    pub fn new(items: impl Into<Vec<UpcomingInvoiceScheduleDetailsPhasesItems>>) -> Self {
         Self {
             add_invoice_items: None,
             application_fee_percent: None,
@@ -1393,7 +1402,7 @@ impl<'a> UpcomingInvoiceScheduleDetailsPhases<'a> {
             discounts: None,
             end_date: None,
             invoice_settings: None,
-            items,
+            items: items.into(),
             iterations: None,
             metadata: None,
             on_behalf_of: None,
@@ -1407,42 +1416,42 @@ impl<'a> UpcomingInvoiceScheduleDetailsPhases<'a> {
 }
 /// A list of prices and quantities that will generate invoice items appended to the next invoice for this phase.
 /// You may pass up to 20 items.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpcomingInvoiceScheduleDetailsPhasesAddInvoiceItems<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpcomingInvoiceScheduleDetailsPhasesAddInvoiceItems {
     /// The coupons to redeem into discounts for the item.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub discounts: Option<&'a [DiscountsDataParam<'a>]>,
+    pub discounts: Option<Vec<DiscountsDataParam>>,
     /// The ID of the price object.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price: Option<&'a str>,
+    pub price: Option<String>,
     /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price_data: Option<UpcomingInvoiceScheduleDetailsPhasesAddInvoiceItemsPriceData<'a>>,
+    pub price_data: Option<UpcomingInvoiceScheduleDetailsPhasesAddInvoiceItemsPriceData>,
     /// Quantity for this item. Defaults to 1.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub quantity: Option<u64>,
     /// The tax rates which apply to the item. When set, the `default_tax_rates` do not apply to this item.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_rates: Option<&'a [&'a str]>,
+    pub tax_rates: Option<Vec<String>>,
 }
-impl<'a> UpcomingInvoiceScheduleDetailsPhasesAddInvoiceItems<'a> {
+impl UpcomingInvoiceScheduleDetailsPhasesAddInvoiceItems {
     pub fn new() -> Self {
         Self { discounts: None, price: None, price_data: None, quantity: None, tax_rates: None }
     }
 }
-impl<'a> Default for UpcomingInvoiceScheduleDetailsPhasesAddInvoiceItems<'a> {
+impl Default for UpcomingInvoiceScheduleDetailsPhasesAddInvoiceItems {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpcomingInvoiceScheduleDetailsPhasesAddInvoiceItemsPriceData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpcomingInvoiceScheduleDetailsPhasesAddInvoiceItemsPriceData {
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     /// Must be a [supported currency](https://stripe.com/docs/currencies).
     pub currency: stripe_types::Currency,
     /// The ID of the product that this price will belong to.
-    pub product: &'a str,
+    pub product: String,
     /// Only required if a [default tax behavior](https://stripe.com/docs/tax/products-prices-tax-categories-tax-behavior#setting-a-default-tax-behavior-(recommended)) was not provided in the Stripe Tax settings.
     /// Specifies whether the price is considered inclusive of taxes or exclusive of taxes.
     /// One of `inclusive`, `exclusive`, or `unspecified`.
@@ -1456,11 +1465,17 @@ pub struct UpcomingInvoiceScheduleDetailsPhasesAddInvoiceItemsPriceData<'a> {
     /// Same as `unit_amount`, but accepts a decimal value in cents (or local equivalent) with at most 12 decimal places.
     /// Only one of `unit_amount` and `unit_amount_decimal` can be set.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub unit_amount_decimal: Option<&'a str>,
+    pub unit_amount_decimal: Option<String>,
 }
-impl<'a> UpcomingInvoiceScheduleDetailsPhasesAddInvoiceItemsPriceData<'a> {
-    pub fn new(currency: stripe_types::Currency, product: &'a str) -> Self {
-        Self { currency, product, tax_behavior: None, unit_amount: None, unit_amount_decimal: None }
+impl UpcomingInvoiceScheduleDetailsPhasesAddInvoiceItemsPriceData {
+    pub fn new(currency: impl Into<stripe_types::Currency>, product: impl Into<String>) -> Self {
+        Self {
+            currency: currency.into(),
+            product: product.into(),
+            tax_behavior: None,
+            unit_amount: None,
+            unit_amount_decimal: None,
+        }
     }
 }
 /// Only required if a [default tax behavior](https://stripe.com/docs/tax/products-prices-tax-categories-tax-behavior#setting-a-default-tax-behavior-(recommended)) was not provided in the Stripe Tax settings.
@@ -1526,36 +1541,38 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// Automatic tax settings for this phase.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpcomingInvoiceScheduleDetailsPhasesAutomaticTax<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpcomingInvoiceScheduleDetailsPhasesAutomaticTax {
     /// Enabled automatic tax calculation which will automatically compute tax rates on all invoices generated by the subscription.
     pub enabled: bool,
     /// The account that's liable for tax.
     /// If set, the business address and tax registrations required to perform the tax calculation are loaded from this account.
     /// The tax transaction is returned in the report of the connected account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub liability: Option<UpcomingInvoiceScheduleDetailsPhasesAutomaticTaxLiability<'a>>,
+    pub liability: Option<UpcomingInvoiceScheduleDetailsPhasesAutomaticTaxLiability>,
 }
-impl<'a> UpcomingInvoiceScheduleDetailsPhasesAutomaticTax<'a> {
-    pub fn new(enabled: bool) -> Self {
-        Self { enabled, liability: None }
+impl UpcomingInvoiceScheduleDetailsPhasesAutomaticTax {
+    pub fn new(enabled: impl Into<bool>) -> Self {
+        Self { enabled: enabled.into(), liability: None }
     }
 }
 /// The account that's liable for tax.
 /// If set, the business address and tax registrations required to perform the tax calculation are loaded from this account.
 /// The tax transaction is returned in the report of the connected account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpcomingInvoiceScheduleDetailsPhasesAutomaticTaxLiability<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpcomingInvoiceScheduleDetailsPhasesAutomaticTaxLiability {
     /// The connected account being referenced when `type` is `account`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account: Option<&'a str>,
+    pub account: Option<String>,
     /// Type of the account referenced in the request.
     #[serde(rename = "type")]
     pub type_: UpcomingInvoiceScheduleDetailsPhasesAutomaticTaxLiabilityType,
 }
-impl<'a> UpcomingInvoiceScheduleDetailsPhasesAutomaticTaxLiability<'a> {
-    pub fn new(type_: UpcomingInvoiceScheduleDetailsPhasesAutomaticTaxLiabilityType) -> Self {
-        Self { account: None, type_ }
+impl UpcomingInvoiceScheduleDetailsPhasesAutomaticTaxLiability {
+    pub fn new(
+        type_: impl Into<UpcomingInvoiceScheduleDetailsPhasesAutomaticTaxLiabilityType>,
+    ) -> Self {
+        Self { account: None, type_: type_.into() }
     }
 }
 /// Type of the account referenced in the request.
@@ -1688,12 +1705,12 @@ pub enum UpcomingInvoiceScheduleDetailsPhasesEndDate {
     Timestamp(stripe_types::Timestamp),
 }
 /// All invoices will be billed using the specified settings.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpcomingInvoiceScheduleDetailsPhasesInvoiceSettings<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpcomingInvoiceScheduleDetailsPhasesInvoiceSettings {
     /// The account tax IDs associated with this phase of the subscription schedule.
     /// Will be set on invoices generated by this phase of the subscription schedule.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account_tax_ids: Option<&'a [&'a str]>,
+    pub account_tax_ids: Option<Vec<String>>,
     /// Number of days within which a customer must pay invoices generated by this subscription schedule.
     /// This value will be `null` for subscription schedules where `billing=charge_automatically`.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1701,32 +1718,34 @@ pub struct UpcomingInvoiceScheduleDetailsPhasesInvoiceSettings<'a> {
     /// The connected account that issues the invoice.
     /// The invoice is presented with the branding and support information of the specified account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub issuer: Option<UpcomingInvoiceScheduleDetailsPhasesInvoiceSettingsIssuer<'a>>,
+    pub issuer: Option<UpcomingInvoiceScheduleDetailsPhasesInvoiceSettingsIssuer>,
 }
-impl<'a> UpcomingInvoiceScheduleDetailsPhasesInvoiceSettings<'a> {
+impl UpcomingInvoiceScheduleDetailsPhasesInvoiceSettings {
     pub fn new() -> Self {
         Self { account_tax_ids: None, days_until_due: None, issuer: None }
     }
 }
-impl<'a> Default for UpcomingInvoiceScheduleDetailsPhasesInvoiceSettings<'a> {
+impl Default for UpcomingInvoiceScheduleDetailsPhasesInvoiceSettings {
     fn default() -> Self {
         Self::new()
     }
 }
 /// The connected account that issues the invoice.
 /// The invoice is presented with the branding and support information of the specified account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpcomingInvoiceScheduleDetailsPhasesInvoiceSettingsIssuer<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpcomingInvoiceScheduleDetailsPhasesInvoiceSettingsIssuer {
     /// The connected account being referenced when `type` is `account`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account: Option<&'a str>,
+    pub account: Option<String>,
     /// Type of the account referenced in the request.
     #[serde(rename = "type")]
     pub type_: UpcomingInvoiceScheduleDetailsPhasesInvoiceSettingsIssuerType,
 }
-impl<'a> UpcomingInvoiceScheduleDetailsPhasesInvoiceSettingsIssuer<'a> {
-    pub fn new(type_: UpcomingInvoiceScheduleDetailsPhasesInvoiceSettingsIssuerType) -> Self {
-        Self { account: None, type_ }
+impl UpcomingInvoiceScheduleDetailsPhasesInvoiceSettingsIssuer {
+    pub fn new(
+        type_: impl Into<UpcomingInvoiceScheduleDetailsPhasesInvoiceSettingsIssuerType>,
+    ) -> Self {
+        Self { account: None, type_: type_.into() }
     }
 }
 /// Type of the account referenced in the request.
@@ -1790,30 +1809,30 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// List of configuration items, each with an attached price, to apply during this phase of the subscription schedule.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpcomingInvoiceScheduleDetailsPhasesItems<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpcomingInvoiceScheduleDetailsPhasesItems {
     /// Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period.
     /// When updating, pass an empty string to remove previously-defined thresholds.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub billing_thresholds: Option<ItemBillingThresholdsParam>,
     /// The coupons to redeem into discounts for the subscription item.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub discounts: Option<&'a [DiscountsDataParam<'a>]>,
+    pub discounts: Option<Vec<DiscountsDataParam>>,
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to a configuration item.
     /// Metadata on a configuration item will update the underlying subscription item's `metadata` when the phase is entered, adding new keys and replacing existing keys.
     /// Individual keys in the subscription item's `metadata` can be unset by posting an empty value to them in the configuration item's `metadata`.
     /// To unset all keys in the subscription item's `metadata`, update the subscription item directly or unset every key individually from the configuration item's `metadata`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// The plan ID to subscribe to. You may specify the same ID in `plan` and `price`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub plan: Option<&'a str>,
+    pub plan: Option<String>,
     /// The ID of the price object.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price: Option<&'a str>,
+    pub price: Option<String>,
     /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price_data: Option<UpcomingInvoiceScheduleDetailsPhasesItemsPriceData<'a>>,
+    pub price_data: Option<UpcomingInvoiceScheduleDetailsPhasesItemsPriceData>,
     /// Quantity for the given price.
     /// Can be set only if the price's `usage_type` is `licensed` and not `metered`.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1822,9 +1841,9 @@ pub struct UpcomingInvoiceScheduleDetailsPhasesItems<'a> {
     /// These Tax Rates will override the [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates) on the Subscription.
     /// When updating, pass an empty string to remove previously-defined tax rates.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_rates: Option<&'a [&'a str]>,
+    pub tax_rates: Option<Vec<String>>,
 }
-impl<'a> UpcomingInvoiceScheduleDetailsPhasesItems<'a> {
+impl UpcomingInvoiceScheduleDetailsPhasesItems {
     pub fn new() -> Self {
         Self {
             billing_thresholds: None,
@@ -1838,19 +1857,19 @@ impl<'a> UpcomingInvoiceScheduleDetailsPhasesItems<'a> {
         }
     }
 }
-impl<'a> Default for UpcomingInvoiceScheduleDetailsPhasesItems<'a> {
+impl Default for UpcomingInvoiceScheduleDetailsPhasesItems {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpcomingInvoiceScheduleDetailsPhasesItemsPriceData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpcomingInvoiceScheduleDetailsPhasesItemsPriceData {
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     /// Must be a [supported currency](https://stripe.com/docs/currencies).
     pub currency: stripe_types::Currency,
     /// The ID of the product that this price will belong to.
-    pub product: &'a str,
+    pub product: String,
     /// The recurring components of a price such as `interval` and `interval_count`.
     pub recurring: UpcomingInvoiceScheduleDetailsPhasesItemsPriceDataRecurring,
     /// Only required if a [default tax behavior](https://stripe.com/docs/tax/products-prices-tax-categories-tax-behavior#setting-a-default-tax-behavior-(recommended)) was not provided in the Stripe Tax settings.
@@ -1865,18 +1884,18 @@ pub struct UpcomingInvoiceScheduleDetailsPhasesItemsPriceData<'a> {
     /// Same as `unit_amount`, but accepts a decimal value in cents (or local equivalent) with at most 12 decimal places.
     /// Only one of `unit_amount` and `unit_amount_decimal` can be set.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub unit_amount_decimal: Option<&'a str>,
+    pub unit_amount_decimal: Option<String>,
 }
-impl<'a> UpcomingInvoiceScheduleDetailsPhasesItemsPriceData<'a> {
+impl UpcomingInvoiceScheduleDetailsPhasesItemsPriceData {
     pub fn new(
-        currency: stripe_types::Currency,
-        product: &'a str,
-        recurring: UpcomingInvoiceScheduleDetailsPhasesItemsPriceDataRecurring,
+        currency: impl Into<stripe_types::Currency>,
+        product: impl Into<String>,
+        recurring: impl Into<UpcomingInvoiceScheduleDetailsPhasesItemsPriceDataRecurring>,
     ) -> Self {
         Self {
-            currency,
-            product,
-            recurring,
+            currency: currency.into(),
+            product: product.into(),
+            recurring: recurring.into(),
             tax_behavior: None,
             unit_amount: None,
             unit_amount_decimal: None,
@@ -1896,9 +1915,9 @@ pub struct UpcomingInvoiceScheduleDetailsPhasesItemsPriceDataRecurring {
 }
 impl UpcomingInvoiceScheduleDetailsPhasesItemsPriceDataRecurring {
     pub fn new(
-        interval: UpcomingInvoiceScheduleDetailsPhasesItemsPriceDataRecurringInterval,
+        interval: impl Into<UpcomingInvoiceScheduleDetailsPhasesItemsPriceDataRecurringInterval>,
     ) -> Self {
-        Self { interval, interval_count: None }
+        Self { interval: interval.into(), interval_count: None }
     }
 }
 /// Specifies billing frequency. Either `day`, `week`, `month` or `year`.
@@ -2187,8 +2206,8 @@ pub enum UpcomingInvoiceSubscriptionBillingCycleAnchor {
 }
 /// The subscription creation or modification params to apply as a preview.
 /// Cannot be used with `schedule` or `schedule_details` fields.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpcomingInvoiceSubscriptionDetails<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpcomingInvoiceSubscriptionDetails {
     /// For new subscriptions, a future timestamp to anchor the subscription's [billing cycle](https://stripe.com/docs/subscriptions/billing-cycle).
     /// This is used to determine the date of the first full invoice, and, for plans with `month` or `year` intervals, the day of the month for subsequent invoices.
     /// For existing subscriptions, the value can only be set to `now` or `unchanged`.
@@ -2208,10 +2227,10 @@ pub struct UpcomingInvoiceSubscriptionDetails<'a> {
     /// If provided, the invoice returned will preview updating or creating a subscription with these default tax rates.
     /// The default tax rates will apply to any line item that does not have `tax_rates` set.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub default_tax_rates: Option<&'a [&'a str]>,
+    pub default_tax_rates: Option<Vec<String>>,
     /// A list of up to 20 subscription items, each with an attached price.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub items: Option<&'a [UpcomingInvoiceSubscriptionDetailsItems<'a>]>,
+    pub items: Option<Vec<UpcomingInvoiceSubscriptionDetailsItems>>,
     /// Determines how to handle [prorations](https://stripe.com/docs/billing/subscriptions/prorations) when the billing cycle changes (e.g., when switching plans, resetting `billing_cycle_anchor=now`, or starting a trial), or if an item's `quantity` changes.
     /// The default value is `create_prorations`.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2233,7 +2252,7 @@ pub struct UpcomingInvoiceSubscriptionDetails<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub trial_end: Option<UpcomingInvoiceSubscriptionDetailsTrialEnd>,
 }
-impl<'a> UpcomingInvoiceSubscriptionDetails<'a> {
+impl UpcomingInvoiceSubscriptionDetails {
     pub fn new() -> Self {
         Self {
             billing_cycle_anchor: None,
@@ -2250,7 +2269,7 @@ impl<'a> UpcomingInvoiceSubscriptionDetails<'a> {
         }
     }
 }
-impl<'a> Default for UpcomingInvoiceSubscriptionDetails<'a> {
+impl Default for UpcomingInvoiceSubscriptionDetails {
     fn default() -> Self {
         Self::new()
     }
@@ -2267,8 +2286,8 @@ pub enum UpcomingInvoiceSubscriptionDetailsBillingCycleAnchor {
     Timestamp(stripe_types::Timestamp),
 }
 /// A list of up to 20 subscription items, each with an attached price.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpcomingInvoiceSubscriptionDetailsItems<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpcomingInvoiceSubscriptionDetailsItems {
     /// Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period.
     /// When updating, pass an empty string to remove previously-defined thresholds.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2282,26 +2301,26 @@ pub struct UpcomingInvoiceSubscriptionDetailsItems<'a> {
     pub deleted: Option<bool>,
     /// The coupons to redeem into discounts for the subscription item.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub discounts: Option<&'a [DiscountsDataParam<'a>]>,
+    pub discounts: Option<Vec<DiscountsDataParam>>,
     /// Subscription item to update.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub id: Option<&'a str>,
+    pub id: Option<String>,
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// Plan ID for this item, as a string.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub plan: Option<&'a str>,
+    pub plan: Option<String>,
     /// The ID of the price object.
     /// When changing a subscription item's price, `quantity` is set to 1 unless a `quantity` parameter is provided.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price: Option<&'a str>,
+    pub price: Option<String>,
     /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price_data: Option<UpcomingInvoiceSubscriptionDetailsItemsPriceData<'a>>,
+    pub price_data: Option<UpcomingInvoiceSubscriptionDetailsItemsPriceData>,
     /// Quantity for this item.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub quantity: Option<u64>,
@@ -2309,9 +2328,9 @@ pub struct UpcomingInvoiceSubscriptionDetailsItems<'a> {
     /// These Tax Rates will override the [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates) on the Subscription.
     /// When updating, pass an empty string to remove previously-defined tax rates.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_rates: Option<&'a [&'a str]>,
+    pub tax_rates: Option<Vec<String>>,
 }
-impl<'a> UpcomingInvoiceSubscriptionDetailsItems<'a> {
+impl UpcomingInvoiceSubscriptionDetailsItems {
     pub fn new() -> Self {
         Self {
             billing_thresholds: None,
@@ -2328,19 +2347,19 @@ impl<'a> UpcomingInvoiceSubscriptionDetailsItems<'a> {
         }
     }
 }
-impl<'a> Default for UpcomingInvoiceSubscriptionDetailsItems<'a> {
+impl Default for UpcomingInvoiceSubscriptionDetailsItems {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpcomingInvoiceSubscriptionDetailsItemsPriceData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpcomingInvoiceSubscriptionDetailsItemsPriceData {
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     /// Must be a [supported currency](https://stripe.com/docs/currencies).
     pub currency: stripe_types::Currency,
     /// The ID of the product that this price will belong to.
-    pub product: &'a str,
+    pub product: String,
     /// The recurring components of a price such as `interval` and `interval_count`.
     pub recurring: UpcomingInvoiceSubscriptionDetailsItemsPriceDataRecurring,
     /// Only required if a [default tax behavior](https://stripe.com/docs/tax/products-prices-tax-categories-tax-behavior#setting-a-default-tax-behavior-(recommended)) was not provided in the Stripe Tax settings.
@@ -2355,18 +2374,18 @@ pub struct UpcomingInvoiceSubscriptionDetailsItemsPriceData<'a> {
     /// Same as `unit_amount`, but accepts a decimal value in cents (or local equivalent) with at most 12 decimal places.
     /// Only one of `unit_amount` and `unit_amount_decimal` can be set.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub unit_amount_decimal: Option<&'a str>,
+    pub unit_amount_decimal: Option<String>,
 }
-impl<'a> UpcomingInvoiceSubscriptionDetailsItemsPriceData<'a> {
+impl UpcomingInvoiceSubscriptionDetailsItemsPriceData {
     pub fn new(
-        currency: stripe_types::Currency,
-        product: &'a str,
-        recurring: UpcomingInvoiceSubscriptionDetailsItemsPriceDataRecurring,
+        currency: impl Into<stripe_types::Currency>,
+        product: impl Into<String>,
+        recurring: impl Into<UpcomingInvoiceSubscriptionDetailsItemsPriceDataRecurring>,
     ) -> Self {
         Self {
-            currency,
-            product,
-            recurring,
+            currency: currency.into(),
+            product: product.into(),
+            recurring: recurring.into(),
             tax_behavior: None,
             unit_amount: None,
             unit_amount_decimal: None,
@@ -2386,9 +2405,9 @@ pub struct UpcomingInvoiceSubscriptionDetailsItemsPriceDataRecurring {
 }
 impl UpcomingInvoiceSubscriptionDetailsItemsPriceDataRecurring {
     pub fn new(
-        interval: UpcomingInvoiceSubscriptionDetailsItemsPriceDataRecurringInterval,
+        interval: impl Into<UpcomingInvoiceSubscriptionDetailsItemsPriceDataRecurringInterval>,
     ) -> Self {
-        Self { interval, interval_count: None }
+        Self { interval: interval.into(), interval_count: None }
     }
 }
 /// Specifies billing frequency. Either `day`, `week`, `month` or `year`.
@@ -2644,8 +2663,8 @@ pub enum UpcomingInvoiceSubscriptionDetailsTrialEnd {
 /// A list of up to 20 subscription items, each with an attached price.
 /// This field has been deprecated and will be removed in a future API version.
 /// Use `subscription_details.items` instead.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpcomingInvoiceSubscriptionItems<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpcomingInvoiceSubscriptionItems {
     /// Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period.
     /// When updating, pass an empty string to remove previously-defined thresholds.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2659,26 +2678,26 @@ pub struct UpcomingInvoiceSubscriptionItems<'a> {
     pub deleted: Option<bool>,
     /// The coupons to redeem into discounts for the subscription item.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub discounts: Option<&'a [DiscountsDataParam<'a>]>,
+    pub discounts: Option<Vec<DiscountsDataParam>>,
     /// Subscription item to update.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub id: Option<&'a str>,
+    pub id: Option<String>,
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// Plan ID for this item, as a string.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub plan: Option<&'a str>,
+    pub plan: Option<String>,
     /// The ID of the price object.
     /// When changing a subscription item's price, `quantity` is set to 1 unless a `quantity` parameter is provided.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price: Option<&'a str>,
+    pub price: Option<String>,
     /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price_data: Option<UpcomingInvoiceSubscriptionItemsPriceData<'a>>,
+    pub price_data: Option<UpcomingInvoiceSubscriptionItemsPriceData>,
     /// Quantity for this item.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub quantity: Option<u64>,
@@ -2686,9 +2705,9 @@ pub struct UpcomingInvoiceSubscriptionItems<'a> {
     /// These Tax Rates will override the [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates) on the Subscription.
     /// When updating, pass an empty string to remove previously-defined tax rates.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_rates: Option<&'a [&'a str]>,
+    pub tax_rates: Option<Vec<String>>,
 }
-impl<'a> UpcomingInvoiceSubscriptionItems<'a> {
+impl UpcomingInvoiceSubscriptionItems {
     pub fn new() -> Self {
         Self {
             billing_thresholds: None,
@@ -2705,19 +2724,19 @@ impl<'a> UpcomingInvoiceSubscriptionItems<'a> {
         }
     }
 }
-impl<'a> Default for UpcomingInvoiceSubscriptionItems<'a> {
+impl Default for UpcomingInvoiceSubscriptionItems {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpcomingInvoiceSubscriptionItemsPriceData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpcomingInvoiceSubscriptionItemsPriceData {
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     /// Must be a [supported currency](https://stripe.com/docs/currencies).
     pub currency: stripe_types::Currency,
     /// The ID of the product that this price will belong to.
-    pub product: &'a str,
+    pub product: String,
     /// The recurring components of a price such as `interval` and `interval_count`.
     pub recurring: UpcomingInvoiceSubscriptionItemsPriceDataRecurring,
     /// Only required if a [default tax behavior](https://stripe.com/docs/tax/products-prices-tax-categories-tax-behavior#setting-a-default-tax-behavior-(recommended)) was not provided in the Stripe Tax settings.
@@ -2732,18 +2751,18 @@ pub struct UpcomingInvoiceSubscriptionItemsPriceData<'a> {
     /// Same as `unit_amount`, but accepts a decimal value in cents (or local equivalent) with at most 12 decimal places.
     /// Only one of `unit_amount` and `unit_amount_decimal` can be set.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub unit_amount_decimal: Option<&'a str>,
+    pub unit_amount_decimal: Option<String>,
 }
-impl<'a> UpcomingInvoiceSubscriptionItemsPriceData<'a> {
+impl UpcomingInvoiceSubscriptionItemsPriceData {
     pub fn new(
-        currency: stripe_types::Currency,
-        product: &'a str,
-        recurring: UpcomingInvoiceSubscriptionItemsPriceDataRecurring,
+        currency: impl Into<stripe_types::Currency>,
+        product: impl Into<String>,
+        recurring: impl Into<UpcomingInvoiceSubscriptionItemsPriceDataRecurring>,
     ) -> Self {
         Self {
-            currency,
-            product,
-            recurring,
+            currency: currency.into(),
+            product: product.into(),
+            recurring: recurring.into(),
             tax_behavior: None,
             unit_amount: None,
             unit_amount_decimal: None,
@@ -2762,8 +2781,10 @@ pub struct UpcomingInvoiceSubscriptionItemsPriceDataRecurring {
     pub interval_count: Option<u64>,
 }
 impl UpcomingInvoiceSubscriptionItemsPriceDataRecurring {
-    pub fn new(interval: UpcomingInvoiceSubscriptionItemsPriceDataRecurringInterval) -> Self {
-        Self { interval, interval_count: None }
+    pub fn new(
+        interval: impl Into<UpcomingInvoiceSubscriptionItemsPriceDataRecurringInterval>,
+    ) -> Self {
+        Self { interval: interval.into(), interval_count: None }
     }
 }
 /// Specifies billing frequency. Either `day`, `week`, `month` or `year`.
@@ -3036,97 +3057,100 @@ pub enum UpcomingInvoiceSubscriptionTrialEnd {
 /// To ensure that the actual proration is calculated exactly the same as the previewed proration, you should pass the `subscription_details.proration_date` parameter when doing the actual subscription update.
 /// The recommended way to get only the prorations being previewed is to consider only proration line items where `period[start]` is equal to the `subscription_details.proration_date` value passed in the request.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpcomingInvoice<'a> {
-    inner: UpcomingInvoiceBuilder<'a>,
+pub struct UpcomingInvoice {
+    inner: UpcomingInvoiceBuilder,
 }
-impl<'a> UpcomingInvoice<'a> {
+impl UpcomingInvoice {
     /// Construct a new `UpcomingInvoice`.
     pub fn new() -> Self {
         Self { inner: UpcomingInvoiceBuilder::new() }
     }
     /// Settings for automatic tax lookup for this invoice preview.
-    pub fn automatic_tax(mut self, automatic_tax: UpcomingInvoiceAutomaticTax<'a>) -> Self {
-        self.inner.automatic_tax = Some(automatic_tax);
+    pub fn automatic_tax(mut self, automatic_tax: impl Into<UpcomingInvoiceAutomaticTax>) -> Self {
+        self.inner.automatic_tax = Some(automatic_tax.into());
         self
     }
     /// The ID of the coupon to apply to this phase of the subscription schedule.
     /// This field has been deprecated and will be removed in a future API version.
     /// Use `discounts` instead.
-    pub fn coupon(mut self, coupon: &'a str) -> Self {
-        self.inner.coupon = Some(coupon);
+    pub fn coupon(mut self, coupon: impl Into<String>) -> Self {
+        self.inner.coupon = Some(coupon.into());
         self
     }
     /// The currency to preview this invoice in. Defaults to that of `customer` if not specified.
-    pub fn currency(mut self, currency: stripe_types::Currency) -> Self {
-        self.inner.currency = Some(currency);
+    pub fn currency(mut self, currency: impl Into<stripe_types::Currency>) -> Self {
+        self.inner.currency = Some(currency.into());
         self
     }
     /// The identifier of the customer whose upcoming invoice you'd like to retrieve.
     /// If `automatic_tax` is enabled then one of `customer`, `customer_details`, `subscription`, or `schedule` must be set.
-    pub fn customer(mut self, customer: &'a str) -> Self {
-        self.inner.customer = Some(customer);
+    pub fn customer(mut self, customer: impl Into<String>) -> Self {
+        self.inner.customer = Some(customer.into());
         self
     }
     /// Details about the customer you want to invoice or overrides for an existing customer.
     /// If `automatic_tax` is enabled then one of `customer`, `customer_details`, `subscription`, or `schedule` must be set.
     pub fn customer_details(
         mut self,
-        customer_details: UpcomingInvoiceCustomerDetails<'a>,
+        customer_details: impl Into<UpcomingInvoiceCustomerDetails>,
     ) -> Self {
-        self.inner.customer_details = Some(customer_details);
+        self.inner.customer_details = Some(customer_details.into());
         self
     }
     /// The coupons to redeem into discounts for the invoice preview.
     /// If not specified, inherits the discount from the subscription or customer.
     /// This works for both coupons directly applied to an invoice and coupons applied to a subscription.
     /// Pass an empty string to avoid inheriting any discounts.
-    pub fn discounts(mut self, discounts: &'a [DiscountsDataParam<'a>]) -> Self {
-        self.inner.discounts = Some(discounts);
+    pub fn discounts(mut self, discounts: impl Into<Vec<DiscountsDataParam>>) -> Self {
+        self.inner.discounts = Some(discounts.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// List of invoice items to add or update in the upcoming invoice preview.
-    pub fn invoice_items(mut self, invoice_items: &'a [UpcomingInvoiceInvoiceItems<'a>]) -> Self {
-        self.inner.invoice_items = Some(invoice_items);
+    pub fn invoice_items(
+        mut self,
+        invoice_items: impl Into<Vec<UpcomingInvoiceInvoiceItems>>,
+    ) -> Self {
+        self.inner.invoice_items = Some(invoice_items.into());
         self
     }
     /// The connected account that issues the invoice.
     /// The invoice is presented with the branding and support information of the specified account.
-    pub fn issuer(mut self, issuer: UpcomingInvoiceIssuer<'a>) -> Self {
-        self.inner.issuer = Some(issuer);
+    pub fn issuer(mut self, issuer: impl Into<UpcomingInvoiceIssuer>) -> Self {
+        self.inner.issuer = Some(issuer.into());
         self
     }
     /// The account (if any) for which the funds of the invoice payment are intended.
     /// If set, the invoice will be presented with the branding and support information of the specified account.
     /// See the [Invoices with Connect](https://stripe.com/docs/billing/invoices/connect) documentation for details.
-    pub fn on_behalf_of(mut self, on_behalf_of: &'a str) -> Self {
-        self.inner.on_behalf_of = Some(on_behalf_of);
+    pub fn on_behalf_of(mut self, on_behalf_of: impl Into<String>) -> Self {
+        self.inner.on_behalf_of = Some(on_behalf_of.into());
         self
     }
     /// The identifier of the schedule whose upcoming invoice you'd like to retrieve.
     /// Cannot be used with subscription or subscription fields.
-    pub fn schedule(mut self, schedule: &'a str) -> Self {
-        self.inner.schedule = Some(schedule);
+    pub fn schedule(mut self, schedule: impl Into<String>) -> Self {
+        self.inner.schedule = Some(schedule.into());
         self
     }
     /// The schedule creation or modification params to apply as a preview.
     /// Cannot be used with `subscription` or `subscription_` prefixed fields.
     pub fn schedule_details(
         mut self,
-        schedule_details: UpcomingInvoiceScheduleDetails<'a>,
+        schedule_details: impl Into<UpcomingInvoiceScheduleDetails>,
     ) -> Self {
-        self.inner.schedule_details = Some(schedule_details);
+        self.inner.schedule_details = Some(schedule_details.into());
         self
     }
     /// The identifier of the subscription for which you'd like to retrieve the upcoming invoice.
     /// If not provided, but a `subscription_items` is provided, you will preview creating a subscription with those items.
     /// If neither `subscription` nor `subscription_items` is provided, you will retrieve the next upcoming invoice from among the customer's subscriptions.
-    pub fn subscription(mut self, subscription: &'a str) -> Self {
-        self.inner.subscription = Some(subscription);
+    pub fn subscription(mut self, subscription: impl Into<String>) -> Self {
+        self.inner.subscription = Some(subscription.into());
         self
     }
     /// For new subscriptions, a future timestamp to anchor the subscription's [billing cycle](https://stripe.com/docs/subscriptions/billing-cycle).
@@ -3136,9 +3160,10 @@ impl<'a> UpcomingInvoice<'a> {
     /// Use `subscription_details.billing_cycle_anchor` instead.
     pub fn subscription_billing_cycle_anchor(
         mut self,
-        subscription_billing_cycle_anchor: UpcomingInvoiceSubscriptionBillingCycleAnchor,
+        subscription_billing_cycle_anchor: impl Into<UpcomingInvoiceSubscriptionBillingCycleAnchor>,
     ) -> Self {
-        self.inner.subscription_billing_cycle_anchor = Some(subscription_billing_cycle_anchor);
+        self.inner.subscription_billing_cycle_anchor =
+            Some(subscription_billing_cycle_anchor.into());
         self
     }
     /// A timestamp at which the subscription should cancel.
@@ -3148,9 +3173,9 @@ impl<'a> UpcomingInvoice<'a> {
     /// Use `subscription_details.cancel_at` instead.
     pub fn subscription_cancel_at(
         mut self,
-        subscription_cancel_at: stripe_types::Timestamp,
+        subscription_cancel_at: impl Into<stripe_types::Timestamp>,
     ) -> Self {
-        self.inner.subscription_cancel_at = Some(subscription_cancel_at);
+        self.inner.subscription_cancel_at = Some(subscription_cancel_at.into());
         self
     }
     /// Boolean indicating whether this subscription should cancel at the end of the current period.
@@ -3158,16 +3183,17 @@ impl<'a> UpcomingInvoice<'a> {
     /// Use `subscription_details.cancel_at_period_end` instead.
     pub fn subscription_cancel_at_period_end(
         mut self,
-        subscription_cancel_at_period_end: bool,
+        subscription_cancel_at_period_end: impl Into<bool>,
     ) -> Self {
-        self.inner.subscription_cancel_at_period_end = Some(subscription_cancel_at_period_end);
+        self.inner.subscription_cancel_at_period_end =
+            Some(subscription_cancel_at_period_end.into());
         self
     }
     /// This simulates the subscription being canceled or expired immediately.
     /// This field has been deprecated and will be removed in a future API version.
     /// Use `subscription_details.cancel_now` instead.
-    pub fn subscription_cancel_now(mut self, subscription_cancel_now: bool) -> Self {
-        self.inner.subscription_cancel_now = Some(subscription_cancel_now);
+    pub fn subscription_cancel_now(mut self, subscription_cancel_now: impl Into<bool>) -> Self {
+        self.inner.subscription_cancel_now = Some(subscription_cancel_now.into());
         self
     }
     /// If provided, the invoice returned will preview updating or creating a subscription with these default tax rates.
@@ -3176,18 +3202,18 @@ impl<'a> UpcomingInvoice<'a> {
     /// Use `subscription_details.default_tax_rates` instead.
     pub fn subscription_default_tax_rates(
         mut self,
-        subscription_default_tax_rates: &'a [&'a str],
+        subscription_default_tax_rates: impl Into<Vec<String>>,
     ) -> Self {
-        self.inner.subscription_default_tax_rates = Some(subscription_default_tax_rates);
+        self.inner.subscription_default_tax_rates = Some(subscription_default_tax_rates.into());
         self
     }
     /// The subscription creation or modification params to apply as a preview.
     /// Cannot be used with `schedule` or `schedule_details` fields.
     pub fn subscription_details(
         mut self,
-        subscription_details: UpcomingInvoiceSubscriptionDetails<'a>,
+        subscription_details: impl Into<UpcomingInvoiceSubscriptionDetails>,
     ) -> Self {
-        self.inner.subscription_details = Some(subscription_details);
+        self.inner.subscription_details = Some(subscription_details.into());
         self
     }
     /// A list of up to 20 subscription items, each with an attached price.
@@ -3195,9 +3221,9 @@ impl<'a> UpcomingInvoice<'a> {
     /// Use `subscription_details.items` instead.
     pub fn subscription_items(
         mut self,
-        subscription_items: &'a [UpcomingInvoiceSubscriptionItems<'a>],
+        subscription_items: impl Into<Vec<UpcomingInvoiceSubscriptionItems>>,
     ) -> Self {
-        self.inner.subscription_items = Some(subscription_items);
+        self.inner.subscription_items = Some(subscription_items.into());
         self
     }
     /// Determines how to handle [prorations](https://stripe.com/docs/billing/subscriptions/prorations) when the billing cycle changes (e.g., when switching plans, resetting `billing_cycle_anchor=now`, or starting a trial), or if an item's `quantity` changes.
@@ -3206,9 +3232,9 @@ impl<'a> UpcomingInvoice<'a> {
     /// Use `subscription_details.proration_behavior` instead.
     pub fn subscription_proration_behavior(
         mut self,
-        subscription_proration_behavior: UpcomingInvoiceSubscriptionProrationBehavior,
+        subscription_proration_behavior: impl Into<UpcomingInvoiceSubscriptionProrationBehavior>,
     ) -> Self {
-        self.inner.subscription_proration_behavior = Some(subscription_proration_behavior);
+        self.inner.subscription_proration_behavior = Some(subscription_proration_behavior.into());
         self
     }
     /// If previewing an update to a subscription, and doing proration, `subscription_proration_date` forces the proration to be calculated as though the update was done at the specified time.
@@ -3219,9 +3245,9 @@ impl<'a> UpcomingInvoice<'a> {
     /// Use `subscription_details.proration_date` instead.
     pub fn subscription_proration_date(
         mut self,
-        subscription_proration_date: stripe_types::Timestamp,
+        subscription_proration_date: impl Into<stripe_types::Timestamp>,
     ) -> Self {
-        self.inner.subscription_proration_date = Some(subscription_proration_date);
+        self.inner.subscription_proration_date = Some(subscription_proration_date.into());
         self
     }
     /// For paused subscriptions, setting `subscription_resume_at` to `now` will preview the invoice that will be generated if the subscription is resumed.
@@ -3229,9 +3255,9 @@ impl<'a> UpcomingInvoice<'a> {
     /// Use `subscription_details.resume_at` instead.
     pub fn subscription_resume_at(
         mut self,
-        subscription_resume_at: UpcomingInvoiceSubscriptionResumeAt,
+        subscription_resume_at: impl Into<UpcomingInvoiceSubscriptionResumeAt>,
     ) -> Self {
-        self.inner.subscription_resume_at = Some(subscription_resume_at);
+        self.inner.subscription_resume_at = Some(subscription_resume_at.into());
         self
     }
     /// Date a subscription is intended to start (can be future or past).
@@ -3239,9 +3265,9 @@ impl<'a> UpcomingInvoice<'a> {
     /// Use `subscription_details.start_date` instead.
     pub fn subscription_start_date(
         mut self,
-        subscription_start_date: stripe_types::Timestamp,
+        subscription_start_date: impl Into<stripe_types::Timestamp>,
     ) -> Self {
-        self.inner.subscription_start_date = Some(subscription_start_date);
+        self.inner.subscription_start_date = Some(subscription_start_date.into());
         self
     }
     /// If provided, the invoice returned will preview updating or creating a subscription with that trial end.
@@ -3250,26 +3276,29 @@ impl<'a> UpcomingInvoice<'a> {
     /// Use `subscription_details.trial_end` instead.
     pub fn subscription_trial_end(
         mut self,
-        subscription_trial_end: UpcomingInvoiceSubscriptionTrialEnd,
+        subscription_trial_end: impl Into<UpcomingInvoiceSubscriptionTrialEnd>,
     ) -> Self {
-        self.inner.subscription_trial_end = Some(subscription_trial_end);
+        self.inner.subscription_trial_end = Some(subscription_trial_end.into());
         self
     }
     /// Indicates if a plan's `trial_period_days` should be applied to the subscription.
     /// Setting `subscription_trial_end` per subscription is preferred, and this defaults to `false`.
     /// Setting this flag to `true` together with `subscription_trial_end` is not allowed.
     /// See [Using trial periods on subscriptions](https://stripe.com/docs/billing/subscriptions/trials) to learn more.
-    pub fn subscription_trial_from_plan(mut self, subscription_trial_from_plan: bool) -> Self {
-        self.inner.subscription_trial_from_plan = Some(subscription_trial_from_plan);
+    pub fn subscription_trial_from_plan(
+        mut self,
+        subscription_trial_from_plan: impl Into<bool>,
+    ) -> Self {
+        self.inner.subscription_trial_from_plan = Some(subscription_trial_from_plan.into());
         self
     }
 }
-impl<'a> Default for UpcomingInvoice<'a> {
+impl Default for UpcomingInvoice {
     fn default() -> Self {
         Self::new()
     }
 }
-impl UpcomingInvoice<'_> {
+impl UpcomingInvoice {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -3287,47 +3316,47 @@ impl UpcomingInvoice<'_> {
     }
 }
 
-impl StripeRequest for UpcomingInvoice<'_> {
+impl StripeRequest for UpcomingInvoice {
     type Output = stripe_shared::Invoice;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/invoices/upcoming").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpcomingLinesInvoiceBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpcomingLinesInvoiceBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    automatic_tax: Option<UpcomingLinesInvoiceAutomaticTax<'a>>,
+    automatic_tax: Option<UpcomingLinesInvoiceAutomaticTax>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    coupon: Option<&'a str>,
+    coupon: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     currency: Option<stripe_types::Currency>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    customer: Option<&'a str>,
+    customer: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    customer_details: Option<UpcomingLinesInvoiceCustomerDetails<'a>>,
+    customer_details: Option<UpcomingLinesInvoiceCustomerDetails>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    discounts: Option<&'a [DiscountsDataParam<'a>]>,
+    discounts: Option<Vec<DiscountsDataParam>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    invoice_items: Option<&'a [UpcomingLinesInvoiceInvoiceItems<'a>]>,
+    invoice_items: Option<Vec<UpcomingLinesInvoiceInvoiceItems>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    issuer: Option<UpcomingLinesInvoiceIssuer<'a>>,
+    issuer: Option<UpcomingLinesInvoiceIssuer>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    on_behalf_of: Option<&'a str>,
+    on_behalf_of: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    schedule: Option<&'a str>,
+    schedule: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    schedule_details: Option<UpcomingLinesInvoiceScheduleDetails<'a>>,
+    schedule_details: Option<UpcomingLinesInvoiceScheduleDetails>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    subscription: Option<&'a str>,
+    subscription: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     subscription_billing_cycle_anchor: Option<UpcomingLinesInvoiceSubscriptionBillingCycleAnchor>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -3337,11 +3366,11 @@ struct UpcomingLinesInvoiceBuilder<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     subscription_cancel_now: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    subscription_default_tax_rates: Option<&'a [&'a str]>,
+    subscription_default_tax_rates: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    subscription_details: Option<UpcomingLinesInvoiceSubscriptionDetails<'a>>,
+    subscription_details: Option<UpcomingLinesInvoiceSubscriptionDetails>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    subscription_items: Option<&'a [UpcomingLinesInvoiceSubscriptionItems<'a>]>,
+    subscription_items: Option<Vec<UpcomingLinesInvoiceSubscriptionItems>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     subscription_proration_behavior: Option<UpcomingLinesInvoiceSubscriptionProrationBehavior>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -3355,7 +3384,7 @@ struct UpcomingLinesInvoiceBuilder<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     subscription_trial_from_plan: Option<bool>,
 }
-impl<'a> UpcomingLinesInvoiceBuilder<'a> {
+impl UpcomingLinesInvoiceBuilder {
     fn new() -> Self {
         Self {
             automatic_tax: None,
@@ -3391,8 +3420,8 @@ impl<'a> UpcomingLinesInvoiceBuilder<'a> {
     }
 }
 /// Settings for automatic tax lookup for this invoice preview.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpcomingLinesInvoiceAutomaticTax<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpcomingLinesInvoiceAutomaticTax {
     /// Whether Stripe automatically computes tax on this invoice.
     /// Note that incompatible invoice items (invoice items with manually specified [tax rates](https://stripe.com/docs/api/tax_rates), negative amounts, or `tax_behavior=unspecified`) cannot be added to automatic tax invoices.
     pub enabled: bool,
@@ -3400,28 +3429,28 @@ pub struct UpcomingLinesInvoiceAutomaticTax<'a> {
     /// If set, the business address and tax registrations required to perform the tax calculation are loaded from this account.
     /// The tax transaction is returned in the report of the connected account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub liability: Option<UpcomingLinesInvoiceAutomaticTaxLiability<'a>>,
+    pub liability: Option<UpcomingLinesInvoiceAutomaticTaxLiability>,
 }
-impl<'a> UpcomingLinesInvoiceAutomaticTax<'a> {
-    pub fn new(enabled: bool) -> Self {
-        Self { enabled, liability: None }
+impl UpcomingLinesInvoiceAutomaticTax {
+    pub fn new(enabled: impl Into<bool>) -> Self {
+        Self { enabled: enabled.into(), liability: None }
     }
 }
 /// The account that's liable for tax.
 /// If set, the business address and tax registrations required to perform the tax calculation are loaded from this account.
 /// The tax transaction is returned in the report of the connected account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpcomingLinesInvoiceAutomaticTaxLiability<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpcomingLinesInvoiceAutomaticTaxLiability {
     /// The connected account being referenced when `type` is `account`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account: Option<&'a str>,
+    pub account: Option<String>,
     /// Type of the account referenced in the request.
     #[serde(rename = "type")]
     pub type_: UpcomingLinesInvoiceAutomaticTaxLiabilityType,
 }
-impl<'a> UpcomingLinesInvoiceAutomaticTaxLiability<'a> {
-    pub fn new(type_: UpcomingLinesInvoiceAutomaticTaxLiabilityType) -> Self {
-        Self { account: None, type_ }
+impl UpcomingLinesInvoiceAutomaticTaxLiability {
+    pub fn new(type_: impl Into<UpcomingLinesInvoiceAutomaticTaxLiabilityType>) -> Self {
+        Self { account: None, type_: type_.into() }
     }
 }
 /// Type of the account referenced in the request.
@@ -3484,30 +3513,30 @@ impl<'de> serde::Deserialize<'de> for UpcomingLinesInvoiceAutomaticTaxLiabilityT
 }
 /// Details about the customer you want to invoice or overrides for an existing customer.
 /// If `automatic_tax` is enabled then one of `customer`, `customer_details`, `subscription`, or `schedule` must be set.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpcomingLinesInvoiceCustomerDetails<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpcomingLinesInvoiceCustomerDetails {
     /// The customer's address.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub address: Option<OptionalFieldsAddress<'a>>,
+    pub address: Option<OptionalFieldsAddress>,
     /// The customer's shipping information. Appears on invoices emailed to this customer.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub shipping: Option<CustomerShipping<'a>>,
+    pub shipping: Option<CustomerShipping>,
     /// Tax details about the customer.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax: Option<TaxParam<'a>>,
+    pub tax: Option<TaxParam>,
     /// The customer's tax exemption. One of `none`, `exempt`, or `reverse`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tax_exempt: Option<UpcomingLinesInvoiceCustomerDetailsTaxExempt>,
     /// The customer's tax IDs.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_ids: Option<&'a [UpcomingLinesInvoiceCustomerDetailsTaxIds<'a>]>,
+    pub tax_ids: Option<Vec<UpcomingLinesInvoiceCustomerDetailsTaxIds>>,
 }
-impl<'a> UpcomingLinesInvoiceCustomerDetails<'a> {
+impl UpcomingLinesInvoiceCustomerDetails {
     pub fn new() -> Self {
         Self { address: None, shipping: None, tax: None, tax_exempt: None, tax_ids: None }
     }
 }
-impl<'a> Default for UpcomingLinesInvoiceCustomerDetails<'a> {
+impl Default for UpcomingLinesInvoiceCustomerDetails {
     fn default() -> Self {
         Self::new()
     }
@@ -3574,17 +3603,20 @@ impl<'de> serde::Deserialize<'de> for UpcomingLinesInvoiceCustomerDetailsTaxExem
     }
 }
 /// The customer's tax IDs.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpcomingLinesInvoiceCustomerDetailsTaxIds<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpcomingLinesInvoiceCustomerDetailsTaxIds {
     /// Type of the tax ID, one of `ad_nrt`, `ae_trn`, `ar_cuit`, `au_abn`, `au_arn`, `bg_uic`, `bh_vat`, `bo_tin`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `cn_tin`, `co_nit`, `cr_tin`, `do_rcn`, `ec_ruc`, `eg_tin`, `es_cif`, `eu_oss_vat`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `hu_tin`, `id_npwp`, `il_vat`, `in_gst`, `is_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `ke_pin`, `kr_brn`, `kz_bin`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `ng_tin`, `no_vat`, `no_voec`, `nz_gst`, `om_vat`, `pe_ruc`, `ph_tin`, `ro_tin`, `rs_pib`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `si_tin`, `sv_nit`, `th_vat`, `tr_tin`, `tw_vat`, `ua_vat`, `us_ein`, `uy_ruc`, `ve_rif`, `vn_tin`, or `za_vat`.
     #[serde(rename = "type")]
     pub type_: UpcomingLinesInvoiceCustomerDetailsTaxIdsType,
     /// Value of the tax ID.
-    pub value: &'a str,
+    pub value: String,
 }
-impl<'a> UpcomingLinesInvoiceCustomerDetailsTaxIds<'a> {
-    pub fn new(type_: UpcomingLinesInvoiceCustomerDetailsTaxIdsType, value: &'a str) -> Self {
-        Self { type_, value }
+impl UpcomingLinesInvoiceCustomerDetailsTaxIds {
+    pub fn new(
+        type_: impl Into<UpcomingLinesInvoiceCustomerDetailsTaxIdsType>,
+        value: impl Into<String>,
+    ) -> Self {
+        Self { type_: type_.into(), value: value.into() }
     }
 }
 /// Type of the tax ID, one of `ad_nrt`, `ae_trn`, `ar_cuit`, `au_abn`, `au_arn`, `bg_uic`, `bh_vat`, `bo_tin`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `cn_tin`, `co_nit`, `cr_tin`, `do_rcn`, `ec_ruc`, `eg_tin`, `es_cif`, `eu_oss_vat`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `hu_tin`, `id_npwp`, `il_vat`, `in_gst`, `is_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `ke_pin`, `kr_brn`, `kz_bin`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `ng_tin`, `no_vat`, `no_voec`, `nz_gst`, `om_vat`, `pe_ruc`, `ph_tin`, `ro_tin`, `rs_pib`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `si_tin`, `sv_nit`, `th_vat`, `tr_tin`, `tw_vat`, `ua_vat`, `us_ein`, `uy_ruc`, `ve_rif`, `vn_tin`, or `za_vat`.
@@ -3853,8 +3885,8 @@ impl<'de> serde::Deserialize<'de> for UpcomingLinesInvoiceCustomerDetailsTaxIdsT
     }
 }
 /// List of invoice items to add or update in the upcoming invoice preview.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpcomingLinesInvoiceInvoiceItems<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpcomingLinesInvoiceInvoiceItems {
     /// The integer amount in cents (or local equivalent) of previewed invoice item.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub amount: Option<i64>,
@@ -3866,24 +3898,24 @@ pub struct UpcomingLinesInvoiceInvoiceItems<'a> {
     /// An arbitrary string which you can attach to the invoice item.
     /// The description is displayed in the invoice for easy tracking.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<&'a str>,
+    pub description: Option<String>,
     /// Explicitly controls whether discounts apply to this invoice item.
     /// Defaults to true, except for negative invoice items.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub discountable: Option<bool>,
     /// The coupons to redeem into discounts for the invoice item in the preview.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub discounts: Option<&'a [DiscountsDataParam<'a>]>,
+    pub discounts: Option<Vec<DiscountsDataParam>>,
     /// The ID of the invoice item to update in preview.
     /// If not specified, a new invoice item will be added to the preview of the upcoming invoice.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub invoiceitem: Option<&'a str>,
+    pub invoiceitem: Option<String>,
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// The period associated with this invoice item.
     /// When set to different values, the period will be rendered on the invoice.
     /// If you have [Stripe Revenue Recognition](https://stripe.com/docs/revenue-recognition) enabled, the period will be used to recognize and defer revenue.
@@ -3892,10 +3924,10 @@ pub struct UpcomingLinesInvoiceInvoiceItems<'a> {
     pub period: Option<Period>,
     /// The ID of the price object.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price: Option<&'a str>,
+    pub price: Option<String>,
     /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price_data: Option<UpcomingLinesInvoiceInvoiceItemsPriceData<'a>>,
+    pub price_data: Option<UpcomingLinesInvoiceInvoiceItemsPriceData>,
     /// Non-negative integer. The quantity of units for the invoice item.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub quantity: Option<u64>,
@@ -3907,10 +3939,10 @@ pub struct UpcomingLinesInvoiceInvoiceItems<'a> {
     pub tax_behavior: Option<UpcomingLinesInvoiceInvoiceItemsTaxBehavior>,
     /// A [tax code](https://stripe.com/docs/tax/tax-categories) ID.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_code: Option<&'a str>,
+    pub tax_code: Option<String>,
     /// The tax rates that apply to the item. When set, any `default_tax_rates` do not apply to this item.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_rates: Option<&'a [&'a str]>,
+    pub tax_rates: Option<Vec<String>>,
     /// The integer unit amount in cents (or local equivalent) of the charge to be applied to the upcoming invoice.
     /// This unit_amount will be multiplied by the quantity to get the full amount.
     /// If you want to apply a credit to the customer's account, pass a negative unit_amount.
@@ -3919,9 +3951,9 @@ pub struct UpcomingLinesInvoiceInvoiceItems<'a> {
     /// Same as `unit_amount`, but accepts a decimal value in cents (or local equivalent) with at most 12 decimal places.
     /// Only one of `unit_amount` and `unit_amount_decimal` can be set.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub unit_amount_decimal: Option<&'a str>,
+    pub unit_amount_decimal: Option<String>,
 }
-impl<'a> UpcomingLinesInvoiceInvoiceItems<'a> {
+impl UpcomingLinesInvoiceInvoiceItems {
     pub fn new() -> Self {
         Self {
             amount: None,
@@ -3943,19 +3975,19 @@ impl<'a> UpcomingLinesInvoiceInvoiceItems<'a> {
         }
     }
 }
-impl<'a> Default for UpcomingLinesInvoiceInvoiceItems<'a> {
+impl Default for UpcomingLinesInvoiceInvoiceItems {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpcomingLinesInvoiceInvoiceItemsPriceData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpcomingLinesInvoiceInvoiceItemsPriceData {
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     /// Must be a [supported currency](https://stripe.com/docs/currencies).
     pub currency: stripe_types::Currency,
     /// The ID of the product that this price will belong to.
-    pub product: &'a str,
+    pub product: String,
     /// Only required if a [default tax behavior](https://stripe.com/docs/tax/products-prices-tax-categories-tax-behavior#setting-a-default-tax-behavior-(recommended)) was not provided in the Stripe Tax settings.
     /// Specifies whether the price is considered inclusive of taxes or exclusive of taxes.
     /// One of `inclusive`, `exclusive`, or `unspecified`.
@@ -3968,11 +4000,17 @@ pub struct UpcomingLinesInvoiceInvoiceItemsPriceData<'a> {
     /// Same as `unit_amount`, but accepts a decimal value in cents (or local equivalent) with at most 12 decimal places.
     /// Only one of `unit_amount` and `unit_amount_decimal` can be set.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub unit_amount_decimal: Option<&'a str>,
+    pub unit_amount_decimal: Option<String>,
 }
-impl<'a> UpcomingLinesInvoiceInvoiceItemsPriceData<'a> {
-    pub fn new(currency: stripe_types::Currency, product: &'a str) -> Self {
-        Self { currency, product, tax_behavior: None, unit_amount: None, unit_amount_decimal: None }
+impl UpcomingLinesInvoiceInvoiceItemsPriceData {
+    pub fn new(currency: impl Into<stripe_types::Currency>, product: impl Into<String>) -> Self {
+        Self {
+            currency: currency.into(),
+            product: product.into(),
+            tax_behavior: None,
+            unit_amount: None,
+            unit_amount_decimal: None,
+        }
     }
 }
 /// Only required if a [default tax behavior](https://stripe.com/docs/tax/products-prices-tax-categories-tax-behavior#setting-a-default-tax-behavior-(recommended)) was not provided in the Stripe Tax settings.
@@ -4105,18 +4143,18 @@ impl<'de> serde::Deserialize<'de> for UpcomingLinesInvoiceInvoiceItemsTaxBehavio
 }
 /// The connected account that issues the invoice.
 /// The invoice is presented with the branding and support information of the specified account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpcomingLinesInvoiceIssuer<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpcomingLinesInvoiceIssuer {
     /// The connected account being referenced when `type` is `account`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account: Option<&'a str>,
+    pub account: Option<String>,
     /// Type of the account referenced in the request.
     #[serde(rename = "type")]
     pub type_: UpcomingLinesInvoiceIssuerType,
 }
-impl<'a> UpcomingLinesInvoiceIssuer<'a> {
-    pub fn new(type_: UpcomingLinesInvoiceIssuerType) -> Self {
-        Self { account: None, type_ }
+impl UpcomingLinesInvoiceIssuer {
+    pub fn new(type_: impl Into<UpcomingLinesInvoiceIssuerType>) -> Self {
+        Self { account: None, type_: type_.into() }
     }
 }
 /// Type of the account referenced in the request.
@@ -4177,8 +4215,8 @@ impl<'de> serde::Deserialize<'de> for UpcomingLinesInvoiceIssuerType {
 }
 /// The schedule creation or modification params to apply as a preview.
 /// Cannot be used with `subscription` or `subscription_` prefixed fields.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpcomingLinesInvoiceScheduleDetails<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpcomingLinesInvoiceScheduleDetails {
     /// Behavior of the subscription schedule and underlying subscription when it ends.
     /// Possible values are `release` or `cancel` with the default being `release`.
     /// `release` will end the subscription schedule and keep the underlying subscription running.
@@ -4189,17 +4227,17 @@ pub struct UpcomingLinesInvoiceScheduleDetails<'a> {
     /// Each phase can be customized to have different durations, plans, and coupons.
     /// If there are multiple phases, the `end_date` of one phase will always equal the `start_date` of the next phase.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub phases: Option<&'a [UpcomingLinesInvoiceScheduleDetailsPhases<'a>]>,
+    pub phases: Option<Vec<UpcomingLinesInvoiceScheduleDetailsPhases>>,
     /// In cases where the `schedule_details` params update the currently active phase, specifies if and how to prorate at the time of the request.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub proration_behavior: Option<UpcomingLinesInvoiceScheduleDetailsProrationBehavior>,
 }
-impl<'a> UpcomingLinesInvoiceScheduleDetails<'a> {
+impl UpcomingLinesInvoiceScheduleDetails {
     pub fn new() -> Self {
         Self { end_behavior: None, phases: None, proration_behavior: None }
     }
 }
-impl<'a> Default for UpcomingLinesInvoiceScheduleDetails<'a> {
+impl Default for UpcomingLinesInvoiceScheduleDetails {
     fn default() -> Self {
         Self::new()
     }
@@ -4268,13 +4306,12 @@ impl<'de> serde::Deserialize<'de> for UpcomingLinesInvoiceScheduleDetailsEndBeha
 /// List representing phases of the subscription schedule.
 /// Each phase can be customized to have different durations, plans, and coupons.
 /// If there are multiple phases, the `end_date` of one phase will always equal the `start_date` of the next phase.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpcomingLinesInvoiceScheduleDetailsPhases<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpcomingLinesInvoiceScheduleDetailsPhases {
     /// A list of prices and quantities that will generate invoice items appended to the next invoice for this phase.
     /// You may pass up to 20 items.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub add_invoice_items:
-        Option<&'a [UpcomingLinesInvoiceScheduleDetailsPhasesAddInvoiceItems<'a>]>,
+    pub add_invoice_items: Option<Vec<UpcomingLinesInvoiceScheduleDetailsPhasesAddInvoiceItems>>,
     /// A non-negative decimal between 0 and 100, with at most two decimal places.
     /// This represents the percentage of the subscription invoice total that will be transferred to the application owner's Stripe account.
     /// The request must be made by a platform account on a connected account in order to set an application fee percentage.
@@ -4283,7 +4320,7 @@ pub struct UpcomingLinesInvoiceScheduleDetailsPhases<'a> {
     pub application_fee_percent: Option<f64>,
     /// Automatic tax settings for this phase.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub automatic_tax: Option<UpcomingLinesInvoiceScheduleDetailsPhasesAutomaticTax<'a>>,
+    pub automatic_tax: Option<UpcomingLinesInvoiceScheduleDetailsPhasesAutomaticTax>,
     /// Can be set to `phase_start` to set the anchor to the start of the phase or `automatic` to automatically change it if needed.
     /// Cannot be set to `phase_start` if this phase specifies a trial.
     /// For more information, see the billing cycle [documentation](https://stripe.com/docs/billing/subscriptions/billing-cycle).
@@ -4303,7 +4340,7 @@ pub struct UpcomingLinesInvoiceScheduleDetailsPhases<'a> {
     /// This field has been deprecated and will be removed in a future API version.
     /// Use `discounts` instead.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub coupon: Option<&'a str>,
+    pub coupon: Option<String>,
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     /// Must be a [supported currency](https://stripe.com/docs/currencies).
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -4312,29 +4349,29 @@ pub struct UpcomingLinesInvoiceScheduleDetailsPhases<'a> {
     /// It must belong to the customer associated with the subscription schedule.
     /// If not set, invoices will use the default payment method in the customer's invoice settings.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub default_payment_method: Option<&'a str>,
+    pub default_payment_method: Option<String>,
     /// A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids.
     /// These Tax Rates will set the Subscription's [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates), which means they will be the Invoice's [`default_tax_rates`](https://stripe.com/docs/api/invoices/create#create_invoice-default_tax_rates) for any Invoices issued by the Subscription during this Phase.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub default_tax_rates: Option<&'a [&'a str]>,
+    pub default_tax_rates: Option<Vec<String>>,
     /// Subscription description, meant to be displayable to the customer.
     /// Use this field to optionally store an explanation of the subscription for rendering in Stripe surfaces and certain local payment methods UIs.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<&'a str>,
+    pub description: Option<String>,
     /// The coupons to redeem into discounts for the schedule phase.
     /// If not specified, inherits the discount from the subscription's customer.
     /// Pass an empty string to avoid inheriting any discounts.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub discounts: Option<&'a [DiscountsDataParam<'a>]>,
+    pub discounts: Option<Vec<DiscountsDataParam>>,
     /// The date at which this phase of the subscription schedule ends.
     /// If set, `iterations` must not be set.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub end_date: Option<UpcomingLinesInvoiceScheduleDetailsPhasesEndDate>,
     /// All invoices will be billed using the specified settings.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub invoice_settings: Option<UpcomingLinesInvoiceScheduleDetailsPhasesInvoiceSettings<'a>>,
+    pub invoice_settings: Option<UpcomingLinesInvoiceScheduleDetailsPhasesInvoiceSettings>,
     /// List of configuration items, each with an attached price, to apply during this phase of the subscription schedule.
-    pub items: &'a [UpcomingLinesInvoiceScheduleDetailsPhasesItems<'a>],
+    pub items: Vec<UpcomingLinesInvoiceScheduleDetailsPhasesItems>,
     /// Integer representing the multiplier applied to the price interval.
     /// For example, `iterations=2` applied to a price with `interval=month` and `interval_count=3` results in a phase of duration `2 * 3 months = 6 months`.
     /// If set, `end_date` must not be set.
@@ -4345,10 +4382,10 @@ pub struct UpcomingLinesInvoiceScheduleDetailsPhases<'a> {
     /// Individual keys in the subscription's `metadata` can be unset by posting an empty value to them in the phase's `metadata`.
     /// To unset all keys in the subscription's `metadata`, update the subscription directly or unset every key individually from the phase's `metadata`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// The account on behalf of which to charge, for each of the associated subscription's invoices.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub on_behalf_of: Option<&'a str>,
+    pub on_behalf_of: Option<String>,
     /// Whether the subscription schedule will create [prorations](https://stripe.com/docs/billing/subscriptions/prorations) when transitioning to this phase.
     /// The default value is `create_prorations`.
     /// This setting controls prorations when a phase is started asynchronously and it is persisted as a field on the phase.
@@ -4361,7 +4398,7 @@ pub struct UpcomingLinesInvoiceScheduleDetailsPhases<'a> {
     pub start_date: Option<UpcomingLinesInvoiceScheduleDetailsPhasesStartDate>,
     /// The data with which to automatically create a Transfer for each of the associated subscription's invoices.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub transfer_data: Option<TransferDataSpecs<'a>>,
+    pub transfer_data: Option<TransferDataSpecs>,
     /// If set to true the entire phase is counted as a trial and the customer will not be charged for any fees.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub trial: Option<bool>,
@@ -4370,8 +4407,8 @@ pub struct UpcomingLinesInvoiceScheduleDetailsPhases<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub trial_end: Option<UpcomingLinesInvoiceScheduleDetailsPhasesTrialEnd>,
 }
-impl<'a> UpcomingLinesInvoiceScheduleDetailsPhases<'a> {
-    pub fn new(items: &'a [UpcomingLinesInvoiceScheduleDetailsPhasesItems<'a>]) -> Self {
+impl UpcomingLinesInvoiceScheduleDetailsPhases {
+    pub fn new(items: impl Into<Vec<UpcomingLinesInvoiceScheduleDetailsPhasesItems>>) -> Self {
         Self {
             add_invoice_items: None,
             application_fee_percent: None,
@@ -4387,7 +4424,7 @@ impl<'a> UpcomingLinesInvoiceScheduleDetailsPhases<'a> {
             discounts: None,
             end_date: None,
             invoice_settings: None,
-            items,
+            items: items.into(),
             iterations: None,
             metadata: None,
             on_behalf_of: None,
@@ -4401,42 +4438,42 @@ impl<'a> UpcomingLinesInvoiceScheduleDetailsPhases<'a> {
 }
 /// A list of prices and quantities that will generate invoice items appended to the next invoice for this phase.
 /// You may pass up to 20 items.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpcomingLinesInvoiceScheduleDetailsPhasesAddInvoiceItems<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpcomingLinesInvoiceScheduleDetailsPhasesAddInvoiceItems {
     /// The coupons to redeem into discounts for the item.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub discounts: Option<&'a [DiscountsDataParam<'a>]>,
+    pub discounts: Option<Vec<DiscountsDataParam>>,
     /// The ID of the price object.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price: Option<&'a str>,
+    pub price: Option<String>,
     /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price_data: Option<UpcomingLinesInvoiceScheduleDetailsPhasesAddInvoiceItemsPriceData<'a>>,
+    pub price_data: Option<UpcomingLinesInvoiceScheduleDetailsPhasesAddInvoiceItemsPriceData>,
     /// Quantity for this item. Defaults to 1.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub quantity: Option<u64>,
     /// The tax rates which apply to the item. When set, the `default_tax_rates` do not apply to this item.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_rates: Option<&'a [&'a str]>,
+    pub tax_rates: Option<Vec<String>>,
 }
-impl<'a> UpcomingLinesInvoiceScheduleDetailsPhasesAddInvoiceItems<'a> {
+impl UpcomingLinesInvoiceScheduleDetailsPhasesAddInvoiceItems {
     pub fn new() -> Self {
         Self { discounts: None, price: None, price_data: None, quantity: None, tax_rates: None }
     }
 }
-impl<'a> Default for UpcomingLinesInvoiceScheduleDetailsPhasesAddInvoiceItems<'a> {
+impl Default for UpcomingLinesInvoiceScheduleDetailsPhasesAddInvoiceItems {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpcomingLinesInvoiceScheduleDetailsPhasesAddInvoiceItemsPriceData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpcomingLinesInvoiceScheduleDetailsPhasesAddInvoiceItemsPriceData {
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     /// Must be a [supported currency](https://stripe.com/docs/currencies).
     pub currency: stripe_types::Currency,
     /// The ID of the product that this price will belong to.
-    pub product: &'a str,
+    pub product: String,
     /// Only required if a [default tax behavior](https://stripe.com/docs/tax/products-prices-tax-categories-tax-behavior#setting-a-default-tax-behavior-(recommended)) was not provided in the Stripe Tax settings.
     /// Specifies whether the price is considered inclusive of taxes or exclusive of taxes.
     /// One of `inclusive`, `exclusive`, or `unspecified`.
@@ -4450,11 +4487,17 @@ pub struct UpcomingLinesInvoiceScheduleDetailsPhasesAddInvoiceItemsPriceData<'a>
     /// Same as `unit_amount`, but accepts a decimal value in cents (or local equivalent) with at most 12 decimal places.
     /// Only one of `unit_amount` and `unit_amount_decimal` can be set.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub unit_amount_decimal: Option<&'a str>,
+    pub unit_amount_decimal: Option<String>,
 }
-impl<'a> UpcomingLinesInvoiceScheduleDetailsPhasesAddInvoiceItemsPriceData<'a> {
-    pub fn new(currency: stripe_types::Currency, product: &'a str) -> Self {
-        Self { currency, product, tax_behavior: None, unit_amount: None, unit_amount_decimal: None }
+impl UpcomingLinesInvoiceScheduleDetailsPhasesAddInvoiceItemsPriceData {
+    pub fn new(currency: impl Into<stripe_types::Currency>, product: impl Into<String>) -> Self {
+        Self {
+            currency: currency.into(),
+            product: product.into(),
+            tax_behavior: None,
+            unit_amount: None,
+            unit_amount_decimal: None,
+        }
     }
 }
 /// Only required if a [default tax behavior](https://stripe.com/docs/tax/products-prices-tax-categories-tax-behavior#setting-a-default-tax-behavior-(recommended)) was not provided in the Stripe Tax settings.
@@ -4528,36 +4571,38 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// Automatic tax settings for this phase.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpcomingLinesInvoiceScheduleDetailsPhasesAutomaticTax<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpcomingLinesInvoiceScheduleDetailsPhasesAutomaticTax {
     /// Enabled automatic tax calculation which will automatically compute tax rates on all invoices generated by the subscription.
     pub enabled: bool,
     /// The account that's liable for tax.
     /// If set, the business address and tax registrations required to perform the tax calculation are loaded from this account.
     /// The tax transaction is returned in the report of the connected account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub liability: Option<UpcomingLinesInvoiceScheduleDetailsPhasesAutomaticTaxLiability<'a>>,
+    pub liability: Option<UpcomingLinesInvoiceScheduleDetailsPhasesAutomaticTaxLiability>,
 }
-impl<'a> UpcomingLinesInvoiceScheduleDetailsPhasesAutomaticTax<'a> {
-    pub fn new(enabled: bool) -> Self {
-        Self { enabled, liability: None }
+impl UpcomingLinesInvoiceScheduleDetailsPhasesAutomaticTax {
+    pub fn new(enabled: impl Into<bool>) -> Self {
+        Self { enabled: enabled.into(), liability: None }
     }
 }
 /// The account that's liable for tax.
 /// If set, the business address and tax registrations required to perform the tax calculation are loaded from this account.
 /// The tax transaction is returned in the report of the connected account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpcomingLinesInvoiceScheduleDetailsPhasesAutomaticTaxLiability<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpcomingLinesInvoiceScheduleDetailsPhasesAutomaticTaxLiability {
     /// The connected account being referenced when `type` is `account`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account: Option<&'a str>,
+    pub account: Option<String>,
     /// Type of the account referenced in the request.
     #[serde(rename = "type")]
     pub type_: UpcomingLinesInvoiceScheduleDetailsPhasesAutomaticTaxLiabilityType,
 }
-impl<'a> UpcomingLinesInvoiceScheduleDetailsPhasesAutomaticTaxLiability<'a> {
-    pub fn new(type_: UpcomingLinesInvoiceScheduleDetailsPhasesAutomaticTaxLiabilityType) -> Self {
-        Self { account: None, type_ }
+impl UpcomingLinesInvoiceScheduleDetailsPhasesAutomaticTaxLiability {
+    pub fn new(
+        type_: impl Into<UpcomingLinesInvoiceScheduleDetailsPhasesAutomaticTaxLiabilityType>,
+    ) -> Self {
+        Self { account: None, type_: type_.into() }
     }
 }
 /// Type of the account referenced in the request.
@@ -4686,12 +4731,12 @@ pub enum UpcomingLinesInvoiceScheduleDetailsPhasesEndDate {
     Timestamp(stripe_types::Timestamp),
 }
 /// All invoices will be billed using the specified settings.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpcomingLinesInvoiceScheduleDetailsPhasesInvoiceSettings<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpcomingLinesInvoiceScheduleDetailsPhasesInvoiceSettings {
     /// The account tax IDs associated with this phase of the subscription schedule.
     /// Will be set on invoices generated by this phase of the subscription schedule.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account_tax_ids: Option<&'a [&'a str]>,
+    pub account_tax_ids: Option<Vec<String>>,
     /// Number of days within which a customer must pay invoices generated by this subscription schedule.
     /// This value will be `null` for subscription schedules where `billing=charge_automatically`.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -4699,32 +4744,34 @@ pub struct UpcomingLinesInvoiceScheduleDetailsPhasesInvoiceSettings<'a> {
     /// The connected account that issues the invoice.
     /// The invoice is presented with the branding and support information of the specified account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub issuer: Option<UpcomingLinesInvoiceScheduleDetailsPhasesInvoiceSettingsIssuer<'a>>,
+    pub issuer: Option<UpcomingLinesInvoiceScheduleDetailsPhasesInvoiceSettingsIssuer>,
 }
-impl<'a> UpcomingLinesInvoiceScheduleDetailsPhasesInvoiceSettings<'a> {
+impl UpcomingLinesInvoiceScheduleDetailsPhasesInvoiceSettings {
     pub fn new() -> Self {
         Self { account_tax_ids: None, days_until_due: None, issuer: None }
     }
 }
-impl<'a> Default for UpcomingLinesInvoiceScheduleDetailsPhasesInvoiceSettings<'a> {
+impl Default for UpcomingLinesInvoiceScheduleDetailsPhasesInvoiceSettings {
     fn default() -> Self {
         Self::new()
     }
 }
 /// The connected account that issues the invoice.
 /// The invoice is presented with the branding and support information of the specified account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpcomingLinesInvoiceScheduleDetailsPhasesInvoiceSettingsIssuer<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpcomingLinesInvoiceScheduleDetailsPhasesInvoiceSettingsIssuer {
     /// The connected account being referenced when `type` is `account`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account: Option<&'a str>,
+    pub account: Option<String>,
     /// Type of the account referenced in the request.
     #[serde(rename = "type")]
     pub type_: UpcomingLinesInvoiceScheduleDetailsPhasesInvoiceSettingsIssuerType,
 }
-impl<'a> UpcomingLinesInvoiceScheduleDetailsPhasesInvoiceSettingsIssuer<'a> {
-    pub fn new(type_: UpcomingLinesInvoiceScheduleDetailsPhasesInvoiceSettingsIssuerType) -> Self {
-        Self { account: None, type_ }
+impl UpcomingLinesInvoiceScheduleDetailsPhasesInvoiceSettingsIssuer {
+    pub fn new(
+        type_: impl Into<UpcomingLinesInvoiceScheduleDetailsPhasesInvoiceSettingsIssuerType>,
+    ) -> Self {
+        Self { account: None, type_: type_.into() }
     }
 }
 /// Type of the account referenced in the request.
@@ -4784,30 +4831,30 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// List of configuration items, each with an attached price, to apply during this phase of the subscription schedule.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpcomingLinesInvoiceScheduleDetailsPhasesItems<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpcomingLinesInvoiceScheduleDetailsPhasesItems {
     /// Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period.
     /// When updating, pass an empty string to remove previously-defined thresholds.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub billing_thresholds: Option<ItemBillingThresholdsParam>,
     /// The coupons to redeem into discounts for the subscription item.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub discounts: Option<&'a [DiscountsDataParam<'a>]>,
+    pub discounts: Option<Vec<DiscountsDataParam>>,
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to a configuration item.
     /// Metadata on a configuration item will update the underlying subscription item's `metadata` when the phase is entered, adding new keys and replacing existing keys.
     /// Individual keys in the subscription item's `metadata` can be unset by posting an empty value to them in the configuration item's `metadata`.
     /// To unset all keys in the subscription item's `metadata`, update the subscription item directly or unset every key individually from the configuration item's `metadata`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// The plan ID to subscribe to. You may specify the same ID in `plan` and `price`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub plan: Option<&'a str>,
+    pub plan: Option<String>,
     /// The ID of the price object.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price: Option<&'a str>,
+    pub price: Option<String>,
     /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price_data: Option<UpcomingLinesInvoiceScheduleDetailsPhasesItemsPriceData<'a>>,
+    pub price_data: Option<UpcomingLinesInvoiceScheduleDetailsPhasesItemsPriceData>,
     /// Quantity for the given price.
     /// Can be set only if the price's `usage_type` is `licensed` and not `metered`.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -4816,9 +4863,9 @@ pub struct UpcomingLinesInvoiceScheduleDetailsPhasesItems<'a> {
     /// These Tax Rates will override the [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates) on the Subscription.
     /// When updating, pass an empty string to remove previously-defined tax rates.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_rates: Option<&'a [&'a str]>,
+    pub tax_rates: Option<Vec<String>>,
 }
-impl<'a> UpcomingLinesInvoiceScheduleDetailsPhasesItems<'a> {
+impl UpcomingLinesInvoiceScheduleDetailsPhasesItems {
     pub fn new() -> Self {
         Self {
             billing_thresholds: None,
@@ -4832,19 +4879,19 @@ impl<'a> UpcomingLinesInvoiceScheduleDetailsPhasesItems<'a> {
         }
     }
 }
-impl<'a> Default for UpcomingLinesInvoiceScheduleDetailsPhasesItems<'a> {
+impl Default for UpcomingLinesInvoiceScheduleDetailsPhasesItems {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpcomingLinesInvoiceScheduleDetailsPhasesItemsPriceData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpcomingLinesInvoiceScheduleDetailsPhasesItemsPriceData {
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     /// Must be a [supported currency](https://stripe.com/docs/currencies).
     pub currency: stripe_types::Currency,
     /// The ID of the product that this price will belong to.
-    pub product: &'a str,
+    pub product: String,
     /// The recurring components of a price such as `interval` and `interval_count`.
     pub recurring: UpcomingLinesInvoiceScheduleDetailsPhasesItemsPriceDataRecurring,
     /// Only required if a [default tax behavior](https://stripe.com/docs/tax/products-prices-tax-categories-tax-behavior#setting-a-default-tax-behavior-(recommended)) was not provided in the Stripe Tax settings.
@@ -4859,18 +4906,18 @@ pub struct UpcomingLinesInvoiceScheduleDetailsPhasesItemsPriceData<'a> {
     /// Same as `unit_amount`, but accepts a decimal value in cents (or local equivalent) with at most 12 decimal places.
     /// Only one of `unit_amount` and `unit_amount_decimal` can be set.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub unit_amount_decimal: Option<&'a str>,
+    pub unit_amount_decimal: Option<String>,
 }
-impl<'a> UpcomingLinesInvoiceScheduleDetailsPhasesItemsPriceData<'a> {
+impl UpcomingLinesInvoiceScheduleDetailsPhasesItemsPriceData {
     pub fn new(
-        currency: stripe_types::Currency,
-        product: &'a str,
-        recurring: UpcomingLinesInvoiceScheduleDetailsPhasesItemsPriceDataRecurring,
+        currency: impl Into<stripe_types::Currency>,
+        product: impl Into<String>,
+        recurring: impl Into<UpcomingLinesInvoiceScheduleDetailsPhasesItemsPriceDataRecurring>,
     ) -> Self {
         Self {
-            currency,
-            product,
-            recurring,
+            currency: currency.into(),
+            product: product.into(),
+            recurring: recurring.into(),
             tax_behavior: None,
             unit_amount: None,
             unit_amount_decimal: None,
@@ -4890,9 +4937,9 @@ pub struct UpcomingLinesInvoiceScheduleDetailsPhasesItemsPriceDataRecurring {
 }
 impl UpcomingLinesInvoiceScheduleDetailsPhasesItemsPriceDataRecurring {
     pub fn new(
-        interval: UpcomingLinesInvoiceScheduleDetailsPhasesItemsPriceDataRecurringInterval,
+        interval: impl Into<UpcomingLinesInvoiceScheduleDetailsPhasesItemsPriceDataRecurringInterval>,
     ) -> Self {
-        Self { interval, interval_count: None }
+        Self { interval: interval.into(), interval_count: None }
     }
 }
 /// Specifies billing frequency. Either `day`, `week`, `month` or `year`.
@@ -5181,8 +5228,8 @@ pub enum UpcomingLinesInvoiceSubscriptionBillingCycleAnchor {
 }
 /// The subscription creation or modification params to apply as a preview.
 /// Cannot be used with `schedule` or `schedule_details` fields.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpcomingLinesInvoiceSubscriptionDetails<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpcomingLinesInvoiceSubscriptionDetails {
     /// For new subscriptions, a future timestamp to anchor the subscription's [billing cycle](https://stripe.com/docs/subscriptions/billing-cycle).
     /// This is used to determine the date of the first full invoice, and, for plans with `month` or `year` intervals, the day of the month for subsequent invoices.
     /// For existing subscriptions, the value can only be set to `now` or `unchanged`.
@@ -5202,10 +5249,10 @@ pub struct UpcomingLinesInvoiceSubscriptionDetails<'a> {
     /// If provided, the invoice returned will preview updating or creating a subscription with these default tax rates.
     /// The default tax rates will apply to any line item that does not have `tax_rates` set.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub default_tax_rates: Option<&'a [&'a str]>,
+    pub default_tax_rates: Option<Vec<String>>,
     /// A list of up to 20 subscription items, each with an attached price.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub items: Option<&'a [UpcomingLinesInvoiceSubscriptionDetailsItems<'a>]>,
+    pub items: Option<Vec<UpcomingLinesInvoiceSubscriptionDetailsItems>>,
     /// Determines how to handle [prorations](https://stripe.com/docs/billing/subscriptions/prorations) when the billing cycle changes (e.g., when switching plans, resetting `billing_cycle_anchor=now`, or starting a trial), or if an item's `quantity` changes.
     /// The default value is `create_prorations`.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -5227,7 +5274,7 @@ pub struct UpcomingLinesInvoiceSubscriptionDetails<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub trial_end: Option<UpcomingLinesInvoiceSubscriptionDetailsTrialEnd>,
 }
-impl<'a> UpcomingLinesInvoiceSubscriptionDetails<'a> {
+impl UpcomingLinesInvoiceSubscriptionDetails {
     pub fn new() -> Self {
         Self {
             billing_cycle_anchor: None,
@@ -5244,7 +5291,7 @@ impl<'a> UpcomingLinesInvoiceSubscriptionDetails<'a> {
         }
     }
 }
-impl<'a> Default for UpcomingLinesInvoiceSubscriptionDetails<'a> {
+impl Default for UpcomingLinesInvoiceSubscriptionDetails {
     fn default() -> Self {
         Self::new()
     }
@@ -5261,8 +5308,8 @@ pub enum UpcomingLinesInvoiceSubscriptionDetailsBillingCycleAnchor {
     Timestamp(stripe_types::Timestamp),
 }
 /// A list of up to 20 subscription items, each with an attached price.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpcomingLinesInvoiceSubscriptionDetailsItems<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpcomingLinesInvoiceSubscriptionDetailsItems {
     /// Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period.
     /// When updating, pass an empty string to remove previously-defined thresholds.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -5276,26 +5323,26 @@ pub struct UpcomingLinesInvoiceSubscriptionDetailsItems<'a> {
     pub deleted: Option<bool>,
     /// The coupons to redeem into discounts for the subscription item.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub discounts: Option<&'a [DiscountsDataParam<'a>]>,
+    pub discounts: Option<Vec<DiscountsDataParam>>,
     /// Subscription item to update.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub id: Option<&'a str>,
+    pub id: Option<String>,
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// Plan ID for this item, as a string.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub plan: Option<&'a str>,
+    pub plan: Option<String>,
     /// The ID of the price object.
     /// When changing a subscription item's price, `quantity` is set to 1 unless a `quantity` parameter is provided.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price: Option<&'a str>,
+    pub price: Option<String>,
     /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price_data: Option<UpcomingLinesInvoiceSubscriptionDetailsItemsPriceData<'a>>,
+    pub price_data: Option<UpcomingLinesInvoiceSubscriptionDetailsItemsPriceData>,
     /// Quantity for this item.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub quantity: Option<u64>,
@@ -5303,9 +5350,9 @@ pub struct UpcomingLinesInvoiceSubscriptionDetailsItems<'a> {
     /// These Tax Rates will override the [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates) on the Subscription.
     /// When updating, pass an empty string to remove previously-defined tax rates.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_rates: Option<&'a [&'a str]>,
+    pub tax_rates: Option<Vec<String>>,
 }
-impl<'a> UpcomingLinesInvoiceSubscriptionDetailsItems<'a> {
+impl UpcomingLinesInvoiceSubscriptionDetailsItems {
     pub fn new() -> Self {
         Self {
             billing_thresholds: None,
@@ -5322,19 +5369,19 @@ impl<'a> UpcomingLinesInvoiceSubscriptionDetailsItems<'a> {
         }
     }
 }
-impl<'a> Default for UpcomingLinesInvoiceSubscriptionDetailsItems<'a> {
+impl Default for UpcomingLinesInvoiceSubscriptionDetailsItems {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpcomingLinesInvoiceSubscriptionDetailsItemsPriceData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpcomingLinesInvoiceSubscriptionDetailsItemsPriceData {
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     /// Must be a [supported currency](https://stripe.com/docs/currencies).
     pub currency: stripe_types::Currency,
     /// The ID of the product that this price will belong to.
-    pub product: &'a str,
+    pub product: String,
     /// The recurring components of a price such as `interval` and `interval_count`.
     pub recurring: UpcomingLinesInvoiceSubscriptionDetailsItemsPriceDataRecurring,
     /// Only required if a [default tax behavior](https://stripe.com/docs/tax/products-prices-tax-categories-tax-behavior#setting-a-default-tax-behavior-(recommended)) was not provided in the Stripe Tax settings.
@@ -5349,18 +5396,18 @@ pub struct UpcomingLinesInvoiceSubscriptionDetailsItemsPriceData<'a> {
     /// Same as `unit_amount`, but accepts a decimal value in cents (or local equivalent) with at most 12 decimal places.
     /// Only one of `unit_amount` and `unit_amount_decimal` can be set.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub unit_amount_decimal: Option<&'a str>,
+    pub unit_amount_decimal: Option<String>,
 }
-impl<'a> UpcomingLinesInvoiceSubscriptionDetailsItemsPriceData<'a> {
+impl UpcomingLinesInvoiceSubscriptionDetailsItemsPriceData {
     pub fn new(
-        currency: stripe_types::Currency,
-        product: &'a str,
-        recurring: UpcomingLinesInvoiceSubscriptionDetailsItemsPriceDataRecurring,
+        currency: impl Into<stripe_types::Currency>,
+        product: impl Into<String>,
+        recurring: impl Into<UpcomingLinesInvoiceSubscriptionDetailsItemsPriceDataRecurring>,
     ) -> Self {
         Self {
-            currency,
-            product,
-            recurring,
+            currency: currency.into(),
+            product: product.into(),
+            recurring: recurring.into(),
             tax_behavior: None,
             unit_amount: None,
             unit_amount_decimal: None,
@@ -5380,9 +5427,9 @@ pub struct UpcomingLinesInvoiceSubscriptionDetailsItemsPriceDataRecurring {
 }
 impl UpcomingLinesInvoiceSubscriptionDetailsItemsPriceDataRecurring {
     pub fn new(
-        interval: UpcomingLinesInvoiceSubscriptionDetailsItemsPriceDataRecurringInterval,
+        interval: impl Into<UpcomingLinesInvoiceSubscriptionDetailsItemsPriceDataRecurringInterval>,
     ) -> Self {
-        Self { interval, interval_count: None }
+        Self { interval: interval.into(), interval_count: None }
     }
 }
 /// Specifies billing frequency. Either `day`, `week`, `month` or `year`.
@@ -5638,8 +5685,8 @@ pub enum UpcomingLinesInvoiceSubscriptionDetailsTrialEnd {
 /// A list of up to 20 subscription items, each with an attached price.
 /// This field has been deprecated and will be removed in a future API version.
 /// Use `subscription_details.items` instead.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpcomingLinesInvoiceSubscriptionItems<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpcomingLinesInvoiceSubscriptionItems {
     /// Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period.
     /// When updating, pass an empty string to remove previously-defined thresholds.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -5653,26 +5700,26 @@ pub struct UpcomingLinesInvoiceSubscriptionItems<'a> {
     pub deleted: Option<bool>,
     /// The coupons to redeem into discounts for the subscription item.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub discounts: Option<&'a [DiscountsDataParam<'a>]>,
+    pub discounts: Option<Vec<DiscountsDataParam>>,
     /// Subscription item to update.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub id: Option<&'a str>,
+    pub id: Option<String>,
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// Plan ID for this item, as a string.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub plan: Option<&'a str>,
+    pub plan: Option<String>,
     /// The ID of the price object.
     /// When changing a subscription item's price, `quantity` is set to 1 unless a `quantity` parameter is provided.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price: Option<&'a str>,
+    pub price: Option<String>,
     /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price_data: Option<UpcomingLinesInvoiceSubscriptionItemsPriceData<'a>>,
+    pub price_data: Option<UpcomingLinesInvoiceSubscriptionItemsPriceData>,
     /// Quantity for this item.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub quantity: Option<u64>,
@@ -5680,9 +5727,9 @@ pub struct UpcomingLinesInvoiceSubscriptionItems<'a> {
     /// These Tax Rates will override the [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates) on the Subscription.
     /// When updating, pass an empty string to remove previously-defined tax rates.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_rates: Option<&'a [&'a str]>,
+    pub tax_rates: Option<Vec<String>>,
 }
-impl<'a> UpcomingLinesInvoiceSubscriptionItems<'a> {
+impl UpcomingLinesInvoiceSubscriptionItems {
     pub fn new() -> Self {
         Self {
             billing_thresholds: None,
@@ -5699,19 +5746,19 @@ impl<'a> UpcomingLinesInvoiceSubscriptionItems<'a> {
         }
     }
 }
-impl<'a> Default for UpcomingLinesInvoiceSubscriptionItems<'a> {
+impl Default for UpcomingLinesInvoiceSubscriptionItems {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpcomingLinesInvoiceSubscriptionItemsPriceData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpcomingLinesInvoiceSubscriptionItemsPriceData {
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     /// Must be a [supported currency](https://stripe.com/docs/currencies).
     pub currency: stripe_types::Currency,
     /// The ID of the product that this price will belong to.
-    pub product: &'a str,
+    pub product: String,
     /// The recurring components of a price such as `interval` and `interval_count`.
     pub recurring: UpcomingLinesInvoiceSubscriptionItemsPriceDataRecurring,
     /// Only required if a [default tax behavior](https://stripe.com/docs/tax/products-prices-tax-categories-tax-behavior#setting-a-default-tax-behavior-(recommended)) was not provided in the Stripe Tax settings.
@@ -5726,18 +5773,18 @@ pub struct UpcomingLinesInvoiceSubscriptionItemsPriceData<'a> {
     /// Same as `unit_amount`, but accepts a decimal value in cents (or local equivalent) with at most 12 decimal places.
     /// Only one of `unit_amount` and `unit_amount_decimal` can be set.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub unit_amount_decimal: Option<&'a str>,
+    pub unit_amount_decimal: Option<String>,
 }
-impl<'a> UpcomingLinesInvoiceSubscriptionItemsPriceData<'a> {
+impl UpcomingLinesInvoiceSubscriptionItemsPriceData {
     pub fn new(
-        currency: stripe_types::Currency,
-        product: &'a str,
-        recurring: UpcomingLinesInvoiceSubscriptionItemsPriceDataRecurring,
+        currency: impl Into<stripe_types::Currency>,
+        product: impl Into<String>,
+        recurring: impl Into<UpcomingLinesInvoiceSubscriptionItemsPriceDataRecurring>,
     ) -> Self {
         Self {
-            currency,
-            product,
-            recurring,
+            currency: currency.into(),
+            product: product.into(),
+            recurring: recurring.into(),
             tax_behavior: None,
             unit_amount: None,
             unit_amount_decimal: None,
@@ -5756,8 +5803,10 @@ pub struct UpcomingLinesInvoiceSubscriptionItemsPriceDataRecurring {
     pub interval_count: Option<u64>,
 }
 impl UpcomingLinesInvoiceSubscriptionItemsPriceDataRecurring {
-    pub fn new(interval: UpcomingLinesInvoiceSubscriptionItemsPriceDataRecurringInterval) -> Self {
-        Self { interval, interval_count: None }
+    pub fn new(
+        interval: impl Into<UpcomingLinesInvoiceSubscriptionItemsPriceDataRecurringInterval>,
+    ) -> Self {
+        Self { interval: interval.into(), interval_count: None }
     }
 }
 /// Specifies billing frequency. Either `day`, `week`, `month` or `year`.
@@ -6023,120 +6072,123 @@ pub enum UpcomingLinesInvoiceSubscriptionTrialEnd {
 /// When retrieving an upcoming invoice, you’ll get a **lines** property containing the total count of line items and the first handful of those items.
 /// There is also a URL where you can retrieve the full (paginated) list of line items.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpcomingLinesInvoice<'a> {
-    inner: UpcomingLinesInvoiceBuilder<'a>,
+pub struct UpcomingLinesInvoice {
+    inner: UpcomingLinesInvoiceBuilder,
 }
-impl<'a> UpcomingLinesInvoice<'a> {
+impl UpcomingLinesInvoice {
     /// Construct a new `UpcomingLinesInvoice`.
     pub fn new() -> Self {
         Self { inner: UpcomingLinesInvoiceBuilder::new() }
     }
     /// Settings for automatic tax lookup for this invoice preview.
-    pub fn automatic_tax(mut self, automatic_tax: UpcomingLinesInvoiceAutomaticTax<'a>) -> Self {
-        self.inner.automatic_tax = Some(automatic_tax);
+    pub fn automatic_tax(
+        mut self,
+        automatic_tax: impl Into<UpcomingLinesInvoiceAutomaticTax>,
+    ) -> Self {
+        self.inner.automatic_tax = Some(automatic_tax.into());
         self
     }
     /// The ID of the coupon to apply to this phase of the subscription schedule.
     /// This field has been deprecated and will be removed in a future API version.
     /// Use `discounts` instead.
-    pub fn coupon(mut self, coupon: &'a str) -> Self {
-        self.inner.coupon = Some(coupon);
+    pub fn coupon(mut self, coupon: impl Into<String>) -> Self {
+        self.inner.coupon = Some(coupon.into());
         self
     }
     /// The currency to preview this invoice in. Defaults to that of `customer` if not specified.
-    pub fn currency(mut self, currency: stripe_types::Currency) -> Self {
-        self.inner.currency = Some(currency);
+    pub fn currency(mut self, currency: impl Into<stripe_types::Currency>) -> Self {
+        self.inner.currency = Some(currency.into());
         self
     }
     /// The identifier of the customer whose upcoming invoice you'd like to retrieve.
     /// If `automatic_tax` is enabled then one of `customer`, `customer_details`, `subscription`, or `schedule` must be set.
-    pub fn customer(mut self, customer: &'a str) -> Self {
-        self.inner.customer = Some(customer);
+    pub fn customer(mut self, customer: impl Into<String>) -> Self {
+        self.inner.customer = Some(customer.into());
         self
     }
     /// Details about the customer you want to invoice or overrides for an existing customer.
     /// If `automatic_tax` is enabled then one of `customer`, `customer_details`, `subscription`, or `schedule` must be set.
     pub fn customer_details(
         mut self,
-        customer_details: UpcomingLinesInvoiceCustomerDetails<'a>,
+        customer_details: impl Into<UpcomingLinesInvoiceCustomerDetails>,
     ) -> Self {
-        self.inner.customer_details = Some(customer_details);
+        self.inner.customer_details = Some(customer_details.into());
         self
     }
     /// The coupons to redeem into discounts for the invoice preview.
     /// If not specified, inherits the discount from the subscription or customer.
     /// This works for both coupons directly applied to an invoice and coupons applied to a subscription.
     /// Pass an empty string to avoid inheriting any discounts.
-    pub fn discounts(mut self, discounts: &'a [DiscountsDataParam<'a>]) -> Self {
-        self.inner.discounts = Some(discounts);
+    pub fn discounts(mut self, discounts: impl Into<Vec<DiscountsDataParam>>) -> Self {
+        self.inner.discounts = Some(discounts.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// List of invoice items to add or update in the upcoming invoice preview.
     pub fn invoice_items(
         mut self,
-        invoice_items: &'a [UpcomingLinesInvoiceInvoiceItems<'a>],
+        invoice_items: impl Into<Vec<UpcomingLinesInvoiceInvoiceItems>>,
     ) -> Self {
-        self.inner.invoice_items = Some(invoice_items);
+        self.inner.invoice_items = Some(invoice_items.into());
         self
     }
     /// The connected account that issues the invoice.
     /// The invoice is presented with the branding and support information of the specified account.
-    pub fn issuer(mut self, issuer: UpcomingLinesInvoiceIssuer<'a>) -> Self {
-        self.inner.issuer = Some(issuer);
+    pub fn issuer(mut self, issuer: impl Into<UpcomingLinesInvoiceIssuer>) -> Self {
+        self.inner.issuer = Some(issuer.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// The account (if any) for which the funds of the invoice payment are intended.
     /// If set, the invoice will be presented with the branding and support information of the specified account.
     /// See the [Invoices with Connect](https://stripe.com/docs/billing/invoices/connect) documentation for details.
-    pub fn on_behalf_of(mut self, on_behalf_of: &'a str) -> Self {
-        self.inner.on_behalf_of = Some(on_behalf_of);
+    pub fn on_behalf_of(mut self, on_behalf_of: impl Into<String>) -> Self {
+        self.inner.on_behalf_of = Some(on_behalf_of.into());
         self
     }
     /// The identifier of the schedule whose upcoming invoice you'd like to retrieve.
     /// Cannot be used with subscription or subscription fields.
-    pub fn schedule(mut self, schedule: &'a str) -> Self {
-        self.inner.schedule = Some(schedule);
+    pub fn schedule(mut self, schedule: impl Into<String>) -> Self {
+        self.inner.schedule = Some(schedule.into());
         self
     }
     /// The schedule creation or modification params to apply as a preview.
     /// Cannot be used with `subscription` or `subscription_` prefixed fields.
     pub fn schedule_details(
         mut self,
-        schedule_details: UpcomingLinesInvoiceScheduleDetails<'a>,
+        schedule_details: impl Into<UpcomingLinesInvoiceScheduleDetails>,
     ) -> Self {
-        self.inner.schedule_details = Some(schedule_details);
+        self.inner.schedule_details = Some(schedule_details.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
     /// The identifier of the subscription for which you'd like to retrieve the upcoming invoice.
     /// If not provided, but a `subscription_items` is provided, you will preview creating a subscription with those items.
     /// If neither `subscription` nor `subscription_items` is provided, you will retrieve the next upcoming invoice from among the customer's subscriptions.
-    pub fn subscription(mut self, subscription: &'a str) -> Self {
-        self.inner.subscription = Some(subscription);
+    pub fn subscription(mut self, subscription: impl Into<String>) -> Self {
+        self.inner.subscription = Some(subscription.into());
         self
     }
     /// For new subscriptions, a future timestamp to anchor the subscription's [billing cycle](https://stripe.com/docs/subscriptions/billing-cycle).
@@ -6146,9 +6198,10 @@ impl<'a> UpcomingLinesInvoice<'a> {
     /// Use `subscription_details.billing_cycle_anchor` instead.
     pub fn subscription_billing_cycle_anchor(
         mut self,
-        subscription_billing_cycle_anchor: UpcomingLinesInvoiceSubscriptionBillingCycleAnchor,
+        subscription_billing_cycle_anchor: impl Into<UpcomingLinesInvoiceSubscriptionBillingCycleAnchor>,
     ) -> Self {
-        self.inner.subscription_billing_cycle_anchor = Some(subscription_billing_cycle_anchor);
+        self.inner.subscription_billing_cycle_anchor =
+            Some(subscription_billing_cycle_anchor.into());
         self
     }
     /// A timestamp at which the subscription should cancel.
@@ -6158,9 +6211,9 @@ impl<'a> UpcomingLinesInvoice<'a> {
     /// Use `subscription_details.cancel_at` instead.
     pub fn subscription_cancel_at(
         mut self,
-        subscription_cancel_at: stripe_types::Timestamp,
+        subscription_cancel_at: impl Into<stripe_types::Timestamp>,
     ) -> Self {
-        self.inner.subscription_cancel_at = Some(subscription_cancel_at);
+        self.inner.subscription_cancel_at = Some(subscription_cancel_at.into());
         self
     }
     /// Boolean indicating whether this subscription should cancel at the end of the current period.
@@ -6168,16 +6221,17 @@ impl<'a> UpcomingLinesInvoice<'a> {
     /// Use `subscription_details.cancel_at_period_end` instead.
     pub fn subscription_cancel_at_period_end(
         mut self,
-        subscription_cancel_at_period_end: bool,
+        subscription_cancel_at_period_end: impl Into<bool>,
     ) -> Self {
-        self.inner.subscription_cancel_at_period_end = Some(subscription_cancel_at_period_end);
+        self.inner.subscription_cancel_at_period_end =
+            Some(subscription_cancel_at_period_end.into());
         self
     }
     /// This simulates the subscription being canceled or expired immediately.
     /// This field has been deprecated and will be removed in a future API version.
     /// Use `subscription_details.cancel_now` instead.
-    pub fn subscription_cancel_now(mut self, subscription_cancel_now: bool) -> Self {
-        self.inner.subscription_cancel_now = Some(subscription_cancel_now);
+    pub fn subscription_cancel_now(mut self, subscription_cancel_now: impl Into<bool>) -> Self {
+        self.inner.subscription_cancel_now = Some(subscription_cancel_now.into());
         self
     }
     /// If provided, the invoice returned will preview updating or creating a subscription with these default tax rates.
@@ -6186,18 +6240,18 @@ impl<'a> UpcomingLinesInvoice<'a> {
     /// Use `subscription_details.default_tax_rates` instead.
     pub fn subscription_default_tax_rates(
         mut self,
-        subscription_default_tax_rates: &'a [&'a str],
+        subscription_default_tax_rates: impl Into<Vec<String>>,
     ) -> Self {
-        self.inner.subscription_default_tax_rates = Some(subscription_default_tax_rates);
+        self.inner.subscription_default_tax_rates = Some(subscription_default_tax_rates.into());
         self
     }
     /// The subscription creation or modification params to apply as a preview.
     /// Cannot be used with `schedule` or `schedule_details` fields.
     pub fn subscription_details(
         mut self,
-        subscription_details: UpcomingLinesInvoiceSubscriptionDetails<'a>,
+        subscription_details: impl Into<UpcomingLinesInvoiceSubscriptionDetails>,
     ) -> Self {
-        self.inner.subscription_details = Some(subscription_details);
+        self.inner.subscription_details = Some(subscription_details.into());
         self
     }
     /// A list of up to 20 subscription items, each with an attached price.
@@ -6205,9 +6259,9 @@ impl<'a> UpcomingLinesInvoice<'a> {
     /// Use `subscription_details.items` instead.
     pub fn subscription_items(
         mut self,
-        subscription_items: &'a [UpcomingLinesInvoiceSubscriptionItems<'a>],
+        subscription_items: impl Into<Vec<UpcomingLinesInvoiceSubscriptionItems>>,
     ) -> Self {
-        self.inner.subscription_items = Some(subscription_items);
+        self.inner.subscription_items = Some(subscription_items.into());
         self
     }
     /// Determines how to handle [prorations](https://stripe.com/docs/billing/subscriptions/prorations) when the billing cycle changes (e.g., when switching plans, resetting `billing_cycle_anchor=now`, or starting a trial), or if an item's `quantity` changes.
@@ -6216,9 +6270,9 @@ impl<'a> UpcomingLinesInvoice<'a> {
     /// Use `subscription_details.proration_behavior` instead.
     pub fn subscription_proration_behavior(
         mut self,
-        subscription_proration_behavior: UpcomingLinesInvoiceSubscriptionProrationBehavior,
+        subscription_proration_behavior: impl Into<UpcomingLinesInvoiceSubscriptionProrationBehavior>,
     ) -> Self {
-        self.inner.subscription_proration_behavior = Some(subscription_proration_behavior);
+        self.inner.subscription_proration_behavior = Some(subscription_proration_behavior.into());
         self
     }
     /// If previewing an update to a subscription, and doing proration, `subscription_proration_date` forces the proration to be calculated as though the update was done at the specified time.
@@ -6229,9 +6283,9 @@ impl<'a> UpcomingLinesInvoice<'a> {
     /// Use `subscription_details.proration_date` instead.
     pub fn subscription_proration_date(
         mut self,
-        subscription_proration_date: stripe_types::Timestamp,
+        subscription_proration_date: impl Into<stripe_types::Timestamp>,
     ) -> Self {
-        self.inner.subscription_proration_date = Some(subscription_proration_date);
+        self.inner.subscription_proration_date = Some(subscription_proration_date.into());
         self
     }
     /// For paused subscriptions, setting `subscription_resume_at` to `now` will preview the invoice that will be generated if the subscription is resumed.
@@ -6239,9 +6293,9 @@ impl<'a> UpcomingLinesInvoice<'a> {
     /// Use `subscription_details.resume_at` instead.
     pub fn subscription_resume_at(
         mut self,
-        subscription_resume_at: UpcomingLinesInvoiceSubscriptionResumeAt,
+        subscription_resume_at: impl Into<UpcomingLinesInvoiceSubscriptionResumeAt>,
     ) -> Self {
-        self.inner.subscription_resume_at = Some(subscription_resume_at);
+        self.inner.subscription_resume_at = Some(subscription_resume_at.into());
         self
     }
     /// Date a subscription is intended to start (can be future or past).
@@ -6249,9 +6303,9 @@ impl<'a> UpcomingLinesInvoice<'a> {
     /// Use `subscription_details.start_date` instead.
     pub fn subscription_start_date(
         mut self,
-        subscription_start_date: stripe_types::Timestamp,
+        subscription_start_date: impl Into<stripe_types::Timestamp>,
     ) -> Self {
-        self.inner.subscription_start_date = Some(subscription_start_date);
+        self.inner.subscription_start_date = Some(subscription_start_date.into());
         self
     }
     /// If provided, the invoice returned will preview updating or creating a subscription with that trial end.
@@ -6260,26 +6314,29 @@ impl<'a> UpcomingLinesInvoice<'a> {
     /// Use `subscription_details.trial_end` instead.
     pub fn subscription_trial_end(
         mut self,
-        subscription_trial_end: UpcomingLinesInvoiceSubscriptionTrialEnd,
+        subscription_trial_end: impl Into<UpcomingLinesInvoiceSubscriptionTrialEnd>,
     ) -> Self {
-        self.inner.subscription_trial_end = Some(subscription_trial_end);
+        self.inner.subscription_trial_end = Some(subscription_trial_end.into());
         self
     }
     /// Indicates if a plan's `trial_period_days` should be applied to the subscription.
     /// Setting `subscription_trial_end` per subscription is preferred, and this defaults to `false`.
     /// Setting this flag to `true` together with `subscription_trial_end` is not allowed.
     /// See [Using trial periods on subscriptions](https://stripe.com/docs/billing/subscriptions/trials) to learn more.
-    pub fn subscription_trial_from_plan(mut self, subscription_trial_from_plan: bool) -> Self {
-        self.inner.subscription_trial_from_plan = Some(subscription_trial_from_plan);
+    pub fn subscription_trial_from_plan(
+        mut self,
+        subscription_trial_from_plan: impl Into<bool>,
+    ) -> Self {
+        self.inner.subscription_trial_from_plan = Some(subscription_trial_from_plan.into());
         self
     }
 }
-impl<'a> Default for UpcomingLinesInvoice<'a> {
+impl Default for UpcomingLinesInvoice {
     fn default() -> Self {
         Self::new()
     }
 }
-impl UpcomingLinesInvoice<'_> {
+impl UpcomingLinesInvoice {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -6299,11 +6356,11 @@ impl UpcomingLinesInvoice<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::InvoiceLineItem>> {
-        stripe_client_core::ListPaginator::new_list("/invoices/upcoming/lines", self.inner)
+        stripe_client_core::ListPaginator::new_list("/invoices/upcoming/lines", &self.inner)
     }
 }
 
-impl StripeRequest for UpcomingLinesInvoice<'_> {
+impl StripeRequest for UpcomingLinesInvoice {
     type Output = stripe_types::List<stripe_shared::InvoiceLineItem>;
 
     fn build(&self) -> RequestBuilder {
@@ -6311,71 +6368,71 @@ impl StripeRequest for UpcomingLinesInvoice<'_> {
     }
 }
 #[derive(Clone, Debug, serde::Serialize)]
-struct CreateInvoiceBuilder<'a> {
+struct CreateInvoiceBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    account_tax_ids: Option<&'a [&'a str]>,
+    account_tax_ids: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     application_fee_amount: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     auto_advance: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    automatic_tax: Option<CreateInvoiceAutomaticTax<'a>>,
+    automatic_tax: Option<CreateInvoiceAutomaticTax>,
     #[serde(skip_serializing_if = "Option::is_none")]
     collection_method: Option<stripe_shared::InvoiceCollectionMethod>,
     #[serde(skip_serializing_if = "Option::is_none")]
     currency: Option<stripe_types::Currency>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    custom_fields: Option<&'a [CustomFieldParams<'a>]>,
+    custom_fields: Option<Vec<CustomFieldParams>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    customer: Option<&'a str>,
+    customer: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     days_until_due: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    default_payment_method: Option<&'a str>,
+    default_payment_method: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    default_source: Option<&'a str>,
+    default_source: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    default_tax_rates: Option<&'a [&'a str]>,
+    default_tax_rates: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<&'a str>,
+    description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    discounts: Option<&'a [DiscountsDataParam<'a>]>,
+    discounts: Option<Vec<DiscountsDataParam>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     due_date: Option<stripe_types::Timestamp>,
     #[serde(skip_serializing_if = "Option::is_none")]
     effective_at: Option<stripe_types::Timestamp>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    footer: Option<&'a str>,
+    footer: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    from_invoice: Option<CreateInvoiceFromInvoice<'a>>,
+    from_invoice: Option<CreateInvoiceFromInvoice>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    issuer: Option<CreateInvoiceIssuer<'a>>,
+    issuer: Option<CreateInvoiceIssuer>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    number: Option<&'a str>,
+    number: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    on_behalf_of: Option<&'a str>,
+    on_behalf_of: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_settings: Option<CreateInvoicePaymentSettings<'a>>,
+    payment_settings: Option<CreateInvoicePaymentSettings>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pending_invoice_items_behavior: Option<CreateInvoicePendingInvoiceItemsBehavior>,
     #[serde(skip_serializing_if = "Option::is_none")]
     rendering: Option<CreateInvoiceRendering>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    shipping_cost: Option<CreateInvoiceShippingCost<'a>>,
+    shipping_cost: Option<CreateInvoiceShippingCost>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    shipping_details: Option<RecipientShippingWithOptionalFieldsAddress<'a>>,
+    shipping_details: Option<RecipientShippingWithOptionalFieldsAddress>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    statement_descriptor: Option<&'a str>,
+    statement_descriptor: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    subscription: Option<&'a str>,
+    subscription: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    transfer_data: Option<CreateInvoiceTransferData<'a>>,
+    transfer_data: Option<CreateInvoiceTransferData>,
 }
-impl<'a> CreateInvoiceBuilder<'a> {
+impl CreateInvoiceBuilder {
     fn new() -> Self {
         Self {
             account_tax_ids: None,
@@ -6413,8 +6470,8 @@ impl<'a> CreateInvoiceBuilder<'a> {
     }
 }
 /// Settings for automatic tax lookup for this invoice.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateInvoiceAutomaticTax<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateInvoiceAutomaticTax {
     /// Whether Stripe automatically computes tax on this invoice.
     /// Note that incompatible invoice items (invoice items with manually specified [tax rates](https://stripe.com/docs/api/tax_rates), negative amounts, or `tax_behavior=unspecified`) cannot be added to automatic tax invoices.
     pub enabled: bool,
@@ -6422,28 +6479,28 @@ pub struct CreateInvoiceAutomaticTax<'a> {
     /// If set, the business address and tax registrations required to perform the tax calculation are loaded from this account.
     /// The tax transaction is returned in the report of the connected account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub liability: Option<CreateInvoiceAutomaticTaxLiability<'a>>,
+    pub liability: Option<CreateInvoiceAutomaticTaxLiability>,
 }
-impl<'a> CreateInvoiceAutomaticTax<'a> {
-    pub fn new(enabled: bool) -> Self {
-        Self { enabled, liability: None }
+impl CreateInvoiceAutomaticTax {
+    pub fn new(enabled: impl Into<bool>) -> Self {
+        Self { enabled: enabled.into(), liability: None }
     }
 }
 /// The account that's liable for tax.
 /// If set, the business address and tax registrations required to perform the tax calculation are loaded from this account.
 /// The tax transaction is returned in the report of the connected account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateInvoiceAutomaticTaxLiability<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateInvoiceAutomaticTaxLiability {
     /// The connected account being referenced when `type` is `account`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account: Option<&'a str>,
+    pub account: Option<String>,
     /// Type of the account referenced in the request.
     #[serde(rename = "type")]
     pub type_: CreateInvoiceAutomaticTaxLiabilityType,
 }
-impl<'a> CreateInvoiceAutomaticTaxLiability<'a> {
-    pub fn new(type_: CreateInvoiceAutomaticTaxLiabilityType) -> Self {
-        Self { account: None, type_ }
+impl CreateInvoiceAutomaticTaxLiability {
+    pub fn new(type_: impl Into<CreateInvoiceAutomaticTaxLiabilityType>) -> Self {
+        Self { account: None, type_: type_.into() }
     }
 }
 /// Type of the account referenced in the request.
@@ -6505,17 +6562,20 @@ impl<'de> serde::Deserialize<'de> for CreateInvoiceAutomaticTaxLiabilityType {
 /// Revise an existing invoice.
 /// The new invoice will be created in `status=draft`.
 /// See the [revision documentation](https://stripe.com/docs/invoicing/invoice-revisions) for more details.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateInvoiceFromInvoice<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateInvoiceFromInvoice {
     /// The relation between the new invoice and the original invoice.
     /// Currently, only 'revision' is permitted.
     pub action: CreateInvoiceFromInvoiceAction,
     /// The `id` of the invoice that will be cloned.
-    pub invoice: &'a str,
+    pub invoice: String,
 }
-impl<'a> CreateInvoiceFromInvoice<'a> {
-    pub fn new(action: CreateInvoiceFromInvoiceAction, invoice: &'a str) -> Self {
-        Self { action, invoice }
+impl CreateInvoiceFromInvoice {
+    pub fn new(
+        action: impl Into<CreateInvoiceFromInvoiceAction>,
+        invoice: impl Into<String>,
+    ) -> Self {
+        Self { action: action.into(), invoice: invoice.into() }
     }
 }
 /// The relation between the new invoice and the original invoice.
@@ -6574,18 +6634,18 @@ impl<'de> serde::Deserialize<'de> for CreateInvoiceFromInvoiceAction {
 }
 /// The connected account that issues the invoice.
 /// The invoice is presented with the branding and support information of the specified account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateInvoiceIssuer<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateInvoiceIssuer {
     /// The connected account being referenced when `type` is `account`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account: Option<&'a str>,
+    pub account: Option<String>,
     /// Type of the account referenced in the request.
     #[serde(rename = "type")]
     pub type_: CreateInvoiceIssuerType,
 }
-impl<'a> CreateInvoiceIssuer<'a> {
-    pub fn new(type_: CreateInvoiceIssuerType) -> Self {
-        Self { account: None, type_ }
+impl CreateInvoiceIssuer {
+    pub fn new(type_: impl Into<CreateInvoiceIssuerType>) -> Self {
+        Self { account: None, type_: type_.into() }
     }
 }
 /// Type of the account referenced in the request.
@@ -6645,33 +6705,33 @@ impl<'de> serde::Deserialize<'de> for CreateInvoiceIssuerType {
 }
 /// Configuration settings for the PaymentIntent that is generated when the invoice is finalized.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateInvoicePaymentSettings<'a> {
+pub struct CreateInvoicePaymentSettings {
     /// ID of the mandate to be used for this invoice.
     /// It must correspond to the payment method used to pay the invoice, including the invoice's default_payment_method or default_source, if set.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub default_mandate: Option<&'a str>,
+    pub default_mandate: Option<String>,
     /// Payment-method-specific configuration to provide to the invoice’s PaymentIntent.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub payment_method_options: Option<CreateInvoicePaymentSettingsPaymentMethodOptions<'a>>,
+    pub payment_method_options: Option<CreateInvoicePaymentSettingsPaymentMethodOptions>,
     /// The list of payment method types (e.g.
     /// card) to provide to the invoice’s PaymentIntent.
     /// If not set, Stripe attempts to automatically determine the types to use by looking at the invoice’s default payment method, the subscription’s default payment method, the customer’s default payment method, and your [invoice template settings](https://dashboard.stripe.com/settings/billing/invoice).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub payment_method_types: Option<&'a [CreateInvoicePaymentSettingsPaymentMethodTypes]>,
+    pub payment_method_types: Option<Vec<CreateInvoicePaymentSettingsPaymentMethodTypes>>,
 }
-impl<'a> CreateInvoicePaymentSettings<'a> {
+impl CreateInvoicePaymentSettings {
     pub fn new() -> Self {
         Self { default_mandate: None, payment_method_options: None, payment_method_types: None }
     }
 }
-impl<'a> Default for CreateInvoicePaymentSettings<'a> {
+impl Default for CreateInvoicePaymentSettings {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Payment-method-specific configuration to provide to the invoice’s PaymentIntent.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateInvoicePaymentSettingsPaymentMethodOptions<'a> {
+pub struct CreateInvoicePaymentSettingsPaymentMethodOptions {
     /// If paying by `acss_debit`, this sub-hash contains details about the Canadian pre-authorized debit payment method options to pass to the invoice’s PaymentIntent.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub acss_debit: Option<CreateInvoicePaymentSettingsPaymentMethodOptionsAcssDebit>,
@@ -6683,7 +6743,7 @@ pub struct CreateInvoicePaymentSettingsPaymentMethodOptions<'a> {
     pub card: Option<CreateInvoicePaymentSettingsPaymentMethodOptionsCard>,
     /// If paying by `customer_balance`, this sub-hash contains details about the Bank transfer payment method options to pass to the invoice’s PaymentIntent.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub customer_balance: Option<InvoicePaymentMethodOptionsParam<'a>>,
+    pub customer_balance: Option<InvoicePaymentMethodOptionsParam>,
     /// If paying by `konbini`, this sub-hash contains details about the Konbini payment method options to pass to the invoice’s PaymentIntent.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
@@ -6694,9 +6754,9 @@ pub struct CreateInvoicePaymentSettingsPaymentMethodOptions<'a> {
     pub sepa_debit: Option<miniserde::json::Value>,
     /// If paying by `us_bank_account`, this sub-hash contains details about the ACH direct debit payment method options to pass to the invoice’s PaymentIntent.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub us_bank_account: Option<CreateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccount<'a>>,
+    pub us_bank_account: Option<CreateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccount>,
 }
-impl<'a> CreateInvoicePaymentSettingsPaymentMethodOptions<'a> {
+impl CreateInvoicePaymentSettingsPaymentMethodOptions {
     pub fn new() -> Self {
         Self {
             acss_debit: None,
@@ -6709,7 +6769,7 @@ impl<'a> CreateInvoicePaymentSettingsPaymentMethodOptions<'a> {
         }
     }
 }
-impl<'a> Default for CreateInvoicePaymentSettingsPaymentMethodOptions<'a> {
+impl Default for CreateInvoicePaymentSettingsPaymentMethodOptions {
     fn default() -> Self {
         Self::new()
     }
@@ -7036,11 +7096,13 @@ pub struct CreateInvoicePaymentSettingsPaymentMethodOptionsCardInstallmentsPlan 
 }
 impl CreateInvoicePaymentSettingsPaymentMethodOptionsCardInstallmentsPlan {
     pub fn new(
-        count: u64,
-        interval: CreateInvoicePaymentSettingsPaymentMethodOptionsCardInstallmentsPlanInterval,
-        type_: CreateInvoicePaymentSettingsPaymentMethodOptionsCardInstallmentsPlanType,
+        count: impl Into<u64>,
+        interval: impl Into<
+            CreateInvoicePaymentSettingsPaymentMethodOptionsCardInstallmentsPlanInterval,
+        >,
+        type_: impl Into<CreateInvoicePaymentSettingsPaymentMethodOptionsCardInstallmentsPlanType>,
     ) -> Self {
-        Self { count, interval, type_ }
+        Self { count: count.into(), interval: interval.into(), type_: type_.into() }
     }
 }
 /// For `fixed_count` installment plans, this is the interval between installment payments your customer will make to their credit card.
@@ -7224,49 +7286,46 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// If paying by `us_bank_account`, this sub-hash contains details about the ACH direct debit payment method options to pass to the invoice’s PaymentIntent.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccount<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccount {
     /// Additional fields for Financial Connections Session creation
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub financial_connections: Option<
-        CreateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccountFinancialConnections<'a>,
-    >,
+    pub financial_connections:
+        Option<CreateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccountFinancialConnections>,
     /// Verification method for the intent
     #[serde(skip_serializing_if = "Option::is_none")]
     pub verification_method:
         Option<CreateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccountVerificationMethod>,
 }
-impl<'a> CreateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccount<'a> {
+impl CreateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccount {
     pub fn new() -> Self {
         Self { financial_connections: None, verification_method: None }
     }
 }
-impl<'a> Default for CreateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccount<'a> {
+impl Default for CreateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccount {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Additional fields for Financial Connections Session creation
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccountFinancialConnections<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccountFinancialConnections {
         /// The list of permissions to request.
     /// If this parameter is passed, the `payment_method` permission must be included.
     /// Valid permissions include: `balances`, `ownership`, `payment_method`, and `transactions`.
 #[serde(skip_serializing_if = "Option::is_none")]
-pub permissions: Option<&'a [CreateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccountFinancialConnectionsPermissions]>,
+pub permissions: Option<Vec<CreateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccountFinancialConnectionsPermissions>>,
     /// List of data features that you would like to retrieve upon account creation.
 #[serde(skip_serializing_if = "Option::is_none")]
-pub prefetch: Option<&'a [CreateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccountFinancialConnectionsPrefetch]>,
+pub prefetch: Option<Vec<CreateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccountFinancialConnectionsPrefetch>>,
 
 }
-impl<'a> CreateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccountFinancialConnections<'a> {
+impl CreateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccountFinancialConnections {
     pub fn new() -> Self {
         Self { permissions: None, prefetch: None }
     }
 }
-impl<'a> Default
-    for CreateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccountFinancialConnections<'a>
-{
+impl Default for CreateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccountFinancialConnections {
     fn default() -> Self {
         Self::new()
     }
@@ -7836,44 +7895,44 @@ impl<'de> serde::Deserialize<'de> for CreateInvoiceRenderingPdfPageSize {
     }
 }
 /// Settings for the cost of shipping for this invoice.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateInvoiceShippingCost<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateInvoiceShippingCost {
     /// The ID of the shipping rate to use for this order.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub shipping_rate: Option<&'a str>,
+    pub shipping_rate: Option<String>,
     /// Parameters to create a new ad-hoc shipping rate for this order.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub shipping_rate_data: Option<CreateInvoiceShippingCostShippingRateData<'a>>,
+    pub shipping_rate_data: Option<CreateInvoiceShippingCostShippingRateData>,
 }
-impl<'a> CreateInvoiceShippingCost<'a> {
+impl CreateInvoiceShippingCost {
     pub fn new() -> Self {
         Self { shipping_rate: None, shipping_rate_data: None }
     }
 }
-impl<'a> Default for CreateInvoiceShippingCost<'a> {
+impl Default for CreateInvoiceShippingCost {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Parameters to create a new ad-hoc shipping rate for this order.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateInvoiceShippingCostShippingRateData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateInvoiceShippingCostShippingRateData {
     /// The estimated range for how long shipping will take, meant to be displayable to the customer.
     /// This will appear on CheckoutSessions.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub delivery_estimate: Option<CreateInvoiceShippingCostShippingRateDataDeliveryEstimate>,
     /// The name of the shipping rate, meant to be displayable to the customer.
     /// This will appear on CheckoutSessions.
-    pub display_name: &'a str,
+    pub display_name: String,
     /// Describes a fixed amount to charge for shipping. Must be present if type is `fixed_amount`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub fixed_amount: Option<CreateInvoiceShippingCostShippingRateDataFixedAmount<'a>>,
+    pub fixed_amount: Option<CreateInvoiceShippingCostShippingRateDataFixedAmount>,
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// Specifies whether the rate is considered inclusive of taxes or exclusive of taxes.
     /// One of `inclusive`, `exclusive`, or `unspecified`.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -7881,17 +7940,17 @@ pub struct CreateInvoiceShippingCostShippingRateData<'a> {
     /// A [tax code](https://stripe.com/docs/tax/tax-categories) ID.
     /// The Shipping tax code is `txcd_92010001`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_code: Option<&'a str>,
+    pub tax_code: Option<String>,
     /// The type of calculation to use on the shipping rate. Can only be `fixed_amount` for now.
     #[serde(rename = "type")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub type_: Option<CreateInvoiceShippingCostShippingRateDataType>,
 }
-impl<'a> CreateInvoiceShippingCostShippingRateData<'a> {
-    pub fn new(display_name: &'a str) -> Self {
+impl CreateInvoiceShippingCostShippingRateData {
+    pub fn new(display_name: impl Into<String>) -> Self {
         Self {
             delivery_estimate: None,
-            display_name,
+            display_name: display_name.into(),
             fixed_amount: None,
             metadata: None,
             tax_behavior: None,
@@ -7931,10 +7990,10 @@ pub struct CreateInvoiceShippingCostShippingRateDataDeliveryEstimateMaximum {
 }
 impl CreateInvoiceShippingCostShippingRateDataDeliveryEstimateMaximum {
     pub fn new(
-        unit: CreateInvoiceShippingCostShippingRateDataDeliveryEstimateMaximumUnit,
-        value: i64,
+        unit: impl Into<CreateInvoiceShippingCostShippingRateDataDeliveryEstimateMaximumUnit>,
+        value: impl Into<i64>,
     ) -> Self {
-        Self { unit, value }
+        Self { unit: unit.into(), value: value.into() }
     }
 }
 /// A unit of time.
@@ -8012,10 +8071,10 @@ pub struct CreateInvoiceShippingCostShippingRateDataDeliveryEstimateMinimum {
 }
 impl CreateInvoiceShippingCostShippingRateDataDeliveryEstimateMinimum {
     pub fn new(
-        unit: CreateInvoiceShippingCostShippingRateDataDeliveryEstimateMinimumUnit,
-        value: i64,
+        unit: impl Into<CreateInvoiceShippingCostShippingRateDataDeliveryEstimateMinimumUnit>,
+        value: impl Into<i64>,
     ) -> Self {
-        Self { unit, value }
+        Self { unit: unit.into(), value: value.into() }
     }
 }
 /// A unit of time.
@@ -8084,8 +8143,8 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// Describes a fixed amount to charge for shipping. Must be present if type is `fixed_amount`.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateInvoiceShippingCostShippingRateDataFixedAmount<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateInvoiceShippingCostShippingRateDataFixedAmount {
     /// A non-negative integer in cents representing how much to charge.
     pub amount: i64,
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
@@ -8095,15 +8154,15 @@ pub struct CreateInvoiceShippingCostShippingRateDataFixedAmount<'a> {
     /// Each key must be a three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html) and a [supported currency](https://stripe.com/docs/currencies).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub currency_options: Option<
-        &'a std::collections::HashMap<
+        std::collections::HashMap<
             stripe_types::Currency,
             CreateInvoiceShippingCostShippingRateDataFixedAmountCurrencyOptions,
         >,
     >,
 }
-impl<'a> CreateInvoiceShippingCostShippingRateDataFixedAmount<'a> {
-    pub fn new(amount: i64, currency: stripe_types::Currency) -> Self {
-        Self { amount, currency, currency_options: None }
+impl CreateInvoiceShippingCostShippingRateDataFixedAmount {
+    pub fn new(amount: impl Into<i64>, currency: impl Into<stripe_types::Currency>) -> Self {
+        Self { amount: amount.into(), currency: currency.into(), currency_options: None }
     }
 }
 /// Shipping rates defined in each available currency option.
@@ -8119,8 +8178,8 @@ pub struct CreateInvoiceShippingCostShippingRateDataFixedAmountCurrencyOptions {
         Option<CreateInvoiceShippingCostShippingRateDataFixedAmountCurrencyOptionsTaxBehavior>,
 }
 impl CreateInvoiceShippingCostShippingRateDataFixedAmountCurrencyOptions {
-    pub fn new(amount: i64) -> Self {
-        Self { amount, tax_behavior: None }
+    pub fn new(amount: impl Into<i64>) -> Self {
+        Self { amount: amount.into(), tax_behavior: None }
     }
 }
 /// Specifies whether the rate is considered inclusive of taxes or exclusive of taxes.
@@ -8309,52 +8368,52 @@ impl<'de> serde::Deserialize<'de> for CreateInvoiceShippingCostShippingRateDataT
     }
 }
 /// If specified, the funds from the invoice will be transferred to the destination and the ID of the resulting transfer will be found on the invoice's charge.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateInvoiceTransferData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateInvoiceTransferData {
     /// The amount that will be transferred automatically when the invoice is paid.
     /// If no amount is set, the full amount is transferred.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub amount: Option<i64>,
     /// ID of an existing, connected Stripe account.
-    pub destination: &'a str,
+    pub destination: String,
 }
-impl<'a> CreateInvoiceTransferData<'a> {
-    pub fn new(destination: &'a str) -> Self {
-        Self { amount: None, destination }
+impl CreateInvoiceTransferData {
+    pub fn new(destination: impl Into<String>) -> Self {
+        Self { amount: None, destination: destination.into() }
     }
 }
 /// This endpoint creates a draft invoice for a given customer.
 /// The invoice remains a draft until you [finalize](https://stripe.com/docs/api#finalize_invoice) the invoice, which allows you to [pay](https://stripe.com/docs/api#pay_invoice) or [send](https://stripe.com/docs/api#send_invoice) the invoice to your customers.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateInvoice<'a> {
-    inner: CreateInvoiceBuilder<'a>,
+pub struct CreateInvoice {
+    inner: CreateInvoiceBuilder,
 }
-impl<'a> CreateInvoice<'a> {
+impl CreateInvoice {
     /// Construct a new `CreateInvoice`.
     pub fn new() -> Self {
         Self { inner: CreateInvoiceBuilder::new() }
     }
     /// The account tax IDs associated with the invoice. Only editable when the invoice is a draft.
-    pub fn account_tax_ids(mut self, account_tax_ids: &'a [&'a str]) -> Self {
-        self.inner.account_tax_ids = Some(account_tax_ids);
+    pub fn account_tax_ids(mut self, account_tax_ids: impl Into<Vec<String>>) -> Self {
+        self.inner.account_tax_ids = Some(account_tax_ids.into());
         self
     }
     /// A fee in cents (or local equivalent) that will be applied to the invoice and transferred to the application owner's Stripe account.
     /// The request must be made with an OAuth key or the Stripe-Account header in order to take an application fee.
     /// For more information, see the application fees [documentation](https://stripe.com/docs/billing/invoices/connect#collecting-fees).
-    pub fn application_fee_amount(mut self, application_fee_amount: i64) -> Self {
-        self.inner.application_fee_amount = Some(application_fee_amount);
+    pub fn application_fee_amount(mut self, application_fee_amount: impl Into<i64>) -> Self {
+        self.inner.application_fee_amount = Some(application_fee_amount.into());
         self
     }
     /// Controls whether Stripe performs [automatic collection](https://stripe.com/docs/invoicing/integration/automatic-advancement-collection) of the invoice.
     /// If `false`, the invoice's state doesn't automatically advance without an explicit action.
-    pub fn auto_advance(mut self, auto_advance: bool) -> Self {
-        self.inner.auto_advance = Some(auto_advance);
+    pub fn auto_advance(mut self, auto_advance: impl Into<bool>) -> Self {
+        self.inner.auto_advance = Some(auto_advance.into());
         self
     }
     /// Settings for automatic tax lookup for this invoice.
-    pub fn automatic_tax(mut self, automatic_tax: CreateInvoiceAutomaticTax<'a>) -> Self {
-        self.inner.automatic_tax = Some(automatic_tax);
+    pub fn automatic_tax(mut self, automatic_tax: impl Into<CreateInvoiceAutomaticTax>) -> Self {
+        self.inner.automatic_tax = Some(automatic_tax.into());
         self
     }
     /// Either `charge_automatically`, or `send_invoice`.
@@ -8363,107 +8422,110 @@ impl<'a> CreateInvoice<'a> {
     /// Defaults to `charge_automatically`.
     pub fn collection_method(
         mut self,
-        collection_method: stripe_shared::InvoiceCollectionMethod,
+        collection_method: impl Into<stripe_shared::InvoiceCollectionMethod>,
     ) -> Self {
-        self.inner.collection_method = Some(collection_method);
+        self.inner.collection_method = Some(collection_method.into());
         self
     }
     /// The currency to create this invoice in. Defaults to that of `customer` if not specified.
-    pub fn currency(mut self, currency: stripe_types::Currency) -> Self {
-        self.inner.currency = Some(currency);
+    pub fn currency(mut self, currency: impl Into<stripe_types::Currency>) -> Self {
+        self.inner.currency = Some(currency.into());
         self
     }
     /// A list of up to 4 custom fields to be displayed on the invoice.
-    pub fn custom_fields(mut self, custom_fields: &'a [CustomFieldParams<'a>]) -> Self {
-        self.inner.custom_fields = Some(custom_fields);
+    pub fn custom_fields(mut self, custom_fields: impl Into<Vec<CustomFieldParams>>) -> Self {
+        self.inner.custom_fields = Some(custom_fields.into());
         self
     }
     /// The ID of the customer who will be billed.
-    pub fn customer(mut self, customer: &'a str) -> Self {
-        self.inner.customer = Some(customer);
+    pub fn customer(mut self, customer: impl Into<String>) -> Self {
+        self.inner.customer = Some(customer.into());
         self
     }
     /// The number of days from when the invoice is created until it is due.
     /// Valid only for invoices where `collection_method=send_invoice`.
-    pub fn days_until_due(mut self, days_until_due: u32) -> Self {
-        self.inner.days_until_due = Some(days_until_due);
+    pub fn days_until_due(mut self, days_until_due: impl Into<u32>) -> Self {
+        self.inner.days_until_due = Some(days_until_due.into());
         self
     }
     /// ID of the default payment method for the invoice.
     /// It must belong to the customer associated with the invoice.
     /// If not set, defaults to the subscription's default payment method, if any, or to the default payment method in the customer's invoice settings.
-    pub fn default_payment_method(mut self, default_payment_method: &'a str) -> Self {
-        self.inner.default_payment_method = Some(default_payment_method);
+    pub fn default_payment_method(mut self, default_payment_method: impl Into<String>) -> Self {
+        self.inner.default_payment_method = Some(default_payment_method.into());
         self
     }
     /// ID of the default payment source for the invoice.
     /// It must belong to the customer associated with the invoice and be in a chargeable state.
     /// If not set, defaults to the subscription's default source, if any, or to the customer's default source.
-    pub fn default_source(mut self, default_source: &'a str) -> Self {
-        self.inner.default_source = Some(default_source);
+    pub fn default_source(mut self, default_source: impl Into<String>) -> Self {
+        self.inner.default_source = Some(default_source.into());
         self
     }
     /// The tax rates that will apply to any line item that does not have `tax_rates` set.
-    pub fn default_tax_rates(mut self, default_tax_rates: &'a [&'a str]) -> Self {
-        self.inner.default_tax_rates = Some(default_tax_rates);
+    pub fn default_tax_rates(mut self, default_tax_rates: impl Into<Vec<String>>) -> Self {
+        self.inner.default_tax_rates = Some(default_tax_rates.into());
         self
     }
     /// An arbitrary string attached to the object.
     /// Often useful for displaying to users.
     /// Referenced as 'memo' in the Dashboard.
-    pub fn description(mut self, description: &'a str) -> Self {
-        self.inner.description = Some(description);
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.inner.description = Some(description.into());
         self
     }
     /// The coupons and promotion codes to redeem into discounts for the invoice.
     /// If not specified, inherits the discount from the invoice's customer.
     /// Pass an empty string to avoid inheriting any discounts.
-    pub fn discounts(mut self, discounts: &'a [DiscountsDataParam<'a>]) -> Self {
-        self.inner.discounts = Some(discounts);
+    pub fn discounts(mut self, discounts: impl Into<Vec<DiscountsDataParam>>) -> Self {
+        self.inner.discounts = Some(discounts.into());
         self
     }
     /// The date on which payment for this invoice is due.
     /// Valid only for invoices where `collection_method=send_invoice`.
-    pub fn due_date(mut self, due_date: stripe_types::Timestamp) -> Self {
-        self.inner.due_date = Some(due_date);
+    pub fn due_date(mut self, due_date: impl Into<stripe_types::Timestamp>) -> Self {
+        self.inner.due_date = Some(due_date.into());
         self
     }
     /// The date when this invoice is in effect.
     /// Same as `finalized_at` unless overwritten.
     /// When defined, this value replaces the system-generated 'Date of issue' printed on the invoice PDF and receipt.
-    pub fn effective_at(mut self, effective_at: stripe_types::Timestamp) -> Self {
-        self.inner.effective_at = Some(effective_at);
+    pub fn effective_at(mut self, effective_at: impl Into<stripe_types::Timestamp>) -> Self {
+        self.inner.effective_at = Some(effective_at.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Footer to be displayed on the invoice.
-    pub fn footer(mut self, footer: &'a str) -> Self {
-        self.inner.footer = Some(footer);
+    pub fn footer(mut self, footer: impl Into<String>) -> Self {
+        self.inner.footer = Some(footer.into());
         self
     }
     /// Revise an existing invoice.
     /// The new invoice will be created in `status=draft`.
     /// See the [revision documentation](https://stripe.com/docs/invoicing/invoice-revisions) for more details.
-    pub fn from_invoice(mut self, from_invoice: CreateInvoiceFromInvoice<'a>) -> Self {
-        self.inner.from_invoice = Some(from_invoice);
+    pub fn from_invoice(mut self, from_invoice: impl Into<CreateInvoiceFromInvoice>) -> Self {
+        self.inner.from_invoice = Some(from_invoice.into());
         self
     }
     /// The connected account that issues the invoice.
     /// The invoice is presented with the branding and support information of the specified account.
-    pub fn issuer(mut self, issuer: CreateInvoiceIssuer<'a>) -> Self {
-        self.inner.issuer = Some(issuer);
+    pub fn issuer(mut self, issuer: impl Into<CreateInvoiceIssuer>) -> Self {
+        self.inner.issuer = Some(issuer.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// Set the number for this invoice.
@@ -8471,76 +8533,79 @@ impl<'a> CreateInvoice<'a> {
     /// In many markets, regulations require invoices to be unique, sequential and / or gapless.
     /// You are responsible for ensuring this is true across all your different invoicing systems in the event that you edit the invoice number using our API.
     /// If you use only Stripe for your invoices and do not change invoice numbers, Stripe handles this aspect of compliance for you automatically.
-    pub fn number(mut self, number: &'a str) -> Self {
-        self.inner.number = Some(number);
+    pub fn number(mut self, number: impl Into<String>) -> Self {
+        self.inner.number = Some(number.into());
         self
     }
     /// The account (if any) for which the funds of the invoice payment are intended.
     /// If set, the invoice will be presented with the branding and support information of the specified account.
     /// See the [Invoices with Connect](https://stripe.com/docs/billing/invoices/connect) documentation for details.
-    pub fn on_behalf_of(mut self, on_behalf_of: &'a str) -> Self {
-        self.inner.on_behalf_of = Some(on_behalf_of);
+    pub fn on_behalf_of(mut self, on_behalf_of: impl Into<String>) -> Self {
+        self.inner.on_behalf_of = Some(on_behalf_of.into());
         self
     }
     /// Configuration settings for the PaymentIntent that is generated when the invoice is finalized.
-    pub fn payment_settings(mut self, payment_settings: CreateInvoicePaymentSettings<'a>) -> Self {
-        self.inner.payment_settings = Some(payment_settings);
+    pub fn payment_settings(
+        mut self,
+        payment_settings: impl Into<CreateInvoicePaymentSettings>,
+    ) -> Self {
+        self.inner.payment_settings = Some(payment_settings.into());
         self
     }
     /// How to handle pending invoice items on invoice creation.
     /// Defaults to `exclude` if the parameter is omitted.
     pub fn pending_invoice_items_behavior(
         mut self,
-        pending_invoice_items_behavior: CreateInvoicePendingInvoiceItemsBehavior,
+        pending_invoice_items_behavior: impl Into<CreateInvoicePendingInvoiceItemsBehavior>,
     ) -> Self {
-        self.inner.pending_invoice_items_behavior = Some(pending_invoice_items_behavior);
+        self.inner.pending_invoice_items_behavior = Some(pending_invoice_items_behavior.into());
         self
     }
     /// The rendering-related settings that control how the invoice is displayed on customer-facing surfaces such as PDF and Hosted Invoice Page.
-    pub fn rendering(mut self, rendering: CreateInvoiceRendering) -> Self {
-        self.inner.rendering = Some(rendering);
+    pub fn rendering(mut self, rendering: impl Into<CreateInvoiceRendering>) -> Self {
+        self.inner.rendering = Some(rendering.into());
         self
     }
     /// Settings for the cost of shipping for this invoice.
-    pub fn shipping_cost(mut self, shipping_cost: CreateInvoiceShippingCost<'a>) -> Self {
-        self.inner.shipping_cost = Some(shipping_cost);
+    pub fn shipping_cost(mut self, shipping_cost: impl Into<CreateInvoiceShippingCost>) -> Self {
+        self.inner.shipping_cost = Some(shipping_cost.into());
         self
     }
     /// Shipping details for the invoice.
     /// The Invoice PDF will use the `shipping_details` value if it is set, otherwise the PDF will render the shipping address from the customer.
     pub fn shipping_details(
         mut self,
-        shipping_details: RecipientShippingWithOptionalFieldsAddress<'a>,
+        shipping_details: impl Into<RecipientShippingWithOptionalFieldsAddress>,
     ) -> Self {
-        self.inner.shipping_details = Some(shipping_details);
+        self.inner.shipping_details = Some(shipping_details.into());
         self
     }
     /// Extra information about a charge for the customer's credit card statement.
     /// It must contain at least one letter.
     /// If not specified and this invoice is part of a subscription, the default `statement_descriptor` will be set to the first subscription item's product's `statement_descriptor`.
-    pub fn statement_descriptor(mut self, statement_descriptor: &'a str) -> Self {
-        self.inner.statement_descriptor = Some(statement_descriptor);
+    pub fn statement_descriptor(mut self, statement_descriptor: impl Into<String>) -> Self {
+        self.inner.statement_descriptor = Some(statement_descriptor.into());
         self
     }
     /// The ID of the subscription to invoice, if any.
     /// If set, the created invoice will only include pending invoice items for that subscription.
     /// The subscription's billing cycle and regular subscription events won't be affected.
-    pub fn subscription(mut self, subscription: &'a str) -> Self {
-        self.inner.subscription = Some(subscription);
+    pub fn subscription(mut self, subscription: impl Into<String>) -> Self {
+        self.inner.subscription = Some(subscription.into());
         self
     }
     /// If specified, the funds from the invoice will be transferred to the destination and the ID of the resulting transfer will be found on the invoice's charge.
-    pub fn transfer_data(mut self, transfer_data: CreateInvoiceTransferData<'a>) -> Self {
-        self.inner.transfer_data = Some(transfer_data);
+    pub fn transfer_data(mut self, transfer_data: impl Into<CreateInvoiceTransferData>) -> Self {
+        self.inner.transfer_data = Some(transfer_data.into());
         self
     }
 }
-impl<'a> Default for CreateInvoice<'a> {
+impl Default for CreateInvoice {
     fn default() -> Self {
         Self::new()
     }
 }
-impl CreateInvoice<'_> {
+impl CreateInvoice {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -8558,7 +8623,7 @@ impl CreateInvoice<'_> {
     }
 }
 
-impl StripeRequest for CreateInvoice<'_> {
+impl StripeRequest for CreateInvoice {
     type Output = stripe_shared::Invoice;
 
     fn build(&self) -> RequestBuilder {
@@ -8566,61 +8631,61 @@ impl StripeRequest for CreateInvoice<'_> {
     }
 }
 #[derive(Clone, Debug, serde::Serialize)]
-struct UpdateInvoiceBuilder<'a> {
+struct UpdateInvoiceBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    account_tax_ids: Option<&'a [&'a str]>,
+    account_tax_ids: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     application_fee_amount: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     auto_advance: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    automatic_tax: Option<UpdateInvoiceAutomaticTax<'a>>,
+    automatic_tax: Option<UpdateInvoiceAutomaticTax>,
     #[serde(skip_serializing_if = "Option::is_none")]
     collection_method: Option<stripe_shared::InvoiceCollectionMethod>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    custom_fields: Option<&'a [CustomFieldParams<'a>]>,
+    custom_fields: Option<Vec<CustomFieldParams>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     days_until_due: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    default_payment_method: Option<&'a str>,
+    default_payment_method: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    default_source: Option<&'a str>,
+    default_source: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    default_tax_rates: Option<&'a [&'a str]>,
+    default_tax_rates: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<&'a str>,
+    description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    discounts: Option<&'a [DiscountsDataParam<'a>]>,
+    discounts: Option<Vec<DiscountsDataParam>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     due_date: Option<stripe_types::Timestamp>,
     #[serde(skip_serializing_if = "Option::is_none")]
     effective_at: Option<stripe_types::Timestamp>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    footer: Option<&'a str>,
+    footer: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    issuer: Option<UpdateInvoiceIssuer<'a>>,
+    issuer: Option<UpdateInvoiceIssuer>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    number: Option<&'a str>,
+    number: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    on_behalf_of: Option<&'a str>,
+    on_behalf_of: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_settings: Option<UpdateInvoicePaymentSettings<'a>>,
+    payment_settings: Option<UpdateInvoicePaymentSettings>,
     #[serde(skip_serializing_if = "Option::is_none")]
     rendering: Option<UpdateInvoiceRendering>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    shipping_cost: Option<UpdateInvoiceShippingCost<'a>>,
+    shipping_cost: Option<UpdateInvoiceShippingCost>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    shipping_details: Option<RecipientShippingWithOptionalFieldsAddress<'a>>,
+    shipping_details: Option<RecipientShippingWithOptionalFieldsAddress>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    statement_descriptor: Option<&'a str>,
+    statement_descriptor: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    transfer_data: Option<UpdateInvoiceTransferData<'a>>,
+    transfer_data: Option<UpdateInvoiceTransferData>,
 }
-impl<'a> UpdateInvoiceBuilder<'a> {
+impl UpdateInvoiceBuilder {
     fn new() -> Self {
         Self {
             account_tax_ids: None,
@@ -8653,8 +8718,8 @@ impl<'a> UpdateInvoiceBuilder<'a> {
     }
 }
 /// Settings for automatic tax lookup for this invoice.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateInvoiceAutomaticTax<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateInvoiceAutomaticTax {
     /// Whether Stripe automatically computes tax on this invoice.
     /// Note that incompatible invoice items (invoice items with manually specified [tax rates](https://stripe.com/docs/api/tax_rates), negative amounts, or `tax_behavior=unspecified`) cannot be added to automatic tax invoices.
     pub enabled: bool,
@@ -8662,28 +8727,28 @@ pub struct UpdateInvoiceAutomaticTax<'a> {
     /// If set, the business address and tax registrations required to perform the tax calculation are loaded from this account.
     /// The tax transaction is returned in the report of the connected account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub liability: Option<UpdateInvoiceAutomaticTaxLiability<'a>>,
+    pub liability: Option<UpdateInvoiceAutomaticTaxLiability>,
 }
-impl<'a> UpdateInvoiceAutomaticTax<'a> {
-    pub fn new(enabled: bool) -> Self {
-        Self { enabled, liability: None }
+impl UpdateInvoiceAutomaticTax {
+    pub fn new(enabled: impl Into<bool>) -> Self {
+        Self { enabled: enabled.into(), liability: None }
     }
 }
 /// The account that's liable for tax.
 /// If set, the business address and tax registrations required to perform the tax calculation are loaded from this account.
 /// The tax transaction is returned in the report of the connected account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateInvoiceAutomaticTaxLiability<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateInvoiceAutomaticTaxLiability {
     /// The connected account being referenced when `type` is `account`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account: Option<&'a str>,
+    pub account: Option<String>,
     /// Type of the account referenced in the request.
     #[serde(rename = "type")]
     pub type_: UpdateInvoiceAutomaticTaxLiabilityType,
 }
-impl<'a> UpdateInvoiceAutomaticTaxLiability<'a> {
-    pub fn new(type_: UpdateInvoiceAutomaticTaxLiabilityType) -> Self {
-        Self { account: None, type_ }
+impl UpdateInvoiceAutomaticTaxLiability {
+    pub fn new(type_: impl Into<UpdateInvoiceAutomaticTaxLiabilityType>) -> Self {
+        Self { account: None, type_: type_.into() }
     }
 }
 /// Type of the account referenced in the request.
@@ -8744,18 +8809,18 @@ impl<'de> serde::Deserialize<'de> for UpdateInvoiceAutomaticTaxLiabilityType {
 }
 /// The connected account that issues the invoice.
 /// The invoice is presented with the branding and support information of the specified account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateInvoiceIssuer<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateInvoiceIssuer {
     /// The connected account being referenced when `type` is `account`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account: Option<&'a str>,
+    pub account: Option<String>,
     /// Type of the account referenced in the request.
     #[serde(rename = "type")]
     pub type_: UpdateInvoiceIssuerType,
 }
-impl<'a> UpdateInvoiceIssuer<'a> {
-    pub fn new(type_: UpdateInvoiceIssuerType) -> Self {
-        Self { account: None, type_ }
+impl UpdateInvoiceIssuer {
+    pub fn new(type_: impl Into<UpdateInvoiceIssuerType>) -> Self {
+        Self { account: None, type_: type_.into() }
     }
 }
 /// Type of the account referenced in the request.
@@ -8815,33 +8880,33 @@ impl<'de> serde::Deserialize<'de> for UpdateInvoiceIssuerType {
 }
 /// Configuration settings for the PaymentIntent that is generated when the invoice is finalized.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateInvoicePaymentSettings<'a> {
+pub struct UpdateInvoicePaymentSettings {
     /// ID of the mandate to be used for this invoice.
     /// It must correspond to the payment method used to pay the invoice, including the invoice's default_payment_method or default_source, if set.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub default_mandate: Option<&'a str>,
+    pub default_mandate: Option<String>,
     /// Payment-method-specific configuration to provide to the invoice’s PaymentIntent.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub payment_method_options: Option<UpdateInvoicePaymentSettingsPaymentMethodOptions<'a>>,
+    pub payment_method_options: Option<UpdateInvoicePaymentSettingsPaymentMethodOptions>,
     /// The list of payment method types (e.g.
     /// card) to provide to the invoice’s PaymentIntent.
     /// If not set, Stripe attempts to automatically determine the types to use by looking at the invoice’s default payment method, the subscription’s default payment method, the customer’s default payment method, and your [invoice template settings](https://dashboard.stripe.com/settings/billing/invoice).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub payment_method_types: Option<&'a [UpdateInvoicePaymentSettingsPaymentMethodTypes]>,
+    pub payment_method_types: Option<Vec<UpdateInvoicePaymentSettingsPaymentMethodTypes>>,
 }
-impl<'a> UpdateInvoicePaymentSettings<'a> {
+impl UpdateInvoicePaymentSettings {
     pub fn new() -> Self {
         Self { default_mandate: None, payment_method_options: None, payment_method_types: None }
     }
 }
-impl<'a> Default for UpdateInvoicePaymentSettings<'a> {
+impl Default for UpdateInvoicePaymentSettings {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Payment-method-specific configuration to provide to the invoice’s PaymentIntent.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateInvoicePaymentSettingsPaymentMethodOptions<'a> {
+pub struct UpdateInvoicePaymentSettingsPaymentMethodOptions {
     /// If paying by `acss_debit`, this sub-hash contains details about the Canadian pre-authorized debit payment method options to pass to the invoice’s PaymentIntent.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub acss_debit: Option<UpdateInvoicePaymentSettingsPaymentMethodOptionsAcssDebit>,
@@ -8853,7 +8918,7 @@ pub struct UpdateInvoicePaymentSettingsPaymentMethodOptions<'a> {
     pub card: Option<UpdateInvoicePaymentSettingsPaymentMethodOptionsCard>,
     /// If paying by `customer_balance`, this sub-hash contains details about the Bank transfer payment method options to pass to the invoice’s PaymentIntent.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub customer_balance: Option<InvoicePaymentMethodOptionsParam<'a>>,
+    pub customer_balance: Option<InvoicePaymentMethodOptionsParam>,
     /// If paying by `konbini`, this sub-hash contains details about the Konbini payment method options to pass to the invoice’s PaymentIntent.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
@@ -8864,9 +8929,9 @@ pub struct UpdateInvoicePaymentSettingsPaymentMethodOptions<'a> {
     pub sepa_debit: Option<miniserde::json::Value>,
     /// If paying by `us_bank_account`, this sub-hash contains details about the ACH direct debit payment method options to pass to the invoice’s PaymentIntent.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub us_bank_account: Option<UpdateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccount<'a>>,
+    pub us_bank_account: Option<UpdateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccount>,
 }
-impl<'a> UpdateInvoicePaymentSettingsPaymentMethodOptions<'a> {
+impl UpdateInvoicePaymentSettingsPaymentMethodOptions {
     pub fn new() -> Self {
         Self {
             acss_debit: None,
@@ -8879,7 +8944,7 @@ impl<'a> UpdateInvoicePaymentSettingsPaymentMethodOptions<'a> {
         }
     }
 }
-impl<'a> Default for UpdateInvoicePaymentSettingsPaymentMethodOptions<'a> {
+impl Default for UpdateInvoicePaymentSettingsPaymentMethodOptions {
     fn default() -> Self {
         Self::new()
     }
@@ -9206,11 +9271,13 @@ pub struct UpdateInvoicePaymentSettingsPaymentMethodOptionsCardInstallmentsPlan 
 }
 impl UpdateInvoicePaymentSettingsPaymentMethodOptionsCardInstallmentsPlan {
     pub fn new(
-        count: u64,
-        interval: UpdateInvoicePaymentSettingsPaymentMethodOptionsCardInstallmentsPlanInterval,
-        type_: UpdateInvoicePaymentSettingsPaymentMethodOptionsCardInstallmentsPlanType,
+        count: impl Into<u64>,
+        interval: impl Into<
+            UpdateInvoicePaymentSettingsPaymentMethodOptionsCardInstallmentsPlanInterval,
+        >,
+        type_: impl Into<UpdateInvoicePaymentSettingsPaymentMethodOptionsCardInstallmentsPlanType>,
     ) -> Self {
-        Self { count, interval, type_ }
+        Self { count: count.into(), interval: interval.into(), type_: type_.into() }
     }
 }
 /// For `fixed_count` installment plans, this is the interval between installment payments your customer will make to their credit card.
@@ -9394,49 +9461,46 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// If paying by `us_bank_account`, this sub-hash contains details about the ACH direct debit payment method options to pass to the invoice’s PaymentIntent.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccount<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccount {
     /// Additional fields for Financial Connections Session creation
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub financial_connections: Option<
-        UpdateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccountFinancialConnections<'a>,
-    >,
+    pub financial_connections:
+        Option<UpdateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccountFinancialConnections>,
     /// Verification method for the intent
     #[serde(skip_serializing_if = "Option::is_none")]
     pub verification_method:
         Option<UpdateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccountVerificationMethod>,
 }
-impl<'a> UpdateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccount<'a> {
+impl UpdateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccount {
     pub fn new() -> Self {
         Self { financial_connections: None, verification_method: None }
     }
 }
-impl<'a> Default for UpdateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccount<'a> {
+impl Default for UpdateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccount {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Additional fields for Financial Connections Session creation
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccountFinancialConnections<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccountFinancialConnections {
         /// The list of permissions to request.
     /// If this parameter is passed, the `payment_method` permission must be included.
     /// Valid permissions include: `balances`, `ownership`, `payment_method`, and `transactions`.
 #[serde(skip_serializing_if = "Option::is_none")]
-pub permissions: Option<&'a [UpdateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccountFinancialConnectionsPermissions]>,
+pub permissions: Option<Vec<UpdateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccountFinancialConnectionsPermissions>>,
     /// List of data features that you would like to retrieve upon account creation.
 #[serde(skip_serializing_if = "Option::is_none")]
-pub prefetch: Option<&'a [UpdateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccountFinancialConnectionsPrefetch]>,
+pub prefetch: Option<Vec<UpdateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccountFinancialConnectionsPrefetch>>,
 
 }
-impl<'a> UpdateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccountFinancialConnections<'a> {
+impl UpdateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccountFinancialConnections {
     pub fn new() -> Self {
         Self { permissions: None, prefetch: None }
     }
 }
-impl<'a> Default
-    for UpdateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccountFinancialConnections<'a>
-{
+impl Default for UpdateInvoicePaymentSettingsPaymentMethodOptionsUsBankAccountFinancialConnections {
     fn default() -> Self {
         Self::new()
     }
@@ -9949,44 +10013,44 @@ impl<'de> serde::Deserialize<'de> for UpdateInvoiceRenderingPdfPageSize {
     }
 }
 /// Settings for the cost of shipping for this invoice.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateInvoiceShippingCost<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateInvoiceShippingCost {
     /// The ID of the shipping rate to use for this order.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub shipping_rate: Option<&'a str>,
+    pub shipping_rate: Option<String>,
     /// Parameters to create a new ad-hoc shipping rate for this order.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub shipping_rate_data: Option<UpdateInvoiceShippingCostShippingRateData<'a>>,
+    pub shipping_rate_data: Option<UpdateInvoiceShippingCostShippingRateData>,
 }
-impl<'a> UpdateInvoiceShippingCost<'a> {
+impl UpdateInvoiceShippingCost {
     pub fn new() -> Self {
         Self { shipping_rate: None, shipping_rate_data: None }
     }
 }
-impl<'a> Default for UpdateInvoiceShippingCost<'a> {
+impl Default for UpdateInvoiceShippingCost {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Parameters to create a new ad-hoc shipping rate for this order.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateInvoiceShippingCostShippingRateData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateInvoiceShippingCostShippingRateData {
     /// The estimated range for how long shipping will take, meant to be displayable to the customer.
     /// This will appear on CheckoutSessions.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub delivery_estimate: Option<UpdateInvoiceShippingCostShippingRateDataDeliveryEstimate>,
     /// The name of the shipping rate, meant to be displayable to the customer.
     /// This will appear on CheckoutSessions.
-    pub display_name: &'a str,
+    pub display_name: String,
     /// Describes a fixed amount to charge for shipping. Must be present if type is `fixed_amount`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub fixed_amount: Option<UpdateInvoiceShippingCostShippingRateDataFixedAmount<'a>>,
+    pub fixed_amount: Option<UpdateInvoiceShippingCostShippingRateDataFixedAmount>,
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// Specifies whether the rate is considered inclusive of taxes or exclusive of taxes.
     /// One of `inclusive`, `exclusive`, or `unspecified`.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -9994,17 +10058,17 @@ pub struct UpdateInvoiceShippingCostShippingRateData<'a> {
     /// A [tax code](https://stripe.com/docs/tax/tax-categories) ID.
     /// The Shipping tax code is `txcd_92010001`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_code: Option<&'a str>,
+    pub tax_code: Option<String>,
     /// The type of calculation to use on the shipping rate. Can only be `fixed_amount` for now.
     #[serde(rename = "type")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub type_: Option<UpdateInvoiceShippingCostShippingRateDataType>,
 }
-impl<'a> UpdateInvoiceShippingCostShippingRateData<'a> {
-    pub fn new(display_name: &'a str) -> Self {
+impl UpdateInvoiceShippingCostShippingRateData {
+    pub fn new(display_name: impl Into<String>) -> Self {
         Self {
             delivery_estimate: None,
-            display_name,
+            display_name: display_name.into(),
             fixed_amount: None,
             metadata: None,
             tax_behavior: None,
@@ -10044,10 +10108,10 @@ pub struct UpdateInvoiceShippingCostShippingRateDataDeliveryEstimateMaximum {
 }
 impl UpdateInvoiceShippingCostShippingRateDataDeliveryEstimateMaximum {
     pub fn new(
-        unit: UpdateInvoiceShippingCostShippingRateDataDeliveryEstimateMaximumUnit,
-        value: i64,
+        unit: impl Into<UpdateInvoiceShippingCostShippingRateDataDeliveryEstimateMaximumUnit>,
+        value: impl Into<i64>,
     ) -> Self {
-        Self { unit, value }
+        Self { unit: unit.into(), value: value.into() }
     }
 }
 /// A unit of time.
@@ -10125,10 +10189,10 @@ pub struct UpdateInvoiceShippingCostShippingRateDataDeliveryEstimateMinimum {
 }
 impl UpdateInvoiceShippingCostShippingRateDataDeliveryEstimateMinimum {
     pub fn new(
-        unit: UpdateInvoiceShippingCostShippingRateDataDeliveryEstimateMinimumUnit,
-        value: i64,
+        unit: impl Into<UpdateInvoiceShippingCostShippingRateDataDeliveryEstimateMinimumUnit>,
+        value: impl Into<i64>,
     ) -> Self {
-        Self { unit, value }
+        Self { unit: unit.into(), value: value.into() }
     }
 }
 /// A unit of time.
@@ -10197,8 +10261,8 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// Describes a fixed amount to charge for shipping. Must be present if type is `fixed_amount`.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateInvoiceShippingCostShippingRateDataFixedAmount<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateInvoiceShippingCostShippingRateDataFixedAmount {
     /// A non-negative integer in cents representing how much to charge.
     pub amount: i64,
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
@@ -10208,15 +10272,15 @@ pub struct UpdateInvoiceShippingCostShippingRateDataFixedAmount<'a> {
     /// Each key must be a three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html) and a [supported currency](https://stripe.com/docs/currencies).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub currency_options: Option<
-        &'a std::collections::HashMap<
+        std::collections::HashMap<
             stripe_types::Currency,
             UpdateInvoiceShippingCostShippingRateDataFixedAmountCurrencyOptions,
         >,
     >,
 }
-impl<'a> UpdateInvoiceShippingCostShippingRateDataFixedAmount<'a> {
-    pub fn new(amount: i64, currency: stripe_types::Currency) -> Self {
-        Self { amount, currency, currency_options: None }
+impl UpdateInvoiceShippingCostShippingRateDataFixedAmount {
+    pub fn new(amount: impl Into<i64>, currency: impl Into<stripe_types::Currency>) -> Self {
+        Self { amount: amount.into(), currency: currency.into(), currency_options: None }
     }
 }
 /// Shipping rates defined in each available currency option.
@@ -10232,8 +10296,8 @@ pub struct UpdateInvoiceShippingCostShippingRateDataFixedAmountCurrencyOptions {
         Option<UpdateInvoiceShippingCostShippingRateDataFixedAmountCurrencyOptionsTaxBehavior>,
 }
 impl UpdateInvoiceShippingCostShippingRateDataFixedAmountCurrencyOptions {
-    pub fn new(amount: i64) -> Self {
-        Self { amount, tax_behavior: None }
+    pub fn new(amount: impl Into<i64>) -> Self {
+        Self { amount: amount.into(), tax_behavior: None }
     }
 }
 /// Specifies whether the rate is considered inclusive of taxes or exclusive of taxes.
@@ -10423,18 +10487,18 @@ impl<'de> serde::Deserialize<'de> for UpdateInvoiceShippingCostShippingRateDataT
 }
 /// If specified, the funds from the invoice will be transferred to the destination and the ID of the resulting transfer will be found on the invoice's charge.
 /// This will be unset if you POST an empty value.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateInvoiceTransferData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateInvoiceTransferData {
     /// The amount that will be transferred automatically when the invoice is paid.
     /// If no amount is set, the full amount is transferred.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub amount: Option<i64>,
     /// ID of an existing, connected Stripe account.
-    pub destination: &'a str,
+    pub destination: String,
 }
-impl<'a> UpdateInvoiceTransferData<'a> {
-    pub fn new(destination: &'a str) -> Self {
-        Self { amount: None, destination }
+impl UpdateInvoiceTransferData {
+    pub fn new(destination: impl Into<String>) -> Self {
+        Self { amount: None, destination: destination.into() }
     }
 }
 /// Draft invoices are fully editable.
@@ -10445,129 +10509,132 @@ impl<'a> UpdateInvoiceTransferData<'a> {
 /// sending reminders for, or [automatically reconciling](https://stripe.com/docs/billing/invoices/reconciliation) invoices, pass.
 /// `auto_advance=false`.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateInvoice<'a> {
-    inner: UpdateInvoiceBuilder<'a>,
-    invoice: &'a stripe_shared::InvoiceId,
+pub struct UpdateInvoice {
+    inner: UpdateInvoiceBuilder,
+    invoice: stripe_shared::InvoiceId,
 }
-impl<'a> UpdateInvoice<'a> {
+impl UpdateInvoice {
     /// Construct a new `UpdateInvoice`.
-    pub fn new(invoice: &'a stripe_shared::InvoiceId) -> Self {
-        Self { invoice, inner: UpdateInvoiceBuilder::new() }
+    pub fn new(invoice: impl Into<stripe_shared::InvoiceId>) -> Self {
+        Self { invoice: invoice.into(), inner: UpdateInvoiceBuilder::new() }
     }
     /// The account tax IDs associated with the invoice. Only editable when the invoice is a draft.
-    pub fn account_tax_ids(mut self, account_tax_ids: &'a [&'a str]) -> Self {
-        self.inner.account_tax_ids = Some(account_tax_ids);
+    pub fn account_tax_ids(mut self, account_tax_ids: impl Into<Vec<String>>) -> Self {
+        self.inner.account_tax_ids = Some(account_tax_ids.into());
         self
     }
     /// A fee in cents (or local equivalent) that will be applied to the invoice and transferred to the application owner's Stripe account.
     /// The request must be made with an OAuth key or the Stripe-Account header in order to take an application fee.
     /// For more information, see the application fees [documentation](https://stripe.com/docs/billing/invoices/connect#collecting-fees).
-    pub fn application_fee_amount(mut self, application_fee_amount: i64) -> Self {
-        self.inner.application_fee_amount = Some(application_fee_amount);
+    pub fn application_fee_amount(mut self, application_fee_amount: impl Into<i64>) -> Self {
+        self.inner.application_fee_amount = Some(application_fee_amount.into());
         self
     }
     /// Controls whether Stripe performs [automatic collection](https://stripe.com/docs/invoicing/integration/automatic-advancement-collection) of the invoice.
-    pub fn auto_advance(mut self, auto_advance: bool) -> Self {
-        self.inner.auto_advance = Some(auto_advance);
+    pub fn auto_advance(mut self, auto_advance: impl Into<bool>) -> Self {
+        self.inner.auto_advance = Some(auto_advance.into());
         self
     }
     /// Settings for automatic tax lookup for this invoice.
-    pub fn automatic_tax(mut self, automatic_tax: UpdateInvoiceAutomaticTax<'a>) -> Self {
-        self.inner.automatic_tax = Some(automatic_tax);
+    pub fn automatic_tax(mut self, automatic_tax: impl Into<UpdateInvoiceAutomaticTax>) -> Self {
+        self.inner.automatic_tax = Some(automatic_tax.into());
         self
     }
     /// Either `charge_automatically` or `send_invoice`.
     /// This field can be updated only on `draft` invoices.
     pub fn collection_method(
         mut self,
-        collection_method: stripe_shared::InvoiceCollectionMethod,
+        collection_method: impl Into<stripe_shared::InvoiceCollectionMethod>,
     ) -> Self {
-        self.inner.collection_method = Some(collection_method);
+        self.inner.collection_method = Some(collection_method.into());
         self
     }
     /// A list of up to 4 custom fields to be displayed on the invoice.
     /// If a value for `custom_fields` is specified, the list specified will replace the existing custom field list on this invoice.
     /// Pass an empty string to remove previously-defined fields.
-    pub fn custom_fields(mut self, custom_fields: &'a [CustomFieldParams<'a>]) -> Self {
-        self.inner.custom_fields = Some(custom_fields);
+    pub fn custom_fields(mut self, custom_fields: impl Into<Vec<CustomFieldParams>>) -> Self {
+        self.inner.custom_fields = Some(custom_fields.into());
         self
     }
     /// The number of days from which the invoice is created until it is due.
     /// Only valid for invoices where `collection_method=send_invoice`.
     /// This field can only be updated on `draft` invoices.
-    pub fn days_until_due(mut self, days_until_due: u32) -> Self {
-        self.inner.days_until_due = Some(days_until_due);
+    pub fn days_until_due(mut self, days_until_due: impl Into<u32>) -> Self {
+        self.inner.days_until_due = Some(days_until_due.into());
         self
     }
     /// ID of the default payment method for the invoice.
     /// It must belong to the customer associated with the invoice.
     /// If not set, defaults to the subscription's default payment method, if any, or to the default payment method in the customer's invoice settings.
-    pub fn default_payment_method(mut self, default_payment_method: &'a str) -> Self {
-        self.inner.default_payment_method = Some(default_payment_method);
+    pub fn default_payment_method(mut self, default_payment_method: impl Into<String>) -> Self {
+        self.inner.default_payment_method = Some(default_payment_method.into());
         self
     }
     /// ID of the default payment source for the invoice.
     /// It must belong to the customer associated with the invoice and be in a chargeable state.
     /// If not set, defaults to the subscription's default source, if any, or to the customer's default source.
-    pub fn default_source(mut self, default_source: &'a str) -> Self {
-        self.inner.default_source = Some(default_source);
+    pub fn default_source(mut self, default_source: impl Into<String>) -> Self {
+        self.inner.default_source = Some(default_source.into());
         self
     }
     /// The tax rates that will apply to any line item that does not have `tax_rates` set.
     /// Pass an empty string to remove previously-defined tax rates.
-    pub fn default_tax_rates(mut self, default_tax_rates: &'a [&'a str]) -> Self {
-        self.inner.default_tax_rates = Some(default_tax_rates);
+    pub fn default_tax_rates(mut self, default_tax_rates: impl Into<Vec<String>>) -> Self {
+        self.inner.default_tax_rates = Some(default_tax_rates.into());
         self
     }
     /// An arbitrary string attached to the object.
     /// Often useful for displaying to users.
     /// Referenced as 'memo' in the Dashboard.
-    pub fn description(mut self, description: &'a str) -> Self {
-        self.inner.description = Some(description);
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.inner.description = Some(description.into());
         self
     }
     /// The discounts that will apply to the invoice.
     /// Pass an empty string to remove previously-defined discounts.
-    pub fn discounts(mut self, discounts: &'a [DiscountsDataParam<'a>]) -> Self {
-        self.inner.discounts = Some(discounts);
+    pub fn discounts(mut self, discounts: impl Into<Vec<DiscountsDataParam>>) -> Self {
+        self.inner.discounts = Some(discounts.into());
         self
     }
     /// The date on which payment for this invoice is due.
     /// Only valid for invoices where `collection_method=send_invoice`.
     /// This field can only be updated on `draft` invoices.
-    pub fn due_date(mut self, due_date: stripe_types::Timestamp) -> Self {
-        self.inner.due_date = Some(due_date);
+    pub fn due_date(mut self, due_date: impl Into<stripe_types::Timestamp>) -> Self {
+        self.inner.due_date = Some(due_date.into());
         self
     }
     /// The date when this invoice is in effect.
     /// Same as `finalized_at` unless overwritten.
     /// When defined, this value replaces the system-generated 'Date of issue' printed on the invoice PDF and receipt.
-    pub fn effective_at(mut self, effective_at: stripe_types::Timestamp) -> Self {
-        self.inner.effective_at = Some(effective_at);
+    pub fn effective_at(mut self, effective_at: impl Into<stripe_types::Timestamp>) -> Self {
+        self.inner.effective_at = Some(effective_at.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Footer to be displayed on the invoice.
-    pub fn footer(mut self, footer: &'a str) -> Self {
-        self.inner.footer = Some(footer);
+    pub fn footer(mut self, footer: impl Into<String>) -> Self {
+        self.inner.footer = Some(footer.into());
         self
     }
     /// The connected account that issues the invoice.
     /// The invoice is presented with the branding and support information of the specified account.
-    pub fn issuer(mut self, issuer: UpdateInvoiceIssuer<'a>) -> Self {
-        self.inner.issuer = Some(issuer);
+    pub fn issuer(mut self, issuer: impl Into<UpdateInvoiceIssuer>) -> Self {
+        self.inner.issuer = Some(issuer.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// Set the number for this invoice.
@@ -10575,56 +10642,59 @@ impl<'a> UpdateInvoice<'a> {
     /// In many markets, regulations require invoices to be unique, sequential and / or gapless.
     /// You are responsible for ensuring this is true across all your different invoicing systems in the event that you edit the invoice number using our API.
     /// If you use only Stripe for your invoices and do not change invoice numbers, Stripe handles this aspect of compliance for you automatically.
-    pub fn number(mut self, number: &'a str) -> Self {
-        self.inner.number = Some(number);
+    pub fn number(mut self, number: impl Into<String>) -> Self {
+        self.inner.number = Some(number.into());
         self
     }
     /// The account (if any) for which the funds of the invoice payment are intended.
     /// If set, the invoice will be presented with the branding and support information of the specified account.
     /// See the [Invoices with Connect](https://stripe.com/docs/billing/invoices/connect) documentation for details.
-    pub fn on_behalf_of(mut self, on_behalf_of: &'a str) -> Self {
-        self.inner.on_behalf_of = Some(on_behalf_of);
+    pub fn on_behalf_of(mut self, on_behalf_of: impl Into<String>) -> Self {
+        self.inner.on_behalf_of = Some(on_behalf_of.into());
         self
     }
     /// Configuration settings for the PaymentIntent that is generated when the invoice is finalized.
-    pub fn payment_settings(mut self, payment_settings: UpdateInvoicePaymentSettings<'a>) -> Self {
-        self.inner.payment_settings = Some(payment_settings);
+    pub fn payment_settings(
+        mut self,
+        payment_settings: impl Into<UpdateInvoicePaymentSettings>,
+    ) -> Self {
+        self.inner.payment_settings = Some(payment_settings.into());
         self
     }
     /// The rendering-related settings that control how the invoice is displayed on customer-facing surfaces such as PDF and Hosted Invoice Page.
-    pub fn rendering(mut self, rendering: UpdateInvoiceRendering) -> Self {
-        self.inner.rendering = Some(rendering);
+    pub fn rendering(mut self, rendering: impl Into<UpdateInvoiceRendering>) -> Self {
+        self.inner.rendering = Some(rendering.into());
         self
     }
     /// Settings for the cost of shipping for this invoice.
-    pub fn shipping_cost(mut self, shipping_cost: UpdateInvoiceShippingCost<'a>) -> Self {
-        self.inner.shipping_cost = Some(shipping_cost);
+    pub fn shipping_cost(mut self, shipping_cost: impl Into<UpdateInvoiceShippingCost>) -> Self {
+        self.inner.shipping_cost = Some(shipping_cost.into());
         self
     }
     /// Shipping details for the invoice.
     /// The Invoice PDF will use the `shipping_details` value if it is set, otherwise the PDF will render the shipping address from the customer.
     pub fn shipping_details(
         mut self,
-        shipping_details: RecipientShippingWithOptionalFieldsAddress<'a>,
+        shipping_details: impl Into<RecipientShippingWithOptionalFieldsAddress>,
     ) -> Self {
-        self.inner.shipping_details = Some(shipping_details);
+        self.inner.shipping_details = Some(shipping_details.into());
         self
     }
     /// Extra information about a charge for the customer's credit card statement.
     /// It must contain at least one letter.
     /// If not specified and this invoice is part of a subscription, the default `statement_descriptor` will be set to the first subscription item's product's `statement_descriptor`.
-    pub fn statement_descriptor(mut self, statement_descriptor: &'a str) -> Self {
-        self.inner.statement_descriptor = Some(statement_descriptor);
+    pub fn statement_descriptor(mut self, statement_descriptor: impl Into<String>) -> Self {
+        self.inner.statement_descriptor = Some(statement_descriptor.into());
         self
     }
     /// If specified, the funds from the invoice will be transferred to the destination and the ID of the resulting transfer will be found on the invoice's charge.
     /// This will be unset if you POST an empty value.
-    pub fn transfer_data(mut self, transfer_data: UpdateInvoiceTransferData<'a>) -> Self {
-        self.inner.transfer_data = Some(transfer_data);
+    pub fn transfer_data(mut self, transfer_data: impl Into<UpdateInvoiceTransferData>) -> Self {
+        self.inner.transfer_data = Some(transfer_data.into());
         self
     }
 }
-impl UpdateInvoice<'_> {
+impl UpdateInvoice {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -10642,22 +10712,22 @@ impl UpdateInvoice<'_> {
     }
 }
 
-impl StripeRequest for UpdateInvoice<'_> {
+impl StripeRequest for UpdateInvoice {
     type Output = stripe_shared::Invoice;
 
     fn build(&self) -> RequestBuilder {
-        let invoice = self.invoice;
+        let invoice = &self.invoice;
         RequestBuilder::new(StripeMethod::Post, format!("/invoices/{invoice}")).form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct FinalizeInvoiceInvoiceBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct FinalizeInvoiceInvoiceBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     auto_advance: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> FinalizeInvoiceInvoiceBuilder<'a> {
+impl FinalizeInvoiceInvoiceBuilder {
     fn new() -> Self {
         Self { auto_advance: None, expand: None }
     }
@@ -10665,28 +10735,28 @@ impl<'a> FinalizeInvoiceInvoiceBuilder<'a> {
 /// Stripe automatically finalizes drafts before sending and attempting payment on invoices.
 /// However, if you’d like to finalize a draft invoice manually, you can do so using this method.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct FinalizeInvoiceInvoice<'a> {
-    inner: FinalizeInvoiceInvoiceBuilder<'a>,
-    invoice: &'a stripe_shared::InvoiceId,
+pub struct FinalizeInvoiceInvoice {
+    inner: FinalizeInvoiceInvoiceBuilder,
+    invoice: stripe_shared::InvoiceId,
 }
-impl<'a> FinalizeInvoiceInvoice<'a> {
+impl FinalizeInvoiceInvoice {
     /// Construct a new `FinalizeInvoiceInvoice`.
-    pub fn new(invoice: &'a stripe_shared::InvoiceId) -> Self {
-        Self { invoice, inner: FinalizeInvoiceInvoiceBuilder::new() }
+    pub fn new(invoice: impl Into<stripe_shared::InvoiceId>) -> Self {
+        Self { invoice: invoice.into(), inner: FinalizeInvoiceInvoiceBuilder::new() }
     }
     /// Controls whether Stripe performs [automatic collection](https://stripe.com/docs/invoicing/integration/automatic-advancement-collection) of the invoice.
     /// If `false`, the invoice's state doesn't automatically advance without an explicit action.
-    pub fn auto_advance(mut self, auto_advance: bool) -> Self {
-        self.inner.auto_advance = Some(auto_advance);
+    pub fn auto_advance(mut self, auto_advance: impl Into<bool>) -> Self {
+        self.inner.auto_advance = Some(auto_advance.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl FinalizeInvoiceInvoice<'_> {
+impl FinalizeInvoiceInvoice {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -10704,43 +10774,43 @@ impl FinalizeInvoiceInvoice<'_> {
     }
 }
 
-impl StripeRequest for FinalizeInvoiceInvoice<'_> {
+impl StripeRequest for FinalizeInvoiceInvoice {
     type Output = stripe_shared::Invoice;
 
     fn build(&self) -> RequestBuilder {
-        let invoice = self.invoice;
+        let invoice = &self.invoice;
         RequestBuilder::new(StripeMethod::Post, format!("/invoices/{invoice}/finalize"))
             .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct MarkUncollectibleInvoiceBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct MarkUncollectibleInvoiceBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> MarkUncollectibleInvoiceBuilder<'a> {
+impl MarkUncollectibleInvoiceBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Marking an invoice as uncollectible is useful for keeping track of bad debts that can be written off for accounting purposes.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct MarkUncollectibleInvoice<'a> {
-    inner: MarkUncollectibleInvoiceBuilder<'a>,
-    invoice: &'a stripe_shared::InvoiceId,
+pub struct MarkUncollectibleInvoice {
+    inner: MarkUncollectibleInvoiceBuilder,
+    invoice: stripe_shared::InvoiceId,
 }
-impl<'a> MarkUncollectibleInvoice<'a> {
+impl MarkUncollectibleInvoice {
     /// Construct a new `MarkUncollectibleInvoice`.
-    pub fn new(invoice: &'a stripe_shared::InvoiceId) -> Self {
-        Self { invoice, inner: MarkUncollectibleInvoiceBuilder::new() }
+    pub fn new(invoice: impl Into<stripe_shared::InvoiceId>) -> Self {
+        Self { invoice: invoice.into(), inner: MarkUncollectibleInvoiceBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl MarkUncollectibleInvoice<'_> {
+impl MarkUncollectibleInvoice {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -10758,33 +10828,33 @@ impl MarkUncollectibleInvoice<'_> {
     }
 }
 
-impl StripeRequest for MarkUncollectibleInvoice<'_> {
+impl StripeRequest for MarkUncollectibleInvoice {
     type Output = stripe_shared::Invoice;
 
     fn build(&self) -> RequestBuilder {
-        let invoice = self.invoice;
+        let invoice = &self.invoice;
         RequestBuilder::new(StripeMethod::Post, format!("/invoices/{invoice}/mark_uncollectible"))
             .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct PayInvoiceBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct PayInvoiceBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     forgive: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    mandate: Option<&'a str>,
+    mandate: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     off_session: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     paid_out_of_band: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_method: Option<&'a str>,
+    payment_method: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    source: Option<&'a str>,
+    source: Option<String>,
 }
-impl<'a> PayInvoiceBuilder<'a> {
+impl PayInvoiceBuilder {
     fn new() -> Self {
         Self {
             expand: None,
@@ -10800,18 +10870,18 @@ impl<'a> PayInvoiceBuilder<'a> {
 /// Stripe automatically creates and then attempts to collect payment on invoices for customers on subscriptions according to your [subscriptions settings](https://dashboard.stripe.com/account/billing/automatic).
 /// However, if you’d like to attempt payment on an invoice out of the normal collection schedule or for some other reason, you can do so.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct PayInvoice<'a> {
-    inner: PayInvoiceBuilder<'a>,
-    invoice: &'a stripe_shared::InvoiceId,
+pub struct PayInvoice {
+    inner: PayInvoiceBuilder,
+    invoice: stripe_shared::InvoiceId,
 }
-impl<'a> PayInvoice<'a> {
+impl PayInvoice {
     /// Construct a new `PayInvoice`.
-    pub fn new(invoice: &'a stripe_shared::InvoiceId) -> Self {
-        Self { invoice, inner: PayInvoiceBuilder::new() }
+    pub fn new(invoice: impl Into<stripe_shared::InvoiceId>) -> Self {
+        Self { invoice: invoice.into(), inner: PayInvoiceBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// In cases where the source used to pay the invoice has insufficient funds, passing `forgive=true` controls whether a charge should be attempted for the full amount available on the source, up to the amount to fully pay the invoice.
@@ -10821,43 +10891,43 @@ impl<'a> PayInvoice<'a> {
     /// Passing `forgive=false` will fail the charge if the source hasn't been pre-funded with the right amount.
     /// An example for this case is with ACH Credit Transfers and wires: if the amount wired is less than the amount due by a small amount, you might want to forgive the difference.
     /// Defaults to `false`.
-    pub fn forgive(mut self, forgive: bool) -> Self {
-        self.inner.forgive = Some(forgive);
+    pub fn forgive(mut self, forgive: impl Into<bool>) -> Self {
+        self.inner.forgive = Some(forgive.into());
         self
     }
     /// ID of the mandate to be used for this invoice.
     /// It must correspond to the payment method used to pay the invoice, including the payment_method param or the invoice's default_payment_method or default_source, if set.
-    pub fn mandate(mut self, mandate: &'a str) -> Self {
-        self.inner.mandate = Some(mandate);
+    pub fn mandate(mut self, mandate: impl Into<String>) -> Self {
+        self.inner.mandate = Some(mandate.into());
         self
     }
     /// Indicates if a customer is on or off-session while an invoice payment is attempted.
     /// Defaults to `true` (off-session).
-    pub fn off_session(mut self, off_session: bool) -> Self {
-        self.inner.off_session = Some(off_session);
+    pub fn off_session(mut self, off_session: impl Into<bool>) -> Self {
+        self.inner.off_session = Some(off_session.into());
         self
     }
     /// Boolean representing whether an invoice is paid outside of Stripe.
     /// This will result in no charge being made.
     /// Defaults to `false`.
-    pub fn paid_out_of_band(mut self, paid_out_of_band: bool) -> Self {
-        self.inner.paid_out_of_band = Some(paid_out_of_band);
+    pub fn paid_out_of_band(mut self, paid_out_of_band: impl Into<bool>) -> Self {
+        self.inner.paid_out_of_band = Some(paid_out_of_band.into());
         self
     }
     /// A PaymentMethod to be charged.
     /// The PaymentMethod must be the ID of a PaymentMethod belonging to the customer associated with the invoice being paid.
-    pub fn payment_method(mut self, payment_method: &'a str) -> Self {
-        self.inner.payment_method = Some(payment_method);
+    pub fn payment_method(mut self, payment_method: impl Into<String>) -> Self {
+        self.inner.payment_method = Some(payment_method.into());
         self
     }
     /// A payment source to be charged.
     /// The source must be the ID of a source belonging to the customer associated with the invoice being paid.
-    pub fn source(mut self, source: &'a str) -> Self {
-        self.inner.source = Some(source);
+    pub fn source(mut self, source: impl Into<String>) -> Self {
+        self.inner.source = Some(source.into());
         self
     }
 }
-impl PayInvoice<'_> {
+impl PayInvoice {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -10875,21 +10945,21 @@ impl PayInvoice<'_> {
     }
 }
 
-impl StripeRequest for PayInvoice<'_> {
+impl StripeRequest for PayInvoice {
     type Output = stripe_shared::Invoice;
 
     fn build(&self) -> RequestBuilder {
-        let invoice = self.invoice;
+        let invoice = &self.invoice;
         RequestBuilder::new(StripeMethod::Post, format!("/invoices/{invoice}/pay"))
             .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct SendInvoiceInvoiceBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct SendInvoiceInvoiceBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> SendInvoiceInvoiceBuilder<'a> {
+impl SendInvoiceInvoiceBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
@@ -10900,22 +10970,22 @@ impl<'a> SendInvoiceInvoiceBuilder<'a> {
 ///
 /// Requests made in test-mode result in no emails being sent, despite sending an `invoice.sent` event.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct SendInvoiceInvoice<'a> {
-    inner: SendInvoiceInvoiceBuilder<'a>,
-    invoice: &'a stripe_shared::InvoiceId,
+pub struct SendInvoiceInvoice {
+    inner: SendInvoiceInvoiceBuilder,
+    invoice: stripe_shared::InvoiceId,
 }
-impl<'a> SendInvoiceInvoice<'a> {
+impl SendInvoiceInvoice {
     /// Construct a new `SendInvoiceInvoice`.
-    pub fn new(invoice: &'a stripe_shared::InvoiceId) -> Self {
-        Self { invoice, inner: SendInvoiceInvoiceBuilder::new() }
+    pub fn new(invoice: impl Into<stripe_shared::InvoiceId>) -> Self {
+        Self { invoice: invoice.into(), inner: SendInvoiceInvoiceBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl SendInvoiceInvoice<'_> {
+impl SendInvoiceInvoice {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -10933,21 +11003,21 @@ impl SendInvoiceInvoice<'_> {
     }
 }
 
-impl StripeRequest for SendInvoiceInvoice<'_> {
+impl StripeRequest for SendInvoiceInvoice {
     type Output = stripe_shared::Invoice;
 
     fn build(&self) -> RequestBuilder {
-        let invoice = self.invoice;
+        let invoice = &self.invoice;
         RequestBuilder::new(StripeMethod::Post, format!("/invoices/{invoice}/send"))
             .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct VoidInvoiceInvoiceBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct VoidInvoiceInvoiceBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> VoidInvoiceInvoiceBuilder<'a> {
+impl VoidInvoiceInvoiceBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
@@ -10960,22 +11030,22 @@ impl<'a> VoidInvoiceInvoiceBuilder<'a> {
 /// You might need to [issue another invoice](https://stripe.com/docs/api#create_invoice) or [credit note](https://stripe.com/docs/api#create_credit_note) instead.
 /// Stripe recommends that you consult with your legal counsel for advice specific to your business.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct VoidInvoiceInvoice<'a> {
-    inner: VoidInvoiceInvoiceBuilder<'a>,
-    invoice: &'a stripe_shared::InvoiceId,
+pub struct VoidInvoiceInvoice {
+    inner: VoidInvoiceInvoiceBuilder,
+    invoice: stripe_shared::InvoiceId,
 }
-impl<'a> VoidInvoiceInvoice<'a> {
+impl VoidInvoiceInvoice {
     /// Construct a new `VoidInvoiceInvoice`.
-    pub fn new(invoice: &'a stripe_shared::InvoiceId) -> Self {
-        Self { invoice, inner: VoidInvoiceInvoiceBuilder::new() }
+    pub fn new(invoice: impl Into<stripe_shared::InvoiceId>) -> Self {
+        Self { invoice: invoice.into(), inner: VoidInvoiceInvoiceBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl VoidInvoiceInvoice<'_> {
+impl VoidInvoiceInvoice {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -10993,47 +11063,47 @@ impl VoidInvoiceInvoice<'_> {
     }
 }
 
-impl StripeRequest for VoidInvoiceInvoice<'_> {
+impl StripeRequest for VoidInvoiceInvoice {
     type Output = stripe_shared::Invoice;
 
     fn build(&self) -> RequestBuilder {
-        let invoice = self.invoice;
+        let invoice = &self.invoice;
         RequestBuilder::new(StripeMethod::Post, format!("/invoices/{invoice}/void"))
             .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreatePreviewInvoiceBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreatePreviewInvoiceBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    automatic_tax: Option<CreatePreviewInvoiceAutomaticTax<'a>>,
+    automatic_tax: Option<CreatePreviewInvoiceAutomaticTax>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    coupon: Option<&'a str>,
+    coupon: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     currency: Option<stripe_types::Currency>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    customer: Option<&'a str>,
+    customer: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    customer_details: Option<CreatePreviewInvoiceCustomerDetails<'a>>,
+    customer_details: Option<CreatePreviewInvoiceCustomerDetails>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    discounts: Option<&'a [DiscountsDataParam<'a>]>,
+    discounts: Option<Vec<DiscountsDataParam>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    invoice_items: Option<&'a [CreatePreviewInvoiceInvoiceItems<'a>]>,
+    invoice_items: Option<Vec<CreatePreviewInvoiceInvoiceItems>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    issuer: Option<CreatePreviewInvoiceIssuer<'a>>,
+    issuer: Option<CreatePreviewInvoiceIssuer>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    on_behalf_of: Option<&'a str>,
+    on_behalf_of: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    schedule: Option<&'a str>,
+    schedule: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    schedule_details: Option<CreatePreviewInvoiceScheduleDetails<'a>>,
+    schedule_details: Option<CreatePreviewInvoiceScheduleDetails>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    subscription: Option<&'a str>,
+    subscription: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    subscription_details: Option<CreatePreviewInvoiceSubscriptionDetails<'a>>,
+    subscription_details: Option<CreatePreviewInvoiceSubscriptionDetails>,
 }
-impl<'a> CreatePreviewInvoiceBuilder<'a> {
+impl CreatePreviewInvoiceBuilder {
     fn new() -> Self {
         Self {
             automatic_tax: None,
@@ -11054,8 +11124,8 @@ impl<'a> CreatePreviewInvoiceBuilder<'a> {
     }
 }
 /// Settings for automatic tax lookup for this invoice preview.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePreviewInvoiceAutomaticTax<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePreviewInvoiceAutomaticTax {
     /// Whether Stripe automatically computes tax on this invoice.
     /// Note that incompatible invoice items (invoice items with manually specified [tax rates](https://stripe.com/docs/api/tax_rates), negative amounts, or `tax_behavior=unspecified`) cannot be added to automatic tax invoices.
     pub enabled: bool,
@@ -11063,28 +11133,28 @@ pub struct CreatePreviewInvoiceAutomaticTax<'a> {
     /// If set, the business address and tax registrations required to perform the tax calculation are loaded from this account.
     /// The tax transaction is returned in the report of the connected account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub liability: Option<CreatePreviewInvoiceAutomaticTaxLiability<'a>>,
+    pub liability: Option<CreatePreviewInvoiceAutomaticTaxLiability>,
 }
-impl<'a> CreatePreviewInvoiceAutomaticTax<'a> {
-    pub fn new(enabled: bool) -> Self {
-        Self { enabled, liability: None }
+impl CreatePreviewInvoiceAutomaticTax {
+    pub fn new(enabled: impl Into<bool>) -> Self {
+        Self { enabled: enabled.into(), liability: None }
     }
 }
 /// The account that's liable for tax.
 /// If set, the business address and tax registrations required to perform the tax calculation are loaded from this account.
 /// The tax transaction is returned in the report of the connected account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePreviewInvoiceAutomaticTaxLiability<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePreviewInvoiceAutomaticTaxLiability {
     /// The connected account being referenced when `type` is `account`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account: Option<&'a str>,
+    pub account: Option<String>,
     /// Type of the account referenced in the request.
     #[serde(rename = "type")]
     pub type_: CreatePreviewInvoiceAutomaticTaxLiabilityType,
 }
-impl<'a> CreatePreviewInvoiceAutomaticTaxLiability<'a> {
-    pub fn new(type_: CreatePreviewInvoiceAutomaticTaxLiabilityType) -> Self {
-        Self { account: None, type_ }
+impl CreatePreviewInvoiceAutomaticTaxLiability {
+    pub fn new(type_: impl Into<CreatePreviewInvoiceAutomaticTaxLiabilityType>) -> Self {
+        Self { account: None, type_: type_.into() }
     }
 }
 /// Type of the account referenced in the request.
@@ -11147,30 +11217,30 @@ impl<'de> serde::Deserialize<'de> for CreatePreviewInvoiceAutomaticTaxLiabilityT
 }
 /// Details about the customer you want to invoice or overrides for an existing customer.
 /// If `automatic_tax` is enabled then one of `customer`, `customer_details`, `subscription`, or `schedule` must be set.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePreviewInvoiceCustomerDetails<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePreviewInvoiceCustomerDetails {
     /// The customer's address.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub address: Option<OptionalFieldsAddress<'a>>,
+    pub address: Option<OptionalFieldsAddress>,
     /// The customer's shipping information. Appears on invoices emailed to this customer.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub shipping: Option<CustomerShipping<'a>>,
+    pub shipping: Option<CustomerShipping>,
     /// Tax details about the customer.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax: Option<TaxParam<'a>>,
+    pub tax: Option<TaxParam>,
     /// The customer's tax exemption. One of `none`, `exempt`, or `reverse`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tax_exempt: Option<CreatePreviewInvoiceCustomerDetailsTaxExempt>,
     /// The customer's tax IDs.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_ids: Option<&'a [CreatePreviewInvoiceCustomerDetailsTaxIds<'a>]>,
+    pub tax_ids: Option<Vec<CreatePreviewInvoiceCustomerDetailsTaxIds>>,
 }
-impl<'a> CreatePreviewInvoiceCustomerDetails<'a> {
+impl CreatePreviewInvoiceCustomerDetails {
     pub fn new() -> Self {
         Self { address: None, shipping: None, tax: None, tax_exempt: None, tax_ids: None }
     }
 }
-impl<'a> Default for CreatePreviewInvoiceCustomerDetails<'a> {
+impl Default for CreatePreviewInvoiceCustomerDetails {
     fn default() -> Self {
         Self::new()
     }
@@ -11237,17 +11307,20 @@ impl<'de> serde::Deserialize<'de> for CreatePreviewInvoiceCustomerDetailsTaxExem
     }
 }
 /// The customer's tax IDs.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePreviewInvoiceCustomerDetailsTaxIds<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePreviewInvoiceCustomerDetailsTaxIds {
     /// Type of the tax ID, one of `ad_nrt`, `ae_trn`, `ar_cuit`, `au_abn`, `au_arn`, `bg_uic`, `bh_vat`, `bo_tin`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `cn_tin`, `co_nit`, `cr_tin`, `do_rcn`, `ec_ruc`, `eg_tin`, `es_cif`, `eu_oss_vat`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `hu_tin`, `id_npwp`, `il_vat`, `in_gst`, `is_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `ke_pin`, `kr_brn`, `kz_bin`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `ng_tin`, `no_vat`, `no_voec`, `nz_gst`, `om_vat`, `pe_ruc`, `ph_tin`, `ro_tin`, `rs_pib`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `si_tin`, `sv_nit`, `th_vat`, `tr_tin`, `tw_vat`, `ua_vat`, `us_ein`, `uy_ruc`, `ve_rif`, `vn_tin`, or `za_vat`.
     #[serde(rename = "type")]
     pub type_: CreatePreviewInvoiceCustomerDetailsTaxIdsType,
     /// Value of the tax ID.
-    pub value: &'a str,
+    pub value: String,
 }
-impl<'a> CreatePreviewInvoiceCustomerDetailsTaxIds<'a> {
-    pub fn new(type_: CreatePreviewInvoiceCustomerDetailsTaxIdsType, value: &'a str) -> Self {
-        Self { type_, value }
+impl CreatePreviewInvoiceCustomerDetailsTaxIds {
+    pub fn new(
+        type_: impl Into<CreatePreviewInvoiceCustomerDetailsTaxIdsType>,
+        value: impl Into<String>,
+    ) -> Self {
+        Self { type_: type_.into(), value: value.into() }
     }
 }
 /// Type of the tax ID, one of `ad_nrt`, `ae_trn`, `ar_cuit`, `au_abn`, `au_arn`, `bg_uic`, `bh_vat`, `bo_tin`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `cn_tin`, `co_nit`, `cr_tin`, `do_rcn`, `ec_ruc`, `eg_tin`, `es_cif`, `eu_oss_vat`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `hu_tin`, `id_npwp`, `il_vat`, `in_gst`, `is_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `ke_pin`, `kr_brn`, `kz_bin`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `ng_tin`, `no_vat`, `no_voec`, `nz_gst`, `om_vat`, `pe_ruc`, `ph_tin`, `ro_tin`, `rs_pib`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `si_tin`, `sv_nit`, `th_vat`, `tr_tin`, `tw_vat`, `ua_vat`, `us_ein`, `uy_ruc`, `ve_rif`, `vn_tin`, or `za_vat`.
@@ -11516,8 +11589,8 @@ impl<'de> serde::Deserialize<'de> for CreatePreviewInvoiceCustomerDetailsTaxIdsT
     }
 }
 /// List of invoice items to add or update in the upcoming invoice preview.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePreviewInvoiceInvoiceItems<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePreviewInvoiceInvoiceItems {
     /// The integer amount in cents (or local equivalent) of previewed invoice item.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub amount: Option<i64>,
@@ -11529,24 +11602,24 @@ pub struct CreatePreviewInvoiceInvoiceItems<'a> {
     /// An arbitrary string which you can attach to the invoice item.
     /// The description is displayed in the invoice for easy tracking.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<&'a str>,
+    pub description: Option<String>,
     /// Explicitly controls whether discounts apply to this invoice item.
     /// Defaults to true, except for negative invoice items.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub discountable: Option<bool>,
     /// The coupons to redeem into discounts for the invoice item in the preview.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub discounts: Option<&'a [DiscountsDataParam<'a>]>,
+    pub discounts: Option<Vec<DiscountsDataParam>>,
     /// The ID of the invoice item to update in preview.
     /// If not specified, a new invoice item will be added to the preview of the upcoming invoice.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub invoiceitem: Option<&'a str>,
+    pub invoiceitem: Option<String>,
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// The period associated with this invoice item.
     /// When set to different values, the period will be rendered on the invoice.
     /// If you have [Stripe Revenue Recognition](https://stripe.com/docs/revenue-recognition) enabled, the period will be used to recognize and defer revenue.
@@ -11555,10 +11628,10 @@ pub struct CreatePreviewInvoiceInvoiceItems<'a> {
     pub period: Option<Period>,
     /// The ID of the price object.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price: Option<&'a str>,
+    pub price: Option<String>,
     /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price_data: Option<CreatePreviewInvoiceInvoiceItemsPriceData<'a>>,
+    pub price_data: Option<CreatePreviewInvoiceInvoiceItemsPriceData>,
     /// Non-negative integer. The quantity of units for the invoice item.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub quantity: Option<u64>,
@@ -11570,10 +11643,10 @@ pub struct CreatePreviewInvoiceInvoiceItems<'a> {
     pub tax_behavior: Option<CreatePreviewInvoiceInvoiceItemsTaxBehavior>,
     /// A [tax code](https://stripe.com/docs/tax/tax-categories) ID.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_code: Option<&'a str>,
+    pub tax_code: Option<String>,
     /// The tax rates that apply to the item. When set, any `default_tax_rates` do not apply to this item.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_rates: Option<&'a [&'a str]>,
+    pub tax_rates: Option<Vec<String>>,
     /// The integer unit amount in cents (or local equivalent) of the charge to be applied to the upcoming invoice.
     /// This unit_amount will be multiplied by the quantity to get the full amount.
     /// If you want to apply a credit to the customer's account, pass a negative unit_amount.
@@ -11582,9 +11655,9 @@ pub struct CreatePreviewInvoiceInvoiceItems<'a> {
     /// Same as `unit_amount`, but accepts a decimal value in cents (or local equivalent) with at most 12 decimal places.
     /// Only one of `unit_amount` and `unit_amount_decimal` can be set.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub unit_amount_decimal: Option<&'a str>,
+    pub unit_amount_decimal: Option<String>,
 }
-impl<'a> CreatePreviewInvoiceInvoiceItems<'a> {
+impl CreatePreviewInvoiceInvoiceItems {
     pub fn new() -> Self {
         Self {
             amount: None,
@@ -11606,19 +11679,19 @@ impl<'a> CreatePreviewInvoiceInvoiceItems<'a> {
         }
     }
 }
-impl<'a> Default for CreatePreviewInvoiceInvoiceItems<'a> {
+impl Default for CreatePreviewInvoiceInvoiceItems {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePreviewInvoiceInvoiceItemsPriceData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePreviewInvoiceInvoiceItemsPriceData {
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     /// Must be a [supported currency](https://stripe.com/docs/currencies).
     pub currency: stripe_types::Currency,
     /// The ID of the product that this price will belong to.
-    pub product: &'a str,
+    pub product: String,
     /// Only required if a [default tax behavior](https://stripe.com/docs/tax/products-prices-tax-categories-tax-behavior#setting-a-default-tax-behavior-(recommended)) was not provided in the Stripe Tax settings.
     /// Specifies whether the price is considered inclusive of taxes or exclusive of taxes.
     /// One of `inclusive`, `exclusive`, or `unspecified`.
@@ -11631,11 +11704,17 @@ pub struct CreatePreviewInvoiceInvoiceItemsPriceData<'a> {
     /// Same as `unit_amount`, but accepts a decimal value in cents (or local equivalent) with at most 12 decimal places.
     /// Only one of `unit_amount` and `unit_amount_decimal` can be set.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub unit_amount_decimal: Option<&'a str>,
+    pub unit_amount_decimal: Option<String>,
 }
-impl<'a> CreatePreviewInvoiceInvoiceItemsPriceData<'a> {
-    pub fn new(currency: stripe_types::Currency, product: &'a str) -> Self {
-        Self { currency, product, tax_behavior: None, unit_amount: None, unit_amount_decimal: None }
+impl CreatePreviewInvoiceInvoiceItemsPriceData {
+    pub fn new(currency: impl Into<stripe_types::Currency>, product: impl Into<String>) -> Self {
+        Self {
+            currency: currency.into(),
+            product: product.into(),
+            tax_behavior: None,
+            unit_amount: None,
+            unit_amount_decimal: None,
+        }
     }
 }
 /// Only required if a [default tax behavior](https://stripe.com/docs/tax/products-prices-tax-categories-tax-behavior#setting-a-default-tax-behavior-(recommended)) was not provided in the Stripe Tax settings.
@@ -11768,18 +11847,18 @@ impl<'de> serde::Deserialize<'de> for CreatePreviewInvoiceInvoiceItemsTaxBehavio
 }
 /// The connected account that issues the invoice.
 /// The invoice is presented with the branding and support information of the specified account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePreviewInvoiceIssuer<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePreviewInvoiceIssuer {
     /// The connected account being referenced when `type` is `account`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account: Option<&'a str>,
+    pub account: Option<String>,
     /// Type of the account referenced in the request.
     #[serde(rename = "type")]
     pub type_: CreatePreviewInvoiceIssuerType,
 }
-impl<'a> CreatePreviewInvoiceIssuer<'a> {
-    pub fn new(type_: CreatePreviewInvoiceIssuerType) -> Self {
-        Self { account: None, type_ }
+impl CreatePreviewInvoiceIssuer {
+    pub fn new(type_: impl Into<CreatePreviewInvoiceIssuerType>) -> Self {
+        Self { account: None, type_: type_.into() }
     }
 }
 /// Type of the account referenced in the request.
@@ -11840,8 +11919,8 @@ impl<'de> serde::Deserialize<'de> for CreatePreviewInvoiceIssuerType {
 }
 /// The schedule creation or modification params to apply as a preview.
 /// Cannot be used with `subscription` or `subscription_` prefixed fields.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePreviewInvoiceScheduleDetails<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePreviewInvoiceScheduleDetails {
     /// Behavior of the subscription schedule and underlying subscription when it ends.
     /// Possible values are `release` or `cancel` with the default being `release`.
     /// `release` will end the subscription schedule and keep the underlying subscription running.
@@ -11852,17 +11931,17 @@ pub struct CreatePreviewInvoiceScheduleDetails<'a> {
     /// Each phase can be customized to have different durations, plans, and coupons.
     /// If there are multiple phases, the `end_date` of one phase will always equal the `start_date` of the next phase.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub phases: Option<&'a [CreatePreviewInvoiceScheduleDetailsPhases<'a>]>,
+    pub phases: Option<Vec<CreatePreviewInvoiceScheduleDetailsPhases>>,
     /// In cases where the `schedule_details` params update the currently active phase, specifies if and how to prorate at the time of the request.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub proration_behavior: Option<CreatePreviewInvoiceScheduleDetailsProrationBehavior>,
 }
-impl<'a> CreatePreviewInvoiceScheduleDetails<'a> {
+impl CreatePreviewInvoiceScheduleDetails {
     pub fn new() -> Self {
         Self { end_behavior: None, phases: None, proration_behavior: None }
     }
 }
-impl<'a> Default for CreatePreviewInvoiceScheduleDetails<'a> {
+impl Default for CreatePreviewInvoiceScheduleDetails {
     fn default() -> Self {
         Self::new()
     }
@@ -11931,13 +12010,12 @@ impl<'de> serde::Deserialize<'de> for CreatePreviewInvoiceScheduleDetailsEndBeha
 /// List representing phases of the subscription schedule.
 /// Each phase can be customized to have different durations, plans, and coupons.
 /// If there are multiple phases, the `end_date` of one phase will always equal the `start_date` of the next phase.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePreviewInvoiceScheduleDetailsPhases<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePreviewInvoiceScheduleDetailsPhases {
     /// A list of prices and quantities that will generate invoice items appended to the next invoice for this phase.
     /// You may pass up to 20 items.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub add_invoice_items:
-        Option<&'a [CreatePreviewInvoiceScheduleDetailsPhasesAddInvoiceItems<'a>]>,
+    pub add_invoice_items: Option<Vec<CreatePreviewInvoiceScheduleDetailsPhasesAddInvoiceItems>>,
     /// A non-negative decimal between 0 and 100, with at most two decimal places.
     /// This represents the percentage of the subscription invoice total that will be transferred to the application owner's Stripe account.
     /// The request must be made by a platform account on a connected account in order to set an application fee percentage.
@@ -11946,7 +12024,7 @@ pub struct CreatePreviewInvoiceScheduleDetailsPhases<'a> {
     pub application_fee_percent: Option<f64>,
     /// Automatic tax settings for this phase.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub automatic_tax: Option<CreatePreviewInvoiceScheduleDetailsPhasesAutomaticTax<'a>>,
+    pub automatic_tax: Option<CreatePreviewInvoiceScheduleDetailsPhasesAutomaticTax>,
     /// Can be set to `phase_start` to set the anchor to the start of the phase or `automatic` to automatically change it if needed.
     /// Cannot be set to `phase_start` if this phase specifies a trial.
     /// For more information, see the billing cycle [documentation](https://stripe.com/docs/billing/subscriptions/billing-cycle).
@@ -11966,7 +12044,7 @@ pub struct CreatePreviewInvoiceScheduleDetailsPhases<'a> {
     /// This field has been deprecated and will be removed in a future API version.
     /// Use `discounts` instead.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub coupon: Option<&'a str>,
+    pub coupon: Option<String>,
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     /// Must be a [supported currency](https://stripe.com/docs/currencies).
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -11975,29 +12053,29 @@ pub struct CreatePreviewInvoiceScheduleDetailsPhases<'a> {
     /// It must belong to the customer associated with the subscription schedule.
     /// If not set, invoices will use the default payment method in the customer's invoice settings.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub default_payment_method: Option<&'a str>,
+    pub default_payment_method: Option<String>,
     /// A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids.
     /// These Tax Rates will set the Subscription's [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates), which means they will be the Invoice's [`default_tax_rates`](https://stripe.com/docs/api/invoices/create#create_invoice-default_tax_rates) for any Invoices issued by the Subscription during this Phase.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub default_tax_rates: Option<&'a [&'a str]>,
+    pub default_tax_rates: Option<Vec<String>>,
     /// Subscription description, meant to be displayable to the customer.
     /// Use this field to optionally store an explanation of the subscription for rendering in Stripe surfaces and certain local payment methods UIs.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<&'a str>,
+    pub description: Option<String>,
     /// The coupons to redeem into discounts for the schedule phase.
     /// If not specified, inherits the discount from the subscription's customer.
     /// Pass an empty string to avoid inheriting any discounts.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub discounts: Option<&'a [DiscountsDataParam<'a>]>,
+    pub discounts: Option<Vec<DiscountsDataParam>>,
     /// The date at which this phase of the subscription schedule ends.
     /// If set, `iterations` must not be set.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub end_date: Option<CreatePreviewInvoiceScheduleDetailsPhasesEndDate>,
     /// All invoices will be billed using the specified settings.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub invoice_settings: Option<CreatePreviewInvoiceScheduleDetailsPhasesInvoiceSettings<'a>>,
+    pub invoice_settings: Option<CreatePreviewInvoiceScheduleDetailsPhasesInvoiceSettings>,
     /// List of configuration items, each with an attached price, to apply during this phase of the subscription schedule.
-    pub items: &'a [CreatePreviewInvoiceScheduleDetailsPhasesItems<'a>],
+    pub items: Vec<CreatePreviewInvoiceScheduleDetailsPhasesItems>,
     /// Integer representing the multiplier applied to the price interval.
     /// For example, `iterations=2` applied to a price with `interval=month` and `interval_count=3` results in a phase of duration `2 * 3 months = 6 months`.
     /// If set, `end_date` must not be set.
@@ -12008,10 +12086,10 @@ pub struct CreatePreviewInvoiceScheduleDetailsPhases<'a> {
     /// Individual keys in the subscription's `metadata` can be unset by posting an empty value to them in the phase's `metadata`.
     /// To unset all keys in the subscription's `metadata`, update the subscription directly or unset every key individually from the phase's `metadata`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// The account on behalf of which to charge, for each of the associated subscription's invoices.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub on_behalf_of: Option<&'a str>,
+    pub on_behalf_of: Option<String>,
     /// Whether the subscription schedule will create [prorations](https://stripe.com/docs/billing/subscriptions/prorations) when transitioning to this phase.
     /// The default value is `create_prorations`.
     /// This setting controls prorations when a phase is started asynchronously and it is persisted as a field on the phase.
@@ -12024,7 +12102,7 @@ pub struct CreatePreviewInvoiceScheduleDetailsPhases<'a> {
     pub start_date: Option<CreatePreviewInvoiceScheduleDetailsPhasesStartDate>,
     /// The data with which to automatically create a Transfer for each of the associated subscription's invoices.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub transfer_data: Option<TransferDataSpecs<'a>>,
+    pub transfer_data: Option<TransferDataSpecs>,
     /// If set to true the entire phase is counted as a trial and the customer will not be charged for any fees.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub trial: Option<bool>,
@@ -12033,8 +12111,8 @@ pub struct CreatePreviewInvoiceScheduleDetailsPhases<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub trial_end: Option<CreatePreviewInvoiceScheduleDetailsPhasesTrialEnd>,
 }
-impl<'a> CreatePreviewInvoiceScheduleDetailsPhases<'a> {
-    pub fn new(items: &'a [CreatePreviewInvoiceScheduleDetailsPhasesItems<'a>]) -> Self {
+impl CreatePreviewInvoiceScheduleDetailsPhases {
+    pub fn new(items: impl Into<Vec<CreatePreviewInvoiceScheduleDetailsPhasesItems>>) -> Self {
         Self {
             add_invoice_items: None,
             application_fee_percent: None,
@@ -12050,7 +12128,7 @@ impl<'a> CreatePreviewInvoiceScheduleDetailsPhases<'a> {
             discounts: None,
             end_date: None,
             invoice_settings: None,
-            items,
+            items: items.into(),
             iterations: None,
             metadata: None,
             on_behalf_of: None,
@@ -12064,42 +12142,42 @@ impl<'a> CreatePreviewInvoiceScheduleDetailsPhases<'a> {
 }
 /// A list of prices and quantities that will generate invoice items appended to the next invoice for this phase.
 /// You may pass up to 20 items.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePreviewInvoiceScheduleDetailsPhasesAddInvoiceItems<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePreviewInvoiceScheduleDetailsPhasesAddInvoiceItems {
     /// The coupons to redeem into discounts for the item.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub discounts: Option<&'a [DiscountsDataParam<'a>]>,
+    pub discounts: Option<Vec<DiscountsDataParam>>,
     /// The ID of the price object.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price: Option<&'a str>,
+    pub price: Option<String>,
     /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price_data: Option<CreatePreviewInvoiceScheduleDetailsPhasesAddInvoiceItemsPriceData<'a>>,
+    pub price_data: Option<CreatePreviewInvoiceScheduleDetailsPhasesAddInvoiceItemsPriceData>,
     /// Quantity for this item. Defaults to 1.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub quantity: Option<u64>,
     /// The tax rates which apply to the item. When set, the `default_tax_rates` do not apply to this item.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_rates: Option<&'a [&'a str]>,
+    pub tax_rates: Option<Vec<String>>,
 }
-impl<'a> CreatePreviewInvoiceScheduleDetailsPhasesAddInvoiceItems<'a> {
+impl CreatePreviewInvoiceScheduleDetailsPhasesAddInvoiceItems {
     pub fn new() -> Self {
         Self { discounts: None, price: None, price_data: None, quantity: None, tax_rates: None }
     }
 }
-impl<'a> Default for CreatePreviewInvoiceScheduleDetailsPhasesAddInvoiceItems<'a> {
+impl Default for CreatePreviewInvoiceScheduleDetailsPhasesAddInvoiceItems {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePreviewInvoiceScheduleDetailsPhasesAddInvoiceItemsPriceData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePreviewInvoiceScheduleDetailsPhasesAddInvoiceItemsPriceData {
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     /// Must be a [supported currency](https://stripe.com/docs/currencies).
     pub currency: stripe_types::Currency,
     /// The ID of the product that this price will belong to.
-    pub product: &'a str,
+    pub product: String,
     /// Only required if a [default tax behavior](https://stripe.com/docs/tax/products-prices-tax-categories-tax-behavior#setting-a-default-tax-behavior-(recommended)) was not provided in the Stripe Tax settings.
     /// Specifies whether the price is considered inclusive of taxes or exclusive of taxes.
     /// One of `inclusive`, `exclusive`, or `unspecified`.
@@ -12113,11 +12191,17 @@ pub struct CreatePreviewInvoiceScheduleDetailsPhasesAddInvoiceItemsPriceData<'a>
     /// Same as `unit_amount`, but accepts a decimal value in cents (or local equivalent) with at most 12 decimal places.
     /// Only one of `unit_amount` and `unit_amount_decimal` can be set.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub unit_amount_decimal: Option<&'a str>,
+    pub unit_amount_decimal: Option<String>,
 }
-impl<'a> CreatePreviewInvoiceScheduleDetailsPhasesAddInvoiceItemsPriceData<'a> {
-    pub fn new(currency: stripe_types::Currency, product: &'a str) -> Self {
-        Self { currency, product, tax_behavior: None, unit_amount: None, unit_amount_decimal: None }
+impl CreatePreviewInvoiceScheduleDetailsPhasesAddInvoiceItemsPriceData {
+    pub fn new(currency: impl Into<stripe_types::Currency>, product: impl Into<String>) -> Self {
+        Self {
+            currency: currency.into(),
+            product: product.into(),
+            tax_behavior: None,
+            unit_amount: None,
+            unit_amount_decimal: None,
+        }
     }
 }
 /// Only required if a [default tax behavior](https://stripe.com/docs/tax/products-prices-tax-categories-tax-behavior#setting-a-default-tax-behavior-(recommended)) was not provided in the Stripe Tax settings.
@@ -12191,36 +12275,38 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// Automatic tax settings for this phase.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePreviewInvoiceScheduleDetailsPhasesAutomaticTax<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePreviewInvoiceScheduleDetailsPhasesAutomaticTax {
     /// Enabled automatic tax calculation which will automatically compute tax rates on all invoices generated by the subscription.
     pub enabled: bool,
     /// The account that's liable for tax.
     /// If set, the business address and tax registrations required to perform the tax calculation are loaded from this account.
     /// The tax transaction is returned in the report of the connected account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub liability: Option<CreatePreviewInvoiceScheduleDetailsPhasesAutomaticTaxLiability<'a>>,
+    pub liability: Option<CreatePreviewInvoiceScheduleDetailsPhasesAutomaticTaxLiability>,
 }
-impl<'a> CreatePreviewInvoiceScheduleDetailsPhasesAutomaticTax<'a> {
-    pub fn new(enabled: bool) -> Self {
-        Self { enabled, liability: None }
+impl CreatePreviewInvoiceScheduleDetailsPhasesAutomaticTax {
+    pub fn new(enabled: impl Into<bool>) -> Self {
+        Self { enabled: enabled.into(), liability: None }
     }
 }
 /// The account that's liable for tax.
 /// If set, the business address and tax registrations required to perform the tax calculation are loaded from this account.
 /// The tax transaction is returned in the report of the connected account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePreviewInvoiceScheduleDetailsPhasesAutomaticTaxLiability<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePreviewInvoiceScheduleDetailsPhasesAutomaticTaxLiability {
     /// The connected account being referenced when `type` is `account`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account: Option<&'a str>,
+    pub account: Option<String>,
     /// Type of the account referenced in the request.
     #[serde(rename = "type")]
     pub type_: CreatePreviewInvoiceScheduleDetailsPhasesAutomaticTaxLiabilityType,
 }
-impl<'a> CreatePreviewInvoiceScheduleDetailsPhasesAutomaticTaxLiability<'a> {
-    pub fn new(type_: CreatePreviewInvoiceScheduleDetailsPhasesAutomaticTaxLiabilityType) -> Self {
-        Self { account: None, type_ }
+impl CreatePreviewInvoiceScheduleDetailsPhasesAutomaticTaxLiability {
+    pub fn new(
+        type_: impl Into<CreatePreviewInvoiceScheduleDetailsPhasesAutomaticTaxLiabilityType>,
+    ) -> Self {
+        Self { account: None, type_: type_.into() }
     }
 }
 /// Type of the account referenced in the request.
@@ -12349,12 +12435,12 @@ pub enum CreatePreviewInvoiceScheduleDetailsPhasesEndDate {
     Timestamp(stripe_types::Timestamp),
 }
 /// All invoices will be billed using the specified settings.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePreviewInvoiceScheduleDetailsPhasesInvoiceSettings<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePreviewInvoiceScheduleDetailsPhasesInvoiceSettings {
     /// The account tax IDs associated with this phase of the subscription schedule.
     /// Will be set on invoices generated by this phase of the subscription schedule.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account_tax_ids: Option<&'a [&'a str]>,
+    pub account_tax_ids: Option<Vec<String>>,
     /// Number of days within which a customer must pay invoices generated by this subscription schedule.
     /// This value will be `null` for subscription schedules where `billing=charge_automatically`.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -12362,32 +12448,34 @@ pub struct CreatePreviewInvoiceScheduleDetailsPhasesInvoiceSettings<'a> {
     /// The connected account that issues the invoice.
     /// The invoice is presented with the branding and support information of the specified account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub issuer: Option<CreatePreviewInvoiceScheduleDetailsPhasesInvoiceSettingsIssuer<'a>>,
+    pub issuer: Option<CreatePreviewInvoiceScheduleDetailsPhasesInvoiceSettingsIssuer>,
 }
-impl<'a> CreatePreviewInvoiceScheduleDetailsPhasesInvoiceSettings<'a> {
+impl CreatePreviewInvoiceScheduleDetailsPhasesInvoiceSettings {
     pub fn new() -> Self {
         Self { account_tax_ids: None, days_until_due: None, issuer: None }
     }
 }
-impl<'a> Default for CreatePreviewInvoiceScheduleDetailsPhasesInvoiceSettings<'a> {
+impl Default for CreatePreviewInvoiceScheduleDetailsPhasesInvoiceSettings {
     fn default() -> Self {
         Self::new()
     }
 }
 /// The connected account that issues the invoice.
 /// The invoice is presented with the branding and support information of the specified account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePreviewInvoiceScheduleDetailsPhasesInvoiceSettingsIssuer<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePreviewInvoiceScheduleDetailsPhasesInvoiceSettingsIssuer {
     /// The connected account being referenced when `type` is `account`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account: Option<&'a str>,
+    pub account: Option<String>,
     /// Type of the account referenced in the request.
     #[serde(rename = "type")]
     pub type_: CreatePreviewInvoiceScheduleDetailsPhasesInvoiceSettingsIssuerType,
 }
-impl<'a> CreatePreviewInvoiceScheduleDetailsPhasesInvoiceSettingsIssuer<'a> {
-    pub fn new(type_: CreatePreviewInvoiceScheduleDetailsPhasesInvoiceSettingsIssuerType) -> Self {
-        Self { account: None, type_ }
+impl CreatePreviewInvoiceScheduleDetailsPhasesInvoiceSettingsIssuer {
+    pub fn new(
+        type_: impl Into<CreatePreviewInvoiceScheduleDetailsPhasesInvoiceSettingsIssuerType>,
+    ) -> Self {
+        Self { account: None, type_: type_.into() }
     }
 }
 /// Type of the account referenced in the request.
@@ -12447,30 +12535,30 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// List of configuration items, each with an attached price, to apply during this phase of the subscription schedule.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePreviewInvoiceScheduleDetailsPhasesItems<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePreviewInvoiceScheduleDetailsPhasesItems {
     /// Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period.
     /// When updating, pass an empty string to remove previously-defined thresholds.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub billing_thresholds: Option<ItemBillingThresholdsParam>,
     /// The coupons to redeem into discounts for the subscription item.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub discounts: Option<&'a [DiscountsDataParam<'a>]>,
+    pub discounts: Option<Vec<DiscountsDataParam>>,
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to a configuration item.
     /// Metadata on a configuration item will update the underlying subscription item's `metadata` when the phase is entered, adding new keys and replacing existing keys.
     /// Individual keys in the subscription item's `metadata` can be unset by posting an empty value to them in the configuration item's `metadata`.
     /// To unset all keys in the subscription item's `metadata`, update the subscription item directly or unset every key individually from the configuration item's `metadata`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// The plan ID to subscribe to. You may specify the same ID in `plan` and `price`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub plan: Option<&'a str>,
+    pub plan: Option<String>,
     /// The ID of the price object.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price: Option<&'a str>,
+    pub price: Option<String>,
     /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price_data: Option<CreatePreviewInvoiceScheduleDetailsPhasesItemsPriceData<'a>>,
+    pub price_data: Option<CreatePreviewInvoiceScheduleDetailsPhasesItemsPriceData>,
     /// Quantity for the given price.
     /// Can be set only if the price's `usage_type` is `licensed` and not `metered`.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -12479,9 +12567,9 @@ pub struct CreatePreviewInvoiceScheduleDetailsPhasesItems<'a> {
     /// These Tax Rates will override the [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates) on the Subscription.
     /// When updating, pass an empty string to remove previously-defined tax rates.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_rates: Option<&'a [&'a str]>,
+    pub tax_rates: Option<Vec<String>>,
 }
-impl<'a> CreatePreviewInvoiceScheduleDetailsPhasesItems<'a> {
+impl CreatePreviewInvoiceScheduleDetailsPhasesItems {
     pub fn new() -> Self {
         Self {
             billing_thresholds: None,
@@ -12495,19 +12583,19 @@ impl<'a> CreatePreviewInvoiceScheduleDetailsPhasesItems<'a> {
         }
     }
 }
-impl<'a> Default for CreatePreviewInvoiceScheduleDetailsPhasesItems<'a> {
+impl Default for CreatePreviewInvoiceScheduleDetailsPhasesItems {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePreviewInvoiceScheduleDetailsPhasesItemsPriceData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePreviewInvoiceScheduleDetailsPhasesItemsPriceData {
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     /// Must be a [supported currency](https://stripe.com/docs/currencies).
     pub currency: stripe_types::Currency,
     /// The ID of the product that this price will belong to.
-    pub product: &'a str,
+    pub product: String,
     /// The recurring components of a price such as `interval` and `interval_count`.
     pub recurring: CreatePreviewInvoiceScheduleDetailsPhasesItemsPriceDataRecurring,
     /// Only required if a [default tax behavior](https://stripe.com/docs/tax/products-prices-tax-categories-tax-behavior#setting-a-default-tax-behavior-(recommended)) was not provided in the Stripe Tax settings.
@@ -12522,18 +12610,18 @@ pub struct CreatePreviewInvoiceScheduleDetailsPhasesItemsPriceData<'a> {
     /// Same as `unit_amount`, but accepts a decimal value in cents (or local equivalent) with at most 12 decimal places.
     /// Only one of `unit_amount` and `unit_amount_decimal` can be set.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub unit_amount_decimal: Option<&'a str>,
+    pub unit_amount_decimal: Option<String>,
 }
-impl<'a> CreatePreviewInvoiceScheduleDetailsPhasesItemsPriceData<'a> {
+impl CreatePreviewInvoiceScheduleDetailsPhasesItemsPriceData {
     pub fn new(
-        currency: stripe_types::Currency,
-        product: &'a str,
-        recurring: CreatePreviewInvoiceScheduleDetailsPhasesItemsPriceDataRecurring,
+        currency: impl Into<stripe_types::Currency>,
+        product: impl Into<String>,
+        recurring: impl Into<CreatePreviewInvoiceScheduleDetailsPhasesItemsPriceDataRecurring>,
     ) -> Self {
         Self {
-            currency,
-            product,
-            recurring,
+            currency: currency.into(),
+            product: product.into(),
+            recurring: recurring.into(),
             tax_behavior: None,
             unit_amount: None,
             unit_amount_decimal: None,
@@ -12553,9 +12641,9 @@ pub struct CreatePreviewInvoiceScheduleDetailsPhasesItemsPriceDataRecurring {
 }
 impl CreatePreviewInvoiceScheduleDetailsPhasesItemsPriceDataRecurring {
     pub fn new(
-        interval: CreatePreviewInvoiceScheduleDetailsPhasesItemsPriceDataRecurringInterval,
+        interval: impl Into<CreatePreviewInvoiceScheduleDetailsPhasesItemsPriceDataRecurringInterval>,
     ) -> Self {
-        Self { interval, interval_count: None }
+        Self { interval: interval.into(), interval_count: None }
     }
 }
 /// Specifies billing frequency. Either `day`, `week`, `month` or `year`.
@@ -12831,8 +12919,8 @@ impl<'de> serde::Deserialize<'de> for CreatePreviewInvoiceScheduleDetailsProrati
 }
 /// The subscription creation or modification params to apply as a preview.
 /// Cannot be used with `schedule` or `schedule_details` fields.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePreviewInvoiceSubscriptionDetails<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePreviewInvoiceSubscriptionDetails {
     /// For new subscriptions, a future timestamp to anchor the subscription's [billing cycle](https://stripe.com/docs/subscriptions/billing-cycle).
     /// This is used to determine the date of the first full invoice, and, for plans with `month` or `year` intervals, the day of the month for subsequent invoices.
     /// For existing subscriptions, the value can only be set to `now` or `unchanged`.
@@ -12852,10 +12940,10 @@ pub struct CreatePreviewInvoiceSubscriptionDetails<'a> {
     /// If provided, the invoice returned will preview updating or creating a subscription with these default tax rates.
     /// The default tax rates will apply to any line item that does not have `tax_rates` set.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub default_tax_rates: Option<&'a [&'a str]>,
+    pub default_tax_rates: Option<Vec<String>>,
     /// A list of up to 20 subscription items, each with an attached price.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub items: Option<&'a [CreatePreviewInvoiceSubscriptionDetailsItems<'a>]>,
+    pub items: Option<Vec<CreatePreviewInvoiceSubscriptionDetailsItems>>,
     /// Determines how to handle [prorations](https://stripe.com/docs/billing/subscriptions/prorations) when the billing cycle changes (e.g., when switching plans, resetting `billing_cycle_anchor=now`, or starting a trial), or if an item's `quantity` changes.
     /// The default value is `create_prorations`.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -12877,7 +12965,7 @@ pub struct CreatePreviewInvoiceSubscriptionDetails<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub trial_end: Option<CreatePreviewInvoiceSubscriptionDetailsTrialEnd>,
 }
-impl<'a> CreatePreviewInvoiceSubscriptionDetails<'a> {
+impl CreatePreviewInvoiceSubscriptionDetails {
     pub fn new() -> Self {
         Self {
             billing_cycle_anchor: None,
@@ -12894,7 +12982,7 @@ impl<'a> CreatePreviewInvoiceSubscriptionDetails<'a> {
         }
     }
 }
-impl<'a> Default for CreatePreviewInvoiceSubscriptionDetails<'a> {
+impl Default for CreatePreviewInvoiceSubscriptionDetails {
     fn default() -> Self {
         Self::new()
     }
@@ -12911,8 +12999,8 @@ pub enum CreatePreviewInvoiceSubscriptionDetailsBillingCycleAnchor {
     Timestamp(stripe_types::Timestamp),
 }
 /// A list of up to 20 subscription items, each with an attached price.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePreviewInvoiceSubscriptionDetailsItems<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePreviewInvoiceSubscriptionDetailsItems {
     /// Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period.
     /// When updating, pass an empty string to remove previously-defined thresholds.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -12926,26 +13014,26 @@ pub struct CreatePreviewInvoiceSubscriptionDetailsItems<'a> {
     pub deleted: Option<bool>,
     /// The coupons to redeem into discounts for the subscription item.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub discounts: Option<&'a [DiscountsDataParam<'a>]>,
+    pub discounts: Option<Vec<DiscountsDataParam>>,
     /// Subscription item to update.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub id: Option<&'a str>,
+    pub id: Option<String>,
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// Plan ID for this item, as a string.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub plan: Option<&'a str>,
+    pub plan: Option<String>,
     /// The ID of the price object.
     /// When changing a subscription item's price, `quantity` is set to 1 unless a `quantity` parameter is provided.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price: Option<&'a str>,
+    pub price: Option<String>,
     /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price_data: Option<CreatePreviewInvoiceSubscriptionDetailsItemsPriceData<'a>>,
+    pub price_data: Option<CreatePreviewInvoiceSubscriptionDetailsItemsPriceData>,
     /// Quantity for this item.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub quantity: Option<u64>,
@@ -12953,9 +13041,9 @@ pub struct CreatePreviewInvoiceSubscriptionDetailsItems<'a> {
     /// These Tax Rates will override the [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates) on the Subscription.
     /// When updating, pass an empty string to remove previously-defined tax rates.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_rates: Option<&'a [&'a str]>,
+    pub tax_rates: Option<Vec<String>>,
 }
-impl<'a> CreatePreviewInvoiceSubscriptionDetailsItems<'a> {
+impl CreatePreviewInvoiceSubscriptionDetailsItems {
     pub fn new() -> Self {
         Self {
             billing_thresholds: None,
@@ -12972,19 +13060,19 @@ impl<'a> CreatePreviewInvoiceSubscriptionDetailsItems<'a> {
         }
     }
 }
-impl<'a> Default for CreatePreviewInvoiceSubscriptionDetailsItems<'a> {
+impl Default for CreatePreviewInvoiceSubscriptionDetailsItems {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePreviewInvoiceSubscriptionDetailsItemsPriceData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePreviewInvoiceSubscriptionDetailsItemsPriceData {
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     /// Must be a [supported currency](https://stripe.com/docs/currencies).
     pub currency: stripe_types::Currency,
     /// The ID of the product that this price will belong to.
-    pub product: &'a str,
+    pub product: String,
     /// The recurring components of a price such as `interval` and `interval_count`.
     pub recurring: CreatePreviewInvoiceSubscriptionDetailsItemsPriceDataRecurring,
     /// Only required if a [default tax behavior](https://stripe.com/docs/tax/products-prices-tax-categories-tax-behavior#setting-a-default-tax-behavior-(recommended)) was not provided in the Stripe Tax settings.
@@ -12999,18 +13087,18 @@ pub struct CreatePreviewInvoiceSubscriptionDetailsItemsPriceData<'a> {
     /// Same as `unit_amount`, but accepts a decimal value in cents (or local equivalent) with at most 12 decimal places.
     /// Only one of `unit_amount` and `unit_amount_decimal` can be set.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub unit_amount_decimal: Option<&'a str>,
+    pub unit_amount_decimal: Option<String>,
 }
-impl<'a> CreatePreviewInvoiceSubscriptionDetailsItemsPriceData<'a> {
+impl CreatePreviewInvoiceSubscriptionDetailsItemsPriceData {
     pub fn new(
-        currency: stripe_types::Currency,
-        product: &'a str,
-        recurring: CreatePreviewInvoiceSubscriptionDetailsItemsPriceDataRecurring,
+        currency: impl Into<stripe_types::Currency>,
+        product: impl Into<String>,
+        recurring: impl Into<CreatePreviewInvoiceSubscriptionDetailsItemsPriceDataRecurring>,
     ) -> Self {
         Self {
-            currency,
-            product,
-            recurring,
+            currency: currency.into(),
+            product: product.into(),
+            recurring: recurring.into(),
             tax_behavior: None,
             unit_amount: None,
             unit_amount_decimal: None,
@@ -13030,9 +13118,9 @@ pub struct CreatePreviewInvoiceSubscriptionDetailsItemsPriceDataRecurring {
 }
 impl CreatePreviewInvoiceSubscriptionDetailsItemsPriceDataRecurring {
     pub fn new(
-        interval: CreatePreviewInvoiceSubscriptionDetailsItemsPriceDataRecurringInterval,
+        interval: impl Into<CreatePreviewInvoiceSubscriptionDetailsItemsPriceDataRecurringInterval>,
     ) -> Self {
-        Self { interval, interval_count: None }
+        Self { interval: interval.into(), interval_count: None }
     }
 }
 /// Specifies billing frequency. Either `day`, `week`, `month` or `year`.
@@ -13297,118 +13385,121 @@ pub enum CreatePreviewInvoiceSubscriptionDetailsTrialEnd {
 /// To ensure that the actual proration is calculated exactly the same as the previewed proration, you should pass the `subscription_details.proration_date` parameter when doing the actual subscription update.
 /// The recommended way to get only the prorations being previewed is to consider only proration line items where `period[start]` is equal to the `subscription_details.proration_date` value passed in the request.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreatePreviewInvoice<'a> {
-    inner: CreatePreviewInvoiceBuilder<'a>,
+pub struct CreatePreviewInvoice {
+    inner: CreatePreviewInvoiceBuilder,
 }
-impl<'a> CreatePreviewInvoice<'a> {
+impl CreatePreviewInvoice {
     /// Construct a new `CreatePreviewInvoice`.
     pub fn new() -> Self {
         Self { inner: CreatePreviewInvoiceBuilder::new() }
     }
     /// Settings for automatic tax lookup for this invoice preview.
-    pub fn automatic_tax(mut self, automatic_tax: CreatePreviewInvoiceAutomaticTax<'a>) -> Self {
-        self.inner.automatic_tax = Some(automatic_tax);
+    pub fn automatic_tax(
+        mut self,
+        automatic_tax: impl Into<CreatePreviewInvoiceAutomaticTax>,
+    ) -> Self {
+        self.inner.automatic_tax = Some(automatic_tax.into());
         self
     }
     /// The ID of the coupon to apply to this phase of the subscription schedule.
     /// This field has been deprecated and will be removed in a future API version.
     /// Use `discounts` instead.
-    pub fn coupon(mut self, coupon: &'a str) -> Self {
-        self.inner.coupon = Some(coupon);
+    pub fn coupon(mut self, coupon: impl Into<String>) -> Self {
+        self.inner.coupon = Some(coupon.into());
         self
     }
     /// The currency to preview this invoice in. Defaults to that of `customer` if not specified.
-    pub fn currency(mut self, currency: stripe_types::Currency) -> Self {
-        self.inner.currency = Some(currency);
+    pub fn currency(mut self, currency: impl Into<stripe_types::Currency>) -> Self {
+        self.inner.currency = Some(currency.into());
         self
     }
     /// The identifier of the customer whose upcoming invoice you'd like to retrieve.
     /// If `automatic_tax` is enabled then one of `customer`, `customer_details`, `subscription`, or `schedule` must be set.
-    pub fn customer(mut self, customer: &'a str) -> Self {
-        self.inner.customer = Some(customer);
+    pub fn customer(mut self, customer: impl Into<String>) -> Self {
+        self.inner.customer = Some(customer.into());
         self
     }
     /// Details about the customer you want to invoice or overrides for an existing customer.
     /// If `automatic_tax` is enabled then one of `customer`, `customer_details`, `subscription`, or `schedule` must be set.
     pub fn customer_details(
         mut self,
-        customer_details: CreatePreviewInvoiceCustomerDetails<'a>,
+        customer_details: impl Into<CreatePreviewInvoiceCustomerDetails>,
     ) -> Self {
-        self.inner.customer_details = Some(customer_details);
+        self.inner.customer_details = Some(customer_details.into());
         self
     }
     /// The coupons to redeem into discounts for the invoice preview.
     /// If not specified, inherits the discount from the subscription or customer.
     /// This works for both coupons directly applied to an invoice and coupons applied to a subscription.
     /// Pass an empty string to avoid inheriting any discounts.
-    pub fn discounts(mut self, discounts: &'a [DiscountsDataParam<'a>]) -> Self {
-        self.inner.discounts = Some(discounts);
+    pub fn discounts(mut self, discounts: impl Into<Vec<DiscountsDataParam>>) -> Self {
+        self.inner.discounts = Some(discounts.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// List of invoice items to add or update in the upcoming invoice preview.
     pub fn invoice_items(
         mut self,
-        invoice_items: &'a [CreatePreviewInvoiceInvoiceItems<'a>],
+        invoice_items: impl Into<Vec<CreatePreviewInvoiceInvoiceItems>>,
     ) -> Self {
-        self.inner.invoice_items = Some(invoice_items);
+        self.inner.invoice_items = Some(invoice_items.into());
         self
     }
     /// The connected account that issues the invoice.
     /// The invoice is presented with the branding and support information of the specified account.
-    pub fn issuer(mut self, issuer: CreatePreviewInvoiceIssuer<'a>) -> Self {
-        self.inner.issuer = Some(issuer);
+    pub fn issuer(mut self, issuer: impl Into<CreatePreviewInvoiceIssuer>) -> Self {
+        self.inner.issuer = Some(issuer.into());
         self
     }
     /// The account (if any) for which the funds of the invoice payment are intended.
     /// If set, the invoice will be presented with the branding and support information of the specified account.
     /// See the [Invoices with Connect](https://stripe.com/docs/billing/invoices/connect) documentation for details.
-    pub fn on_behalf_of(mut self, on_behalf_of: &'a str) -> Self {
-        self.inner.on_behalf_of = Some(on_behalf_of);
+    pub fn on_behalf_of(mut self, on_behalf_of: impl Into<String>) -> Self {
+        self.inner.on_behalf_of = Some(on_behalf_of.into());
         self
     }
     /// The identifier of the schedule whose upcoming invoice you'd like to retrieve.
     /// Cannot be used with subscription or subscription fields.
-    pub fn schedule(mut self, schedule: &'a str) -> Self {
-        self.inner.schedule = Some(schedule);
+    pub fn schedule(mut self, schedule: impl Into<String>) -> Self {
+        self.inner.schedule = Some(schedule.into());
         self
     }
     /// The schedule creation or modification params to apply as a preview.
     /// Cannot be used with `subscription` or `subscription_` prefixed fields.
     pub fn schedule_details(
         mut self,
-        schedule_details: CreatePreviewInvoiceScheduleDetails<'a>,
+        schedule_details: impl Into<CreatePreviewInvoiceScheduleDetails>,
     ) -> Self {
-        self.inner.schedule_details = Some(schedule_details);
+        self.inner.schedule_details = Some(schedule_details.into());
         self
     }
     /// The identifier of the subscription for which you'd like to retrieve the upcoming invoice.
     /// If not provided, but a `subscription_items` is provided, you will preview creating a subscription with those items.
     /// If neither `subscription` nor `subscription_items` is provided, you will retrieve the next upcoming invoice from among the customer's subscriptions.
-    pub fn subscription(mut self, subscription: &'a str) -> Self {
-        self.inner.subscription = Some(subscription);
+    pub fn subscription(mut self, subscription: impl Into<String>) -> Self {
+        self.inner.subscription = Some(subscription.into());
         self
     }
     /// The subscription creation or modification params to apply as a preview.
     /// Cannot be used with `schedule` or `schedule_details` fields.
     pub fn subscription_details(
         mut self,
-        subscription_details: CreatePreviewInvoiceSubscriptionDetails<'a>,
+        subscription_details: impl Into<CreatePreviewInvoiceSubscriptionDetails>,
     ) -> Self {
-        self.inner.subscription_details = Some(subscription_details);
+        self.inner.subscription_details = Some(subscription_details.into());
         self
     }
 }
-impl<'a> Default for CreatePreviewInvoice<'a> {
+impl Default for CreatePreviewInvoice {
     fn default() -> Self {
         Self::new()
     }
 }
-impl CreatePreviewInvoice<'_> {
+impl CreatePreviewInvoice {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -13426,7 +13517,7 @@ impl CreatePreviewInvoice<'_> {
     }
 }
 
-impl StripeRequest for CreatePreviewInvoice<'_> {
+impl StripeRequest for CreatePreviewInvoice {
     type Output = stripe_shared::Invoice;
 
     fn build(&self) -> RequestBuilder {
@@ -13434,73 +13525,73 @@ impl StripeRequest for CreatePreviewInvoice<'_> {
     }
 }
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct OptionalFieldsAddress<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct OptionalFieldsAddress {
     /// City, district, suburb, town, or village.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<&'a str>,
+    pub city: Option<String>,
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub country: Option<&'a str>,
+    pub country: Option<String>,
     /// Address line 1 (e.g., street, PO Box, or company name).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line1: Option<&'a str>,
+    pub line1: Option<String>,
     /// Address line 2 (e.g., apartment, suite, unit, or building).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line2: Option<&'a str>,
+    pub line2: Option<String>,
     /// ZIP or postal code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<&'a str>,
+    pub postal_code: Option<String>,
     /// State, county, province, or region.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
 }
-impl<'a> OptionalFieldsAddress<'a> {
+impl OptionalFieldsAddress {
     pub fn new() -> Self {
         Self { city: None, country: None, line1: None, line2: None, postal_code: None, state: None }
     }
 }
-impl<'a> Default for OptionalFieldsAddress<'a> {
+impl Default for OptionalFieldsAddress {
     fn default() -> Self {
         Self::new()
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct TaxParam<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct TaxParam {
     /// A recent IP address of the customer used for tax reporting and tax location inference.
     /// Stripe recommends updating the IP address when a new PaymentMethod is attached or the address field on the customer is updated.
     /// We recommend against updating this field more frequently since it could result in unexpected tax location/reporting outcomes.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ip_address: Option<&'a str>,
+    pub ip_address: Option<String>,
 }
-impl<'a> TaxParam<'a> {
+impl TaxParam {
     pub fn new() -> Self {
         Self { ip_address: None }
     }
 }
-impl<'a> Default for TaxParam<'a> {
+impl Default for TaxParam {
     fn default() -> Self {
         Self::new()
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct DiscountsDataParam<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct DiscountsDataParam {
     /// ID of the coupon to create a new discount for.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub coupon: Option<&'a str>,
+    pub coupon: Option<String>,
     /// ID of an existing discount on the object (or one of its ancestors) to reuse.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub discount: Option<&'a str>,
+    pub discount: Option<String>,
     /// ID of the promotion code to create a new discount for.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub promotion_code: Option<&'a str>,
+    pub promotion_code: Option<String>,
 }
-impl<'a> DiscountsDataParam<'a> {
+impl DiscountsDataParam {
     pub fn new() -> Self {
         Self { coupon: None, discount: None, promotion_code: None }
     }
 }
-impl<'a> Default for DiscountsDataParam<'a> {
+impl Default for DiscountsDataParam {
     fn default() -> Self {
         Self::new()
     }
@@ -13513,8 +13604,11 @@ pub struct Period {
     pub start: stripe_types::Timestamp,
 }
 impl Period {
-    pub fn new(end: stripe_types::Timestamp, start: stripe_types::Timestamp) -> Self {
-        Self { end, start }
+    pub fn new(
+        end: impl Into<stripe_types::Timestamp>,
+        start: impl Into<stripe_types::Timestamp>,
+    ) -> Self {
+        Self { end: end.into(), start: start.into() }
     }
 }
 #[derive(Copy, Clone, Debug, serde::Serialize)]
@@ -13543,115 +13637,115 @@ pub struct ItemBillingThresholdsParam {
     pub usage_gte: i64,
 }
 impl ItemBillingThresholdsParam {
-    pub fn new(usage_gte: i64) -> Self {
-        Self { usage_gte }
+    pub fn new(usage_gte: impl Into<i64>) -> Self {
+        Self { usage_gte: usage_gte.into() }
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct TransferDataSpecs<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct TransferDataSpecs {
     /// A non-negative decimal between 0 and 100, with at most two decimal places.
     /// This represents the percentage of the subscription invoice total that will be transferred to the destination account.
     /// By default, the entire amount is transferred to the destination.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub amount_percent: Option<f64>,
     /// ID of an existing, connected Stripe account.
-    pub destination: &'a str,
+    pub destination: String,
 }
-impl<'a> TransferDataSpecs<'a> {
-    pub fn new(destination: &'a str) -> Self {
-        Self { amount_percent: None, destination }
+impl TransferDataSpecs {
+    pub fn new(destination: impl Into<String>) -> Self {
+        Self { amount_percent: None, destination: destination.into() }
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CustomFieldParams<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CustomFieldParams {
     /// The name of the custom field. This may be up to 40 characters.
-    pub name: &'a str,
+    pub name: String,
     /// The value of the custom field. This may be up to 140 characters.
-    pub value: &'a str,
+    pub value: String,
 }
-impl<'a> CustomFieldParams<'a> {
-    pub fn new(name: &'a str, value: &'a str) -> Self {
-        Self { name, value }
+impl CustomFieldParams {
+    pub fn new(name: impl Into<String>, value: impl Into<String>) -> Self {
+        Self { name: name.into(), value: value.into() }
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct EuBankTransferParam<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct EuBankTransferParam {
     /// The desired country code of the bank account information.
     /// Permitted values include: `BE`, `DE`, `ES`, `FR`, `IE`, or `NL`.
-    pub country: &'a str,
+    pub country: String,
 }
-impl<'a> EuBankTransferParam<'a> {
-    pub fn new(country: &'a str) -> Self {
-        Self { country }
+impl EuBankTransferParam {
+    pub fn new(country: impl Into<String>) -> Self {
+        Self { country: country.into() }
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CustomerShipping<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CustomerShipping {
     /// Customer shipping address.
-    pub address: OptionalFieldsAddress<'a>,
+    pub address: OptionalFieldsAddress,
     /// Customer name.
-    pub name: &'a str,
+    pub name: String,
     /// Customer phone (including extension).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub phone: Option<&'a str>,
+    pub phone: Option<String>,
 }
-impl<'a> CustomerShipping<'a> {
-    pub fn new(address: OptionalFieldsAddress<'a>, name: &'a str) -> Self {
-        Self { address, name, phone: None }
+impl CustomerShipping {
+    pub fn new(address: impl Into<OptionalFieldsAddress>, name: impl Into<String>) -> Self {
+        Self { address: address.into(), name: name.into(), phone: None }
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct BankTransferParam<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct BankTransferParam {
     /// Configuration for eu_bank_transfer funding type.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub eu_bank_transfer: Option<EuBankTransferParam<'a>>,
+    pub eu_bank_transfer: Option<EuBankTransferParam>,
     /// The bank transfer type that can be used for funding.
     /// Permitted values include: `eu_bank_transfer`, `gb_bank_transfer`, `jp_bank_transfer`, `mx_bank_transfer`, or `us_bank_transfer`.
     #[serde(rename = "type")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub type_: Option<&'a str>,
+    pub type_: Option<String>,
 }
-impl<'a> BankTransferParam<'a> {
+impl BankTransferParam {
     pub fn new() -> Self {
         Self { eu_bank_transfer: None, type_: None }
     }
 }
-impl<'a> Default for BankTransferParam<'a> {
+impl Default for BankTransferParam {
     fn default() -> Self {
         Self::new()
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct RecipientShippingWithOptionalFieldsAddress<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct RecipientShippingWithOptionalFieldsAddress {
     /// Shipping address
-    pub address: OptionalFieldsAddress<'a>,
+    pub address: OptionalFieldsAddress,
     /// Recipient name.
-    pub name: &'a str,
+    pub name: String,
     /// Recipient phone (including extension)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub phone: Option<&'a str>,
+    pub phone: Option<String>,
 }
-impl<'a> RecipientShippingWithOptionalFieldsAddress<'a> {
-    pub fn new(address: OptionalFieldsAddress<'a>, name: &'a str) -> Self {
-        Self { address, name, phone: None }
+impl RecipientShippingWithOptionalFieldsAddress {
+    pub fn new(address: impl Into<OptionalFieldsAddress>, name: impl Into<String>) -> Self {
+        Self { address: address.into(), name: name.into(), phone: None }
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct InvoicePaymentMethodOptionsParam<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct InvoicePaymentMethodOptionsParam {
     /// Configuration for the bank transfer funding type, if the `funding_type` is set to `bank_transfer`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub bank_transfer: Option<BankTransferParam<'a>>,
+    pub bank_transfer: Option<BankTransferParam>,
     /// The funding method type to be used when there are not enough funds in the customer balance.
     /// Permitted values include: `bank_transfer`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub funding_type: Option<&'a str>,
+    pub funding_type: Option<String>,
 }
-impl<'a> InvoicePaymentMethodOptionsParam<'a> {
+impl InvoicePaymentMethodOptionsParam {
     pub fn new() -> Self {
         Self { bank_transfer: None, funding_type: None }
     }
 }
-impl<'a> Default for InvoicePaymentMethodOptionsParam<'a> {
+impl Default for InvoicePaymentMethodOptionsParam {
     fn default() -> Self {
         Self::new()
     }

--- a/generated/async-stripe-billing/src/invoice_item/requests.rs
+++ b/generated/async-stripe-billing/src/invoice_item/requests.rs
@@ -5,16 +5,16 @@ use stripe_client_core::{
 /// Deletes an invoice item, removing it from an invoice.
 /// Deleting invoice items is only possible when they’re not attached to invoices, or if it’s attached to a draft invoice.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct DeleteInvoiceItem<'a> {
-    invoiceitem: &'a stripe_shared::InvoiceItemId,
+pub struct DeleteInvoiceItem {
+    invoiceitem: stripe_shared::InvoiceItemId,
 }
-impl<'a> DeleteInvoiceItem<'a> {
+impl DeleteInvoiceItem {
     /// Construct a new `DeleteInvoiceItem`.
-    pub fn new(invoiceitem: &'a stripe_shared::InvoiceItemId) -> Self {
-        Self { invoiceitem }
+    pub fn new(invoiceitem: impl Into<stripe_shared::InvoiceItemId>) -> Self {
+        Self { invoiceitem: invoiceitem.into() }
     }
 }
-impl DeleteInvoiceItem<'_> {
+impl DeleteInvoiceItem {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -32,34 +32,34 @@ impl DeleteInvoiceItem<'_> {
     }
 }
 
-impl StripeRequest for DeleteInvoiceItem<'_> {
+impl StripeRequest for DeleteInvoiceItem {
     type Output = stripe_shared::DeletedInvoiceitem;
 
     fn build(&self) -> RequestBuilder {
-        let invoiceitem = self.invoiceitem;
+        let invoiceitem = &self.invoiceitem;
         RequestBuilder::new(StripeMethod::Delete, format!("/invoiceitems/{invoiceitem}"))
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListInvoiceItemBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListInvoiceItemBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     created: Option<stripe_types::RangeQueryTs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    customer: Option<&'a str>,
+    customer: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    invoice: Option<&'a str>,
+    invoice: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pending: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListInvoiceItemBuilder<'a> {
+impl ListInvoiceItemBuilder {
     fn new() -> Self {
         Self {
             created: None,
@@ -76,71 +76,71 @@ impl<'a> ListInvoiceItemBuilder<'a> {
 /// Returns a list of your invoice items.
 /// Invoice items are returned sorted by creation date, with the most recently created invoice items appearing first.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListInvoiceItem<'a> {
-    inner: ListInvoiceItemBuilder<'a>,
+pub struct ListInvoiceItem {
+    inner: ListInvoiceItemBuilder,
 }
-impl<'a> ListInvoiceItem<'a> {
+impl ListInvoiceItem {
     /// Construct a new `ListInvoiceItem`.
     pub fn new() -> Self {
         Self { inner: ListInvoiceItemBuilder::new() }
     }
     /// Only return invoice items that were created during the given date interval.
-    pub fn created(mut self, created: stripe_types::RangeQueryTs) -> Self {
-        self.inner.created = Some(created);
+    pub fn created(mut self, created: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.created = Some(created.into());
         self
     }
     /// The identifier of the customer whose invoice items to return.
     /// If none is provided, all invoice items will be returned.
-    pub fn customer(mut self, customer: &'a str) -> Self {
-        self.inner.customer = Some(customer);
+    pub fn customer(mut self, customer: impl Into<String>) -> Self {
+        self.inner.customer = Some(customer.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Only return invoice items belonging to this invoice.
     /// If none is provided, all invoice items will be returned.
     /// If specifying an invoice, no customer identifier is needed.
-    pub fn invoice(mut self, invoice: &'a str) -> Self {
-        self.inner.invoice = Some(invoice);
+    pub fn invoice(mut self, invoice: impl Into<String>) -> Self {
+        self.inner.invoice = Some(invoice.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// Set to `true` to only show pending invoice items, which are not yet attached to any invoices.
     /// Set to `false` to only show invoice items already attached to invoices.
     /// If unspecified, no filter is applied.
-    pub fn pending(mut self, pending: bool) -> Self {
-        self.inner.pending = Some(pending);
+    pub fn pending(mut self, pending: impl Into<bool>) -> Self {
+        self.inner.pending = Some(pending.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl<'a> Default for ListInvoiceItem<'a> {
+impl Default for ListInvoiceItem {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListInvoiceItem<'_> {
+impl ListInvoiceItem {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -160,45 +160,45 @@ impl ListInvoiceItem<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::InvoiceItem>> {
-        stripe_client_core::ListPaginator::new_list("/invoiceitems", self.inner)
+        stripe_client_core::ListPaginator::new_list("/invoiceitems", &self.inner)
     }
 }
 
-impl StripeRequest for ListInvoiceItem<'_> {
+impl StripeRequest for ListInvoiceItem {
     type Output = stripe_types::List<stripe_shared::InvoiceItem>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/invoiceitems").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveInvoiceItemBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveInvoiceItemBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveInvoiceItemBuilder<'a> {
+impl RetrieveInvoiceItemBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves the invoice item with the given ID.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveInvoiceItem<'a> {
-    inner: RetrieveInvoiceItemBuilder<'a>,
-    invoiceitem: &'a stripe_shared::InvoiceItemId,
+pub struct RetrieveInvoiceItem {
+    inner: RetrieveInvoiceItemBuilder,
+    invoiceitem: stripe_shared::InvoiceItemId,
 }
-impl<'a> RetrieveInvoiceItem<'a> {
+impl RetrieveInvoiceItem {
     /// Construct a new `RetrieveInvoiceItem`.
-    pub fn new(invoiceitem: &'a stripe_shared::InvoiceItemId) -> Self {
-        Self { invoiceitem, inner: RetrieveInvoiceItemBuilder::new() }
+    pub fn new(invoiceitem: impl Into<stripe_shared::InvoiceItemId>) -> Self {
+        Self { invoiceitem: invoiceitem.into(), inner: RetrieveInvoiceItemBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveInvoiceItem<'_> {
+impl RetrieveInvoiceItem {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -216,61 +216,61 @@ impl RetrieveInvoiceItem<'_> {
     }
 }
 
-impl StripeRequest for RetrieveInvoiceItem<'_> {
+impl StripeRequest for RetrieveInvoiceItem {
     type Output = stripe_shared::InvoiceItem;
 
     fn build(&self) -> RequestBuilder {
-        let invoiceitem = self.invoiceitem;
+        let invoiceitem = &self.invoiceitem;
         RequestBuilder::new(StripeMethod::Get, format!("/invoiceitems/{invoiceitem}"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateInvoiceItemBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateInvoiceItemBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     amount: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     currency: Option<stripe_types::Currency>,
-    customer: &'a str,
+    customer: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<&'a str>,
+    description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     discountable: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    discounts: Option<&'a [DiscountsDataParam<'a>]>,
+    discounts: Option<Vec<DiscountsDataParam>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    invoice: Option<&'a str>,
+    invoice: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     period: Option<Period>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    price: Option<&'a str>,
+    price: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    price_data: Option<CreateInvoiceItemPriceData<'a>>,
+    price_data: Option<CreateInvoiceItemPriceData>,
     #[serde(skip_serializing_if = "Option::is_none")]
     quantity: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    subscription: Option<&'a str>,
+    subscription: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tax_behavior: Option<CreateInvoiceItemTaxBehavior>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    tax_code: Option<&'a str>,
+    tax_code: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    tax_rates: Option<&'a [&'a str]>,
+    tax_rates: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     unit_amount: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    unit_amount_decimal: Option<&'a str>,
+    unit_amount_decimal: Option<String>,
 }
-impl<'a> CreateInvoiceItemBuilder<'a> {
-    fn new(customer: &'a str) -> Self {
+impl CreateInvoiceItemBuilder {
+    fn new(customer: impl Into<String>) -> Self {
         Self {
             amount: None,
             currency: None,
-            customer,
+            customer: customer.into(),
             description: None,
             discountable: None,
             discounts: None,
@@ -291,13 +291,13 @@ impl<'a> CreateInvoiceItemBuilder<'a> {
     }
 }
 /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateInvoiceItemPriceData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateInvoiceItemPriceData {
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     /// Must be a [supported currency](https://stripe.com/docs/currencies).
     pub currency: stripe_types::Currency,
     /// The ID of the product that this price will belong to.
-    pub product: &'a str,
+    pub product: String,
     /// Only required if a [default tax behavior](https://stripe.com/docs/tax/products-prices-tax-categories-tax-behavior#setting-a-default-tax-behavior-(recommended)) was not provided in the Stripe Tax settings.
     /// Specifies whether the price is considered inclusive of taxes or exclusive of taxes.
     /// One of `inclusive`, `exclusive`, or `unspecified`.
@@ -310,11 +310,17 @@ pub struct CreateInvoiceItemPriceData<'a> {
     /// Same as `unit_amount`, but accepts a decimal value in cents (or local equivalent) with at most 12 decimal places.
     /// Only one of `unit_amount` and `unit_amount_decimal` can be set.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub unit_amount_decimal: Option<&'a str>,
+    pub unit_amount_decimal: Option<String>,
 }
-impl<'a> CreateInvoiceItemPriceData<'a> {
-    pub fn new(currency: stripe_types::Currency, product: &'a str) -> Self {
-        Self { currency, product, tax_behavior: None, unit_amount: None, unit_amount_decimal: None }
+impl CreateInvoiceItemPriceData {
+    pub fn new(currency: impl Into<stripe_types::Currency>, product: impl Into<String>) -> Self {
+        Self {
+            currency: currency.into(),
+            product: product.into(),
+            tax_behavior: None,
+            unit_amount: None,
+            unit_amount_decimal: None,
+        }
     }
 }
 /// Only required if a [default tax behavior](https://stripe.com/docs/tax/products-prices-tax-categories-tax-behavior#setting-a-default-tax-behavior-(recommended)) was not provided in the Stripe Tax settings.
@@ -443,129 +449,132 @@ impl<'de> serde::Deserialize<'de> for CreateInvoiceItemTaxBehavior {
 /// Creates an item to be added to a draft invoice (up to 250 items per invoice).
 /// If no invoice is specified, the item will be on the next invoice created for the customer specified.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateInvoiceItem<'a> {
-    inner: CreateInvoiceItemBuilder<'a>,
+pub struct CreateInvoiceItem {
+    inner: CreateInvoiceItemBuilder,
 }
-impl<'a> CreateInvoiceItem<'a> {
+impl CreateInvoiceItem {
     /// Construct a new `CreateInvoiceItem`.
-    pub fn new(customer: &'a str) -> Self {
-        Self { inner: CreateInvoiceItemBuilder::new(customer) }
+    pub fn new(customer: impl Into<String>) -> Self {
+        Self { inner: CreateInvoiceItemBuilder::new(customer.into()) }
     }
     /// The integer amount in cents (or local equivalent) of the charge to be applied to the upcoming invoice.
     /// Passing in a negative `amount` will reduce the `amount_due` on the invoice.
-    pub fn amount(mut self, amount: i64) -> Self {
-        self.inner.amount = Some(amount);
+    pub fn amount(mut self, amount: impl Into<i64>) -> Self {
+        self.inner.amount = Some(amount.into());
         self
     }
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     /// Must be a [supported currency](https://stripe.com/docs/currencies).
-    pub fn currency(mut self, currency: stripe_types::Currency) -> Self {
-        self.inner.currency = Some(currency);
+    pub fn currency(mut self, currency: impl Into<stripe_types::Currency>) -> Self {
+        self.inner.currency = Some(currency.into());
         self
     }
     /// An arbitrary string which you can attach to the invoice item.
     /// The description is displayed in the invoice for easy tracking.
-    pub fn description(mut self, description: &'a str) -> Self {
-        self.inner.description = Some(description);
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.inner.description = Some(description.into());
         self
     }
     /// Controls whether discounts apply to this invoice item.
     /// Defaults to false for prorations or negative invoice items, and true for all other invoice items.
-    pub fn discountable(mut self, discountable: bool) -> Self {
-        self.inner.discountable = Some(discountable);
+    pub fn discountable(mut self, discountable: impl Into<bool>) -> Self {
+        self.inner.discountable = Some(discountable.into());
         self
     }
     /// The coupons and promotion codes to redeem into discounts for the invoice item or invoice line item.
-    pub fn discounts(mut self, discounts: &'a [DiscountsDataParam<'a>]) -> Self {
-        self.inner.discounts = Some(discounts);
+    pub fn discounts(mut self, discounts: impl Into<Vec<DiscountsDataParam>>) -> Self {
+        self.inner.discounts = Some(discounts.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// The ID of an existing invoice to add this invoice item to.
     /// When left blank, the invoice item will be added to the next upcoming scheduled invoice.
     /// This is useful when adding invoice items in response to an invoice.created webhook.
     /// You can only add invoice items to draft invoices and there is a maximum of 250 items per invoice.
-    pub fn invoice(mut self, invoice: &'a str) -> Self {
-        self.inner.invoice = Some(invoice);
+    pub fn invoice(mut self, invoice: impl Into<String>) -> Self {
+        self.inner.invoice = Some(invoice.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// The period associated with this invoice item.
     /// When set to different values, the period will be rendered on the invoice.
     /// If you have [Stripe Revenue Recognition](https://stripe.com/docs/revenue-recognition) enabled, the period will be used to recognize and defer revenue.
     /// See the [Revenue Recognition documentation](https://stripe.com/docs/revenue-recognition/methodology/subscriptions-and-invoicing) for details.
-    pub fn period(mut self, period: Period) -> Self {
-        self.inner.period = Some(period);
+    pub fn period(mut self, period: impl Into<Period>) -> Self {
+        self.inner.period = Some(period.into());
         self
     }
     /// The ID of the price object.
-    pub fn price(mut self, price: &'a str) -> Self {
-        self.inner.price = Some(price);
+    pub fn price(mut self, price: impl Into<String>) -> Self {
+        self.inner.price = Some(price.into());
         self
     }
     /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
-    pub fn price_data(mut self, price_data: CreateInvoiceItemPriceData<'a>) -> Self {
-        self.inner.price_data = Some(price_data);
+    pub fn price_data(mut self, price_data: impl Into<CreateInvoiceItemPriceData>) -> Self {
+        self.inner.price_data = Some(price_data.into());
         self
     }
     /// Non-negative integer. The quantity of units for the invoice item.
-    pub fn quantity(mut self, quantity: u64) -> Self {
-        self.inner.quantity = Some(quantity);
+    pub fn quantity(mut self, quantity: impl Into<u64>) -> Self {
+        self.inner.quantity = Some(quantity.into());
         self
     }
     /// The ID of a subscription to add this invoice item to.
     /// When left blank, the invoice item will be be added to the next upcoming scheduled invoice.
     /// When set, scheduled invoices for subscriptions other than the specified subscription will ignore the invoice item.
     /// Use this when you want to express that an invoice item has been accrued within the context of a particular subscription.
-    pub fn subscription(mut self, subscription: &'a str) -> Self {
-        self.inner.subscription = Some(subscription);
+    pub fn subscription(mut self, subscription: impl Into<String>) -> Self {
+        self.inner.subscription = Some(subscription.into());
         self
     }
     /// Only required if a [default tax behavior](https://stripe.com/docs/tax/products-prices-tax-categories-tax-behavior#setting-a-default-tax-behavior-(recommended)) was not provided in the Stripe Tax settings.
     /// Specifies whether the price is considered inclusive of taxes or exclusive of taxes.
     /// One of `inclusive`, `exclusive`, or `unspecified`.
     /// Once specified as either `inclusive` or `exclusive`, it cannot be changed.
-    pub fn tax_behavior(mut self, tax_behavior: CreateInvoiceItemTaxBehavior) -> Self {
-        self.inner.tax_behavior = Some(tax_behavior);
+    pub fn tax_behavior(mut self, tax_behavior: impl Into<CreateInvoiceItemTaxBehavior>) -> Self {
+        self.inner.tax_behavior = Some(tax_behavior.into());
         self
     }
     /// A [tax code](https://stripe.com/docs/tax/tax-categories) ID.
-    pub fn tax_code(mut self, tax_code: &'a str) -> Self {
-        self.inner.tax_code = Some(tax_code);
+    pub fn tax_code(mut self, tax_code: impl Into<String>) -> Self {
+        self.inner.tax_code = Some(tax_code.into());
         self
     }
     /// The tax rates which apply to the invoice item.
     /// When set, the `default_tax_rates` on the invoice do not apply to this invoice item.
-    pub fn tax_rates(mut self, tax_rates: &'a [&'a str]) -> Self {
-        self.inner.tax_rates = Some(tax_rates);
+    pub fn tax_rates(mut self, tax_rates: impl Into<Vec<String>>) -> Self {
+        self.inner.tax_rates = Some(tax_rates.into());
         self
     }
     /// The integer unit amount in cents (or local equivalent) of the charge to be applied to the upcoming invoice.
     /// This `unit_amount` will be multiplied by the quantity to get the full amount.
     /// Passing in a negative `unit_amount` will reduce the `amount_due` on the invoice.
-    pub fn unit_amount(mut self, unit_amount: i64) -> Self {
-        self.inner.unit_amount = Some(unit_amount);
+    pub fn unit_amount(mut self, unit_amount: impl Into<i64>) -> Self {
+        self.inner.unit_amount = Some(unit_amount.into());
         self
     }
     /// Same as `unit_amount`, but accepts a decimal value in cents (or local equivalent) with at most 12 decimal places.
     /// Only one of `unit_amount` and `unit_amount_decimal` can be set.
-    pub fn unit_amount_decimal(mut self, unit_amount_decimal: &'a str) -> Self {
-        self.inner.unit_amount_decimal = Some(unit_amount_decimal);
+    pub fn unit_amount_decimal(mut self, unit_amount_decimal: impl Into<String>) -> Self {
+        self.inner.unit_amount_decimal = Some(unit_amount_decimal.into());
         self
     }
 }
-impl CreateInvoiceItem<'_> {
+impl CreateInvoiceItem {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -583,47 +592,47 @@ impl CreateInvoiceItem<'_> {
     }
 }
 
-impl StripeRequest for CreateInvoiceItem<'_> {
+impl StripeRequest for CreateInvoiceItem {
     type Output = stripe_shared::InvoiceItem;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Post, "/invoiceitems").form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdateInvoiceItemBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdateInvoiceItemBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     amount: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<&'a str>,
+    description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     discountable: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    discounts: Option<&'a [DiscountsDataParam<'a>]>,
+    discounts: Option<Vec<DiscountsDataParam>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     period: Option<Period>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    price: Option<&'a str>,
+    price: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    price_data: Option<UpdateInvoiceItemPriceData<'a>>,
+    price_data: Option<UpdateInvoiceItemPriceData>,
     #[serde(skip_serializing_if = "Option::is_none")]
     quantity: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tax_behavior: Option<UpdateInvoiceItemTaxBehavior>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    tax_code: Option<&'a str>,
+    tax_code: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    tax_rates: Option<&'a [&'a str]>,
+    tax_rates: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     unit_amount: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    unit_amount_decimal: Option<&'a str>,
+    unit_amount_decimal: Option<String>,
 }
-impl<'a> UpdateInvoiceItemBuilder<'a> {
+impl UpdateInvoiceItemBuilder {
     fn new() -> Self {
         Self {
             amount: None,
@@ -645,13 +654,13 @@ impl<'a> UpdateInvoiceItemBuilder<'a> {
     }
 }
 /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateInvoiceItemPriceData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateInvoiceItemPriceData {
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     /// Must be a [supported currency](https://stripe.com/docs/currencies).
     pub currency: stripe_types::Currency,
     /// The ID of the product that this price will belong to.
-    pub product: &'a str,
+    pub product: String,
     /// Only required if a [default tax behavior](https://stripe.com/docs/tax/products-prices-tax-categories-tax-behavior#setting-a-default-tax-behavior-(recommended)) was not provided in the Stripe Tax settings.
     /// Specifies whether the price is considered inclusive of taxes or exclusive of taxes.
     /// One of `inclusive`, `exclusive`, or `unspecified`.
@@ -664,11 +673,17 @@ pub struct UpdateInvoiceItemPriceData<'a> {
     /// Same as `unit_amount`, but accepts a decimal value in cents (or local equivalent) with at most 12 decimal places.
     /// Only one of `unit_amount` and `unit_amount_decimal` can be set.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub unit_amount_decimal: Option<&'a str>,
+    pub unit_amount_decimal: Option<String>,
 }
-impl<'a> UpdateInvoiceItemPriceData<'a> {
-    pub fn new(currency: stripe_types::Currency, product: &'a str) -> Self {
-        Self { currency, product, tax_behavior: None, unit_amount: None, unit_amount_decimal: None }
+impl UpdateInvoiceItemPriceData {
+    pub fn new(currency: impl Into<stripe_types::Currency>, product: impl Into<String>) -> Self {
+        Self {
+            currency: currency.into(),
+            product: product.into(),
+            tax_behavior: None,
+            unit_amount: None,
+            unit_amount_decimal: None,
+        }
     }
 }
 /// Only required if a [default tax behavior](https://stripe.com/docs/tax/products-prices-tax-categories-tax-behavior#setting-a-default-tax-behavior-(recommended)) was not provided in the Stripe Tax settings.
@@ -797,112 +812,115 @@ impl<'de> serde::Deserialize<'de> for UpdateInvoiceItemTaxBehavior {
 /// Updates the amount or description of an invoice item on an upcoming invoice.
 /// Updating an invoice item is only possible before the invoice it’s attached to is closed.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateInvoiceItem<'a> {
-    inner: UpdateInvoiceItemBuilder<'a>,
-    invoiceitem: &'a stripe_shared::InvoiceItemId,
+pub struct UpdateInvoiceItem {
+    inner: UpdateInvoiceItemBuilder,
+    invoiceitem: stripe_shared::InvoiceItemId,
 }
-impl<'a> UpdateInvoiceItem<'a> {
+impl UpdateInvoiceItem {
     /// Construct a new `UpdateInvoiceItem`.
-    pub fn new(invoiceitem: &'a stripe_shared::InvoiceItemId) -> Self {
-        Self { invoiceitem, inner: UpdateInvoiceItemBuilder::new() }
+    pub fn new(invoiceitem: impl Into<stripe_shared::InvoiceItemId>) -> Self {
+        Self { invoiceitem: invoiceitem.into(), inner: UpdateInvoiceItemBuilder::new() }
     }
     /// The integer amount in cents (or local equivalent) of the charge to be applied to the upcoming invoice.
     /// If you want to apply a credit to the customer's account, pass a negative amount.
-    pub fn amount(mut self, amount: i64) -> Self {
-        self.inner.amount = Some(amount);
+    pub fn amount(mut self, amount: impl Into<i64>) -> Self {
+        self.inner.amount = Some(amount.into());
         self
     }
     /// An arbitrary string which you can attach to the invoice item.
     /// The description is displayed in the invoice for easy tracking.
-    pub fn description(mut self, description: &'a str) -> Self {
-        self.inner.description = Some(description);
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.inner.description = Some(description.into());
         self
     }
     /// Controls whether discounts apply to this invoice item.
     /// Defaults to false for prorations or negative invoice items, and true for all other invoice items.
     /// Cannot be set to true for prorations.
-    pub fn discountable(mut self, discountable: bool) -> Self {
-        self.inner.discountable = Some(discountable);
+    pub fn discountable(mut self, discountable: impl Into<bool>) -> Self {
+        self.inner.discountable = Some(discountable.into());
         self
     }
     /// The coupons, promotion codes & existing discounts which apply to the invoice item or invoice line item.
     /// Item discounts are applied before invoice discounts.
     /// Pass an empty string to remove previously-defined discounts.
-    pub fn discounts(mut self, discounts: &'a [DiscountsDataParam<'a>]) -> Self {
-        self.inner.discounts = Some(discounts);
+    pub fn discounts(mut self, discounts: impl Into<Vec<DiscountsDataParam>>) -> Self {
+        self.inner.discounts = Some(discounts.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// The period associated with this invoice item.
     /// When set to different values, the period will be rendered on the invoice.
     /// If you have [Stripe Revenue Recognition](https://stripe.com/docs/revenue-recognition) enabled, the period will be used to recognize and defer revenue.
     /// See the [Revenue Recognition documentation](https://stripe.com/docs/revenue-recognition/methodology/subscriptions-and-invoicing) for details.
-    pub fn period(mut self, period: Period) -> Self {
-        self.inner.period = Some(period);
+    pub fn period(mut self, period: impl Into<Period>) -> Self {
+        self.inner.period = Some(period.into());
         self
     }
     /// The ID of the price object.
-    pub fn price(mut self, price: &'a str) -> Self {
-        self.inner.price = Some(price);
+    pub fn price(mut self, price: impl Into<String>) -> Self {
+        self.inner.price = Some(price.into());
         self
     }
     /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
-    pub fn price_data(mut self, price_data: UpdateInvoiceItemPriceData<'a>) -> Self {
-        self.inner.price_data = Some(price_data);
+    pub fn price_data(mut self, price_data: impl Into<UpdateInvoiceItemPriceData>) -> Self {
+        self.inner.price_data = Some(price_data.into());
         self
     }
     /// Non-negative integer. The quantity of units for the invoice item.
-    pub fn quantity(mut self, quantity: u64) -> Self {
-        self.inner.quantity = Some(quantity);
+    pub fn quantity(mut self, quantity: impl Into<u64>) -> Self {
+        self.inner.quantity = Some(quantity.into());
         self
     }
     /// Only required if a [default tax behavior](https://stripe.com/docs/tax/products-prices-tax-categories-tax-behavior#setting-a-default-tax-behavior-(recommended)) was not provided in the Stripe Tax settings.
     /// Specifies whether the price is considered inclusive of taxes or exclusive of taxes.
     /// One of `inclusive`, `exclusive`, or `unspecified`.
     /// Once specified as either `inclusive` or `exclusive`, it cannot be changed.
-    pub fn tax_behavior(mut self, tax_behavior: UpdateInvoiceItemTaxBehavior) -> Self {
-        self.inner.tax_behavior = Some(tax_behavior);
+    pub fn tax_behavior(mut self, tax_behavior: impl Into<UpdateInvoiceItemTaxBehavior>) -> Self {
+        self.inner.tax_behavior = Some(tax_behavior.into());
         self
     }
     /// A [tax code](https://stripe.com/docs/tax/tax-categories) ID.
-    pub fn tax_code(mut self, tax_code: &'a str) -> Self {
-        self.inner.tax_code = Some(tax_code);
+    pub fn tax_code(mut self, tax_code: impl Into<String>) -> Self {
+        self.inner.tax_code = Some(tax_code.into());
         self
     }
     /// The tax rates which apply to the invoice item.
     /// When set, the `default_tax_rates` on the invoice do not apply to this invoice item.
     /// Pass an empty string to remove previously-defined tax rates.
-    pub fn tax_rates(mut self, tax_rates: &'a [&'a str]) -> Self {
-        self.inner.tax_rates = Some(tax_rates);
+    pub fn tax_rates(mut self, tax_rates: impl Into<Vec<String>>) -> Self {
+        self.inner.tax_rates = Some(tax_rates.into());
         self
     }
     /// The integer unit amount in cents (or local equivalent) of the charge to be applied to the upcoming invoice.
     /// This unit_amount will be multiplied by the quantity to get the full amount.
     /// If you want to apply a credit to the customer's account, pass a negative unit_amount.
-    pub fn unit_amount(mut self, unit_amount: i64) -> Self {
-        self.inner.unit_amount = Some(unit_amount);
+    pub fn unit_amount(mut self, unit_amount: impl Into<i64>) -> Self {
+        self.inner.unit_amount = Some(unit_amount.into());
         self
     }
     /// Same as `unit_amount`, but accepts a decimal value in cents (or local equivalent) with at most 12 decimal places.
     /// Only one of `unit_amount` and `unit_amount_decimal` can be set.
-    pub fn unit_amount_decimal(mut self, unit_amount_decimal: &'a str) -> Self {
-        self.inner.unit_amount_decimal = Some(unit_amount_decimal);
+    pub fn unit_amount_decimal(mut self, unit_amount_decimal: impl Into<String>) -> Self {
+        self.inner.unit_amount_decimal = Some(unit_amount_decimal.into());
         self
     }
 }
-impl UpdateInvoiceItem<'_> {
+impl UpdateInvoiceItem {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -920,34 +938,34 @@ impl UpdateInvoiceItem<'_> {
     }
 }
 
-impl StripeRequest for UpdateInvoiceItem<'_> {
+impl StripeRequest for UpdateInvoiceItem {
     type Output = stripe_shared::InvoiceItem;
 
     fn build(&self) -> RequestBuilder {
-        let invoiceitem = self.invoiceitem;
+        let invoiceitem = &self.invoiceitem;
         RequestBuilder::new(StripeMethod::Post, format!("/invoiceitems/{invoiceitem}"))
             .form(&self.inner)
     }
 }
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct DiscountsDataParam<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct DiscountsDataParam {
     /// ID of the coupon to create a new discount for.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub coupon: Option<&'a str>,
+    pub coupon: Option<String>,
     /// ID of an existing discount on the object (or one of its ancestors) to reuse.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub discount: Option<&'a str>,
+    pub discount: Option<String>,
     /// ID of the promotion code to create a new discount for.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub promotion_code: Option<&'a str>,
+    pub promotion_code: Option<String>,
 }
-impl<'a> DiscountsDataParam<'a> {
+impl DiscountsDataParam {
     pub fn new() -> Self {
         Self { coupon: None, discount: None, promotion_code: None }
     }
 }
-impl<'a> Default for DiscountsDataParam<'a> {
+impl Default for DiscountsDataParam {
     fn default() -> Self {
         Self::new()
     }
@@ -960,7 +978,10 @@ pub struct Period {
     pub start: stripe_types::Timestamp,
 }
 impl Period {
-    pub fn new(end: stripe_types::Timestamp, start: stripe_types::Timestamp) -> Self {
-        Self { end, start }
+    pub fn new(
+        end: impl Into<stripe_types::Timestamp>,
+        start: impl Into<stripe_types::Timestamp>,
+    ) -> Self {
+        Self { end: end.into(), start: start.into() }
     }
 }

--- a/generated/async-stripe-billing/src/invoice_line_item/requests.rs
+++ b/generated/async-stripe-billing/src/invoice_line_item/requests.rs
@@ -2,18 +2,18 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListInvoiceInvoiceLineItemBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListInvoiceInvoiceLineItemBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListInvoiceInvoiceLineItemBuilder<'a> {
+impl ListInvoiceInvoiceLineItemBuilder {
     fn new() -> Self {
         Self { ending_before: None, expand: None, limit: None, starting_after: None }
     }
@@ -21,42 +21,42 @@ impl<'a> ListInvoiceInvoiceLineItemBuilder<'a> {
 /// When retrieving an invoice, you’ll get a **lines** property containing the total count of line items and the first handful of those items.
 /// There is also a URL where you can retrieve the full (paginated) list of line items.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListInvoiceInvoiceLineItem<'a> {
-    inner: ListInvoiceInvoiceLineItemBuilder<'a>,
-    invoice: &'a stripe_shared::InvoiceId,
+pub struct ListInvoiceInvoiceLineItem {
+    inner: ListInvoiceInvoiceLineItemBuilder,
+    invoice: stripe_shared::InvoiceId,
 }
-impl<'a> ListInvoiceInvoiceLineItem<'a> {
+impl ListInvoiceInvoiceLineItem {
     /// Construct a new `ListInvoiceInvoiceLineItem`.
-    pub fn new(invoice: &'a stripe_shared::InvoiceId) -> Self {
-        Self { invoice, inner: ListInvoiceInvoiceLineItemBuilder::new() }
+    pub fn new(invoice: impl Into<stripe_shared::InvoiceId>) -> Self {
+        Self { invoice: invoice.into(), inner: ListInvoiceInvoiceLineItemBuilder::new() }
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl ListInvoiceInvoiceLineItem<'_> {
+impl ListInvoiceInvoiceLineItem {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -76,52 +76,52 @@ impl ListInvoiceInvoiceLineItem<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::InvoiceLineItem>> {
-        let invoice = self.invoice;
+        let invoice = &self.invoice;
 
         stripe_client_core::ListPaginator::new_list(
             format!("/invoices/{invoice}/lines"),
-            self.inner,
+            &self.inner,
         )
     }
 }
 
-impl StripeRequest for ListInvoiceInvoiceLineItem<'_> {
+impl StripeRequest for ListInvoiceInvoiceLineItem {
     type Output = stripe_types::List<stripe_shared::InvoiceLineItem>;
 
     fn build(&self) -> RequestBuilder {
-        let invoice = self.invoice;
+        let invoice = &self.invoice;
         RequestBuilder::new(StripeMethod::Get, format!("/invoices/{invoice}/lines"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdateInvoiceLineItemBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdateInvoiceLineItemBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     amount: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<&'a str>,
+    description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     discountable: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    discounts: Option<&'a [UpdateInvoiceLineItemDiscounts<'a>]>,
+    discounts: Option<Vec<UpdateInvoiceLineItemDiscounts>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     period: Option<UpdateInvoiceLineItemPeriod>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    price: Option<&'a str>,
+    price: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    price_data: Option<UpdateInvoiceLineItemPriceData<'a>>,
+    price_data: Option<UpdateInvoiceLineItemPriceData>,
     #[serde(skip_serializing_if = "Option::is_none")]
     quantity: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    tax_amounts: Option<&'a [UpdateInvoiceLineItemTaxAmounts<'a>]>,
+    tax_amounts: Option<Vec<UpdateInvoiceLineItemTaxAmounts>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    tax_rates: Option<&'a [&'a str]>,
+    tax_rates: Option<Vec<String>>,
 }
-impl<'a> UpdateInvoiceLineItemBuilder<'a> {
+impl UpdateInvoiceLineItemBuilder {
     fn new() -> Self {
         Self {
             amount: None,
@@ -142,24 +142,24 @@ impl<'a> UpdateInvoiceLineItemBuilder<'a> {
 /// The coupons, promotion codes & existing discounts which apply to the line item.
 /// Item discounts are applied before invoice discounts.
 /// Pass an empty string to remove previously-defined discounts.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateInvoiceLineItemDiscounts<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateInvoiceLineItemDiscounts {
     /// ID of the coupon to create a new discount for.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub coupon: Option<&'a str>,
+    pub coupon: Option<String>,
     /// ID of an existing discount on the object (or one of its ancestors) to reuse.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub discount: Option<&'a str>,
+    pub discount: Option<String>,
     /// ID of the promotion code to create a new discount for.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub promotion_code: Option<&'a str>,
+    pub promotion_code: Option<String>,
 }
-impl<'a> UpdateInvoiceLineItemDiscounts<'a> {
+impl UpdateInvoiceLineItemDiscounts {
     pub fn new() -> Self {
         Self { coupon: None, discount: None, promotion_code: None }
     }
 }
-impl<'a> Default for UpdateInvoiceLineItemDiscounts<'a> {
+impl Default for UpdateInvoiceLineItemDiscounts {
     fn default() -> Self {
         Self::new()
     }
@@ -176,23 +176,26 @@ pub struct UpdateInvoiceLineItemPeriod {
     pub start: stripe_types::Timestamp,
 }
 impl UpdateInvoiceLineItemPeriod {
-    pub fn new(end: stripe_types::Timestamp, start: stripe_types::Timestamp) -> Self {
-        Self { end, start }
+    pub fn new(
+        end: impl Into<stripe_types::Timestamp>,
+        start: impl Into<stripe_types::Timestamp>,
+    ) -> Self {
+        Self { end: end.into(), start: start.into() }
     }
 }
 /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateInvoiceLineItemPriceData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateInvoiceLineItemPriceData {
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     /// Must be a [supported currency](https://stripe.com/docs/currencies).
     pub currency: stripe_types::Currency,
     /// The ID of the product that this price will belong to.
     /// One of `product` or `product_data` is required.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub product: Option<&'a str>,
+    pub product: Option<String>,
     /// Data used to generate a new product object inline. One of `product` or `product_data` is required.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub product_data: Option<UpdateInvoiceLineItemPriceDataProductData<'a>>,
+    pub product_data: Option<UpdateInvoiceLineItemPriceDataProductData>,
     /// Only required if a [default tax behavior](https://stripe.com/docs/tax/products-prices-tax-categories-tax-behavior#setting-a-default-tax-behavior-(recommended)) was not provided in the Stripe Tax settings.
     /// Specifies whether the price is considered inclusive of taxes or exclusive of taxes.
     /// One of `inclusive`, `exclusive`, or `unspecified`.
@@ -206,12 +209,12 @@ pub struct UpdateInvoiceLineItemPriceData<'a> {
     /// Same as `unit_amount`, but accepts a decimal value in cents (or local equivalent) with at most 12 decimal places.
     /// Only one of `unit_amount` and `unit_amount_decimal` can be set.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub unit_amount_decimal: Option<&'a str>,
+    pub unit_amount_decimal: Option<String>,
 }
-impl<'a> UpdateInvoiceLineItemPriceData<'a> {
-    pub fn new(currency: stripe_types::Currency) -> Self {
+impl UpdateInvoiceLineItemPriceData {
+    pub fn new(currency: impl Into<stripe_types::Currency>) -> Self {
         Self {
-            currency,
+            currency: currency.into(),
             product: None,
             product_data: None,
             tax_behavior: None,
@@ -221,30 +224,30 @@ impl<'a> UpdateInvoiceLineItemPriceData<'a> {
     }
 }
 /// Data used to generate a new product object inline. One of `product` or `product_data` is required.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateInvoiceLineItemPriceDataProductData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateInvoiceLineItemPriceDataProductData {
     /// The product's description, meant to be displayable to the customer.
     /// Use this field to optionally store a long form explanation of the product being sold for your own rendering purposes.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<&'a str>,
+    pub description: Option<String>,
     /// A list of up to 8 URLs of images for this product, meant to be displayable to the customer.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub images: Option<&'a [&'a str]>,
+    pub images: Option<Vec<String>>,
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// The product's name, meant to be displayable to the customer.
-    pub name: &'a str,
+    pub name: String,
     /// A [tax code](https://stripe.com/docs/tax/tax-categories) ID.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_code: Option<&'a str>,
+    pub tax_code: Option<String>,
 }
-impl<'a> UpdateInvoiceLineItemPriceDataProductData<'a> {
-    pub fn new(name: &'a str) -> Self {
-        Self { description: None, images: None, metadata: None, name, tax_code: None }
+impl UpdateInvoiceLineItemPriceDataProductData {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self { description: None, images: None, metadata: None, name: name.into(), tax_code: None }
     }
 }
 /// Only required if a [default tax behavior](https://stripe.com/docs/tax/products-prices-tax-categories-tax-behavior#setting-a-default-tax-behavior-(recommended)) was not provided in the Stripe Tax settings.
@@ -313,8 +316,8 @@ impl<'de> serde::Deserialize<'de> for UpdateInvoiceLineItemPriceDataTaxBehavior 
 /// This can be useful if you calculate taxes on your own or use a third-party to calculate them.
 /// You cannot set tax amounts if any line item has [tax_rates](https://stripe.com/docs/api/invoices/line_item#invoice_line_item_object-tax_rates) or if the invoice has [default_tax_rates](https://stripe.com/docs/api/invoices/object#invoice_object-default_tax_rates) or uses [automatic tax](https://stripe.com/docs/tax/invoicing).
 /// Pass an empty string to remove previously defined tax amounts.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateInvoiceLineItemTaxAmounts<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateInvoiceLineItemTaxAmounts {
     /// The amount, in cents (or local equivalent), of the tax.
     pub amount: i64,
     /// Data to find or create a TaxRate object.
@@ -322,17 +325,21 @@ pub struct UpdateInvoiceLineItemTaxAmounts<'a> {
     /// Stripe automatically creates or reuses a TaxRate object for each tax amount.
     /// If the `tax_rate_data` exactly matches a previous value, Stripe will reuse the TaxRate object.
     /// TaxRate objects created automatically by Stripe are immediately archived, do not appear in the line item’s `tax_rates`, and cannot be directly added to invoices, payments, or line items.
-    pub tax_rate_data: UpdateInvoiceLineItemTaxAmountsTaxRateData<'a>,
+    pub tax_rate_data: UpdateInvoiceLineItemTaxAmountsTaxRateData,
     /// The amount on which tax is calculated, in cents (or local equivalent).
     pub taxable_amount: i64,
 }
-impl<'a> UpdateInvoiceLineItemTaxAmounts<'a> {
+impl UpdateInvoiceLineItemTaxAmounts {
     pub fn new(
-        amount: i64,
-        tax_rate_data: UpdateInvoiceLineItemTaxAmountsTaxRateData<'a>,
-        taxable_amount: i64,
+        amount: impl Into<i64>,
+        tax_rate_data: impl Into<UpdateInvoiceLineItemTaxAmountsTaxRateData>,
+        taxable_amount: impl Into<i64>,
     ) -> Self {
-        Self { amount, tax_rate_data, taxable_amount }
+        Self {
+            amount: amount.into(),
+            tax_rate_data: tax_rate_data.into(),
+            taxable_amount: taxable_amount.into(),
+        }
     }
 }
 /// Data to find or create a TaxRate object.
@@ -340,24 +347,24 @@ impl<'a> UpdateInvoiceLineItemTaxAmounts<'a> {
 /// Stripe automatically creates or reuses a TaxRate object for each tax amount.
 /// If the `tax_rate_data` exactly matches a previous value, Stripe will reuse the TaxRate object.
 /// TaxRate objects created automatically by Stripe are immediately archived, do not appear in the line item’s `tax_rates`, and cannot be directly added to invoices, payments, or line items.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateInvoiceLineItemTaxAmountsTaxRateData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateInvoiceLineItemTaxAmountsTaxRateData {
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub country: Option<&'a str>,
+    pub country: Option<String>,
     /// An arbitrary string attached to the tax rate for your internal use only.
     /// It will not be visible to your customers.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<&'a str>,
+    pub description: Option<String>,
     /// The display name of the tax rate, which will be shown to users.
-    pub display_name: &'a str,
+    pub display_name: String,
     /// This specifies if the tax rate is inclusive or exclusive.
     pub inclusive: bool,
     /// The jurisdiction for the tax rate.
     /// You can use this label field for tax reporting purposes.
     /// It also appears on your customer’s invoice.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub jurisdiction: Option<&'a str>,
+    pub jurisdiction: Option<String>,
     /// The statutory tax rate percent.
     /// This field accepts decimal values between 0 and 100 inclusive with at most 4 decimal places.
     /// To accommodate fixed-amount taxes, set the percentage to zero.
@@ -366,20 +373,24 @@ pub struct UpdateInvoiceLineItemTaxAmountsTaxRateData<'a> {
     /// [ISO 3166-2 subdivision code](https://en.wikipedia.org/wiki/ISO_3166-2:US), without country prefix.
     /// For example, "NY" for New York, United States.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
     /// The high-level tax type, such as `vat` or `sales_tax`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tax_type: Option<UpdateInvoiceLineItemTaxAmountsTaxRateDataTaxType>,
 }
-impl<'a> UpdateInvoiceLineItemTaxAmountsTaxRateData<'a> {
-    pub fn new(display_name: &'a str, inclusive: bool, percentage: f64) -> Self {
+impl UpdateInvoiceLineItemTaxAmountsTaxRateData {
+    pub fn new(
+        display_name: impl Into<String>,
+        inclusive: impl Into<bool>,
+        percentage: impl Into<f64>,
+    ) -> Self {
         Self {
             country: None,
             description: None,
-            display_name,
-            inclusive,
+            display_name: display_name.into(),
+            inclusive: inclusive.into(),
             jurisdiction: None,
-            percentage,
+            percentage: percentage.into(),
             state: None,
             tax_type: None,
         }
@@ -480,45 +491,52 @@ impl<'de> serde::Deserialize<'de> for UpdateInvoiceLineItemTaxAmountsTaxRateData
 /// item and the invoice line item, so updates on this endpoint will propagate to the invoice item as well.
 /// Updating an invoice’s line item is only possible before the invoice is finalized.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateInvoiceLineItem<'a> {
-    inner: UpdateInvoiceLineItemBuilder<'a>,
-    invoice: &'a stripe_shared::InvoiceId,
-    line_item_id: &'a str,
+pub struct UpdateInvoiceLineItem {
+    inner: UpdateInvoiceLineItemBuilder,
+    invoice: stripe_shared::InvoiceId,
+    line_item_id: String,
 }
-impl<'a> UpdateInvoiceLineItem<'a> {
+impl UpdateInvoiceLineItem {
     /// Construct a new `UpdateInvoiceLineItem`.
-    pub fn new(invoice: &'a stripe_shared::InvoiceId, line_item_id: &'a str) -> Self {
-        Self { invoice, line_item_id, inner: UpdateInvoiceLineItemBuilder::new() }
+    pub fn new(
+        invoice: impl Into<stripe_shared::InvoiceId>,
+        line_item_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            invoice: invoice.into(),
+            line_item_id: line_item_id.into(),
+            inner: UpdateInvoiceLineItemBuilder::new(),
+        }
     }
     /// The integer amount in cents (or local equivalent) of the charge to be applied to the upcoming invoice.
     /// If you want to apply a credit to the customer's account, pass a negative amount.
-    pub fn amount(mut self, amount: i64) -> Self {
-        self.inner.amount = Some(amount);
+    pub fn amount(mut self, amount: impl Into<i64>) -> Self {
+        self.inner.amount = Some(amount.into());
         self
     }
     /// An arbitrary string which you can attach to the invoice item.
     /// The description is displayed in the invoice for easy tracking.
-    pub fn description(mut self, description: &'a str) -> Self {
-        self.inner.description = Some(description);
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.inner.description = Some(description.into());
         self
     }
     /// Controls whether discounts apply to this line item.
     /// Defaults to false for prorations or negative line items, and true for all other line items.
     /// Cannot be set to true for prorations.
-    pub fn discountable(mut self, discountable: bool) -> Self {
-        self.inner.discountable = Some(discountable);
+    pub fn discountable(mut self, discountable: impl Into<bool>) -> Self {
+        self.inner.discountable = Some(discountable.into());
         self
     }
     /// The coupons, promotion codes & existing discounts which apply to the line item.
     /// Item discounts are applied before invoice discounts.
     /// Pass an empty string to remove previously-defined discounts.
-    pub fn discounts(mut self, discounts: &'a [UpdateInvoiceLineItemDiscounts<'a>]) -> Self {
-        self.inner.discounts = Some(discounts);
+    pub fn discounts(mut self, discounts: impl Into<Vec<UpdateInvoiceLineItemDiscounts>>) -> Self {
+        self.inner.discounts = Some(discounts.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
@@ -526,50 +544,56 @@ impl<'a> UpdateInvoiceLineItem<'a> {
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
     /// For `type=recurring` line items, the incoming metadata specified on the request is directly used to set this value, in contrast to `type=invoiceitem` line items, where any existing metadata on the invoice line is merged with the incoming data.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// The period associated with this invoice item.
     /// When set to different values, the period will be rendered on the invoice.
     /// If you have [Stripe Revenue Recognition](https://stripe.com/docs/revenue-recognition) enabled, the period will be used to recognize and defer revenue.
     /// See the [Revenue Recognition documentation](https://stripe.com/docs/revenue-recognition/methodology/subscriptions-and-invoicing) for details.
-    pub fn period(mut self, period: UpdateInvoiceLineItemPeriod) -> Self {
-        self.inner.period = Some(period);
+    pub fn period(mut self, period: impl Into<UpdateInvoiceLineItemPeriod>) -> Self {
+        self.inner.period = Some(period.into());
         self
     }
     /// The ID of the price object.
-    pub fn price(mut self, price: &'a str) -> Self {
-        self.inner.price = Some(price);
+    pub fn price(mut self, price: impl Into<String>) -> Self {
+        self.inner.price = Some(price.into());
         self
     }
     /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
-    pub fn price_data(mut self, price_data: UpdateInvoiceLineItemPriceData<'a>) -> Self {
-        self.inner.price_data = Some(price_data);
+    pub fn price_data(mut self, price_data: impl Into<UpdateInvoiceLineItemPriceData>) -> Self {
+        self.inner.price_data = Some(price_data.into());
         self
     }
     /// Non-negative integer. The quantity of units for the line item.
-    pub fn quantity(mut self, quantity: u64) -> Self {
-        self.inner.quantity = Some(quantity);
+    pub fn quantity(mut self, quantity: impl Into<u64>) -> Self {
+        self.inner.quantity = Some(quantity.into());
         self
     }
     /// A list of up to 10 tax amounts for this line item.
     /// This can be useful if you calculate taxes on your own or use a third-party to calculate them.
     /// You cannot set tax amounts if any line item has [tax_rates](https://stripe.com/docs/api/invoices/line_item#invoice_line_item_object-tax_rates) or if the invoice has [default_tax_rates](https://stripe.com/docs/api/invoices/object#invoice_object-default_tax_rates) or uses [automatic tax](https://stripe.com/docs/tax/invoicing).
     /// Pass an empty string to remove previously defined tax amounts.
-    pub fn tax_amounts(mut self, tax_amounts: &'a [UpdateInvoiceLineItemTaxAmounts<'a>]) -> Self {
-        self.inner.tax_amounts = Some(tax_amounts);
+    pub fn tax_amounts(
+        mut self,
+        tax_amounts: impl Into<Vec<UpdateInvoiceLineItemTaxAmounts>>,
+    ) -> Self {
+        self.inner.tax_amounts = Some(tax_amounts.into());
         self
     }
     /// The tax rates which apply to the line item.
     /// When set, the `default_tax_rates` on the invoice do not apply to this line item.
     /// Pass an empty string to remove previously-defined tax rates.
-    pub fn tax_rates(mut self, tax_rates: &'a [&'a str]) -> Self {
-        self.inner.tax_rates = Some(tax_rates);
+    pub fn tax_rates(mut self, tax_rates: impl Into<Vec<String>>) -> Self {
+        self.inner.tax_rates = Some(tax_rates.into());
         self
     }
 }
-impl UpdateInvoiceLineItem<'_> {
+impl UpdateInvoiceLineItem {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -587,12 +611,12 @@ impl UpdateInvoiceLineItem<'_> {
     }
 }
 
-impl StripeRequest for UpdateInvoiceLineItem<'_> {
+impl StripeRequest for UpdateInvoiceLineItem {
     type Output = stripe_shared::InvoiceLineItem;
 
     fn build(&self) -> RequestBuilder {
-        let invoice = self.invoice;
-        let line_item_id = self.line_item_id;
+        let invoice = &self.invoice;
+        let line_item_id = &self.line_item_id;
         RequestBuilder::new(StripeMethod::Post, format!("/invoices/{invoice}/lines/{line_item_id}"))
             .form(&self.inner)
     }

--- a/generated/async-stripe-billing/src/plan/requests.rs
+++ b/generated/async-stripe-billing/src/plan/requests.rs
@@ -4,16 +4,16 @@ use stripe_client_core::{
 
 /// Deleting plans means new subscribers can’t be added. Existing subscribers aren’t affected.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct DeletePlan<'a> {
-    plan: &'a stripe_shared::PlanId,
+pub struct DeletePlan {
+    plan: stripe_shared::PlanId,
 }
-impl<'a> DeletePlan<'a> {
+impl DeletePlan {
     /// Construct a new `DeletePlan`.
-    pub fn new(plan: &'a stripe_shared::PlanId) -> Self {
-        Self { plan }
+    pub fn new(plan: impl Into<stripe_shared::PlanId>) -> Self {
+        Self { plan: plan.into() }
     }
 }
-impl DeletePlan<'_> {
+impl DeletePlan {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -31,32 +31,32 @@ impl DeletePlan<'_> {
     }
 }
 
-impl StripeRequest for DeletePlan<'_> {
+impl StripeRequest for DeletePlan {
     type Output = stripe_shared::DeletedPlan;
 
     fn build(&self) -> RequestBuilder {
-        let plan = self.plan;
+        let plan = &self.plan;
         RequestBuilder::new(StripeMethod::Delete, format!("/plans/{plan}"))
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListPlanBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListPlanBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     active: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     created: Option<stripe_types::RangeQueryTs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    product: Option<&'a str>,
+    product: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListPlanBuilder<'a> {
+impl ListPlanBuilder {
     fn new() -> Self {
         Self {
             active: None,
@@ -71,62 +71,62 @@ impl<'a> ListPlanBuilder<'a> {
 }
 /// Returns a list of your plans.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListPlan<'a> {
-    inner: ListPlanBuilder<'a>,
+pub struct ListPlan {
+    inner: ListPlanBuilder,
 }
-impl<'a> ListPlan<'a> {
+impl ListPlan {
     /// Construct a new `ListPlan`.
     pub fn new() -> Self {
         Self { inner: ListPlanBuilder::new() }
     }
     /// Only return plans that are active or inactive (e.g., pass `false` to list all inactive plans).
-    pub fn active(mut self, active: bool) -> Self {
-        self.inner.active = Some(active);
+    pub fn active(mut self, active: impl Into<bool>) -> Self {
+        self.inner.active = Some(active.into());
         self
     }
     /// A filter on the list, based on the object `created` field.
     /// The value can be a string with an integer Unix timestamp, or it can be a dictionary with a number of different query options.
-    pub fn created(mut self, created: stripe_types::RangeQueryTs) -> Self {
-        self.inner.created = Some(created);
+    pub fn created(mut self, created: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.created = Some(created.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// Only return plans for the given product.
-    pub fn product(mut self, product: &'a str) -> Self {
-        self.inner.product = Some(product);
+    pub fn product(mut self, product: impl Into<String>) -> Self {
+        self.inner.product = Some(product.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl<'a> Default for ListPlan<'a> {
+impl Default for ListPlan {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListPlan<'_> {
+impl ListPlan {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -146,45 +146,45 @@ impl ListPlan<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::Plan>> {
-        stripe_client_core::ListPaginator::new_list("/plans", self.inner)
+        stripe_client_core::ListPaginator::new_list("/plans", &self.inner)
     }
 }
 
-impl StripeRequest for ListPlan<'_> {
+impl StripeRequest for ListPlan {
     type Output = stripe_types::List<stripe_shared::Plan>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/plans").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrievePlanBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrievePlanBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrievePlanBuilder<'a> {
+impl RetrievePlanBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves the plan with the given ID.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrievePlan<'a> {
-    inner: RetrievePlanBuilder<'a>,
-    plan: &'a stripe_shared::PlanId,
+pub struct RetrievePlan {
+    inner: RetrievePlanBuilder,
+    plan: stripe_shared::PlanId,
 }
-impl<'a> RetrievePlan<'a> {
+impl RetrievePlan {
     /// Construct a new `RetrievePlan`.
-    pub fn new(plan: &'a stripe_shared::PlanId) -> Self {
-        Self { plan, inner: RetrievePlanBuilder::new() }
+    pub fn new(plan: impl Into<stripe_shared::PlanId>) -> Self {
+        Self { plan: plan.into(), inner: RetrievePlanBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrievePlan<'_> {
+impl RetrievePlan {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -202,16 +202,16 @@ impl RetrievePlan<'_> {
     }
 }
 
-impl StripeRequest for RetrievePlan<'_> {
+impl StripeRequest for RetrievePlan {
     type Output = stripe_shared::Plan;
 
     fn build(&self) -> RequestBuilder {
-        let plan = self.plan;
+        let plan = &self.plan;
         RequestBuilder::new(StripeMethod::Get, format!("/plans/{plan}")).query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreatePlanBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreatePlanBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     active: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -219,27 +219,27 @@ struct CreatePlanBuilder<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     amount: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    amount_decimal: Option<&'a str>,
+    amount_decimal: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     billing_scheme: Option<stripe_shared::PlanBillingScheme>,
     currency: stripe_types::Currency,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    id: Option<&'a str>,
+    id: Option<String>,
     interval: stripe_shared::PlanInterval,
     #[serde(skip_serializing_if = "Option::is_none")]
     interval_count: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    meter: Option<&'a str>,
+    meter: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    nickname: Option<&'a str>,
+    nickname: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    product: Option<CreatePlanProduct<'a>>,
+    product: Option<CreatePlanProduct>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    tiers: Option<&'a [CreatePlanTiers<'a>]>,
+    tiers: Option<Vec<CreatePlanTiers>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tiers_mode: Option<stripe_shared::PlanTiersMode>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -249,18 +249,21 @@ struct CreatePlanBuilder<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     usage_type: Option<stripe_shared::PlanUsageType>,
 }
-impl<'a> CreatePlanBuilder<'a> {
-    fn new(currency: stripe_types::Currency, interval: stripe_shared::PlanInterval) -> Self {
+impl CreatePlanBuilder {
+    fn new(
+        currency: impl Into<stripe_types::Currency>,
+        interval: impl Into<stripe_shared::PlanInterval>,
+    ) -> Self {
         Self {
             active: None,
             aggregate_usage: None,
             amount: None,
             amount_decimal: None,
             billing_scheme: None,
-            currency,
+            currency: currency.into(),
             expand: None,
             id: None,
-            interval,
+            interval: interval.into(),
             interval_count: None,
             metadata: None,
             meter: None,
@@ -274,16 +277,16 @@ impl<'a> CreatePlanBuilder<'a> {
         }
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
-pub enum CreatePlanProduct<'a> {
+pub enum CreatePlanProduct {
     #[serde(untagged)]
-    InlineProductParams(CreatePlanInlineProductParams<'a>),
+    InlineProductParams(CreatePlanInlineProductParams),
     #[serde(untagged)]
-    Id(&'a str),
+    Id(String),
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePlanInlineProductParams<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePlanInlineProductParams {
     /// Whether the product is currently available for purchase. Defaults to `true`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub active: Option<bool>,
@@ -291,15 +294,15 @@ pub struct CreatePlanInlineProductParams<'a> {
     /// Must be unique.
     /// If not provided, an identifier will be randomly generated.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub id: Option<&'a str>,
+    pub id: Option<String>,
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// The product's name, meant to be displayable to the customer.
-    pub name: &'a str,
+    pub name: String,
     /// An arbitrary string to be displayed on your customer's credit card or bank statement.
     /// While most banks display this information consistently, some may display it incorrectly or not at all.
     ///
@@ -307,22 +310,22 @@ pub struct CreatePlanInlineProductParams<'a> {
     /// The statement description may not include `<`, `>`, `\`, `"`, `'` characters, and will appear on your customer's statement in capital letters.
     /// Non-ASCII characters are automatically stripped.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub statement_descriptor: Option<&'a str>,
+    pub statement_descriptor: Option<String>,
     /// A [tax code](https://stripe.com/docs/tax/tax-categories) ID.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_code: Option<&'a str>,
+    pub tax_code: Option<String>,
     /// A label that represents units of this product.
     /// When set, this will be included in customers' receipts, invoices, Checkout, and the customer portal.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub unit_label: Option<&'a str>,
+    pub unit_label: Option<String>,
 }
-impl<'a> CreatePlanInlineProductParams<'a> {
-    pub fn new(name: &'a str) -> Self {
+impl CreatePlanInlineProductParams {
+    pub fn new(name: impl Into<String>) -> Self {
         Self {
             active: None,
             id: None,
             metadata: None,
-            name,
+            name: name.into(),
             statement_descriptor: None,
             tax_code: None,
             unit_label: None,
@@ -332,35 +335,35 @@ impl<'a> CreatePlanInlineProductParams<'a> {
 /// Each element represents a pricing tier.
 /// This parameter requires `billing_scheme` to be set to `tiered`.
 /// See also the documentation for `billing_scheme`.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePlanTiers<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePlanTiers {
     /// The flat billing amount for an entire tier, regardless of the number of units in the tier.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub flat_amount: Option<i64>,
     /// Same as `flat_amount`, but accepts a decimal value representing an integer in the minor units of the currency.
     /// Only one of `flat_amount` and `flat_amount_decimal` can be set.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub flat_amount_decimal: Option<&'a str>,
+    pub flat_amount_decimal: Option<String>,
     /// The per unit billing amount for each individual unit for which this tier applies.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub unit_amount: Option<i64>,
     /// Same as `unit_amount`, but accepts a decimal value in cents (or local equivalent) with at most 12 decimal places.
     /// Only one of `unit_amount` and `unit_amount_decimal` can be set.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub unit_amount_decimal: Option<&'a str>,
+    pub unit_amount_decimal: Option<String>,
     /// Specifies the upper bound of this tier.
     /// The lower bound of a tier is the upper bound of the previous tier adding one.
     /// Use `inf` to define a fallback tier.
     pub up_to: CreatePlanTiersUpTo,
 }
-impl<'a> CreatePlanTiers<'a> {
-    pub fn new(up_to: CreatePlanTiersUpTo) -> Self {
+impl CreatePlanTiers {
+    pub fn new(up_to: impl Into<CreatePlanTiersUpTo>) -> Self {
         Self {
             flat_amount: None,
             flat_amount_decimal: None,
             unit_amount: None,
             unit_amount_decimal: None,
-            up_to,
+            up_to: up_to.into(),
         }
     }
 }
@@ -384,8 +387,8 @@ pub struct CreatePlanTransformUsage {
     pub round: CreatePlanTransformUsageRound,
 }
 impl CreatePlanTransformUsage {
-    pub fn new(divide_by: i64, round: CreatePlanTransformUsageRound) -> Self {
-        Self { divide_by, round }
+    pub fn new(divide_by: impl Into<i64>, round: impl Into<CreatePlanTransformUsageRound>) -> Self {
+        Self { divide_by: divide_by.into(), round: round.into() }
     }
 }
 /// After division, either round the result `up` or `down`.
@@ -447,109 +450,121 @@ impl<'de> serde::Deserialize<'de> for CreatePlanTransformUsageRound {
 /// You can now model subscriptions more flexibly using the [Prices API](https://stripe.com/docs/api#prices).
 /// It replaces the Plans API and is backwards compatible to simplify your migration.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreatePlan<'a> {
-    inner: CreatePlanBuilder<'a>,
+pub struct CreatePlan {
+    inner: CreatePlanBuilder,
 }
-impl<'a> CreatePlan<'a> {
+impl CreatePlan {
     /// Construct a new `CreatePlan`.
-    pub fn new(currency: stripe_types::Currency, interval: stripe_shared::PlanInterval) -> Self {
-        Self { inner: CreatePlanBuilder::new(currency, interval) }
+    pub fn new(
+        currency: impl Into<stripe_types::Currency>,
+        interval: impl Into<stripe_shared::PlanInterval>,
+    ) -> Self {
+        Self { inner: CreatePlanBuilder::new(currency.into(), interval.into()) }
     }
     /// Whether the plan is currently available for new subscriptions. Defaults to `true`.
-    pub fn active(mut self, active: bool) -> Self {
-        self.inner.active = Some(active);
+    pub fn active(mut self, active: impl Into<bool>) -> Self {
+        self.inner.active = Some(active.into());
         self
     }
     /// Specifies a usage aggregation strategy for plans of `usage_type=metered`.
     /// Allowed values are `sum` for summing up all usage during a period, `last_during_period` for using the last usage record reported within a period, `last_ever` for using the last usage record ever (across period bounds) or `max` which uses the usage record with the maximum reported usage during a period.
     /// Defaults to `sum`.
-    pub fn aggregate_usage(mut self, aggregate_usage: stripe_shared::PlanAggregateUsage) -> Self {
-        self.inner.aggregate_usage = Some(aggregate_usage);
+    pub fn aggregate_usage(
+        mut self,
+        aggregate_usage: impl Into<stripe_shared::PlanAggregateUsage>,
+    ) -> Self {
+        self.inner.aggregate_usage = Some(aggregate_usage.into());
         self
     }
     /// A positive integer in cents (or local equivalent) (or 0 for a free plan) representing how much to charge on a recurring basis.
-    pub fn amount(mut self, amount: i64) -> Self {
-        self.inner.amount = Some(amount);
+    pub fn amount(mut self, amount: impl Into<i64>) -> Self {
+        self.inner.amount = Some(amount.into());
         self
     }
     /// Same as `amount`, but accepts a decimal value with at most 12 decimal places.
     /// Only one of `amount` and `amount_decimal` can be set.
-    pub fn amount_decimal(mut self, amount_decimal: &'a str) -> Self {
-        self.inner.amount_decimal = Some(amount_decimal);
+    pub fn amount_decimal(mut self, amount_decimal: impl Into<String>) -> Self {
+        self.inner.amount_decimal = Some(amount_decimal.into());
         self
     }
     /// Describes how to compute the price per period.
     /// Either `per_unit` or `tiered`.
     /// `per_unit` indicates that the fixed amount (specified in `amount`) will be charged per unit in `quantity` (for plans with `usage_type=licensed`), or per unit of total usage (for plans with `usage_type=metered`).
     /// `tiered` indicates that the unit pricing will be computed using a tiering strategy as defined using the `tiers` and `tiers_mode` attributes.
-    pub fn billing_scheme(mut self, billing_scheme: stripe_shared::PlanBillingScheme) -> Self {
-        self.inner.billing_scheme = Some(billing_scheme);
+    pub fn billing_scheme(
+        mut self,
+        billing_scheme: impl Into<stripe_shared::PlanBillingScheme>,
+    ) -> Self {
+        self.inner.billing_scheme = Some(billing_scheme.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// An identifier randomly generated by Stripe.
     /// Used to identify this plan when subscribing a customer.
     /// You can optionally override this ID, but the ID must be unique across all plans in your Stripe account.
     /// You can, however, use the same plan ID in both live and test modes.
-    pub fn id(mut self, id: &'a str) -> Self {
-        self.inner.id = Some(id);
+    pub fn id(mut self, id: impl Into<String>) -> Self {
+        self.inner.id = Some(id.into());
         self
     }
     /// The number of intervals between subscription billings.
     /// For example, `interval=month` and `interval_count=3` bills every 3 months.
     /// Maximum of three years interval allowed (3 years, 36 months, or 156 weeks).
-    pub fn interval_count(mut self, interval_count: u64) -> Self {
-        self.inner.interval_count = Some(interval_count);
+    pub fn interval_count(mut self, interval_count: impl Into<u64>) -> Self {
+        self.inner.interval_count = Some(interval_count.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// The meter tracking the usage of a metered price
-    pub fn meter(mut self, meter: &'a str) -> Self {
-        self.inner.meter = Some(meter);
+    pub fn meter(mut self, meter: impl Into<String>) -> Self {
+        self.inner.meter = Some(meter.into());
         self
     }
     /// A brief description of the plan, hidden from customers.
-    pub fn nickname(mut self, nickname: &'a str) -> Self {
-        self.inner.nickname = Some(nickname);
+    pub fn nickname(mut self, nickname: impl Into<String>) -> Self {
+        self.inner.nickname = Some(nickname.into());
         self
     }
-    pub fn product(mut self, product: CreatePlanProduct<'a>) -> Self {
-        self.inner.product = Some(product);
+    pub fn product(mut self, product: impl Into<CreatePlanProduct>) -> Self {
+        self.inner.product = Some(product.into());
         self
     }
     /// Each element represents a pricing tier.
     /// This parameter requires `billing_scheme` to be set to `tiered`.
     /// See also the documentation for `billing_scheme`.
-    pub fn tiers(mut self, tiers: &'a [CreatePlanTiers<'a>]) -> Self {
-        self.inner.tiers = Some(tiers);
+    pub fn tiers(mut self, tiers: impl Into<Vec<CreatePlanTiers>>) -> Self {
+        self.inner.tiers = Some(tiers.into());
         self
     }
     /// Defines if the tiering price should be `graduated` or `volume` based.
     /// In `volume`-based tiering, the maximum quantity within a period determines the per unit price, in `graduated` tiering pricing can successively change as the quantity grows.
-    pub fn tiers_mode(mut self, tiers_mode: stripe_shared::PlanTiersMode) -> Self {
-        self.inner.tiers_mode = Some(tiers_mode);
+    pub fn tiers_mode(mut self, tiers_mode: impl Into<stripe_shared::PlanTiersMode>) -> Self {
+        self.inner.tiers_mode = Some(tiers_mode.into());
         self
     }
     /// Apply a transformation to the reported usage or set quantity before computing the billed price.
     /// Cannot be combined with `tiers`.
-    pub fn transform_usage(mut self, transform_usage: CreatePlanTransformUsage) -> Self {
-        self.inner.transform_usage = Some(transform_usage);
+    pub fn transform_usage(mut self, transform_usage: impl Into<CreatePlanTransformUsage>) -> Self {
+        self.inner.transform_usage = Some(transform_usage.into());
         self
     }
     /// Default number of trial days when subscribing a customer to this plan using [`trial_from_plan=true`](https://stripe.com/docs/api#create_subscription-trial_from_plan).
-    pub fn trial_period_days(mut self, trial_period_days: u32) -> Self {
-        self.inner.trial_period_days = Some(trial_period_days);
+    pub fn trial_period_days(mut self, trial_period_days: impl Into<u32>) -> Self {
+        self.inner.trial_period_days = Some(trial_period_days.into());
         self
     }
     /// Configures how the quantity per period should be determined.
@@ -557,12 +572,12 @@ impl<'a> CreatePlan<'a> {
     /// `licensed` automatically bills the `quantity` set when adding it to a subscription.
     /// `metered` aggregates the total usage based on usage records.
     /// Defaults to `licensed`.
-    pub fn usage_type(mut self, usage_type: stripe_shared::PlanUsageType) -> Self {
-        self.inner.usage_type = Some(usage_type);
+    pub fn usage_type(mut self, usage_type: impl Into<stripe_shared::PlanUsageType>) -> Self {
+        self.inner.usage_type = Some(usage_type.into());
         self
     }
 }
-impl CreatePlan<'_> {
+impl CreatePlan {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -580,29 +595,29 @@ impl CreatePlan<'_> {
     }
 }
 
-impl StripeRequest for CreatePlan<'_> {
+impl StripeRequest for CreatePlan {
     type Output = stripe_shared::Plan;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Post, "/plans").form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdatePlanBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdatePlanBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     active: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    nickname: Option<&'a str>,
+    nickname: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    product: Option<&'a str>,
+    product: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     trial_period_days: Option<u32>,
 }
-impl<'a> UpdatePlanBuilder<'a> {
+impl UpdatePlanBuilder {
     fn new() -> Self {
         Self {
             active: None,
@@ -618,51 +633,54 @@ impl<'a> UpdatePlanBuilder<'a> {
 /// Any parameters not provided are left unchanged.
 /// By design, you cannot change a plan’s ID, amount, currency, or billing cycle.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdatePlan<'a> {
-    inner: UpdatePlanBuilder<'a>,
-    plan: &'a stripe_shared::PlanId,
+pub struct UpdatePlan {
+    inner: UpdatePlanBuilder,
+    plan: stripe_shared::PlanId,
 }
-impl<'a> UpdatePlan<'a> {
+impl UpdatePlan {
     /// Construct a new `UpdatePlan`.
-    pub fn new(plan: &'a stripe_shared::PlanId) -> Self {
-        Self { plan, inner: UpdatePlanBuilder::new() }
+    pub fn new(plan: impl Into<stripe_shared::PlanId>) -> Self {
+        Self { plan: plan.into(), inner: UpdatePlanBuilder::new() }
     }
     /// Whether the plan is currently available for new subscriptions.
-    pub fn active(mut self, active: bool) -> Self {
-        self.inner.active = Some(active);
+    pub fn active(mut self, active: impl Into<bool>) -> Self {
+        self.inner.active = Some(active.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// A brief description of the plan, hidden from customers.
-    pub fn nickname(mut self, nickname: &'a str) -> Self {
-        self.inner.nickname = Some(nickname);
+    pub fn nickname(mut self, nickname: impl Into<String>) -> Self {
+        self.inner.nickname = Some(nickname.into());
         self
     }
     /// The product the plan belongs to.
     /// This cannot be changed once it has been used in a subscription or subscription schedule.
-    pub fn product(mut self, product: &'a str) -> Self {
-        self.inner.product = Some(product);
+    pub fn product(mut self, product: impl Into<String>) -> Self {
+        self.inner.product = Some(product.into());
         self
     }
     /// Default number of trial days when subscribing a customer to this plan using [`trial_from_plan=true`](https://stripe.com/docs/api#create_subscription-trial_from_plan).
-    pub fn trial_period_days(mut self, trial_period_days: u32) -> Self {
-        self.inner.trial_period_days = Some(trial_period_days);
+    pub fn trial_period_days(mut self, trial_period_days: impl Into<u32>) -> Self {
+        self.inner.trial_period_days = Some(trial_period_days.into());
         self
     }
 }
-impl UpdatePlan<'_> {
+impl UpdatePlan {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -680,11 +698,11 @@ impl UpdatePlan<'_> {
     }
 }
 
-impl StripeRequest for UpdatePlan<'_> {
+impl StripeRequest for UpdatePlan {
     type Output = stripe_shared::Plan;
 
     fn build(&self) -> RequestBuilder {
-        let plan = self.plan;
+        let plan = &self.plan;
         RequestBuilder::new(StripeMethod::Post, format!("/plans/{plan}")).form(&self.inner)
     }
 }

--- a/generated/async-stripe-billing/src/quote/requests.rs
+++ b/generated/async-stripe-billing/src/quote/requests.rs
@@ -2,24 +2,24 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListQuoteBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListQuoteBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    customer: Option<&'a str>,
+    customer: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     status: Option<stripe_shared::QuoteStatus>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    test_clock: Option<&'a str>,
+    test_clock: Option<String>,
 }
-impl<'a> ListQuoteBuilder<'a> {
+impl ListQuoteBuilder {
     fn new() -> Self {
         Self {
             customer: None,
@@ -34,62 +34,62 @@ impl<'a> ListQuoteBuilder<'a> {
 }
 /// Returns a list of your quotes.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListQuote<'a> {
-    inner: ListQuoteBuilder<'a>,
+pub struct ListQuote {
+    inner: ListQuoteBuilder,
 }
-impl<'a> ListQuote<'a> {
+impl ListQuote {
     /// Construct a new `ListQuote`.
     pub fn new() -> Self {
         Self { inner: ListQuoteBuilder::new() }
     }
     /// The ID of the customer whose quotes will be retrieved.
-    pub fn customer(mut self, customer: &'a str) -> Self {
-        self.inner.customer = Some(customer);
+    pub fn customer(mut self, customer: impl Into<String>) -> Self {
+        self.inner.customer = Some(customer.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
     /// The status of the quote.
-    pub fn status(mut self, status: stripe_shared::QuoteStatus) -> Self {
-        self.inner.status = Some(status);
+    pub fn status(mut self, status: impl Into<stripe_shared::QuoteStatus>) -> Self {
+        self.inner.status = Some(status.into());
         self
     }
     /// Provides a list of quotes that are associated with the specified test clock.
     /// The response will not include quotes with test clocks if this and the customer parameter is not set.
-    pub fn test_clock(mut self, test_clock: &'a str) -> Self {
-        self.inner.test_clock = Some(test_clock);
+    pub fn test_clock(mut self, test_clock: impl Into<String>) -> Self {
+        self.inner.test_clock = Some(test_clock.into());
         self
     }
 }
-impl<'a> Default for ListQuote<'a> {
+impl Default for ListQuote {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListQuote<'_> {
+impl ListQuote {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -109,45 +109,45 @@ impl ListQuote<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::Quote>> {
-        stripe_client_core::ListPaginator::new_list("/quotes", self.inner)
+        stripe_client_core::ListPaginator::new_list("/quotes", &self.inner)
     }
 }
 
-impl StripeRequest for ListQuote<'_> {
+impl StripeRequest for ListQuote {
     type Output = stripe_types::List<stripe_shared::Quote>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/quotes").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveQuoteBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveQuoteBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveQuoteBuilder<'a> {
+impl RetrieveQuoteBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves the quote with the given ID.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveQuote<'a> {
-    inner: RetrieveQuoteBuilder<'a>,
-    quote: &'a stripe_shared::QuoteId,
+pub struct RetrieveQuote {
+    inner: RetrieveQuoteBuilder,
+    quote: stripe_shared::QuoteId,
 }
-impl<'a> RetrieveQuote<'a> {
+impl RetrieveQuote {
     /// Construct a new `RetrieveQuote`.
-    pub fn new(quote: &'a stripe_shared::QuoteId) -> Self {
-        Self { quote, inner: RetrieveQuoteBuilder::new() }
+    pub fn new(quote: impl Into<stripe_shared::QuoteId>) -> Self {
+        Self { quote: quote.into(), inner: RetrieveQuoteBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveQuote<'_> {
+impl RetrieveQuote {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -165,26 +165,26 @@ impl RetrieveQuote<'_> {
     }
 }
 
-impl StripeRequest for RetrieveQuote<'_> {
+impl StripeRequest for RetrieveQuote {
     type Output = stripe_shared::Quote;
 
     fn build(&self) -> RequestBuilder {
-        let quote = self.quote;
+        let quote = &self.quote;
         RequestBuilder::new(StripeMethod::Get, format!("/quotes/{quote}")).query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListComputedUpfrontLineItemsQuoteBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListComputedUpfrontLineItemsQuoteBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListComputedUpfrontLineItemsQuoteBuilder<'a> {
+impl ListComputedUpfrontLineItemsQuoteBuilder {
     fn new() -> Self {
         Self { ending_before: None, expand: None, limit: None, starting_after: None }
     }
@@ -192,42 +192,42 @@ impl<'a> ListComputedUpfrontLineItemsQuoteBuilder<'a> {
 /// When retrieving a quote, there is an includable <a href="<https://stripe.com/docs/api/quotes/object#quote_object-computed-upfront-line_items>">**computed.upfront.line_items**</a> property containing the first handful of those items.
 /// There is also a URL where you can retrieve the full (paginated) list of upfront line items.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListComputedUpfrontLineItemsQuote<'a> {
-    inner: ListComputedUpfrontLineItemsQuoteBuilder<'a>,
-    quote: &'a stripe_shared::QuoteId,
+pub struct ListComputedUpfrontLineItemsQuote {
+    inner: ListComputedUpfrontLineItemsQuoteBuilder,
+    quote: stripe_shared::QuoteId,
 }
-impl<'a> ListComputedUpfrontLineItemsQuote<'a> {
+impl ListComputedUpfrontLineItemsQuote {
     /// Construct a new `ListComputedUpfrontLineItemsQuote`.
-    pub fn new(quote: &'a stripe_shared::QuoteId) -> Self {
-        Self { quote, inner: ListComputedUpfrontLineItemsQuoteBuilder::new() }
+    pub fn new(quote: impl Into<stripe_shared::QuoteId>) -> Self {
+        Self { quote: quote.into(), inner: ListComputedUpfrontLineItemsQuoteBuilder::new() }
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl ListComputedUpfrontLineItemsQuote<'_> {
+impl ListComputedUpfrontLineItemsQuote {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -248,20 +248,20 @@ impl ListComputedUpfrontLineItemsQuote<'_> {
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::CheckoutSessionItem>>
     {
-        let quote = self.quote;
+        let quote = &self.quote;
 
         stripe_client_core::ListPaginator::new_list(
             format!("/quotes/{quote}/computed_upfront_line_items"),
-            self.inner,
+            &self.inner,
         )
     }
 }
 
-impl StripeRequest for ListComputedUpfrontLineItemsQuote<'_> {
+impl StripeRequest for ListComputedUpfrontLineItemsQuote {
     type Output = stripe_types::List<stripe_shared::CheckoutSessionItem>;
 
     fn build(&self) -> RequestBuilder {
-        let quote = self.quote;
+        let quote = &self.quote;
         RequestBuilder::new(
             StripeMethod::Get,
             format!("/quotes/{quote}/computed_upfront_line_items"),
@@ -269,18 +269,18 @@ impl StripeRequest for ListComputedUpfrontLineItemsQuote<'_> {
         .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListLineItemsQuoteBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListLineItemsQuoteBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListLineItemsQuoteBuilder<'a> {
+impl ListLineItemsQuoteBuilder {
     fn new() -> Self {
         Self { ending_before: None, expand: None, limit: None, starting_after: None }
     }
@@ -288,42 +288,42 @@ impl<'a> ListLineItemsQuoteBuilder<'a> {
 /// When retrieving a quote, there is an includable **line_items** property containing the first handful of those items.
 /// There is also a URL where you can retrieve the full (paginated) list of line items.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListLineItemsQuote<'a> {
-    inner: ListLineItemsQuoteBuilder<'a>,
-    quote: &'a stripe_shared::QuoteId,
+pub struct ListLineItemsQuote {
+    inner: ListLineItemsQuoteBuilder,
+    quote: stripe_shared::QuoteId,
 }
-impl<'a> ListLineItemsQuote<'a> {
+impl ListLineItemsQuote {
     /// Construct a new `ListLineItemsQuote`.
-    pub fn new(quote: &'a stripe_shared::QuoteId) -> Self {
-        Self { quote, inner: ListLineItemsQuoteBuilder::new() }
+    pub fn new(quote: impl Into<stripe_shared::QuoteId>) -> Self {
+        Self { quote: quote.into(), inner: ListLineItemsQuoteBuilder::new() }
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl ListLineItemsQuote<'_> {
+impl ListLineItemsQuote {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -344,68 +344,68 @@ impl ListLineItemsQuote<'_> {
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::CheckoutSessionItem>>
     {
-        let quote = self.quote;
+        let quote = &self.quote;
 
         stripe_client_core::ListPaginator::new_list(
             format!("/quotes/{quote}/line_items"),
-            self.inner,
+            &self.inner,
         )
     }
 }
 
-impl StripeRequest for ListLineItemsQuote<'_> {
+impl StripeRequest for ListLineItemsQuote {
     type Output = stripe_types::List<stripe_shared::CheckoutSessionItem>;
 
     fn build(&self) -> RequestBuilder {
-        let quote = self.quote;
+        let quote = &self.quote;
         RequestBuilder::new(StripeMethod::Get, format!("/quotes/{quote}/line_items"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateQuoteBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateQuoteBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     application_fee_amount: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     application_fee_percent: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    automatic_tax: Option<CreateQuoteAutomaticTax<'a>>,
+    automatic_tax: Option<CreateQuoteAutomaticTax>,
     #[serde(skip_serializing_if = "Option::is_none")]
     collection_method: Option<stripe_shared::QuoteCollectionMethod>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    customer: Option<&'a str>,
+    customer: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    default_tax_rates: Option<&'a [&'a str]>,
+    default_tax_rates: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<&'a str>,
+    description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    discounts: Option<&'a [DiscountsDataParam<'a>]>,
+    discounts: Option<Vec<DiscountsDataParam>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     expires_at: Option<stripe_types::Timestamp>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    footer: Option<&'a str>,
+    footer: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    from_quote: Option<CreateQuoteFromQuote<'a>>,
+    from_quote: Option<CreateQuoteFromQuote>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    header: Option<&'a str>,
+    header: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    invoice_settings: Option<CreateQuoteInvoiceSettings<'a>>,
+    invoice_settings: Option<CreateQuoteInvoiceSettings>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    line_items: Option<&'a [CreateQuoteLineItems<'a>]>,
+    line_items: Option<Vec<CreateQuoteLineItems>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    on_behalf_of: Option<&'a str>,
+    on_behalf_of: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    subscription_data: Option<CreateQuoteSubscriptionData<'a>>,
+    subscription_data: Option<CreateQuoteSubscriptionData>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    test_clock: Option<&'a str>,
+    test_clock: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    transfer_data: Option<TransferDataSpecs<'a>>,
+    transfer_data: Option<TransferDataSpecs>,
 }
-impl<'a> CreateQuoteBuilder<'a> {
+impl CreateQuoteBuilder {
     fn new() -> Self {
         Self {
             application_fee_amount: None,
@@ -432,36 +432,36 @@ impl<'a> CreateQuoteBuilder<'a> {
     }
 }
 /// Settings for automatic tax lookup for this quote and resulting invoices and subscriptions.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateQuoteAutomaticTax<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateQuoteAutomaticTax {
     /// Controls whether Stripe will automatically compute tax on the resulting invoices or subscriptions as well as the quote itself.
     pub enabled: bool,
     /// The account that's liable for tax.
     /// If set, the business address and tax registrations required to perform the tax calculation are loaded from this account.
     /// The tax transaction is returned in the report of the connected account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub liability: Option<CreateQuoteAutomaticTaxLiability<'a>>,
+    pub liability: Option<CreateQuoteAutomaticTaxLiability>,
 }
-impl<'a> CreateQuoteAutomaticTax<'a> {
-    pub fn new(enabled: bool) -> Self {
-        Self { enabled, liability: None }
+impl CreateQuoteAutomaticTax {
+    pub fn new(enabled: impl Into<bool>) -> Self {
+        Self { enabled: enabled.into(), liability: None }
     }
 }
 /// The account that's liable for tax.
 /// If set, the business address and tax registrations required to perform the tax calculation are loaded from this account.
 /// The tax transaction is returned in the report of the connected account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateQuoteAutomaticTaxLiability<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateQuoteAutomaticTaxLiability {
     /// The connected account being referenced when `type` is `account`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account: Option<&'a str>,
+    pub account: Option<String>,
     /// Type of the account referenced in the request.
     #[serde(rename = "type")]
     pub type_: CreateQuoteAutomaticTaxLiabilityType,
 }
-impl<'a> CreateQuoteAutomaticTaxLiability<'a> {
-    pub fn new(type_: CreateQuoteAutomaticTaxLiabilityType) -> Self {
-        Self { account: None, type_ }
+impl CreateQuoteAutomaticTaxLiability {
+    pub fn new(type_: impl Into<CreateQuoteAutomaticTaxLiabilityType>) -> Self {
+        Self { account: None, type_: type_.into() }
     }
 }
 /// Type of the account referenced in the request.
@@ -523,22 +523,22 @@ impl<'de> serde::Deserialize<'de> for CreateQuoteAutomaticTaxLiabilityType {
 /// Clone an existing quote.
 /// The new quote will be created in `status=draft`.
 /// When using this parameter, you cannot specify any other parameters except for `expires_at`.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateQuoteFromQuote<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateQuoteFromQuote {
     /// Whether this quote is a revision of the previous quote.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub is_revision: Option<bool>,
     /// The `id` of the quote that will be cloned.
-    pub quote: &'a str,
+    pub quote: String,
 }
-impl<'a> CreateQuoteFromQuote<'a> {
-    pub fn new(quote: &'a str) -> Self {
-        Self { is_revision: None, quote }
+impl CreateQuoteFromQuote {
+    pub fn new(quote: impl Into<String>) -> Self {
+        Self { is_revision: None, quote: quote.into() }
     }
 }
 /// All invoices will be billed using the specified settings.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateQuoteInvoiceSettings<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateQuoteInvoiceSettings {
     /// Number of days within which a customer must pay the invoice generated by this quote.
     /// This value will be `null` for quotes where `collection_method=charge_automatically`.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -546,32 +546,32 @@ pub struct CreateQuoteInvoiceSettings<'a> {
     /// The connected account that issues the invoice.
     /// The invoice is presented with the branding and support information of the specified account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub issuer: Option<CreateQuoteInvoiceSettingsIssuer<'a>>,
+    pub issuer: Option<CreateQuoteInvoiceSettingsIssuer>,
 }
-impl<'a> CreateQuoteInvoiceSettings<'a> {
+impl CreateQuoteInvoiceSettings {
     pub fn new() -> Self {
         Self { days_until_due: None, issuer: None }
     }
 }
-impl<'a> Default for CreateQuoteInvoiceSettings<'a> {
+impl Default for CreateQuoteInvoiceSettings {
     fn default() -> Self {
         Self::new()
     }
 }
 /// The connected account that issues the invoice.
 /// The invoice is presented with the branding and support information of the specified account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateQuoteInvoiceSettingsIssuer<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateQuoteInvoiceSettingsIssuer {
     /// The connected account being referenced when `type` is `account`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account: Option<&'a str>,
+    pub account: Option<String>,
     /// Type of the account referenced in the request.
     #[serde(rename = "type")]
     pub type_: CreateQuoteInvoiceSettingsIssuerType,
 }
-impl<'a> CreateQuoteInvoiceSettingsIssuer<'a> {
-    pub fn new(type_: CreateQuoteInvoiceSettingsIssuerType) -> Self {
-        Self { account: None, type_ }
+impl CreateQuoteInvoiceSettingsIssuer {
+    pub fn new(type_: impl Into<CreateQuoteInvoiceSettingsIssuerType>) -> Self {
+        Self { account: None, type_: type_.into() }
     }
 }
 /// Type of the account referenced in the request.
@@ -632,45 +632,45 @@ impl<'de> serde::Deserialize<'de> for CreateQuoteInvoiceSettingsIssuerType {
 }
 /// A list of line items the customer is being quoted for.
 /// Each line item includes information about the product, the quantity, and the resulting cost.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateQuoteLineItems<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateQuoteLineItems {
     /// The discounts applied to this line item.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub discounts: Option<&'a [DiscountsDataParam<'a>]>,
+    pub discounts: Option<Vec<DiscountsDataParam>>,
     /// The ID of the price object. One of `price` or `price_data` is required.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price: Option<&'a str>,
+    pub price: Option<String>,
     /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
     /// One of `price` or `price_data` is required.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price_data: Option<CreateQuoteLineItemsPriceData<'a>>,
+    pub price_data: Option<CreateQuoteLineItemsPriceData>,
     /// The quantity of the line item.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub quantity: Option<u64>,
     /// The tax rates which apply to the line item.
     /// When set, the `default_tax_rates` on the quote do not apply to this line item.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_rates: Option<&'a [&'a str]>,
+    pub tax_rates: Option<Vec<String>>,
 }
-impl<'a> CreateQuoteLineItems<'a> {
+impl CreateQuoteLineItems {
     pub fn new() -> Self {
         Self { discounts: None, price: None, price_data: None, quantity: None, tax_rates: None }
     }
 }
-impl<'a> Default for CreateQuoteLineItems<'a> {
+impl Default for CreateQuoteLineItems {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
 /// One of `price` or `price_data` is required.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateQuoteLineItemsPriceData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateQuoteLineItemsPriceData {
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     /// Must be a [supported currency](https://stripe.com/docs/currencies).
     pub currency: stripe_types::Currency,
     /// The ID of the product that this price will belong to.
-    pub product: &'a str,
+    pub product: String,
     /// The recurring components of a price such as `interval` and `interval_count`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub recurring: Option<CreateQuoteLineItemsPriceDataRecurring>,
@@ -686,13 +686,13 @@ pub struct CreateQuoteLineItemsPriceData<'a> {
     /// Same as `unit_amount`, but accepts a decimal value in cents (or local equivalent) with at most 12 decimal places.
     /// Only one of `unit_amount` and `unit_amount_decimal` can be set.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub unit_amount_decimal: Option<&'a str>,
+    pub unit_amount_decimal: Option<String>,
 }
-impl<'a> CreateQuoteLineItemsPriceData<'a> {
-    pub fn new(currency: stripe_types::Currency, product: &'a str) -> Self {
+impl CreateQuoteLineItemsPriceData {
+    pub fn new(currency: impl Into<stripe_types::Currency>, product: impl Into<String>) -> Self {
         Self {
-            currency,
-            product,
+            currency: currency.into(),
+            product: product.into(),
             recurring: None,
             tax_behavior: None,
             unit_amount: None,
@@ -712,8 +712,8 @@ pub struct CreateQuoteLineItemsPriceDataRecurring {
     pub interval_count: Option<u64>,
 }
 impl CreateQuoteLineItemsPriceDataRecurring {
-    pub fn new(interval: CreateQuoteLineItemsPriceDataRecurringInterval) -> Self {
-        Self { interval, interval_count: None }
+    pub fn new(interval: impl Into<CreateQuoteLineItemsPriceDataRecurringInterval>) -> Self {
+        Self { interval: interval.into(), interval_count: None }
     }
 }
 /// Specifies billing frequency. Either `day`, `week`, `month` or `year`.
@@ -845,12 +845,12 @@ impl<'de> serde::Deserialize<'de> for CreateQuoteLineItemsPriceDataTaxBehavior {
 /// When creating a subscription or subscription schedule, the specified configuration data will be used.
 /// There must be at least one line item with a recurring price for a subscription or subscription schedule to be created.
 /// A subscription schedule is created if `subscription_data[effective_date]` is present and in the future, otherwise a subscription is created.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateQuoteSubscriptionData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateQuoteSubscriptionData {
     /// The subscription's description, meant to be displayable to the customer.
     /// Use this field to optionally store an explanation of the subscription for rendering in Stripe surfaces and certain local payment methods UIs.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<&'a str>,
+    pub description: Option<String>,
     /// When creating a new subscription, the date of which the subscription schedule will start after the quote is accepted.
     /// When updating a subscription, the date of which the subscription will be updated using a subscription schedule.
     /// The special value `current_period_end` can be provided to update a subscription at the end of its current period.
@@ -863,17 +863,17 @@ pub struct CreateQuoteSubscriptionData<'a> {
     /// Unlike object-level metadata, this field is declarative.
     /// Updates will clear prior values.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// Integer representing the number of trial period days before the customer is charged for the first time.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub trial_period_days: Option<u32>,
 }
-impl<'a> CreateQuoteSubscriptionData<'a> {
+impl CreateQuoteSubscriptionData {
     pub fn new() -> Self {
         Self { description: None, effective_date: None, metadata: None, trial_period_days: None }
     }
 }
-impl<'a> Default for CreateQuoteSubscriptionData<'a> {
+impl Default for CreateQuoteSubscriptionData {
     fn default() -> Self {
         Self::new()
     }
@@ -892,30 +892,30 @@ pub enum CreateQuoteSubscriptionDataEffectiveDate {
 /// A quote models prices and services for a customer.
 /// Default options for `header`, `description`, `footer`, and `expires_at` can be set in the dashboard via the [quote template](https://dashboard.stripe.com/settings/billing/quote).
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateQuote<'a> {
-    inner: CreateQuoteBuilder<'a>,
+pub struct CreateQuote {
+    inner: CreateQuoteBuilder,
 }
-impl<'a> CreateQuote<'a> {
+impl CreateQuote {
     /// Construct a new `CreateQuote`.
     pub fn new() -> Self {
         Self { inner: CreateQuoteBuilder::new() }
     }
     /// The amount of the application fee (if any) that will be requested to be applied to the payment and transferred to the application owner's Stripe account.
     /// There cannot be any line items with recurring prices when using this field.
-    pub fn application_fee_amount(mut self, application_fee_amount: i64) -> Self {
-        self.inner.application_fee_amount = Some(application_fee_amount);
+    pub fn application_fee_amount(mut self, application_fee_amount: impl Into<i64>) -> Self {
+        self.inner.application_fee_amount = Some(application_fee_amount.into());
         self
     }
     /// A non-negative decimal between 0 and 100, with at most two decimal places.
     /// This represents the percentage of the subscription invoice total that will be transferred to the application owner's Stripe account.
     /// There must be at least 1 line item with a recurring price to use this field.
-    pub fn application_fee_percent(mut self, application_fee_percent: f64) -> Self {
-        self.inner.application_fee_percent = Some(application_fee_percent);
+    pub fn application_fee_percent(mut self, application_fee_percent: impl Into<f64>) -> Self {
+        self.inner.application_fee_percent = Some(application_fee_percent.into());
         self
     }
     /// Settings for automatic tax lookup for this quote and resulting invoices and subscriptions.
-    pub fn automatic_tax(mut self, automatic_tax: CreateQuoteAutomaticTax<'a>) -> Self {
-        self.inner.automatic_tax = Some(automatic_tax);
+    pub fn automatic_tax(mut self, automatic_tax: impl Into<CreateQuoteAutomaticTax>) -> Self {
+        self.inner.automatic_tax = Some(automatic_tax.into());
         self
     }
     /// Either `charge_automatically`, or `send_invoice`.
@@ -924,113 +924,122 @@ impl<'a> CreateQuote<'a> {
     /// Defaults to `charge_automatically`.
     pub fn collection_method(
         mut self,
-        collection_method: stripe_shared::QuoteCollectionMethod,
+        collection_method: impl Into<stripe_shared::QuoteCollectionMethod>,
     ) -> Self {
-        self.inner.collection_method = Some(collection_method);
+        self.inner.collection_method = Some(collection_method.into());
         self
     }
     /// The customer for which this quote belongs to.
     /// A customer is required before finalizing the quote.
     /// Once specified, it cannot be changed.
-    pub fn customer(mut self, customer: &'a str) -> Self {
-        self.inner.customer = Some(customer);
+    pub fn customer(mut self, customer: impl Into<String>) -> Self {
+        self.inner.customer = Some(customer.into());
         self
     }
     /// The tax rates that will apply to any line item that does not have `tax_rates` set.
-    pub fn default_tax_rates(mut self, default_tax_rates: &'a [&'a str]) -> Self {
-        self.inner.default_tax_rates = Some(default_tax_rates);
+    pub fn default_tax_rates(mut self, default_tax_rates: impl Into<Vec<String>>) -> Self {
+        self.inner.default_tax_rates = Some(default_tax_rates.into());
         self
     }
     /// A description that will be displayed on the quote PDF.
     /// If no value is passed, the default description configured in your [quote template settings](https://dashboard.stripe.com/settings/billing/quote) will be used.
-    pub fn description(mut self, description: &'a str) -> Self {
-        self.inner.description = Some(description);
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.inner.description = Some(description.into());
         self
     }
     /// The discounts applied to the quote. You can only set up to one discount.
-    pub fn discounts(mut self, discounts: &'a [DiscountsDataParam<'a>]) -> Self {
-        self.inner.discounts = Some(discounts);
+    pub fn discounts(mut self, discounts: impl Into<Vec<DiscountsDataParam>>) -> Self {
+        self.inner.discounts = Some(discounts.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A future timestamp on which the quote will be canceled if in `open` or `draft` status.
     /// Measured in seconds since the Unix epoch.
     /// If no value is passed, the default expiration date configured in your [quote template settings](https://dashboard.stripe.com/settings/billing/quote) will be used.
-    pub fn expires_at(mut self, expires_at: stripe_types::Timestamp) -> Self {
-        self.inner.expires_at = Some(expires_at);
+    pub fn expires_at(mut self, expires_at: impl Into<stripe_types::Timestamp>) -> Self {
+        self.inner.expires_at = Some(expires_at.into());
         self
     }
     /// A footer that will be displayed on the quote PDF.
     /// If no value is passed, the default footer configured in your [quote template settings](https://dashboard.stripe.com/settings/billing/quote) will be used.
-    pub fn footer(mut self, footer: &'a str) -> Self {
-        self.inner.footer = Some(footer);
+    pub fn footer(mut self, footer: impl Into<String>) -> Self {
+        self.inner.footer = Some(footer.into());
         self
     }
     /// Clone an existing quote.
     /// The new quote will be created in `status=draft`.
     /// When using this parameter, you cannot specify any other parameters except for `expires_at`.
-    pub fn from_quote(mut self, from_quote: CreateQuoteFromQuote<'a>) -> Self {
-        self.inner.from_quote = Some(from_quote);
+    pub fn from_quote(mut self, from_quote: impl Into<CreateQuoteFromQuote>) -> Self {
+        self.inner.from_quote = Some(from_quote.into());
         self
     }
     /// A header that will be displayed on the quote PDF.
     /// If no value is passed, the default header configured in your [quote template settings](https://dashboard.stripe.com/settings/billing/quote) will be used.
-    pub fn header(mut self, header: &'a str) -> Self {
-        self.inner.header = Some(header);
+    pub fn header(mut self, header: impl Into<String>) -> Self {
+        self.inner.header = Some(header.into());
         self
     }
     /// All invoices will be billed using the specified settings.
-    pub fn invoice_settings(mut self, invoice_settings: CreateQuoteInvoiceSettings<'a>) -> Self {
-        self.inner.invoice_settings = Some(invoice_settings);
+    pub fn invoice_settings(
+        mut self,
+        invoice_settings: impl Into<CreateQuoteInvoiceSettings>,
+    ) -> Self {
+        self.inner.invoice_settings = Some(invoice_settings.into());
         self
     }
     /// A list of line items the customer is being quoted for.
     /// Each line item includes information about the product, the quantity, and the resulting cost.
-    pub fn line_items(mut self, line_items: &'a [CreateQuoteLineItems<'a>]) -> Self {
-        self.inner.line_items = Some(line_items);
+    pub fn line_items(mut self, line_items: impl Into<Vec<CreateQuoteLineItems>>) -> Self {
+        self.inner.line_items = Some(line_items.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// The account on behalf of which to charge.
-    pub fn on_behalf_of(mut self, on_behalf_of: &'a str) -> Self {
-        self.inner.on_behalf_of = Some(on_behalf_of);
+    pub fn on_behalf_of(mut self, on_behalf_of: impl Into<String>) -> Self {
+        self.inner.on_behalf_of = Some(on_behalf_of.into());
         self
     }
     /// When creating a subscription or subscription schedule, the specified configuration data will be used.
     /// There must be at least one line item with a recurring price for a subscription or subscription schedule to be created.
     /// A subscription schedule is created if `subscription_data[effective_date]` is present and in the future, otherwise a subscription is created.
-    pub fn subscription_data(mut self, subscription_data: CreateQuoteSubscriptionData<'a>) -> Self {
-        self.inner.subscription_data = Some(subscription_data);
+    pub fn subscription_data(
+        mut self,
+        subscription_data: impl Into<CreateQuoteSubscriptionData>,
+    ) -> Self {
+        self.inner.subscription_data = Some(subscription_data.into());
         self
     }
     /// ID of the test clock to attach to the quote.
-    pub fn test_clock(mut self, test_clock: &'a str) -> Self {
-        self.inner.test_clock = Some(test_clock);
+    pub fn test_clock(mut self, test_clock: impl Into<String>) -> Self {
+        self.inner.test_clock = Some(test_clock.into());
         self
     }
     /// The data with which to automatically create a Transfer for each of the invoices.
-    pub fn transfer_data(mut self, transfer_data: TransferDataSpecs<'a>) -> Self {
-        self.inner.transfer_data = Some(transfer_data);
+    pub fn transfer_data(mut self, transfer_data: impl Into<TransferDataSpecs>) -> Self {
+        self.inner.transfer_data = Some(transfer_data.into());
         self
     }
 }
-impl<'a> Default for CreateQuote<'a> {
+impl Default for CreateQuote {
     fn default() -> Self {
         Self::new()
     }
 }
-impl CreateQuote<'_> {
+impl CreateQuote {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -1048,53 +1057,53 @@ impl CreateQuote<'_> {
     }
 }
 
-impl StripeRequest for CreateQuote<'_> {
+impl StripeRequest for CreateQuote {
     type Output = stripe_shared::Quote;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Post, "/quotes").form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdateQuoteBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdateQuoteBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     application_fee_amount: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     application_fee_percent: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    automatic_tax: Option<UpdateQuoteAutomaticTax<'a>>,
+    automatic_tax: Option<UpdateQuoteAutomaticTax>,
     #[serde(skip_serializing_if = "Option::is_none")]
     collection_method: Option<stripe_shared::QuoteCollectionMethod>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    customer: Option<&'a str>,
+    customer: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    default_tax_rates: Option<&'a [&'a str]>,
+    default_tax_rates: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<&'a str>,
+    description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    discounts: Option<&'a [DiscountsDataParam<'a>]>,
+    discounts: Option<Vec<DiscountsDataParam>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     expires_at: Option<stripe_types::Timestamp>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    footer: Option<&'a str>,
+    footer: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    header: Option<&'a str>,
+    header: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    invoice_settings: Option<UpdateQuoteInvoiceSettings<'a>>,
+    invoice_settings: Option<UpdateQuoteInvoiceSettings>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    line_items: Option<&'a [UpdateQuoteLineItems<'a>]>,
+    line_items: Option<Vec<UpdateQuoteLineItems>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    on_behalf_of: Option<&'a str>,
+    on_behalf_of: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    subscription_data: Option<UpdateQuoteSubscriptionData<'a>>,
+    subscription_data: Option<UpdateQuoteSubscriptionData>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    transfer_data: Option<TransferDataSpecs<'a>>,
+    transfer_data: Option<TransferDataSpecs>,
 }
-impl<'a> UpdateQuoteBuilder<'a> {
+impl UpdateQuoteBuilder {
     fn new() -> Self {
         Self {
             application_fee_amount: None,
@@ -1119,36 +1128,36 @@ impl<'a> UpdateQuoteBuilder<'a> {
     }
 }
 /// Settings for automatic tax lookup for this quote and resulting invoices and subscriptions.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateQuoteAutomaticTax<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateQuoteAutomaticTax {
     /// Controls whether Stripe will automatically compute tax on the resulting invoices or subscriptions as well as the quote itself.
     pub enabled: bool,
     /// The account that's liable for tax.
     /// If set, the business address and tax registrations required to perform the tax calculation are loaded from this account.
     /// The tax transaction is returned in the report of the connected account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub liability: Option<UpdateQuoteAutomaticTaxLiability<'a>>,
+    pub liability: Option<UpdateQuoteAutomaticTaxLiability>,
 }
-impl<'a> UpdateQuoteAutomaticTax<'a> {
-    pub fn new(enabled: bool) -> Self {
-        Self { enabled, liability: None }
+impl UpdateQuoteAutomaticTax {
+    pub fn new(enabled: impl Into<bool>) -> Self {
+        Self { enabled: enabled.into(), liability: None }
     }
 }
 /// The account that's liable for tax.
 /// If set, the business address and tax registrations required to perform the tax calculation are loaded from this account.
 /// The tax transaction is returned in the report of the connected account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateQuoteAutomaticTaxLiability<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateQuoteAutomaticTaxLiability {
     /// The connected account being referenced when `type` is `account`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account: Option<&'a str>,
+    pub account: Option<String>,
     /// Type of the account referenced in the request.
     #[serde(rename = "type")]
     pub type_: UpdateQuoteAutomaticTaxLiabilityType,
 }
-impl<'a> UpdateQuoteAutomaticTaxLiability<'a> {
-    pub fn new(type_: UpdateQuoteAutomaticTaxLiabilityType) -> Self {
-        Self { account: None, type_ }
+impl UpdateQuoteAutomaticTaxLiability {
+    pub fn new(type_: impl Into<UpdateQuoteAutomaticTaxLiabilityType>) -> Self {
+        Self { account: None, type_: type_.into() }
     }
 }
 /// Type of the account referenced in the request.
@@ -1208,8 +1217,8 @@ impl<'de> serde::Deserialize<'de> for UpdateQuoteAutomaticTaxLiabilityType {
     }
 }
 /// All invoices will be billed using the specified settings.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateQuoteInvoiceSettings<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateQuoteInvoiceSettings {
     /// Number of days within which a customer must pay the invoice generated by this quote.
     /// This value will be `null` for quotes where `collection_method=charge_automatically`.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1217,32 +1226,32 @@ pub struct UpdateQuoteInvoiceSettings<'a> {
     /// The connected account that issues the invoice.
     /// The invoice is presented with the branding and support information of the specified account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub issuer: Option<UpdateQuoteInvoiceSettingsIssuer<'a>>,
+    pub issuer: Option<UpdateQuoteInvoiceSettingsIssuer>,
 }
-impl<'a> UpdateQuoteInvoiceSettings<'a> {
+impl UpdateQuoteInvoiceSettings {
     pub fn new() -> Self {
         Self { days_until_due: None, issuer: None }
     }
 }
-impl<'a> Default for UpdateQuoteInvoiceSettings<'a> {
+impl Default for UpdateQuoteInvoiceSettings {
     fn default() -> Self {
         Self::new()
     }
 }
 /// The connected account that issues the invoice.
 /// The invoice is presented with the branding and support information of the specified account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateQuoteInvoiceSettingsIssuer<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateQuoteInvoiceSettingsIssuer {
     /// The connected account being referenced when `type` is `account`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account: Option<&'a str>,
+    pub account: Option<String>,
     /// Type of the account referenced in the request.
     #[serde(rename = "type")]
     pub type_: UpdateQuoteInvoiceSettingsIssuerType,
 }
-impl<'a> UpdateQuoteInvoiceSettingsIssuer<'a> {
-    pub fn new(type_: UpdateQuoteInvoiceSettingsIssuerType) -> Self {
-        Self { account: None, type_ }
+impl UpdateQuoteInvoiceSettingsIssuer {
+    pub fn new(type_: impl Into<UpdateQuoteInvoiceSettingsIssuerType>) -> Self {
+        Self { account: None, type_: type_.into() }
     }
 }
 /// Type of the account referenced in the request.
@@ -1303,30 +1312,30 @@ impl<'de> serde::Deserialize<'de> for UpdateQuoteInvoiceSettingsIssuerType {
 }
 /// A list of line items the customer is being quoted for.
 /// Each line item includes information about the product, the quantity, and the resulting cost.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateQuoteLineItems<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateQuoteLineItems {
     /// The discounts applied to this line item.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub discounts: Option<&'a [DiscountsDataParam<'a>]>,
+    pub discounts: Option<Vec<DiscountsDataParam>>,
     /// The ID of an existing line item on the quote.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub id: Option<&'a str>,
+    pub id: Option<String>,
     /// The ID of the price object. One of `price` or `price_data` is required.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price: Option<&'a str>,
+    pub price: Option<String>,
     /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
     /// One of `price` or `price_data` is required.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price_data: Option<UpdateQuoteLineItemsPriceData<'a>>,
+    pub price_data: Option<UpdateQuoteLineItemsPriceData>,
     /// The quantity of the line item.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub quantity: Option<u64>,
     /// The tax rates which apply to the line item.
     /// When set, the `default_tax_rates` on the quote do not apply to this line item.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_rates: Option<&'a [&'a str]>,
+    pub tax_rates: Option<Vec<String>>,
 }
-impl<'a> UpdateQuoteLineItems<'a> {
+impl UpdateQuoteLineItems {
     pub fn new() -> Self {
         Self {
             discounts: None,
@@ -1338,20 +1347,20 @@ impl<'a> UpdateQuoteLineItems<'a> {
         }
     }
 }
-impl<'a> Default for UpdateQuoteLineItems<'a> {
+impl Default for UpdateQuoteLineItems {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
 /// One of `price` or `price_data` is required.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateQuoteLineItemsPriceData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateQuoteLineItemsPriceData {
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     /// Must be a [supported currency](https://stripe.com/docs/currencies).
     pub currency: stripe_types::Currency,
     /// The ID of the product that this price will belong to.
-    pub product: &'a str,
+    pub product: String,
     /// The recurring components of a price such as `interval` and `interval_count`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub recurring: Option<UpdateQuoteLineItemsPriceDataRecurring>,
@@ -1367,13 +1376,13 @@ pub struct UpdateQuoteLineItemsPriceData<'a> {
     /// Same as `unit_amount`, but accepts a decimal value in cents (or local equivalent) with at most 12 decimal places.
     /// Only one of `unit_amount` and `unit_amount_decimal` can be set.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub unit_amount_decimal: Option<&'a str>,
+    pub unit_amount_decimal: Option<String>,
 }
-impl<'a> UpdateQuoteLineItemsPriceData<'a> {
-    pub fn new(currency: stripe_types::Currency, product: &'a str) -> Self {
+impl UpdateQuoteLineItemsPriceData {
+    pub fn new(currency: impl Into<stripe_types::Currency>, product: impl Into<String>) -> Self {
         Self {
-            currency,
-            product,
+            currency: currency.into(),
+            product: product.into(),
             recurring: None,
             tax_behavior: None,
             unit_amount: None,
@@ -1393,8 +1402,8 @@ pub struct UpdateQuoteLineItemsPriceDataRecurring {
     pub interval_count: Option<u64>,
 }
 impl UpdateQuoteLineItemsPriceDataRecurring {
-    pub fn new(interval: UpdateQuoteLineItemsPriceDataRecurringInterval) -> Self {
-        Self { interval, interval_count: None }
+    pub fn new(interval: impl Into<UpdateQuoteLineItemsPriceDataRecurringInterval>) -> Self {
+        Self { interval: interval.into(), interval_count: None }
     }
 }
 /// Specifies billing frequency. Either `day`, `week`, `month` or `year`.
@@ -1526,12 +1535,12 @@ impl<'de> serde::Deserialize<'de> for UpdateQuoteLineItemsPriceDataTaxBehavior {
 /// When creating a subscription or subscription schedule, the specified configuration data will be used.
 /// There must be at least one line item with a recurring price for a subscription or subscription schedule to be created.
 /// A subscription schedule is created if `subscription_data[effective_date]` is present and in the future, otherwise a subscription is created.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateQuoteSubscriptionData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateQuoteSubscriptionData {
     /// The subscription's description, meant to be displayable to the customer.
     /// Use this field to optionally store an explanation of the subscription for rendering in Stripe surfaces and certain local payment methods UIs.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<&'a str>,
+    pub description: Option<String>,
     /// When creating a new subscription, the date of which the subscription schedule will start after the quote is accepted.
     /// When updating a subscription, the date of which the subscription will be updated using a subscription schedule.
     /// The special value `current_period_end` can be provided to update a subscription at the end of its current period.
@@ -1544,17 +1553,17 @@ pub struct UpdateQuoteSubscriptionData<'a> {
     /// Unlike object-level metadata, this field is declarative.
     /// Updates will clear prior values.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// Integer representing the number of trial period days before the customer is charged for the first time.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub trial_period_days: Option<u32>,
 }
-impl<'a> UpdateQuoteSubscriptionData<'a> {
+impl UpdateQuoteSubscriptionData {
     pub fn new() -> Self {
         Self { description: None, effective_date: None, metadata: None, trial_period_days: None }
     }
 }
-impl<'a> Default for UpdateQuoteSubscriptionData<'a> {
+impl Default for UpdateQuoteSubscriptionData {
     fn default() -> Self {
         Self::new()
     }
@@ -1572,31 +1581,31 @@ pub enum UpdateQuoteSubscriptionDataEffectiveDate {
 }
 /// A quote models prices and services for a customer.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateQuote<'a> {
-    inner: UpdateQuoteBuilder<'a>,
-    quote: &'a stripe_shared::QuoteId,
+pub struct UpdateQuote {
+    inner: UpdateQuoteBuilder,
+    quote: stripe_shared::QuoteId,
 }
-impl<'a> UpdateQuote<'a> {
+impl UpdateQuote {
     /// Construct a new `UpdateQuote`.
-    pub fn new(quote: &'a stripe_shared::QuoteId) -> Self {
-        Self { quote, inner: UpdateQuoteBuilder::new() }
+    pub fn new(quote: impl Into<stripe_shared::QuoteId>) -> Self {
+        Self { quote: quote.into(), inner: UpdateQuoteBuilder::new() }
     }
     /// The amount of the application fee (if any) that will be requested to be applied to the payment and transferred to the application owner's Stripe account.
     /// There cannot be any line items with recurring prices when using this field.
-    pub fn application_fee_amount(mut self, application_fee_amount: i64) -> Self {
-        self.inner.application_fee_amount = Some(application_fee_amount);
+    pub fn application_fee_amount(mut self, application_fee_amount: impl Into<i64>) -> Self {
+        self.inner.application_fee_amount = Some(application_fee_amount.into());
         self
     }
     /// A non-negative decimal between 0 and 100, with at most two decimal places.
     /// This represents the percentage of the subscription invoice total that will be transferred to the application owner's Stripe account.
     /// There must be at least 1 line item with a recurring price to use this field.
-    pub fn application_fee_percent(mut self, application_fee_percent: f64) -> Self {
-        self.inner.application_fee_percent = Some(application_fee_percent);
+    pub fn application_fee_percent(mut self, application_fee_percent: impl Into<f64>) -> Self {
+        self.inner.application_fee_percent = Some(application_fee_percent.into());
         self
     }
     /// Settings for automatic tax lookup for this quote and resulting invoices and subscriptions.
-    pub fn automatic_tax(mut self, automatic_tax: UpdateQuoteAutomaticTax<'a>) -> Self {
-        self.inner.automatic_tax = Some(automatic_tax);
+    pub fn automatic_tax(mut self, automatic_tax: impl Into<UpdateQuoteAutomaticTax>) -> Self {
+        self.inner.automatic_tax = Some(automatic_tax.into());
         self
     }
     /// Either `charge_automatically`, or `send_invoice`.
@@ -1605,92 +1614,101 @@ impl<'a> UpdateQuote<'a> {
     /// Defaults to `charge_automatically`.
     pub fn collection_method(
         mut self,
-        collection_method: stripe_shared::QuoteCollectionMethod,
+        collection_method: impl Into<stripe_shared::QuoteCollectionMethod>,
     ) -> Self {
-        self.inner.collection_method = Some(collection_method);
+        self.inner.collection_method = Some(collection_method.into());
         self
     }
     /// The customer for which this quote belongs to.
     /// A customer is required before finalizing the quote.
     /// Once specified, it cannot be changed.
-    pub fn customer(mut self, customer: &'a str) -> Self {
-        self.inner.customer = Some(customer);
+    pub fn customer(mut self, customer: impl Into<String>) -> Self {
+        self.inner.customer = Some(customer.into());
         self
     }
     /// The tax rates that will apply to any line item that does not have `tax_rates` set.
-    pub fn default_tax_rates(mut self, default_tax_rates: &'a [&'a str]) -> Self {
-        self.inner.default_tax_rates = Some(default_tax_rates);
+    pub fn default_tax_rates(mut self, default_tax_rates: impl Into<Vec<String>>) -> Self {
+        self.inner.default_tax_rates = Some(default_tax_rates.into());
         self
     }
     /// A description that will be displayed on the quote PDF.
-    pub fn description(mut self, description: &'a str) -> Self {
-        self.inner.description = Some(description);
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.inner.description = Some(description.into());
         self
     }
     /// The discounts applied to the quote. You can only set up to one discount.
-    pub fn discounts(mut self, discounts: &'a [DiscountsDataParam<'a>]) -> Self {
-        self.inner.discounts = Some(discounts);
+    pub fn discounts(mut self, discounts: impl Into<Vec<DiscountsDataParam>>) -> Self {
+        self.inner.discounts = Some(discounts.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A future timestamp on which the quote will be canceled if in `open` or `draft` status.
     /// Measured in seconds since the Unix epoch.
-    pub fn expires_at(mut self, expires_at: stripe_types::Timestamp) -> Self {
-        self.inner.expires_at = Some(expires_at);
+    pub fn expires_at(mut self, expires_at: impl Into<stripe_types::Timestamp>) -> Self {
+        self.inner.expires_at = Some(expires_at.into());
         self
     }
     /// A footer that will be displayed on the quote PDF.
-    pub fn footer(mut self, footer: &'a str) -> Self {
-        self.inner.footer = Some(footer);
+    pub fn footer(mut self, footer: impl Into<String>) -> Self {
+        self.inner.footer = Some(footer.into());
         self
     }
     /// A header that will be displayed on the quote PDF.
-    pub fn header(mut self, header: &'a str) -> Self {
-        self.inner.header = Some(header);
+    pub fn header(mut self, header: impl Into<String>) -> Self {
+        self.inner.header = Some(header.into());
         self
     }
     /// All invoices will be billed using the specified settings.
-    pub fn invoice_settings(mut self, invoice_settings: UpdateQuoteInvoiceSettings<'a>) -> Self {
-        self.inner.invoice_settings = Some(invoice_settings);
+    pub fn invoice_settings(
+        mut self,
+        invoice_settings: impl Into<UpdateQuoteInvoiceSettings>,
+    ) -> Self {
+        self.inner.invoice_settings = Some(invoice_settings.into());
         self
     }
     /// A list of line items the customer is being quoted for.
     /// Each line item includes information about the product, the quantity, and the resulting cost.
-    pub fn line_items(mut self, line_items: &'a [UpdateQuoteLineItems<'a>]) -> Self {
-        self.inner.line_items = Some(line_items);
+    pub fn line_items(mut self, line_items: impl Into<Vec<UpdateQuoteLineItems>>) -> Self {
+        self.inner.line_items = Some(line_items.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// The account on behalf of which to charge.
-    pub fn on_behalf_of(mut self, on_behalf_of: &'a str) -> Self {
-        self.inner.on_behalf_of = Some(on_behalf_of);
+    pub fn on_behalf_of(mut self, on_behalf_of: impl Into<String>) -> Self {
+        self.inner.on_behalf_of = Some(on_behalf_of.into());
         self
     }
     /// When creating a subscription or subscription schedule, the specified configuration data will be used.
     /// There must be at least one line item with a recurring price for a subscription or subscription schedule to be created.
     /// A subscription schedule is created if `subscription_data[effective_date]` is present and in the future, otherwise a subscription is created.
-    pub fn subscription_data(mut self, subscription_data: UpdateQuoteSubscriptionData<'a>) -> Self {
-        self.inner.subscription_data = Some(subscription_data);
+    pub fn subscription_data(
+        mut self,
+        subscription_data: impl Into<UpdateQuoteSubscriptionData>,
+    ) -> Self {
+        self.inner.subscription_data = Some(subscription_data.into());
         self
     }
     /// The data with which to automatically create a Transfer for each of the invoices.
-    pub fn transfer_data(mut self, transfer_data: TransferDataSpecs<'a>) -> Self {
-        self.inner.transfer_data = Some(transfer_data);
+    pub fn transfer_data(mut self, transfer_data: impl Into<TransferDataSpecs>) -> Self {
+        self.inner.transfer_data = Some(transfer_data.into());
         self
     }
 }
-impl UpdateQuote<'_> {
+impl UpdateQuote {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -1708,42 +1726,42 @@ impl UpdateQuote<'_> {
     }
 }
 
-impl StripeRequest for UpdateQuote<'_> {
+impl StripeRequest for UpdateQuote {
     type Output = stripe_shared::Quote;
 
     fn build(&self) -> RequestBuilder {
-        let quote = self.quote;
+        let quote = &self.quote;
         RequestBuilder::new(StripeMethod::Post, format!("/quotes/{quote}")).form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct AcceptQuoteBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct AcceptQuoteBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> AcceptQuoteBuilder<'a> {
+impl AcceptQuoteBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Accepts the specified quote.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct AcceptQuote<'a> {
-    inner: AcceptQuoteBuilder<'a>,
-    quote: &'a stripe_shared::QuoteId,
+pub struct AcceptQuote {
+    inner: AcceptQuoteBuilder,
+    quote: stripe_shared::QuoteId,
 }
-impl<'a> AcceptQuote<'a> {
+impl AcceptQuote {
     /// Construct a new `AcceptQuote`.
-    pub fn new(quote: &'a stripe_shared::QuoteId) -> Self {
-        Self { quote, inner: AcceptQuoteBuilder::new() }
+    pub fn new(quote: impl Into<stripe_shared::QuoteId>) -> Self {
+        Self { quote: quote.into(), inner: AcceptQuoteBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl AcceptQuote<'_> {
+impl AcceptQuote {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -1761,42 +1779,42 @@ impl AcceptQuote<'_> {
     }
 }
 
-impl StripeRequest for AcceptQuote<'_> {
+impl StripeRequest for AcceptQuote {
     type Output = stripe_shared::Quote;
 
     fn build(&self) -> RequestBuilder {
-        let quote = self.quote;
+        let quote = &self.quote;
         RequestBuilder::new(StripeMethod::Post, format!("/quotes/{quote}/accept")).form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CancelQuoteBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CancelQuoteBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> CancelQuoteBuilder<'a> {
+impl CancelQuoteBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Cancels the quote.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CancelQuote<'a> {
-    inner: CancelQuoteBuilder<'a>,
-    quote: &'a stripe_shared::QuoteId,
+pub struct CancelQuote {
+    inner: CancelQuoteBuilder,
+    quote: stripe_shared::QuoteId,
 }
-impl<'a> CancelQuote<'a> {
+impl CancelQuote {
     /// Construct a new `CancelQuote`.
-    pub fn new(quote: &'a stripe_shared::QuoteId) -> Self {
-        Self { quote, inner: CancelQuoteBuilder::new() }
+    pub fn new(quote: impl Into<stripe_shared::QuoteId>) -> Self {
+        Self { quote: quote.into(), inner: CancelQuoteBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl CancelQuote<'_> {
+impl CancelQuote {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -1814,50 +1832,50 @@ impl CancelQuote<'_> {
     }
 }
 
-impl StripeRequest for CancelQuote<'_> {
+impl StripeRequest for CancelQuote {
     type Output = stripe_shared::Quote;
 
     fn build(&self) -> RequestBuilder {
-        let quote = self.quote;
+        let quote = &self.quote;
         RequestBuilder::new(StripeMethod::Post, format!("/quotes/{quote}/cancel")).form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct FinalizeQuoteQuoteBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct FinalizeQuoteQuoteBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     expires_at: Option<stripe_types::Timestamp>,
 }
-impl<'a> FinalizeQuoteQuoteBuilder<'a> {
+impl FinalizeQuoteQuoteBuilder {
     fn new() -> Self {
         Self { expand: None, expires_at: None }
     }
 }
 /// Finalizes the quote.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct FinalizeQuoteQuote<'a> {
-    inner: FinalizeQuoteQuoteBuilder<'a>,
-    quote: &'a stripe_shared::QuoteId,
+pub struct FinalizeQuoteQuote {
+    inner: FinalizeQuoteQuoteBuilder,
+    quote: stripe_shared::QuoteId,
 }
-impl<'a> FinalizeQuoteQuote<'a> {
+impl FinalizeQuoteQuote {
     /// Construct a new `FinalizeQuoteQuote`.
-    pub fn new(quote: &'a stripe_shared::QuoteId) -> Self {
-        Self { quote, inner: FinalizeQuoteQuoteBuilder::new() }
+    pub fn new(quote: impl Into<stripe_shared::QuoteId>) -> Self {
+        Self { quote: quote.into(), inner: FinalizeQuoteQuoteBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A future timestamp on which the quote will be canceled if in `open` or `draft` status.
     /// Measured in seconds since the Unix epoch.
-    pub fn expires_at(mut self, expires_at: stripe_types::Timestamp) -> Self {
-        self.inner.expires_at = Some(expires_at);
+    pub fn expires_at(mut self, expires_at: impl Into<stripe_types::Timestamp>) -> Self {
+        self.inner.expires_at = Some(expires_at.into());
         self
     }
 }
-impl FinalizeQuoteQuote<'_> {
+impl FinalizeQuoteQuote {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -1875,40 +1893,40 @@ impl FinalizeQuoteQuote<'_> {
     }
 }
 
-impl StripeRequest for FinalizeQuoteQuote<'_> {
+impl StripeRequest for FinalizeQuoteQuote {
     type Output = stripe_shared::Quote;
 
     fn build(&self) -> RequestBuilder {
-        let quote = self.quote;
+        let quote = &self.quote;
         RequestBuilder::new(StripeMethod::Post, format!("/quotes/{quote}/finalize"))
             .form(&self.inner)
     }
 }
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct DiscountsDataParam<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct DiscountsDataParam {
     /// ID of the coupon to create a new discount for.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub coupon: Option<&'a str>,
+    pub coupon: Option<String>,
     /// ID of an existing discount on the object (or one of its ancestors) to reuse.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub discount: Option<&'a str>,
+    pub discount: Option<String>,
     /// ID of the promotion code to create a new discount for.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub promotion_code: Option<&'a str>,
+    pub promotion_code: Option<String>,
 }
-impl<'a> DiscountsDataParam<'a> {
+impl DiscountsDataParam {
     pub fn new() -> Self {
         Self { coupon: None, discount: None, promotion_code: None }
     }
 }
-impl<'a> Default for DiscountsDataParam<'a> {
+impl Default for DiscountsDataParam {
     fn default() -> Self {
         Self::new()
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct TransferDataSpecs<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct TransferDataSpecs {
     /// The amount that will be transferred automatically when the invoice is paid.
     /// If no amount is set, the full amount is transferred.
     /// There cannot be any line items with recurring prices when using this field.
@@ -1921,10 +1939,10 @@ pub struct TransferDataSpecs<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub amount_percent: Option<f64>,
     /// ID of an existing, connected Stripe account.
-    pub destination: &'a str,
+    pub destination: String,
 }
-impl<'a> TransferDataSpecs<'a> {
-    pub fn new(destination: &'a str) -> Self {
-        Self { amount: None, amount_percent: None, destination }
+impl TransferDataSpecs {
+    pub fn new(destination: impl Into<String>) -> Self {
+        Self { amount: None, amount_percent: None, destination: destination.into() }
     }
 }

--- a/generated/async-stripe-billing/src/subscription_item/requests.rs
+++ b/generated/async-stripe-billing/src/subscription_item/requests.rs
@@ -79,38 +79,38 @@ impl<'de> serde::Deserialize<'de> for DeleteSubscriptionItemProrationBehavior {
 /// Deletes an item from the subscription.
 /// Removing a subscription item from a subscription will not cancel the subscription.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct DeleteSubscriptionItem<'a> {
+pub struct DeleteSubscriptionItem {
     inner: DeleteSubscriptionItemBuilder,
-    item: &'a stripe_shared::SubscriptionItemId,
+    item: stripe_shared::SubscriptionItemId,
 }
-impl<'a> DeleteSubscriptionItem<'a> {
+impl DeleteSubscriptionItem {
     /// Construct a new `DeleteSubscriptionItem`.
-    pub fn new(item: &'a stripe_shared::SubscriptionItemId) -> Self {
-        Self { item, inner: DeleteSubscriptionItemBuilder::new() }
+    pub fn new(item: impl Into<stripe_shared::SubscriptionItemId>) -> Self {
+        Self { item: item.into(), inner: DeleteSubscriptionItemBuilder::new() }
     }
     /// Delete all usage for the given subscription item.
     /// Allowed only when the current plan's `usage_type` is `metered`.
-    pub fn clear_usage(mut self, clear_usage: bool) -> Self {
-        self.inner.clear_usage = Some(clear_usage);
+    pub fn clear_usage(mut self, clear_usage: impl Into<bool>) -> Self {
+        self.inner.clear_usage = Some(clear_usage.into());
         self
     }
     /// Determines how to handle [prorations](https://stripe.com/docs/billing/subscriptions/prorations) when the billing cycle changes (e.g., when switching plans, resetting `billing_cycle_anchor=now`, or starting a trial), or if an item's `quantity` changes.
     /// The default value is `create_prorations`.
     pub fn proration_behavior(
         mut self,
-        proration_behavior: DeleteSubscriptionItemProrationBehavior,
+        proration_behavior: impl Into<DeleteSubscriptionItemProrationBehavior>,
     ) -> Self {
-        self.inner.proration_behavior = Some(proration_behavior);
+        self.inner.proration_behavior = Some(proration_behavior.into());
         self
     }
     /// If set, the proration will be calculated as though the subscription was updated at the given time.
     /// This can be used to apply the same proration that was previewed with the [upcoming invoice](https://stripe.com/docs/api#retrieve_customer_invoice) endpoint.
-    pub fn proration_date(mut self, proration_date: stripe_types::Timestamp) -> Self {
-        self.inner.proration_date = Some(proration_date);
+    pub fn proration_date(mut self, proration_date: impl Into<stripe_types::Timestamp>) -> Self {
+        self.inner.proration_date = Some(proration_date.into());
         self
     }
 }
-impl DeleteSubscriptionItem<'_> {
+impl DeleteSubscriptionItem {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -128,69 +128,75 @@ impl DeleteSubscriptionItem<'_> {
     }
 }
 
-impl StripeRequest for DeleteSubscriptionItem<'_> {
+impl StripeRequest for DeleteSubscriptionItem {
     type Output = stripe_shared::DeletedSubscriptionItem;
 
     fn build(&self) -> RequestBuilder {
-        let item = self.item;
+        let item = &self.item;
         RequestBuilder::new(StripeMethod::Delete, format!("/subscription_items/{item}"))
             .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListSubscriptionItemBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListSubscriptionItemBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
-    subscription: &'a str,
+    starting_after: Option<String>,
+    subscription: String,
 }
-impl<'a> ListSubscriptionItemBuilder<'a> {
-    fn new(subscription: &'a str) -> Self {
-        Self { ending_before: None, expand: None, limit: None, starting_after: None, subscription }
+impl ListSubscriptionItemBuilder {
+    fn new(subscription: impl Into<String>) -> Self {
+        Self {
+            ending_before: None,
+            expand: None,
+            limit: None,
+            starting_after: None,
+            subscription: subscription.into(),
+        }
     }
 }
 /// Returns a list of your subscription items for a given subscription.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListSubscriptionItem<'a> {
-    inner: ListSubscriptionItemBuilder<'a>,
+pub struct ListSubscriptionItem {
+    inner: ListSubscriptionItemBuilder,
 }
-impl<'a> ListSubscriptionItem<'a> {
+impl ListSubscriptionItem {
     /// Construct a new `ListSubscriptionItem`.
-    pub fn new(subscription: &'a str) -> Self {
-        Self { inner: ListSubscriptionItemBuilder::new(subscription) }
+    pub fn new(subscription: impl Into<String>) -> Self {
+        Self { inner: ListSubscriptionItemBuilder::new(subscription.into()) }
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl ListSubscriptionItem<'_> {
+impl ListSubscriptionItem {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -211,45 +217,45 @@ impl ListSubscriptionItem<'_> {
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::SubscriptionItem>>
     {
-        stripe_client_core::ListPaginator::new_list("/subscription_items", self.inner)
+        stripe_client_core::ListPaginator::new_list("/subscription_items", &self.inner)
     }
 }
 
-impl StripeRequest for ListSubscriptionItem<'_> {
+impl StripeRequest for ListSubscriptionItem {
     type Output = stripe_types::List<stripe_shared::SubscriptionItem>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/subscription_items").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveSubscriptionItemBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveSubscriptionItemBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveSubscriptionItemBuilder<'a> {
+impl RetrieveSubscriptionItemBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves the subscription item with the given ID.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveSubscriptionItem<'a> {
-    inner: RetrieveSubscriptionItemBuilder<'a>,
-    item: &'a stripe_shared::SubscriptionItemId,
+pub struct RetrieveSubscriptionItem {
+    inner: RetrieveSubscriptionItemBuilder,
+    item: stripe_shared::SubscriptionItemId,
 }
-impl<'a> RetrieveSubscriptionItem<'a> {
+impl RetrieveSubscriptionItem {
     /// Construct a new `RetrieveSubscriptionItem`.
-    pub fn new(item: &'a stripe_shared::SubscriptionItemId) -> Self {
-        Self { item, inner: RetrieveSubscriptionItemBuilder::new() }
+    pub fn new(item: impl Into<stripe_shared::SubscriptionItemId>) -> Self {
+        Self { item: item.into(), inner: RetrieveSubscriptionItemBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveSubscriptionItem<'_> {
+impl RetrieveSubscriptionItem {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -267,27 +273,27 @@ impl RetrieveSubscriptionItem<'_> {
     }
 }
 
-impl StripeRequest for RetrieveSubscriptionItem<'_> {
+impl StripeRequest for RetrieveSubscriptionItem {
     type Output = stripe_shared::SubscriptionItem;
 
     fn build(&self) -> RequestBuilder {
-        let item = self.item;
+        let item = &self.item;
         RequestBuilder::new(StripeMethod::Get, format!("/subscription_items/{item}"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UsageRecordSummariesSubscriptionItemBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UsageRecordSummariesSubscriptionItemBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> UsageRecordSummariesSubscriptionItemBuilder<'a> {
+impl UsageRecordSummariesSubscriptionItemBuilder {
     fn new() -> Self {
         Self { ending_before: None, expand: None, limit: None, starting_after: None }
     }
@@ -299,42 +305,45 @@ impl<'a> UsageRecordSummariesSubscriptionItemBuilder<'a> {
 /// The first list item represents the most current usage period that hasn’t ended yet.
 /// Since new usage records can still be added, the returned summary information for the subscription item’s ID should be seen as unstable until the subscription billing period ends.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UsageRecordSummariesSubscriptionItem<'a> {
-    inner: UsageRecordSummariesSubscriptionItemBuilder<'a>,
-    subscription_item: &'a stripe_shared::SubscriptionItemId,
+pub struct UsageRecordSummariesSubscriptionItem {
+    inner: UsageRecordSummariesSubscriptionItemBuilder,
+    subscription_item: stripe_shared::SubscriptionItemId,
 }
-impl<'a> UsageRecordSummariesSubscriptionItem<'a> {
+impl UsageRecordSummariesSubscriptionItem {
     /// Construct a new `UsageRecordSummariesSubscriptionItem`.
-    pub fn new(subscription_item: &'a stripe_shared::SubscriptionItemId) -> Self {
-        Self { subscription_item, inner: UsageRecordSummariesSubscriptionItemBuilder::new() }
+    pub fn new(subscription_item: impl Into<stripe_shared::SubscriptionItemId>) -> Self {
+        Self {
+            subscription_item: subscription_item.into(),
+            inner: UsageRecordSummariesSubscriptionItemBuilder::new(),
+        }
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl UsageRecordSummariesSubscriptionItem<'_> {
+impl UsageRecordSummariesSubscriptionItem {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -355,20 +364,20 @@ impl UsageRecordSummariesSubscriptionItem<'_> {
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::UsageRecordSummary>>
     {
-        let subscription_item = self.subscription_item;
+        let subscription_item = &self.subscription_item;
 
         stripe_client_core::ListPaginator::new_list(
             format!("/subscription_items/{subscription_item}/usage_record_summaries"),
-            self.inner,
+            &self.inner,
         )
     }
 }
 
-impl StripeRequest for UsageRecordSummariesSubscriptionItem<'_> {
+impl StripeRequest for UsageRecordSummariesSubscriptionItem {
     type Output = stripe_types::List<stripe_shared::UsageRecordSummary>;
 
     fn build(&self) -> RequestBuilder {
-        let subscription_item = self.subscription_item;
+        let subscription_item = &self.subscription_item;
         RequestBuilder::new(
             StripeMethod::Get,
             format!("/subscription_items/{subscription_item}/usage_record_summaries"),
@@ -376,36 +385,36 @@ impl StripeRequest for UsageRecordSummariesSubscriptionItem<'_> {
         .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateSubscriptionItemBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateSubscriptionItemBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     billing_thresholds: Option<ItemBillingThresholdsParam>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    discounts: Option<&'a [DiscountsDataParam<'a>]>,
+    discounts: Option<Vec<DiscountsDataParam>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     payment_behavior: Option<CreateSubscriptionItemPaymentBehavior>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    plan: Option<&'a str>,
+    plan: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    price: Option<&'a str>,
+    price: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    price_data: Option<CreateSubscriptionItemPriceData<'a>>,
+    price_data: Option<CreateSubscriptionItemPriceData>,
     #[serde(skip_serializing_if = "Option::is_none")]
     proration_behavior: Option<CreateSubscriptionItemProrationBehavior>,
     #[serde(skip_serializing_if = "Option::is_none")]
     proration_date: Option<stripe_types::Timestamp>,
     #[serde(skip_serializing_if = "Option::is_none")]
     quantity: Option<u64>,
-    subscription: &'a str,
+    subscription: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    tax_rates: Option<&'a [&'a str]>,
+    tax_rates: Option<Vec<String>>,
 }
-impl<'a> CreateSubscriptionItemBuilder<'a> {
-    fn new(subscription: &'a str) -> Self {
+impl CreateSubscriptionItemBuilder {
+    fn new(subscription: impl Into<String>) -> Self {
         Self {
             billing_thresholds: None,
             discounts: None,
@@ -418,7 +427,7 @@ impl<'a> CreateSubscriptionItemBuilder<'a> {
             proration_behavior: None,
             proration_date: None,
             quantity: None,
-            subscription,
+            subscription: subscription.into(),
             tax_rates: None,
         }
     }
@@ -502,13 +511,13 @@ impl<'de> serde::Deserialize<'de> for CreateSubscriptionItemPaymentBehavior {
     }
 }
 /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateSubscriptionItemPriceData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateSubscriptionItemPriceData {
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     /// Must be a [supported currency](https://stripe.com/docs/currencies).
     pub currency: stripe_types::Currency,
     /// The ID of the product that this price will belong to.
-    pub product: &'a str,
+    pub product: String,
     /// The recurring components of a price such as `interval` and `interval_count`.
     pub recurring: CreateSubscriptionItemPriceDataRecurring,
     /// Only required if a [default tax behavior](https://stripe.com/docs/tax/products-prices-tax-categories-tax-behavior#setting-a-default-tax-behavior-(recommended)) was not provided in the Stripe Tax settings.
@@ -523,18 +532,18 @@ pub struct CreateSubscriptionItemPriceData<'a> {
     /// Same as `unit_amount`, but accepts a decimal value in cents (or local equivalent) with at most 12 decimal places.
     /// Only one of `unit_amount` and `unit_amount_decimal` can be set.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub unit_amount_decimal: Option<&'a str>,
+    pub unit_amount_decimal: Option<String>,
 }
-impl<'a> CreateSubscriptionItemPriceData<'a> {
+impl CreateSubscriptionItemPriceData {
     pub fn new(
-        currency: stripe_types::Currency,
-        product: &'a str,
-        recurring: CreateSubscriptionItemPriceDataRecurring,
+        currency: impl Into<stripe_types::Currency>,
+        product: impl Into<String>,
+        recurring: impl Into<CreateSubscriptionItemPriceDataRecurring>,
     ) -> Self {
         Self {
-            currency,
-            product,
-            recurring,
+            currency: currency.into(),
+            product: product.into(),
+            recurring: recurring.into(),
             tax_behavior: None,
             unit_amount: None,
             unit_amount_decimal: None,
@@ -553,8 +562,8 @@ pub struct CreateSubscriptionItemPriceDataRecurring {
     pub interval_count: Option<u64>,
 }
 impl CreateSubscriptionItemPriceDataRecurring {
-    pub fn new(interval: CreateSubscriptionItemPriceDataRecurringInterval) -> Self {
-        Self { interval, interval_count: None }
+    pub fn new(interval: impl Into<CreateSubscriptionItemPriceDataRecurringInterval>) -> Self {
+        Self { interval: interval.into(), interval_count: None }
     }
 }
 /// Specifies billing frequency. Either `day`, `week`, `month` or `year`.
@@ -745,36 +754,42 @@ impl<'de> serde::Deserialize<'de> for CreateSubscriptionItemProrationBehavior {
 }
 /// Adds a new item to an existing subscription. No existing items will be changed or replaced.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateSubscriptionItem<'a> {
-    inner: CreateSubscriptionItemBuilder<'a>,
+pub struct CreateSubscriptionItem {
+    inner: CreateSubscriptionItemBuilder,
 }
-impl<'a> CreateSubscriptionItem<'a> {
+impl CreateSubscriptionItem {
     /// Construct a new `CreateSubscriptionItem`.
-    pub fn new(subscription: &'a str) -> Self {
-        Self { inner: CreateSubscriptionItemBuilder::new(subscription) }
+    pub fn new(subscription: impl Into<String>) -> Self {
+        Self { inner: CreateSubscriptionItemBuilder::new(subscription.into()) }
     }
     /// Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period.
     /// When updating, pass an empty string to remove previously-defined thresholds.
-    pub fn billing_thresholds(mut self, billing_thresholds: ItemBillingThresholdsParam) -> Self {
-        self.inner.billing_thresholds = Some(billing_thresholds);
+    pub fn billing_thresholds(
+        mut self,
+        billing_thresholds: impl Into<ItemBillingThresholdsParam>,
+    ) -> Self {
+        self.inner.billing_thresholds = Some(billing_thresholds.into());
         self
     }
     /// The coupons to redeem into discounts for the subscription item.
-    pub fn discounts(mut self, discounts: &'a [DiscountsDataParam<'a>]) -> Self {
-        self.inner.discounts = Some(discounts);
+    pub fn discounts(mut self, discounts: impl Into<Vec<DiscountsDataParam>>) -> Self {
+        self.inner.discounts = Some(discounts.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// Use `allow_incomplete` to transition the subscription to `status=past_due` if a payment is required but cannot be paid.
@@ -796,55 +811,55 @@ impl<'a> CreateSubscriptionItem<'a> {
     /// See the [changelog](https://stripe.com/docs/upgrades#2019-03-14) to learn more.
     pub fn payment_behavior(
         mut self,
-        payment_behavior: CreateSubscriptionItemPaymentBehavior,
+        payment_behavior: impl Into<CreateSubscriptionItemPaymentBehavior>,
     ) -> Self {
-        self.inner.payment_behavior = Some(payment_behavior);
+        self.inner.payment_behavior = Some(payment_behavior.into());
         self
     }
     /// The identifier of the plan to add to the subscription.
-    pub fn plan(mut self, plan: &'a str) -> Self {
-        self.inner.plan = Some(plan);
+    pub fn plan(mut self, plan: impl Into<String>) -> Self {
+        self.inner.plan = Some(plan.into());
         self
     }
     /// The ID of the price object.
-    pub fn price(mut self, price: &'a str) -> Self {
-        self.inner.price = Some(price);
+    pub fn price(mut self, price: impl Into<String>) -> Self {
+        self.inner.price = Some(price.into());
         self
     }
     /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
-    pub fn price_data(mut self, price_data: CreateSubscriptionItemPriceData<'a>) -> Self {
-        self.inner.price_data = Some(price_data);
+    pub fn price_data(mut self, price_data: impl Into<CreateSubscriptionItemPriceData>) -> Self {
+        self.inner.price_data = Some(price_data.into());
         self
     }
     /// Determines how to handle [prorations](https://stripe.com/docs/billing/subscriptions/prorations) when the billing cycle changes (e.g., when switching plans, resetting `billing_cycle_anchor=now`, or starting a trial), or if an item's `quantity` changes.
     /// The default value is `create_prorations`.
     pub fn proration_behavior(
         mut self,
-        proration_behavior: CreateSubscriptionItemProrationBehavior,
+        proration_behavior: impl Into<CreateSubscriptionItemProrationBehavior>,
     ) -> Self {
-        self.inner.proration_behavior = Some(proration_behavior);
+        self.inner.proration_behavior = Some(proration_behavior.into());
         self
     }
     /// If set, the proration will be calculated as though the subscription was updated at the given time.
     /// This can be used to apply the same proration that was previewed with the [upcoming invoice](https://stripe.com/docs/api#retrieve_customer_invoice) endpoint.
-    pub fn proration_date(mut self, proration_date: stripe_types::Timestamp) -> Self {
-        self.inner.proration_date = Some(proration_date);
+    pub fn proration_date(mut self, proration_date: impl Into<stripe_types::Timestamp>) -> Self {
+        self.inner.proration_date = Some(proration_date.into());
         self
     }
     /// The quantity you'd like to apply to the subscription item you're creating.
-    pub fn quantity(mut self, quantity: u64) -> Self {
-        self.inner.quantity = Some(quantity);
+    pub fn quantity(mut self, quantity: impl Into<u64>) -> Self {
+        self.inner.quantity = Some(quantity.into());
         self
     }
     /// A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids.
     /// These Tax Rates will override the [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates) on the Subscription.
     /// When updating, pass an empty string to remove previously-defined tax rates.
-    pub fn tax_rates(mut self, tax_rates: &'a [&'a str]) -> Self {
-        self.inner.tax_rates = Some(tax_rates);
+    pub fn tax_rates(mut self, tax_rates: impl Into<Vec<String>>) -> Self {
+        self.inner.tax_rates = Some(tax_rates.into());
         self
     }
 }
-impl CreateSubscriptionItem<'_> {
+impl CreateSubscriptionItem {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -862,33 +877,33 @@ impl CreateSubscriptionItem<'_> {
     }
 }
 
-impl StripeRequest for CreateSubscriptionItem<'_> {
+impl StripeRequest for CreateSubscriptionItem {
     type Output = stripe_shared::SubscriptionItem;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Post, "/subscription_items").form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdateSubscriptionItemBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdateSubscriptionItemBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     billing_thresholds: Option<ItemBillingThresholdsParam>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    discounts: Option<&'a [DiscountsDataParam<'a>]>,
+    discounts: Option<Vec<DiscountsDataParam>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     off_session: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     payment_behavior: Option<UpdateSubscriptionItemPaymentBehavior>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    plan: Option<&'a str>,
+    plan: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    price: Option<&'a str>,
+    price: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    price_data: Option<UpdateSubscriptionItemPriceData<'a>>,
+    price_data: Option<UpdateSubscriptionItemPriceData>,
     #[serde(skip_serializing_if = "Option::is_none")]
     proration_behavior: Option<UpdateSubscriptionItemProrationBehavior>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -896,9 +911,9 @@ struct UpdateSubscriptionItemBuilder<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     quantity: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    tax_rates: Option<&'a [&'a str]>,
+    tax_rates: Option<Vec<String>>,
 }
-impl<'a> UpdateSubscriptionItemBuilder<'a> {
+impl UpdateSubscriptionItemBuilder {
     fn new() -> Self {
         Self {
             billing_thresholds: None,
@@ -996,13 +1011,13 @@ impl<'de> serde::Deserialize<'de> for UpdateSubscriptionItemPaymentBehavior {
     }
 }
 /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateSubscriptionItemPriceData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateSubscriptionItemPriceData {
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     /// Must be a [supported currency](https://stripe.com/docs/currencies).
     pub currency: stripe_types::Currency,
     /// The ID of the product that this price will belong to.
-    pub product: &'a str,
+    pub product: String,
     /// The recurring components of a price such as `interval` and `interval_count`.
     pub recurring: UpdateSubscriptionItemPriceDataRecurring,
     /// Only required if a [default tax behavior](https://stripe.com/docs/tax/products-prices-tax-categories-tax-behavior#setting-a-default-tax-behavior-(recommended)) was not provided in the Stripe Tax settings.
@@ -1017,18 +1032,18 @@ pub struct UpdateSubscriptionItemPriceData<'a> {
     /// Same as `unit_amount`, but accepts a decimal value in cents (or local equivalent) with at most 12 decimal places.
     /// Only one of `unit_amount` and `unit_amount_decimal` can be set.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub unit_amount_decimal: Option<&'a str>,
+    pub unit_amount_decimal: Option<String>,
 }
-impl<'a> UpdateSubscriptionItemPriceData<'a> {
+impl UpdateSubscriptionItemPriceData {
     pub fn new(
-        currency: stripe_types::Currency,
-        product: &'a str,
-        recurring: UpdateSubscriptionItemPriceDataRecurring,
+        currency: impl Into<stripe_types::Currency>,
+        product: impl Into<String>,
+        recurring: impl Into<UpdateSubscriptionItemPriceDataRecurring>,
     ) -> Self {
         Self {
-            currency,
-            product,
-            recurring,
+            currency: currency.into(),
+            product: product.into(),
+            recurring: recurring.into(),
             tax_behavior: None,
             unit_amount: None,
             unit_amount_decimal: None,
@@ -1047,8 +1062,8 @@ pub struct UpdateSubscriptionItemPriceDataRecurring {
     pub interval_count: Option<u64>,
 }
 impl UpdateSubscriptionItemPriceDataRecurring {
-    pub fn new(interval: UpdateSubscriptionItemPriceDataRecurringInterval) -> Self {
-        Self { interval, interval_count: None }
+    pub fn new(interval: impl Into<UpdateSubscriptionItemPriceDataRecurringInterval>) -> Self {
+        Self { interval: interval.into(), interval_count: None }
     }
 }
 /// Specifies billing frequency. Either `day`, `week`, `month` or `year`.
@@ -1239,42 +1254,48 @@ impl<'de> serde::Deserialize<'de> for UpdateSubscriptionItemProrationBehavior {
 }
 /// Updates the plan or quantity of an item on a current subscription.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateSubscriptionItem<'a> {
-    inner: UpdateSubscriptionItemBuilder<'a>,
-    item: &'a stripe_shared::SubscriptionItemId,
+pub struct UpdateSubscriptionItem {
+    inner: UpdateSubscriptionItemBuilder,
+    item: stripe_shared::SubscriptionItemId,
 }
-impl<'a> UpdateSubscriptionItem<'a> {
+impl UpdateSubscriptionItem {
     /// Construct a new `UpdateSubscriptionItem`.
-    pub fn new(item: &'a stripe_shared::SubscriptionItemId) -> Self {
-        Self { item, inner: UpdateSubscriptionItemBuilder::new() }
+    pub fn new(item: impl Into<stripe_shared::SubscriptionItemId>) -> Self {
+        Self { item: item.into(), inner: UpdateSubscriptionItemBuilder::new() }
     }
     /// Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period.
     /// When updating, pass an empty string to remove previously-defined thresholds.
-    pub fn billing_thresholds(mut self, billing_thresholds: ItemBillingThresholdsParam) -> Self {
-        self.inner.billing_thresholds = Some(billing_thresholds);
+    pub fn billing_thresholds(
+        mut self,
+        billing_thresholds: impl Into<ItemBillingThresholdsParam>,
+    ) -> Self {
+        self.inner.billing_thresholds = Some(billing_thresholds.into());
         self
     }
     /// The coupons to redeem into discounts for the subscription item.
-    pub fn discounts(mut self, discounts: &'a [DiscountsDataParam<'a>]) -> Self {
-        self.inner.discounts = Some(discounts);
+    pub fn discounts(mut self, discounts: impl Into<Vec<DiscountsDataParam>>) -> Self {
+        self.inner.discounts = Some(discounts.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// Indicates if a customer is on or off-session while an invoice payment is attempted.
-    pub fn off_session(mut self, off_session: bool) -> Self {
-        self.inner.off_session = Some(off_session);
+    pub fn off_session(mut self, off_session: impl Into<bool>) -> Self {
+        self.inner.off_session = Some(off_session.into());
         self
     }
     /// Use `allow_incomplete` to transition the subscription to `status=past_due` if a payment is required but cannot be paid.
@@ -1296,56 +1317,56 @@ impl<'a> UpdateSubscriptionItem<'a> {
     /// See the [changelog](https://stripe.com/docs/upgrades#2019-03-14) to learn more.
     pub fn payment_behavior(
         mut self,
-        payment_behavior: UpdateSubscriptionItemPaymentBehavior,
+        payment_behavior: impl Into<UpdateSubscriptionItemPaymentBehavior>,
     ) -> Self {
-        self.inner.payment_behavior = Some(payment_behavior);
+        self.inner.payment_behavior = Some(payment_behavior.into());
         self
     }
     /// The identifier of the new plan for this subscription item.
-    pub fn plan(mut self, plan: &'a str) -> Self {
-        self.inner.plan = Some(plan);
+    pub fn plan(mut self, plan: impl Into<String>) -> Self {
+        self.inner.plan = Some(plan.into());
         self
     }
     /// The ID of the price object.
     /// When changing a subscription item's price, `quantity` is set to 1 unless a `quantity` parameter is provided.
-    pub fn price(mut self, price: &'a str) -> Self {
-        self.inner.price = Some(price);
+    pub fn price(mut self, price: impl Into<String>) -> Self {
+        self.inner.price = Some(price.into());
         self
     }
     /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
-    pub fn price_data(mut self, price_data: UpdateSubscriptionItemPriceData<'a>) -> Self {
-        self.inner.price_data = Some(price_data);
+    pub fn price_data(mut self, price_data: impl Into<UpdateSubscriptionItemPriceData>) -> Self {
+        self.inner.price_data = Some(price_data.into());
         self
     }
     /// Determines how to handle [prorations](https://stripe.com/docs/billing/subscriptions/prorations) when the billing cycle changes (e.g., when switching plans, resetting `billing_cycle_anchor=now`, or starting a trial), or if an item's `quantity` changes.
     /// The default value is `create_prorations`.
     pub fn proration_behavior(
         mut self,
-        proration_behavior: UpdateSubscriptionItemProrationBehavior,
+        proration_behavior: impl Into<UpdateSubscriptionItemProrationBehavior>,
     ) -> Self {
-        self.inner.proration_behavior = Some(proration_behavior);
+        self.inner.proration_behavior = Some(proration_behavior.into());
         self
     }
     /// If set, the proration will be calculated as though the subscription was updated at the given time.
     /// This can be used to apply the same proration that was previewed with the [upcoming invoice](https://stripe.com/docs/api#retrieve_customer_invoice) endpoint.
-    pub fn proration_date(mut self, proration_date: stripe_types::Timestamp) -> Self {
-        self.inner.proration_date = Some(proration_date);
+    pub fn proration_date(mut self, proration_date: impl Into<stripe_types::Timestamp>) -> Self {
+        self.inner.proration_date = Some(proration_date.into());
         self
     }
     /// The quantity you'd like to apply to the subscription item you're creating.
-    pub fn quantity(mut self, quantity: u64) -> Self {
-        self.inner.quantity = Some(quantity);
+    pub fn quantity(mut self, quantity: impl Into<u64>) -> Self {
+        self.inner.quantity = Some(quantity.into());
         self
     }
     /// A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids.
     /// These Tax Rates will override the [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates) on the Subscription.
     /// When updating, pass an empty string to remove previously-defined tax rates.
-    pub fn tax_rates(mut self, tax_rates: &'a [&'a str]) -> Self {
-        self.inner.tax_rates = Some(tax_rates);
+    pub fn tax_rates(mut self, tax_rates: impl Into<Vec<String>>) -> Self {
+        self.inner.tax_rates = Some(tax_rates.into());
         self
     }
 }
-impl UpdateSubscriptionItem<'_> {
+impl UpdateSubscriptionItem {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -1363,11 +1384,11 @@ impl UpdateSubscriptionItem<'_> {
     }
 }
 
-impl StripeRequest for UpdateSubscriptionItem<'_> {
+impl StripeRequest for UpdateSubscriptionItem {
     type Output = stripe_shared::SubscriptionItem;
 
     fn build(&self) -> RequestBuilder {
-        let item = self.item;
+        let item = &self.item;
         RequestBuilder::new(StripeMethod::Post, format!("/subscription_items/{item}"))
             .form(&self.inner)
     }
@@ -1379,28 +1400,28 @@ pub struct ItemBillingThresholdsParam {
     pub usage_gte: i64,
 }
 impl ItemBillingThresholdsParam {
-    pub fn new(usage_gte: i64) -> Self {
-        Self { usage_gte }
+    pub fn new(usage_gte: impl Into<i64>) -> Self {
+        Self { usage_gte: usage_gte.into() }
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct DiscountsDataParam<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct DiscountsDataParam {
     /// ID of the coupon to create a new discount for.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub coupon: Option<&'a str>,
+    pub coupon: Option<String>,
     /// ID of an existing discount on the object (or one of its ancestors) to reuse.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub discount: Option<&'a str>,
+    pub discount: Option<String>,
     /// ID of the promotion code to create a new discount for.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub promotion_code: Option<&'a str>,
+    pub promotion_code: Option<String>,
 }
-impl<'a> DiscountsDataParam<'a> {
+impl DiscountsDataParam {
     pub fn new() -> Self {
         Self { coupon: None, discount: None, promotion_code: None }
     }
 }
-impl<'a> Default for DiscountsDataParam<'a> {
+impl Default for DiscountsDataParam {
     fn default() -> Self {
         Self::new()
     }

--- a/generated/async-stripe-billing/src/subscription_schedule/requests.rs
+++ b/generated/async-stripe-billing/src/subscription_schedule/requests.rs
@@ -2,8 +2,8 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListSubscriptionScheduleBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListSubscriptionScheduleBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     canceled_at: Option<stripe_types::RangeQueryTs>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -11,11 +11,11 @@ struct ListSubscriptionScheduleBuilder<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     created: Option<stripe_types::RangeQueryTs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    customer: Option<&'a str>,
+    customer: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -23,9 +23,9 @@ struct ListSubscriptionScheduleBuilder<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     scheduled: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListSubscriptionScheduleBuilder<'a> {
+impl ListSubscriptionScheduleBuilder {
     fn new() -> Self {
         Self {
             canceled_at: None,
@@ -43,76 +43,76 @@ impl<'a> ListSubscriptionScheduleBuilder<'a> {
 }
 /// Retrieves the list of your subscription schedules.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListSubscriptionSchedule<'a> {
-    inner: ListSubscriptionScheduleBuilder<'a>,
+pub struct ListSubscriptionSchedule {
+    inner: ListSubscriptionScheduleBuilder,
 }
-impl<'a> ListSubscriptionSchedule<'a> {
+impl ListSubscriptionSchedule {
     /// Construct a new `ListSubscriptionSchedule`.
     pub fn new() -> Self {
         Self { inner: ListSubscriptionScheduleBuilder::new() }
     }
     /// Only return subscription schedules that were created canceled the given date interval.
-    pub fn canceled_at(mut self, canceled_at: stripe_types::RangeQueryTs) -> Self {
-        self.inner.canceled_at = Some(canceled_at);
+    pub fn canceled_at(mut self, canceled_at: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.canceled_at = Some(canceled_at.into());
         self
     }
     /// Only return subscription schedules that completed during the given date interval.
-    pub fn completed_at(mut self, completed_at: stripe_types::RangeQueryTs) -> Self {
-        self.inner.completed_at = Some(completed_at);
+    pub fn completed_at(mut self, completed_at: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.completed_at = Some(completed_at.into());
         self
     }
     /// Only return subscription schedules that were created during the given date interval.
-    pub fn created(mut self, created: stripe_types::RangeQueryTs) -> Self {
-        self.inner.created = Some(created);
+    pub fn created(mut self, created: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.created = Some(created.into());
         self
     }
     /// Only return subscription schedules for the given customer.
-    pub fn customer(mut self, customer: &'a str) -> Self {
-        self.inner.customer = Some(customer);
+    pub fn customer(mut self, customer: impl Into<String>) -> Self {
+        self.inner.customer = Some(customer.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// Only return subscription schedules that were released during the given date interval.
-    pub fn released_at(mut self, released_at: stripe_types::RangeQueryTs) -> Self {
-        self.inner.released_at = Some(released_at);
+    pub fn released_at(mut self, released_at: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.released_at = Some(released_at.into());
         self
     }
     /// Only return subscription schedules that have not started yet.
-    pub fn scheduled(mut self, scheduled: bool) -> Self {
-        self.inner.scheduled = Some(scheduled);
+    pub fn scheduled(mut self, scheduled: impl Into<bool>) -> Self {
+        self.inner.scheduled = Some(scheduled.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl<'a> Default for ListSubscriptionSchedule<'a> {
+impl Default for ListSubscriptionSchedule {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListSubscriptionSchedule<'_> {
+impl ListSubscriptionSchedule {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -133,23 +133,23 @@ impl ListSubscriptionSchedule<'_> {
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::SubscriptionSchedule>>
     {
-        stripe_client_core::ListPaginator::new_list("/subscription_schedules", self.inner)
+        stripe_client_core::ListPaginator::new_list("/subscription_schedules", &self.inner)
     }
 }
 
-impl StripeRequest for ListSubscriptionSchedule<'_> {
+impl StripeRequest for ListSubscriptionSchedule {
     type Output = stripe_types::List<stripe_shared::SubscriptionSchedule>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/subscription_schedules").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveSubscriptionScheduleBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveSubscriptionScheduleBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveSubscriptionScheduleBuilder<'a> {
+impl RetrieveSubscriptionScheduleBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
@@ -157,22 +157,22 @@ impl<'a> RetrieveSubscriptionScheduleBuilder<'a> {
 /// Retrieves the details of an existing subscription schedule.
 /// You only need to supply the unique subscription schedule identifier that was returned upon subscription schedule creation.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveSubscriptionSchedule<'a> {
-    inner: RetrieveSubscriptionScheduleBuilder<'a>,
-    schedule: &'a stripe_shared::SubscriptionScheduleId,
+pub struct RetrieveSubscriptionSchedule {
+    inner: RetrieveSubscriptionScheduleBuilder,
+    schedule: stripe_shared::SubscriptionScheduleId,
 }
-impl<'a> RetrieveSubscriptionSchedule<'a> {
+impl RetrieveSubscriptionSchedule {
     /// Construct a new `RetrieveSubscriptionSchedule`.
-    pub fn new(schedule: &'a stripe_shared::SubscriptionScheduleId) -> Self {
-        Self { schedule, inner: RetrieveSubscriptionScheduleBuilder::new() }
+    pub fn new(schedule: impl Into<stripe_shared::SubscriptionScheduleId>) -> Self {
+        Self { schedule: schedule.into(), inner: RetrieveSubscriptionScheduleBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveSubscriptionSchedule<'_> {
+impl RetrieveSubscriptionSchedule {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -190,35 +190,35 @@ impl RetrieveSubscriptionSchedule<'_> {
     }
 }
 
-impl StripeRequest for RetrieveSubscriptionSchedule<'_> {
+impl StripeRequest for RetrieveSubscriptionSchedule {
     type Output = stripe_shared::SubscriptionSchedule;
 
     fn build(&self) -> RequestBuilder {
-        let schedule = self.schedule;
+        let schedule = &self.schedule;
         RequestBuilder::new(StripeMethod::Get, format!("/subscription_schedules/{schedule}"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateSubscriptionScheduleBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateSubscriptionScheduleBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    customer: Option<&'a str>,
+    customer: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    default_settings: Option<CreateSubscriptionScheduleDefaultSettings<'a>>,
+    default_settings: Option<CreateSubscriptionScheduleDefaultSettings>,
     #[serde(skip_serializing_if = "Option::is_none")]
     end_behavior: Option<stripe_shared::SubscriptionScheduleEndBehavior>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    from_subscription: Option<&'a str>,
+    from_subscription: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    phases: Option<&'a [CreateSubscriptionSchedulePhases<'a>]>,
+    phases: Option<Vec<CreateSubscriptionSchedulePhases>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     start_date: Option<CreateSubscriptionScheduleStartDate>,
 }
-impl<'a> CreateSubscriptionScheduleBuilder<'a> {
+impl CreateSubscriptionScheduleBuilder {
     fn new() -> Self {
         Self {
             customer: None,
@@ -233,8 +233,8 @@ impl<'a> CreateSubscriptionScheduleBuilder<'a> {
     }
 }
 /// Object representing the subscription schedule's default settings.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateSubscriptionScheduleDefaultSettings<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateSubscriptionScheduleDefaultSettings {
     /// A non-negative decimal between 0 and 100, with at most two decimal places.
     /// This represents the percentage of the subscription invoice total that will be transferred to the application owner's Stripe account.
     /// The request must be made by a platform account on a connected account in order to set an application fee percentage.
@@ -243,7 +243,7 @@ pub struct CreateSubscriptionScheduleDefaultSettings<'a> {
     pub application_fee_percent: Option<f64>,
     /// Default settings for automatic tax computation.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub automatic_tax: Option<CreateSubscriptionScheduleDefaultSettingsAutomaticTax<'a>>,
+    pub automatic_tax: Option<CreateSubscriptionScheduleDefaultSettingsAutomaticTax>,
     /// Can be set to `phase_start` to set the anchor to the start of the phase or `automatic` to automatically change it if needed.
     /// Cannot be set to `phase_start` if this phase specifies a trial.
     /// For more information, see the billing cycle [documentation](https://stripe.com/docs/billing/subscriptions/billing-cycle).
@@ -263,22 +263,22 @@ pub struct CreateSubscriptionScheduleDefaultSettings<'a> {
     /// It must belong to the customer associated with the subscription schedule.
     /// If not set, invoices will use the default payment method in the customer's invoice settings.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub default_payment_method: Option<&'a str>,
+    pub default_payment_method: Option<String>,
     /// Subscription description, meant to be displayable to the customer.
     /// Use this field to optionally store an explanation of the subscription for rendering in Stripe surfaces and certain local payment methods UIs.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<&'a str>,
+    pub description: Option<String>,
     /// All invoices will be billed using the specified settings.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub invoice_settings: Option<CreateSubscriptionScheduleDefaultSettingsInvoiceSettings<'a>>,
+    pub invoice_settings: Option<CreateSubscriptionScheduleDefaultSettingsInvoiceSettings>,
     /// The account on behalf of which to charge, for each of the associated subscription's invoices.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub on_behalf_of: Option<&'a str>,
+    pub on_behalf_of: Option<String>,
     /// The data with which to automatically create a Transfer for each of the associated subscription's invoices.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub transfer_data: Option<TransferDataSpecs<'a>>,
+    pub transfer_data: Option<TransferDataSpecs>,
 }
-impl<'a> CreateSubscriptionScheduleDefaultSettings<'a> {
+impl CreateSubscriptionScheduleDefaultSettings {
     pub fn new() -> Self {
         Self {
             application_fee_percent: None,
@@ -294,42 +294,44 @@ impl<'a> CreateSubscriptionScheduleDefaultSettings<'a> {
         }
     }
 }
-impl<'a> Default for CreateSubscriptionScheduleDefaultSettings<'a> {
+impl Default for CreateSubscriptionScheduleDefaultSettings {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Default settings for automatic tax computation.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateSubscriptionScheduleDefaultSettingsAutomaticTax<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateSubscriptionScheduleDefaultSettingsAutomaticTax {
     /// Enabled automatic tax calculation which will automatically compute tax rates on all invoices generated by the subscription.
     pub enabled: bool,
     /// The account that's liable for tax.
     /// If set, the business address and tax registrations required to perform the tax calculation are loaded from this account.
     /// The tax transaction is returned in the report of the connected account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub liability: Option<CreateSubscriptionScheduleDefaultSettingsAutomaticTaxLiability<'a>>,
+    pub liability: Option<CreateSubscriptionScheduleDefaultSettingsAutomaticTaxLiability>,
 }
-impl<'a> CreateSubscriptionScheduleDefaultSettingsAutomaticTax<'a> {
-    pub fn new(enabled: bool) -> Self {
-        Self { enabled, liability: None }
+impl CreateSubscriptionScheduleDefaultSettingsAutomaticTax {
+    pub fn new(enabled: impl Into<bool>) -> Self {
+        Self { enabled: enabled.into(), liability: None }
     }
 }
 /// The account that's liable for tax.
 /// If set, the business address and tax registrations required to perform the tax calculation are loaded from this account.
 /// The tax transaction is returned in the report of the connected account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateSubscriptionScheduleDefaultSettingsAutomaticTaxLiability<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateSubscriptionScheduleDefaultSettingsAutomaticTaxLiability {
     /// The connected account being referenced when `type` is `account`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account: Option<&'a str>,
+    pub account: Option<String>,
     /// Type of the account referenced in the request.
     #[serde(rename = "type")]
     pub type_: CreateSubscriptionScheduleDefaultSettingsAutomaticTaxLiabilityType,
 }
-impl<'a> CreateSubscriptionScheduleDefaultSettingsAutomaticTaxLiability<'a> {
-    pub fn new(type_: CreateSubscriptionScheduleDefaultSettingsAutomaticTaxLiabilityType) -> Self {
-        Self { account: None, type_ }
+impl CreateSubscriptionScheduleDefaultSettingsAutomaticTaxLiability {
+    pub fn new(
+        type_: impl Into<CreateSubscriptionScheduleDefaultSettingsAutomaticTaxLiabilityType>,
+    ) -> Self {
+        Self { account: None, type_: type_.into() }
     }
 }
 /// Type of the account referenced in the request.
@@ -510,12 +512,12 @@ impl<'de> serde::Deserialize<'de> for CreateSubscriptionScheduleDefaultSettingsC
     }
 }
 /// All invoices will be billed using the specified settings.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateSubscriptionScheduleDefaultSettingsInvoiceSettings<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateSubscriptionScheduleDefaultSettingsInvoiceSettings {
     /// The account tax IDs associated with the subscription schedule.
     /// Will be set on invoices generated by the subscription schedule.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account_tax_ids: Option<&'a [&'a str]>,
+    pub account_tax_ids: Option<Vec<String>>,
     /// Number of days within which a customer must pay invoices generated by this subscription schedule.
     /// This value will be `null` for subscription schedules where `collection_method=charge_automatically`.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -523,32 +525,34 @@ pub struct CreateSubscriptionScheduleDefaultSettingsInvoiceSettings<'a> {
     /// The connected account that issues the invoice.
     /// The invoice is presented with the branding and support information of the specified account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub issuer: Option<CreateSubscriptionScheduleDefaultSettingsInvoiceSettingsIssuer<'a>>,
+    pub issuer: Option<CreateSubscriptionScheduleDefaultSettingsInvoiceSettingsIssuer>,
 }
-impl<'a> CreateSubscriptionScheduleDefaultSettingsInvoiceSettings<'a> {
+impl CreateSubscriptionScheduleDefaultSettingsInvoiceSettings {
     pub fn new() -> Self {
         Self { account_tax_ids: None, days_until_due: None, issuer: None }
     }
 }
-impl<'a> Default for CreateSubscriptionScheduleDefaultSettingsInvoiceSettings<'a> {
+impl Default for CreateSubscriptionScheduleDefaultSettingsInvoiceSettings {
     fn default() -> Self {
         Self::new()
     }
 }
 /// The connected account that issues the invoice.
 /// The invoice is presented with the branding and support information of the specified account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateSubscriptionScheduleDefaultSettingsInvoiceSettingsIssuer<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateSubscriptionScheduleDefaultSettingsInvoiceSettingsIssuer {
     /// The connected account being referenced when `type` is `account`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account: Option<&'a str>,
+    pub account: Option<String>,
     /// Type of the account referenced in the request.
     #[serde(rename = "type")]
     pub type_: CreateSubscriptionScheduleDefaultSettingsInvoiceSettingsIssuerType,
 }
-impl<'a> CreateSubscriptionScheduleDefaultSettingsInvoiceSettingsIssuer<'a> {
-    pub fn new(type_: CreateSubscriptionScheduleDefaultSettingsInvoiceSettingsIssuerType) -> Self {
-        Self { account: None, type_ }
+impl CreateSubscriptionScheduleDefaultSettingsInvoiceSettingsIssuer {
+    pub fn new(
+        type_: impl Into<CreateSubscriptionScheduleDefaultSettingsInvoiceSettingsIssuerType>,
+    ) -> Self {
+        Self { account: None, type_: type_.into() }
     }
 }
 /// Type of the account referenced in the request.
@@ -610,12 +614,12 @@ impl<'de> serde::Deserialize<'de>
 /// List representing phases of the subscription schedule.
 /// Each phase can be customized to have different durations, plans, and coupons.
 /// If there are multiple phases, the `end_date` of one phase will always equal the `start_date` of the next phase.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateSubscriptionSchedulePhases<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateSubscriptionSchedulePhases {
     /// A list of prices and quantities that will generate invoice items appended to the next invoice for this phase.
     /// You may pass up to 20 items.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub add_invoice_items: Option<&'a [CreateSubscriptionSchedulePhasesAddInvoiceItems<'a>]>,
+    pub add_invoice_items: Option<Vec<CreateSubscriptionSchedulePhasesAddInvoiceItems>>,
     /// A non-negative decimal between 0 and 100, with at most two decimal places.
     /// This represents the percentage of the subscription invoice total that will be transferred to the application owner's Stripe account.
     /// The request must be made by a platform account on a connected account in order to set an application fee percentage.
@@ -624,7 +628,7 @@ pub struct CreateSubscriptionSchedulePhases<'a> {
     pub application_fee_percent: Option<f64>,
     /// Automatic tax settings for this phase.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub automatic_tax: Option<CreateSubscriptionSchedulePhasesAutomaticTax<'a>>,
+    pub automatic_tax: Option<CreateSubscriptionSchedulePhasesAutomaticTax>,
     /// Can be set to `phase_start` to set the anchor to the start of the phase or `automatic` to automatically change it if needed.
     /// Cannot be set to `phase_start` if this phase specifies a trial.
     /// For more information, see the billing cycle [documentation](https://stripe.com/docs/billing/subscriptions/billing-cycle).
@@ -644,7 +648,7 @@ pub struct CreateSubscriptionSchedulePhases<'a> {
     /// This field has been deprecated and will be removed in a future API version.
     /// Use `discounts` instead.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub coupon: Option<&'a str>,
+    pub coupon: Option<String>,
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     /// Must be a [supported currency](https://stripe.com/docs/currencies).
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -653,29 +657,29 @@ pub struct CreateSubscriptionSchedulePhases<'a> {
     /// It must belong to the customer associated with the subscription schedule.
     /// If not set, invoices will use the default payment method in the customer's invoice settings.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub default_payment_method: Option<&'a str>,
+    pub default_payment_method: Option<String>,
     /// A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids.
     /// These Tax Rates will set the Subscription's [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates), which means they will be the Invoice's [`default_tax_rates`](https://stripe.com/docs/api/invoices/create#create_invoice-default_tax_rates) for any Invoices issued by the Subscription during this Phase.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub default_tax_rates: Option<&'a [&'a str]>,
+    pub default_tax_rates: Option<Vec<String>>,
     /// Subscription description, meant to be displayable to the customer.
     /// Use this field to optionally store an explanation of the subscription for rendering in Stripe surfaces and certain local payment methods UIs.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<&'a str>,
+    pub description: Option<String>,
     /// The coupons to redeem into discounts for the schedule phase.
     /// If not specified, inherits the discount from the subscription's customer.
     /// Pass an empty string to avoid inheriting any discounts.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub discounts: Option<&'a [DiscountsDataParam<'a>]>,
+    pub discounts: Option<Vec<DiscountsDataParam>>,
     /// The date at which this phase of the subscription schedule ends.
     /// If set, `iterations` must not be set.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub end_date: Option<stripe_types::Timestamp>,
     /// All invoices will be billed using the specified settings.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub invoice_settings: Option<CreateSubscriptionSchedulePhasesInvoiceSettings<'a>>,
+    pub invoice_settings: Option<CreateSubscriptionSchedulePhasesInvoiceSettings>,
     /// List of configuration items, each with an attached price, to apply during this phase of the subscription schedule.
-    pub items: &'a [CreateSubscriptionSchedulePhasesItems<'a>],
+    pub items: Vec<CreateSubscriptionSchedulePhasesItems>,
     /// Integer representing the multiplier applied to the price interval.
     /// For example, `iterations=2` applied to a price with `interval=month` and `interval_count=3` results in a phase of duration `2 * 3 months = 6 months`.
     /// If set, `end_date` must not be set.
@@ -686,10 +690,10 @@ pub struct CreateSubscriptionSchedulePhases<'a> {
     /// Individual keys in the subscription's `metadata` can be unset by posting an empty value to them in the phase's `metadata`.
     /// To unset all keys in the subscription's `metadata`, update the subscription directly or unset every key individually from the phase's `metadata`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// The account on behalf of which to charge, for each of the associated subscription's invoices.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub on_behalf_of: Option<&'a str>,
+    pub on_behalf_of: Option<String>,
     /// Whether the subscription schedule will create [prorations](https://stripe.com/docs/billing/subscriptions/prorations) when transitioning to this phase.
     /// The default value is `create_prorations`.
     /// This setting controls prorations when a phase is started asynchronously and it is persisted as a field on the phase.
@@ -698,7 +702,7 @@ pub struct CreateSubscriptionSchedulePhases<'a> {
     pub proration_behavior: Option<CreateSubscriptionSchedulePhasesProrationBehavior>,
     /// The data with which to automatically create a Transfer for each of the associated subscription's invoices.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub transfer_data: Option<TransferDataSpecs<'a>>,
+    pub transfer_data: Option<TransferDataSpecs>,
     /// If set to true the entire phase is counted as a trial and the customer will not be charged for any fees.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub trial: Option<bool>,
@@ -707,8 +711,8 @@ pub struct CreateSubscriptionSchedulePhases<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub trial_end: Option<stripe_types::Timestamp>,
 }
-impl<'a> CreateSubscriptionSchedulePhases<'a> {
-    pub fn new(items: &'a [CreateSubscriptionSchedulePhasesItems<'a>]) -> Self {
+impl CreateSubscriptionSchedulePhases {
+    pub fn new(items: impl Into<Vec<CreateSubscriptionSchedulePhasesItems>>) -> Self {
         Self {
             add_invoice_items: None,
             application_fee_percent: None,
@@ -724,7 +728,7 @@ impl<'a> CreateSubscriptionSchedulePhases<'a> {
             discounts: None,
             end_date: None,
             invoice_settings: None,
-            items,
+            items: items.into(),
             iterations: None,
             metadata: None,
             on_behalf_of: None,
@@ -737,42 +741,42 @@ impl<'a> CreateSubscriptionSchedulePhases<'a> {
 }
 /// A list of prices and quantities that will generate invoice items appended to the next invoice for this phase.
 /// You may pass up to 20 items.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateSubscriptionSchedulePhasesAddInvoiceItems<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateSubscriptionSchedulePhasesAddInvoiceItems {
     /// The coupons to redeem into discounts for the item.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub discounts: Option<&'a [DiscountsDataParam<'a>]>,
+    pub discounts: Option<Vec<DiscountsDataParam>>,
     /// The ID of the price object.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price: Option<&'a str>,
+    pub price: Option<String>,
     /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price_data: Option<CreateSubscriptionSchedulePhasesAddInvoiceItemsPriceData<'a>>,
+    pub price_data: Option<CreateSubscriptionSchedulePhasesAddInvoiceItemsPriceData>,
     /// Quantity for this item. Defaults to 1.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub quantity: Option<u64>,
     /// The tax rates which apply to the item. When set, the `default_tax_rates` do not apply to this item.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_rates: Option<&'a [&'a str]>,
+    pub tax_rates: Option<Vec<String>>,
 }
-impl<'a> CreateSubscriptionSchedulePhasesAddInvoiceItems<'a> {
+impl CreateSubscriptionSchedulePhasesAddInvoiceItems {
     pub fn new() -> Self {
         Self { discounts: None, price: None, price_data: None, quantity: None, tax_rates: None }
     }
 }
-impl<'a> Default for CreateSubscriptionSchedulePhasesAddInvoiceItems<'a> {
+impl Default for CreateSubscriptionSchedulePhasesAddInvoiceItems {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateSubscriptionSchedulePhasesAddInvoiceItemsPriceData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateSubscriptionSchedulePhasesAddInvoiceItemsPriceData {
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     /// Must be a [supported currency](https://stripe.com/docs/currencies).
     pub currency: stripe_types::Currency,
     /// The ID of the product that this price will belong to.
-    pub product: &'a str,
+    pub product: String,
     /// Only required if a [default tax behavior](https://stripe.com/docs/tax/products-prices-tax-categories-tax-behavior#setting-a-default-tax-behavior-(recommended)) was not provided in the Stripe Tax settings.
     /// Specifies whether the price is considered inclusive of taxes or exclusive of taxes.
     /// One of `inclusive`, `exclusive`, or `unspecified`.
@@ -785,11 +789,17 @@ pub struct CreateSubscriptionSchedulePhasesAddInvoiceItemsPriceData<'a> {
     /// Same as `unit_amount`, but accepts a decimal value in cents (or local equivalent) with at most 12 decimal places.
     /// Only one of `unit_amount` and `unit_amount_decimal` can be set.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub unit_amount_decimal: Option<&'a str>,
+    pub unit_amount_decimal: Option<String>,
 }
-impl<'a> CreateSubscriptionSchedulePhasesAddInvoiceItemsPriceData<'a> {
-    pub fn new(currency: stripe_types::Currency, product: &'a str) -> Self {
-        Self { currency, product, tax_behavior: None, unit_amount: None, unit_amount_decimal: None }
+impl CreateSubscriptionSchedulePhasesAddInvoiceItemsPriceData {
+    pub fn new(currency: impl Into<stripe_types::Currency>, product: impl Into<String>) -> Self {
+        Self {
+            currency: currency.into(),
+            product: product.into(),
+            tax_behavior: None,
+            unit_amount: None,
+            unit_amount_decimal: None,
+        }
     }
 }
 /// Only required if a [default tax behavior](https://stripe.com/docs/tax/products-prices-tax-categories-tax-behavior#setting-a-default-tax-behavior-(recommended)) was not provided in the Stripe Tax settings.
@@ -855,36 +865,38 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// Automatic tax settings for this phase.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateSubscriptionSchedulePhasesAutomaticTax<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateSubscriptionSchedulePhasesAutomaticTax {
     /// Enabled automatic tax calculation which will automatically compute tax rates on all invoices generated by the subscription.
     pub enabled: bool,
     /// The account that's liable for tax.
     /// If set, the business address and tax registrations required to perform the tax calculation are loaded from this account.
     /// The tax transaction is returned in the report of the connected account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub liability: Option<CreateSubscriptionSchedulePhasesAutomaticTaxLiability<'a>>,
+    pub liability: Option<CreateSubscriptionSchedulePhasesAutomaticTaxLiability>,
 }
-impl<'a> CreateSubscriptionSchedulePhasesAutomaticTax<'a> {
-    pub fn new(enabled: bool) -> Self {
-        Self { enabled, liability: None }
+impl CreateSubscriptionSchedulePhasesAutomaticTax {
+    pub fn new(enabled: impl Into<bool>) -> Self {
+        Self { enabled: enabled.into(), liability: None }
     }
 }
 /// The account that's liable for tax.
 /// If set, the business address and tax registrations required to perform the tax calculation are loaded from this account.
 /// The tax transaction is returned in the report of the connected account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateSubscriptionSchedulePhasesAutomaticTaxLiability<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateSubscriptionSchedulePhasesAutomaticTaxLiability {
     /// The connected account being referenced when `type` is `account`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account: Option<&'a str>,
+    pub account: Option<String>,
     /// Type of the account referenced in the request.
     #[serde(rename = "type")]
     pub type_: CreateSubscriptionSchedulePhasesAutomaticTaxLiabilityType,
 }
-impl<'a> CreateSubscriptionSchedulePhasesAutomaticTaxLiability<'a> {
-    pub fn new(type_: CreateSubscriptionSchedulePhasesAutomaticTaxLiabilityType) -> Self {
-        Self { account: None, type_ }
+impl CreateSubscriptionSchedulePhasesAutomaticTaxLiability {
+    pub fn new(
+        type_: impl Into<CreateSubscriptionSchedulePhasesAutomaticTaxLiabilityType>,
+    ) -> Self {
+        Self { account: None, type_: type_.into() }
     }
 }
 /// Type of the account referenced in the request.
@@ -1067,12 +1079,12 @@ impl<'de> serde::Deserialize<'de> for CreateSubscriptionSchedulePhasesCollection
     }
 }
 /// All invoices will be billed using the specified settings.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateSubscriptionSchedulePhasesInvoiceSettings<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateSubscriptionSchedulePhasesInvoiceSettings {
     /// The account tax IDs associated with this phase of the subscription schedule.
     /// Will be set on invoices generated by this phase of the subscription schedule.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account_tax_ids: Option<&'a [&'a str]>,
+    pub account_tax_ids: Option<Vec<String>>,
     /// Number of days within which a customer must pay invoices generated by this subscription schedule.
     /// This value will be `null` for subscription schedules where `billing=charge_automatically`.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1080,32 +1092,34 @@ pub struct CreateSubscriptionSchedulePhasesInvoiceSettings<'a> {
     /// The connected account that issues the invoice.
     /// The invoice is presented with the branding and support information of the specified account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub issuer: Option<CreateSubscriptionSchedulePhasesInvoiceSettingsIssuer<'a>>,
+    pub issuer: Option<CreateSubscriptionSchedulePhasesInvoiceSettingsIssuer>,
 }
-impl<'a> CreateSubscriptionSchedulePhasesInvoiceSettings<'a> {
+impl CreateSubscriptionSchedulePhasesInvoiceSettings {
     pub fn new() -> Self {
         Self { account_tax_ids: None, days_until_due: None, issuer: None }
     }
 }
-impl<'a> Default for CreateSubscriptionSchedulePhasesInvoiceSettings<'a> {
+impl Default for CreateSubscriptionSchedulePhasesInvoiceSettings {
     fn default() -> Self {
         Self::new()
     }
 }
 /// The connected account that issues the invoice.
 /// The invoice is presented with the branding and support information of the specified account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateSubscriptionSchedulePhasesInvoiceSettingsIssuer<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateSubscriptionSchedulePhasesInvoiceSettingsIssuer {
     /// The connected account being referenced when `type` is `account`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account: Option<&'a str>,
+    pub account: Option<String>,
     /// Type of the account referenced in the request.
     #[serde(rename = "type")]
     pub type_: CreateSubscriptionSchedulePhasesInvoiceSettingsIssuerType,
 }
-impl<'a> CreateSubscriptionSchedulePhasesInvoiceSettingsIssuer<'a> {
-    pub fn new(type_: CreateSubscriptionSchedulePhasesInvoiceSettingsIssuerType) -> Self {
-        Self { account: None, type_ }
+impl CreateSubscriptionSchedulePhasesInvoiceSettingsIssuer {
+    pub fn new(
+        type_: impl Into<CreateSubscriptionSchedulePhasesInvoiceSettingsIssuerType>,
+    ) -> Self {
+        Self { account: None, type_: type_.into() }
     }
 }
 /// Type of the account referenced in the request.
@@ -1167,30 +1181,30 @@ impl<'de> serde::Deserialize<'de> for CreateSubscriptionSchedulePhasesInvoiceSet
     }
 }
 /// List of configuration items, each with an attached price, to apply during this phase of the subscription schedule.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateSubscriptionSchedulePhasesItems<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateSubscriptionSchedulePhasesItems {
     /// Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period.
     /// When updating, pass an empty string to remove previously-defined thresholds.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub billing_thresholds: Option<ItemBillingThresholdsParam>,
     /// The coupons to redeem into discounts for the subscription item.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub discounts: Option<&'a [DiscountsDataParam<'a>]>,
+    pub discounts: Option<Vec<DiscountsDataParam>>,
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to a configuration item.
     /// Metadata on a configuration item will update the underlying subscription item's `metadata` when the phase is entered, adding new keys and replacing existing keys.
     /// Individual keys in the subscription item's `metadata` can be unset by posting an empty value to them in the configuration item's `metadata`.
     /// To unset all keys in the subscription item's `metadata`, update the subscription item directly or unset every key individually from the configuration item's `metadata`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// The plan ID to subscribe to. You may specify the same ID in `plan` and `price`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub plan: Option<&'a str>,
+    pub plan: Option<String>,
     /// The ID of the price object.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price: Option<&'a str>,
+    pub price: Option<String>,
     /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price_data: Option<CreateSubscriptionSchedulePhasesItemsPriceData<'a>>,
+    pub price_data: Option<CreateSubscriptionSchedulePhasesItemsPriceData>,
     /// Quantity for the given price.
     /// Can be set only if the price's `usage_type` is `licensed` and not `metered`.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1199,9 +1213,9 @@ pub struct CreateSubscriptionSchedulePhasesItems<'a> {
     /// These Tax Rates will override the [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates) on the Subscription.
     /// When updating, pass an empty string to remove previously-defined tax rates.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_rates: Option<&'a [&'a str]>,
+    pub tax_rates: Option<Vec<String>>,
 }
-impl<'a> CreateSubscriptionSchedulePhasesItems<'a> {
+impl CreateSubscriptionSchedulePhasesItems {
     pub fn new() -> Self {
         Self {
             billing_thresholds: None,
@@ -1215,19 +1229,19 @@ impl<'a> CreateSubscriptionSchedulePhasesItems<'a> {
         }
     }
 }
-impl<'a> Default for CreateSubscriptionSchedulePhasesItems<'a> {
+impl Default for CreateSubscriptionSchedulePhasesItems {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateSubscriptionSchedulePhasesItemsPriceData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateSubscriptionSchedulePhasesItemsPriceData {
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     /// Must be a [supported currency](https://stripe.com/docs/currencies).
     pub currency: stripe_types::Currency,
     /// The ID of the product that this price will belong to.
-    pub product: &'a str,
+    pub product: String,
     /// The recurring components of a price such as `interval` and `interval_count`.
     pub recurring: CreateSubscriptionSchedulePhasesItemsPriceDataRecurring,
     /// Only required if a [default tax behavior](https://stripe.com/docs/tax/products-prices-tax-categories-tax-behavior#setting-a-default-tax-behavior-(recommended)) was not provided in the Stripe Tax settings.
@@ -1242,18 +1256,18 @@ pub struct CreateSubscriptionSchedulePhasesItemsPriceData<'a> {
     /// Same as `unit_amount`, but accepts a decimal value in cents (or local equivalent) with at most 12 decimal places.
     /// Only one of `unit_amount` and `unit_amount_decimal` can be set.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub unit_amount_decimal: Option<&'a str>,
+    pub unit_amount_decimal: Option<String>,
 }
-impl<'a> CreateSubscriptionSchedulePhasesItemsPriceData<'a> {
+impl CreateSubscriptionSchedulePhasesItemsPriceData {
     pub fn new(
-        currency: stripe_types::Currency,
-        product: &'a str,
-        recurring: CreateSubscriptionSchedulePhasesItemsPriceDataRecurring,
+        currency: impl Into<stripe_types::Currency>,
+        product: impl Into<String>,
+        recurring: impl Into<CreateSubscriptionSchedulePhasesItemsPriceDataRecurring>,
     ) -> Self {
         Self {
-            currency,
-            product,
-            recurring,
+            currency: currency.into(),
+            product: product.into(),
+            recurring: recurring.into(),
             tax_behavior: None,
             unit_amount: None,
             unit_amount_decimal: None,
@@ -1272,8 +1286,10 @@ pub struct CreateSubscriptionSchedulePhasesItemsPriceDataRecurring {
     pub interval_count: Option<u64>,
 }
 impl CreateSubscriptionSchedulePhasesItemsPriceDataRecurring {
-    pub fn new(interval: CreateSubscriptionSchedulePhasesItemsPriceDataRecurringInterval) -> Self {
-        Self { interval, interval_count: None }
+    pub fn new(
+        interval: impl Into<CreateSubscriptionSchedulePhasesItemsPriceDataRecurringInterval>,
+    ) -> Self {
+        Self { interval: interval.into(), interval_count: None }
     }
 }
 /// Specifies billing frequency. Either `day`, `week`, `month` or `year`.
@@ -1483,25 +1499,25 @@ pub enum CreateSubscriptionScheduleStartDate {
 /// Creates a new subscription schedule object.
 /// Each customer can have up to 500 active or scheduled subscriptions.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateSubscriptionSchedule<'a> {
-    inner: CreateSubscriptionScheduleBuilder<'a>,
+pub struct CreateSubscriptionSchedule {
+    inner: CreateSubscriptionScheduleBuilder,
 }
-impl<'a> CreateSubscriptionSchedule<'a> {
+impl CreateSubscriptionSchedule {
     /// Construct a new `CreateSubscriptionSchedule`.
     pub fn new() -> Self {
         Self { inner: CreateSubscriptionScheduleBuilder::new() }
     }
     /// The identifier of the customer to create the subscription schedule for.
-    pub fn customer(mut self, customer: &'a str) -> Self {
-        self.inner.customer = Some(customer);
+    pub fn customer(mut self, customer: impl Into<String>) -> Self {
+        self.inner.customer = Some(customer.into());
         self
     }
     /// Object representing the subscription schedule's default settings.
     pub fn default_settings(
         mut self,
-        default_settings: CreateSubscriptionScheduleDefaultSettings<'a>,
+        default_settings: impl Into<CreateSubscriptionScheduleDefaultSettings>,
     ) -> Self {
-        self.inner.default_settings = Some(default_settings);
+        self.inner.default_settings = Some(default_settings.into());
         self
     }
     /// Behavior of the subscription schedule and underlying subscription when it ends.
@@ -1510,53 +1526,59 @@ impl<'a> CreateSubscriptionSchedule<'a> {
     /// `cancel` will end the subscription schedule and cancel the underlying subscription.
     pub fn end_behavior(
         mut self,
-        end_behavior: stripe_shared::SubscriptionScheduleEndBehavior,
+        end_behavior: impl Into<stripe_shared::SubscriptionScheduleEndBehavior>,
     ) -> Self {
-        self.inner.end_behavior = Some(end_behavior);
+        self.inner.end_behavior = Some(end_behavior.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Migrate an existing subscription to be managed by a subscription schedule.
     /// If this parameter is set, a subscription schedule will be created using the subscription's item(s), set to auto-renew using the subscription's interval.
     /// When using this parameter, other parameters (such as phase values) cannot be set.
     /// To create a subscription schedule with other modifications, we recommend making two separate API calls.
-    pub fn from_subscription(mut self, from_subscription: &'a str) -> Self {
-        self.inner.from_subscription = Some(from_subscription);
+    pub fn from_subscription(mut self, from_subscription: impl Into<String>) -> Self {
+        self.inner.from_subscription = Some(from_subscription.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// List representing phases of the subscription schedule.
     /// Each phase can be customized to have different durations, plans, and coupons.
     /// If there are multiple phases, the `end_date` of one phase will always equal the `start_date` of the next phase.
-    pub fn phases(mut self, phases: &'a [CreateSubscriptionSchedulePhases<'a>]) -> Self {
-        self.inner.phases = Some(phases);
+    pub fn phases(mut self, phases: impl Into<Vec<CreateSubscriptionSchedulePhases>>) -> Self {
+        self.inner.phases = Some(phases.into());
         self
     }
     /// When the subscription schedule starts.
     /// We recommend using `now` so that it starts the subscription immediately.
     /// You can also use a Unix timestamp to backdate the subscription so that it starts on a past date, or set a future date for the subscription to start on.
-    pub fn start_date(mut self, start_date: CreateSubscriptionScheduleStartDate) -> Self {
-        self.inner.start_date = Some(start_date);
+    pub fn start_date(
+        mut self,
+        start_date: impl Into<CreateSubscriptionScheduleStartDate>,
+    ) -> Self {
+        self.inner.start_date = Some(start_date.into());
         self
     }
 }
-impl<'a> Default for CreateSubscriptionSchedule<'a> {
+impl Default for CreateSubscriptionSchedule {
     fn default() -> Self {
         Self::new()
     }
 }
-impl CreateSubscriptionSchedule<'_> {
+impl CreateSubscriptionSchedule {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -1574,29 +1596,29 @@ impl CreateSubscriptionSchedule<'_> {
     }
 }
 
-impl StripeRequest for CreateSubscriptionSchedule<'_> {
+impl StripeRequest for CreateSubscriptionSchedule {
     type Output = stripe_shared::SubscriptionSchedule;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Post, "/subscription_schedules").form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdateSubscriptionScheduleBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdateSubscriptionScheduleBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    default_settings: Option<UpdateSubscriptionScheduleDefaultSettings<'a>>,
+    default_settings: Option<UpdateSubscriptionScheduleDefaultSettings>,
     #[serde(skip_serializing_if = "Option::is_none")]
     end_behavior: Option<stripe_shared::SubscriptionScheduleEndBehavior>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    phases: Option<&'a [UpdateSubscriptionSchedulePhases<'a>]>,
+    phases: Option<Vec<UpdateSubscriptionSchedulePhases>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     proration_behavior: Option<UpdateSubscriptionScheduleProrationBehavior>,
 }
-impl<'a> UpdateSubscriptionScheduleBuilder<'a> {
+impl UpdateSubscriptionScheduleBuilder {
     fn new() -> Self {
         Self {
             default_settings: None,
@@ -1609,8 +1631,8 @@ impl<'a> UpdateSubscriptionScheduleBuilder<'a> {
     }
 }
 /// Object representing the subscription schedule's default settings.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateSubscriptionScheduleDefaultSettings<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateSubscriptionScheduleDefaultSettings {
     /// A non-negative decimal between 0 and 100, with at most two decimal places.
     /// This represents the percentage of the subscription invoice total that will be transferred to the application owner's Stripe account.
     /// The request must be made by a platform account on a connected account in order to set an application fee percentage.
@@ -1619,7 +1641,7 @@ pub struct UpdateSubscriptionScheduleDefaultSettings<'a> {
     pub application_fee_percent: Option<f64>,
     /// Default settings for automatic tax computation.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub automatic_tax: Option<UpdateSubscriptionScheduleDefaultSettingsAutomaticTax<'a>>,
+    pub automatic_tax: Option<UpdateSubscriptionScheduleDefaultSettingsAutomaticTax>,
     /// Can be set to `phase_start` to set the anchor to the start of the phase or `automatic` to automatically change it if needed.
     /// Cannot be set to `phase_start` if this phase specifies a trial.
     /// For more information, see the billing cycle [documentation](https://stripe.com/docs/billing/subscriptions/billing-cycle).
@@ -1639,22 +1661,22 @@ pub struct UpdateSubscriptionScheduleDefaultSettings<'a> {
     /// It must belong to the customer associated with the subscription schedule.
     /// If not set, invoices will use the default payment method in the customer's invoice settings.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub default_payment_method: Option<&'a str>,
+    pub default_payment_method: Option<String>,
     /// Subscription description, meant to be displayable to the customer.
     /// Use this field to optionally store an explanation of the subscription for rendering in Stripe surfaces and certain local payment methods UIs.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<&'a str>,
+    pub description: Option<String>,
     /// All invoices will be billed using the specified settings.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub invoice_settings: Option<UpdateSubscriptionScheduleDefaultSettingsInvoiceSettings<'a>>,
+    pub invoice_settings: Option<UpdateSubscriptionScheduleDefaultSettingsInvoiceSettings>,
     /// The account on behalf of which to charge, for each of the associated subscription's invoices.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub on_behalf_of: Option<&'a str>,
+    pub on_behalf_of: Option<String>,
     /// The data with which to automatically create a Transfer for each of the associated subscription's invoices.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub transfer_data: Option<TransferDataSpecs<'a>>,
+    pub transfer_data: Option<TransferDataSpecs>,
 }
-impl<'a> UpdateSubscriptionScheduleDefaultSettings<'a> {
+impl UpdateSubscriptionScheduleDefaultSettings {
     pub fn new() -> Self {
         Self {
             application_fee_percent: None,
@@ -1670,42 +1692,44 @@ impl<'a> UpdateSubscriptionScheduleDefaultSettings<'a> {
         }
     }
 }
-impl<'a> Default for UpdateSubscriptionScheduleDefaultSettings<'a> {
+impl Default for UpdateSubscriptionScheduleDefaultSettings {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Default settings for automatic tax computation.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateSubscriptionScheduleDefaultSettingsAutomaticTax<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateSubscriptionScheduleDefaultSettingsAutomaticTax {
     /// Enabled automatic tax calculation which will automatically compute tax rates on all invoices generated by the subscription.
     pub enabled: bool,
     /// The account that's liable for tax.
     /// If set, the business address and tax registrations required to perform the tax calculation are loaded from this account.
     /// The tax transaction is returned in the report of the connected account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub liability: Option<UpdateSubscriptionScheduleDefaultSettingsAutomaticTaxLiability<'a>>,
+    pub liability: Option<UpdateSubscriptionScheduleDefaultSettingsAutomaticTaxLiability>,
 }
-impl<'a> UpdateSubscriptionScheduleDefaultSettingsAutomaticTax<'a> {
-    pub fn new(enabled: bool) -> Self {
-        Self { enabled, liability: None }
+impl UpdateSubscriptionScheduleDefaultSettingsAutomaticTax {
+    pub fn new(enabled: impl Into<bool>) -> Self {
+        Self { enabled: enabled.into(), liability: None }
     }
 }
 /// The account that's liable for tax.
 /// If set, the business address and tax registrations required to perform the tax calculation are loaded from this account.
 /// The tax transaction is returned in the report of the connected account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateSubscriptionScheduleDefaultSettingsAutomaticTaxLiability<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateSubscriptionScheduleDefaultSettingsAutomaticTaxLiability {
     /// The connected account being referenced when `type` is `account`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account: Option<&'a str>,
+    pub account: Option<String>,
     /// Type of the account referenced in the request.
     #[serde(rename = "type")]
     pub type_: UpdateSubscriptionScheduleDefaultSettingsAutomaticTaxLiabilityType,
 }
-impl<'a> UpdateSubscriptionScheduleDefaultSettingsAutomaticTaxLiability<'a> {
-    pub fn new(type_: UpdateSubscriptionScheduleDefaultSettingsAutomaticTaxLiabilityType) -> Self {
-        Self { account: None, type_ }
+impl UpdateSubscriptionScheduleDefaultSettingsAutomaticTaxLiability {
+    pub fn new(
+        type_: impl Into<UpdateSubscriptionScheduleDefaultSettingsAutomaticTaxLiabilityType>,
+    ) -> Self {
+        Self { account: None, type_: type_.into() }
     }
 }
 /// Type of the account referenced in the request.
@@ -1886,12 +1910,12 @@ impl<'de> serde::Deserialize<'de> for UpdateSubscriptionScheduleDefaultSettingsC
     }
 }
 /// All invoices will be billed using the specified settings.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateSubscriptionScheduleDefaultSettingsInvoiceSettings<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateSubscriptionScheduleDefaultSettingsInvoiceSettings {
     /// The account tax IDs associated with the subscription schedule.
     /// Will be set on invoices generated by the subscription schedule.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account_tax_ids: Option<&'a [&'a str]>,
+    pub account_tax_ids: Option<Vec<String>>,
     /// Number of days within which a customer must pay invoices generated by this subscription schedule.
     /// This value will be `null` for subscription schedules where `collection_method=charge_automatically`.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1899,32 +1923,34 @@ pub struct UpdateSubscriptionScheduleDefaultSettingsInvoiceSettings<'a> {
     /// The connected account that issues the invoice.
     /// The invoice is presented with the branding and support information of the specified account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub issuer: Option<UpdateSubscriptionScheduleDefaultSettingsInvoiceSettingsIssuer<'a>>,
+    pub issuer: Option<UpdateSubscriptionScheduleDefaultSettingsInvoiceSettingsIssuer>,
 }
-impl<'a> UpdateSubscriptionScheduleDefaultSettingsInvoiceSettings<'a> {
+impl UpdateSubscriptionScheduleDefaultSettingsInvoiceSettings {
     pub fn new() -> Self {
         Self { account_tax_ids: None, days_until_due: None, issuer: None }
     }
 }
-impl<'a> Default for UpdateSubscriptionScheduleDefaultSettingsInvoiceSettings<'a> {
+impl Default for UpdateSubscriptionScheduleDefaultSettingsInvoiceSettings {
     fn default() -> Self {
         Self::new()
     }
 }
 /// The connected account that issues the invoice.
 /// The invoice is presented with the branding and support information of the specified account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateSubscriptionScheduleDefaultSettingsInvoiceSettingsIssuer<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateSubscriptionScheduleDefaultSettingsInvoiceSettingsIssuer {
     /// The connected account being referenced when `type` is `account`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account: Option<&'a str>,
+    pub account: Option<String>,
     /// Type of the account referenced in the request.
     #[serde(rename = "type")]
     pub type_: UpdateSubscriptionScheduleDefaultSettingsInvoiceSettingsIssuerType,
 }
-impl<'a> UpdateSubscriptionScheduleDefaultSettingsInvoiceSettingsIssuer<'a> {
-    pub fn new(type_: UpdateSubscriptionScheduleDefaultSettingsInvoiceSettingsIssuerType) -> Self {
-        Self { account: None, type_ }
+impl UpdateSubscriptionScheduleDefaultSettingsInvoiceSettingsIssuer {
+    pub fn new(
+        type_: impl Into<UpdateSubscriptionScheduleDefaultSettingsInvoiceSettingsIssuerType>,
+    ) -> Self {
+        Self { account: None, type_: type_.into() }
     }
 }
 /// Type of the account referenced in the request.
@@ -1987,12 +2013,12 @@ impl<'de> serde::Deserialize<'de>
 /// Each phase can be customized to have different durations, plans, and coupons.
 /// If there are multiple phases, the `end_date` of one phase will always equal the `start_date` of the next phase.
 /// Note that past phases can be omitted.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateSubscriptionSchedulePhases<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateSubscriptionSchedulePhases {
     /// A list of prices and quantities that will generate invoice items appended to the next invoice for this phase.
     /// You may pass up to 20 items.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub add_invoice_items: Option<&'a [UpdateSubscriptionSchedulePhasesAddInvoiceItems<'a>]>,
+    pub add_invoice_items: Option<Vec<UpdateSubscriptionSchedulePhasesAddInvoiceItems>>,
     /// A non-negative decimal between 0 and 100, with at most two decimal places.
     /// This represents the percentage of the subscription invoice total that will be transferred to the application owner's Stripe account.
     /// The request must be made by a platform account on a connected account in order to set an application fee percentage.
@@ -2001,7 +2027,7 @@ pub struct UpdateSubscriptionSchedulePhases<'a> {
     pub application_fee_percent: Option<f64>,
     /// Automatic tax settings for this phase.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub automatic_tax: Option<UpdateSubscriptionSchedulePhasesAutomaticTax<'a>>,
+    pub automatic_tax: Option<UpdateSubscriptionSchedulePhasesAutomaticTax>,
     /// Can be set to `phase_start` to set the anchor to the start of the phase or `automatic` to automatically change it if needed.
     /// Cannot be set to `phase_start` if this phase specifies a trial.
     /// For more information, see the billing cycle [documentation](https://stripe.com/docs/billing/subscriptions/billing-cycle).
@@ -2021,7 +2047,7 @@ pub struct UpdateSubscriptionSchedulePhases<'a> {
     /// This field has been deprecated and will be removed in a future API version.
     /// Use `discounts` instead.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub coupon: Option<&'a str>,
+    pub coupon: Option<String>,
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     /// Must be a [supported currency](https://stripe.com/docs/currencies).
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2030,29 +2056,29 @@ pub struct UpdateSubscriptionSchedulePhases<'a> {
     /// It must belong to the customer associated with the subscription schedule.
     /// If not set, invoices will use the default payment method in the customer's invoice settings.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub default_payment_method: Option<&'a str>,
+    pub default_payment_method: Option<String>,
     /// A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids.
     /// These Tax Rates will set the Subscription's [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates), which means they will be the Invoice's [`default_tax_rates`](https://stripe.com/docs/api/invoices/create#create_invoice-default_tax_rates) for any Invoices issued by the Subscription during this Phase.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub default_tax_rates: Option<&'a [&'a str]>,
+    pub default_tax_rates: Option<Vec<String>>,
     /// Subscription description, meant to be displayable to the customer.
     /// Use this field to optionally store an explanation of the subscription for rendering in Stripe surfaces and certain local payment methods UIs.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<&'a str>,
+    pub description: Option<String>,
     /// The coupons to redeem into discounts for the schedule phase.
     /// If not specified, inherits the discount from the subscription's customer.
     /// Pass an empty string to avoid inheriting any discounts.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub discounts: Option<&'a [DiscountsDataParam<'a>]>,
+    pub discounts: Option<Vec<DiscountsDataParam>>,
     /// The date at which this phase of the subscription schedule ends.
     /// If set, `iterations` must not be set.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub end_date: Option<UpdateSubscriptionSchedulePhasesEndDate>,
     /// All invoices will be billed using the specified settings.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub invoice_settings: Option<UpdateSubscriptionSchedulePhasesInvoiceSettings<'a>>,
+    pub invoice_settings: Option<UpdateSubscriptionSchedulePhasesInvoiceSettings>,
     /// List of configuration items, each with an attached price, to apply during this phase of the subscription schedule.
-    pub items: &'a [UpdateSubscriptionSchedulePhasesItems<'a>],
+    pub items: Vec<UpdateSubscriptionSchedulePhasesItems>,
     /// Integer representing the multiplier applied to the price interval.
     /// For example, `iterations=2` applied to a price with `interval=month` and `interval_count=3` results in a phase of duration `2 * 3 months = 6 months`.
     /// If set, `end_date` must not be set.
@@ -2063,10 +2089,10 @@ pub struct UpdateSubscriptionSchedulePhases<'a> {
     /// Individual keys in the subscription's `metadata` can be unset by posting an empty value to them in the phase's `metadata`.
     /// To unset all keys in the subscription's `metadata`, update the subscription directly or unset every key individually from the phase's `metadata`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// The account on behalf of which to charge, for each of the associated subscription's invoices.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub on_behalf_of: Option<&'a str>,
+    pub on_behalf_of: Option<String>,
     /// Whether the subscription schedule will create [prorations](https://stripe.com/docs/billing/subscriptions/prorations) when transitioning to this phase.
     /// The default value is `create_prorations`.
     /// This setting controls prorations when a phase is started asynchronously and it is persisted as a field on the phase.
@@ -2079,7 +2105,7 @@ pub struct UpdateSubscriptionSchedulePhases<'a> {
     pub start_date: Option<UpdateSubscriptionSchedulePhasesStartDate>,
     /// The data with which to automatically create a Transfer for each of the associated subscription's invoices.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub transfer_data: Option<TransferDataSpecs<'a>>,
+    pub transfer_data: Option<TransferDataSpecs>,
     /// If set to true the entire phase is counted as a trial and the customer will not be charged for any fees.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub trial: Option<bool>,
@@ -2088,8 +2114,8 @@ pub struct UpdateSubscriptionSchedulePhases<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub trial_end: Option<UpdateSubscriptionSchedulePhasesTrialEnd>,
 }
-impl<'a> UpdateSubscriptionSchedulePhases<'a> {
-    pub fn new(items: &'a [UpdateSubscriptionSchedulePhasesItems<'a>]) -> Self {
+impl UpdateSubscriptionSchedulePhases {
+    pub fn new(items: impl Into<Vec<UpdateSubscriptionSchedulePhasesItems>>) -> Self {
         Self {
             add_invoice_items: None,
             application_fee_percent: None,
@@ -2105,7 +2131,7 @@ impl<'a> UpdateSubscriptionSchedulePhases<'a> {
             discounts: None,
             end_date: None,
             invoice_settings: None,
-            items,
+            items: items.into(),
             iterations: None,
             metadata: None,
             on_behalf_of: None,
@@ -2119,42 +2145,42 @@ impl<'a> UpdateSubscriptionSchedulePhases<'a> {
 }
 /// A list of prices and quantities that will generate invoice items appended to the next invoice for this phase.
 /// You may pass up to 20 items.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateSubscriptionSchedulePhasesAddInvoiceItems<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateSubscriptionSchedulePhasesAddInvoiceItems {
     /// The coupons to redeem into discounts for the item.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub discounts: Option<&'a [DiscountsDataParam<'a>]>,
+    pub discounts: Option<Vec<DiscountsDataParam>>,
     /// The ID of the price object.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price: Option<&'a str>,
+    pub price: Option<String>,
     /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price_data: Option<UpdateSubscriptionSchedulePhasesAddInvoiceItemsPriceData<'a>>,
+    pub price_data: Option<UpdateSubscriptionSchedulePhasesAddInvoiceItemsPriceData>,
     /// Quantity for this item. Defaults to 1.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub quantity: Option<u64>,
     /// The tax rates which apply to the item. When set, the `default_tax_rates` do not apply to this item.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_rates: Option<&'a [&'a str]>,
+    pub tax_rates: Option<Vec<String>>,
 }
-impl<'a> UpdateSubscriptionSchedulePhasesAddInvoiceItems<'a> {
+impl UpdateSubscriptionSchedulePhasesAddInvoiceItems {
     pub fn new() -> Self {
         Self { discounts: None, price: None, price_data: None, quantity: None, tax_rates: None }
     }
 }
-impl<'a> Default for UpdateSubscriptionSchedulePhasesAddInvoiceItems<'a> {
+impl Default for UpdateSubscriptionSchedulePhasesAddInvoiceItems {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateSubscriptionSchedulePhasesAddInvoiceItemsPriceData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateSubscriptionSchedulePhasesAddInvoiceItemsPriceData {
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     /// Must be a [supported currency](https://stripe.com/docs/currencies).
     pub currency: stripe_types::Currency,
     /// The ID of the product that this price will belong to.
-    pub product: &'a str,
+    pub product: String,
     /// Only required if a [default tax behavior](https://stripe.com/docs/tax/products-prices-tax-categories-tax-behavior#setting-a-default-tax-behavior-(recommended)) was not provided in the Stripe Tax settings.
     /// Specifies whether the price is considered inclusive of taxes or exclusive of taxes.
     /// One of `inclusive`, `exclusive`, or `unspecified`.
@@ -2167,11 +2193,17 @@ pub struct UpdateSubscriptionSchedulePhasesAddInvoiceItemsPriceData<'a> {
     /// Same as `unit_amount`, but accepts a decimal value in cents (or local equivalent) with at most 12 decimal places.
     /// Only one of `unit_amount` and `unit_amount_decimal` can be set.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub unit_amount_decimal: Option<&'a str>,
+    pub unit_amount_decimal: Option<String>,
 }
-impl<'a> UpdateSubscriptionSchedulePhasesAddInvoiceItemsPriceData<'a> {
-    pub fn new(currency: stripe_types::Currency, product: &'a str) -> Self {
-        Self { currency, product, tax_behavior: None, unit_amount: None, unit_amount_decimal: None }
+impl UpdateSubscriptionSchedulePhasesAddInvoiceItemsPriceData {
+    pub fn new(currency: impl Into<stripe_types::Currency>, product: impl Into<String>) -> Self {
+        Self {
+            currency: currency.into(),
+            product: product.into(),
+            tax_behavior: None,
+            unit_amount: None,
+            unit_amount_decimal: None,
+        }
     }
 }
 /// Only required if a [default tax behavior](https://stripe.com/docs/tax/products-prices-tax-categories-tax-behavior#setting-a-default-tax-behavior-(recommended)) was not provided in the Stripe Tax settings.
@@ -2237,36 +2269,38 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// Automatic tax settings for this phase.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateSubscriptionSchedulePhasesAutomaticTax<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateSubscriptionSchedulePhasesAutomaticTax {
     /// Enabled automatic tax calculation which will automatically compute tax rates on all invoices generated by the subscription.
     pub enabled: bool,
     /// The account that's liable for tax.
     /// If set, the business address and tax registrations required to perform the tax calculation are loaded from this account.
     /// The tax transaction is returned in the report of the connected account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub liability: Option<UpdateSubscriptionSchedulePhasesAutomaticTaxLiability<'a>>,
+    pub liability: Option<UpdateSubscriptionSchedulePhasesAutomaticTaxLiability>,
 }
-impl<'a> UpdateSubscriptionSchedulePhasesAutomaticTax<'a> {
-    pub fn new(enabled: bool) -> Self {
-        Self { enabled, liability: None }
+impl UpdateSubscriptionSchedulePhasesAutomaticTax {
+    pub fn new(enabled: impl Into<bool>) -> Self {
+        Self { enabled: enabled.into(), liability: None }
     }
 }
 /// The account that's liable for tax.
 /// If set, the business address and tax registrations required to perform the tax calculation are loaded from this account.
 /// The tax transaction is returned in the report of the connected account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateSubscriptionSchedulePhasesAutomaticTaxLiability<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateSubscriptionSchedulePhasesAutomaticTaxLiability {
     /// The connected account being referenced when `type` is `account`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account: Option<&'a str>,
+    pub account: Option<String>,
     /// Type of the account referenced in the request.
     #[serde(rename = "type")]
     pub type_: UpdateSubscriptionSchedulePhasesAutomaticTaxLiabilityType,
 }
-impl<'a> UpdateSubscriptionSchedulePhasesAutomaticTaxLiability<'a> {
-    pub fn new(type_: UpdateSubscriptionSchedulePhasesAutomaticTaxLiabilityType) -> Self {
-        Self { account: None, type_ }
+impl UpdateSubscriptionSchedulePhasesAutomaticTaxLiability {
+    pub fn new(
+        type_: impl Into<UpdateSubscriptionSchedulePhasesAutomaticTaxLiabilityType>,
+    ) -> Self {
+        Self { account: None, type_: type_.into() }
     }
 }
 /// Type of the account referenced in the request.
@@ -2458,12 +2492,12 @@ pub enum UpdateSubscriptionSchedulePhasesEndDate {
     Timestamp(stripe_types::Timestamp),
 }
 /// All invoices will be billed using the specified settings.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateSubscriptionSchedulePhasesInvoiceSettings<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateSubscriptionSchedulePhasesInvoiceSettings {
     /// The account tax IDs associated with this phase of the subscription schedule.
     /// Will be set on invoices generated by this phase of the subscription schedule.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account_tax_ids: Option<&'a [&'a str]>,
+    pub account_tax_ids: Option<Vec<String>>,
     /// Number of days within which a customer must pay invoices generated by this subscription schedule.
     /// This value will be `null` for subscription schedules where `billing=charge_automatically`.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2471,32 +2505,34 @@ pub struct UpdateSubscriptionSchedulePhasesInvoiceSettings<'a> {
     /// The connected account that issues the invoice.
     /// The invoice is presented with the branding and support information of the specified account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub issuer: Option<UpdateSubscriptionSchedulePhasesInvoiceSettingsIssuer<'a>>,
+    pub issuer: Option<UpdateSubscriptionSchedulePhasesInvoiceSettingsIssuer>,
 }
-impl<'a> UpdateSubscriptionSchedulePhasesInvoiceSettings<'a> {
+impl UpdateSubscriptionSchedulePhasesInvoiceSettings {
     pub fn new() -> Self {
         Self { account_tax_ids: None, days_until_due: None, issuer: None }
     }
 }
-impl<'a> Default for UpdateSubscriptionSchedulePhasesInvoiceSettings<'a> {
+impl Default for UpdateSubscriptionSchedulePhasesInvoiceSettings {
     fn default() -> Self {
         Self::new()
     }
 }
 /// The connected account that issues the invoice.
 /// The invoice is presented with the branding and support information of the specified account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateSubscriptionSchedulePhasesInvoiceSettingsIssuer<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateSubscriptionSchedulePhasesInvoiceSettingsIssuer {
     /// The connected account being referenced when `type` is `account`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account: Option<&'a str>,
+    pub account: Option<String>,
     /// Type of the account referenced in the request.
     #[serde(rename = "type")]
     pub type_: UpdateSubscriptionSchedulePhasesInvoiceSettingsIssuerType,
 }
-impl<'a> UpdateSubscriptionSchedulePhasesInvoiceSettingsIssuer<'a> {
-    pub fn new(type_: UpdateSubscriptionSchedulePhasesInvoiceSettingsIssuerType) -> Self {
-        Self { account: None, type_ }
+impl UpdateSubscriptionSchedulePhasesInvoiceSettingsIssuer {
+    pub fn new(
+        type_: impl Into<UpdateSubscriptionSchedulePhasesInvoiceSettingsIssuerType>,
+    ) -> Self {
+        Self { account: None, type_: type_.into() }
     }
 }
 /// Type of the account referenced in the request.
@@ -2558,30 +2594,30 @@ impl<'de> serde::Deserialize<'de> for UpdateSubscriptionSchedulePhasesInvoiceSet
     }
 }
 /// List of configuration items, each with an attached price, to apply during this phase of the subscription schedule.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateSubscriptionSchedulePhasesItems<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateSubscriptionSchedulePhasesItems {
     /// Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period.
     /// When updating, pass an empty string to remove previously-defined thresholds.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub billing_thresholds: Option<ItemBillingThresholdsParam>,
     /// The coupons to redeem into discounts for the subscription item.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub discounts: Option<&'a [DiscountsDataParam<'a>]>,
+    pub discounts: Option<Vec<DiscountsDataParam>>,
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to a configuration item.
     /// Metadata on a configuration item will update the underlying subscription item's `metadata` when the phase is entered, adding new keys and replacing existing keys.
     /// Individual keys in the subscription item's `metadata` can be unset by posting an empty value to them in the configuration item's `metadata`.
     /// To unset all keys in the subscription item's `metadata`, update the subscription item directly or unset every key individually from the configuration item's `metadata`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// The plan ID to subscribe to. You may specify the same ID in `plan` and `price`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub plan: Option<&'a str>,
+    pub plan: Option<String>,
     /// The ID of the price object.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price: Option<&'a str>,
+    pub price: Option<String>,
     /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price_data: Option<UpdateSubscriptionSchedulePhasesItemsPriceData<'a>>,
+    pub price_data: Option<UpdateSubscriptionSchedulePhasesItemsPriceData>,
     /// Quantity for the given price.
     /// Can be set only if the price's `usage_type` is `licensed` and not `metered`.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2590,9 +2626,9 @@ pub struct UpdateSubscriptionSchedulePhasesItems<'a> {
     /// These Tax Rates will override the [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates) on the Subscription.
     /// When updating, pass an empty string to remove previously-defined tax rates.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_rates: Option<&'a [&'a str]>,
+    pub tax_rates: Option<Vec<String>>,
 }
-impl<'a> UpdateSubscriptionSchedulePhasesItems<'a> {
+impl UpdateSubscriptionSchedulePhasesItems {
     pub fn new() -> Self {
         Self {
             billing_thresholds: None,
@@ -2606,19 +2642,19 @@ impl<'a> UpdateSubscriptionSchedulePhasesItems<'a> {
         }
     }
 }
-impl<'a> Default for UpdateSubscriptionSchedulePhasesItems<'a> {
+impl Default for UpdateSubscriptionSchedulePhasesItems {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateSubscriptionSchedulePhasesItemsPriceData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateSubscriptionSchedulePhasesItemsPriceData {
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     /// Must be a [supported currency](https://stripe.com/docs/currencies).
     pub currency: stripe_types::Currency,
     /// The ID of the product that this price will belong to.
-    pub product: &'a str,
+    pub product: String,
     /// The recurring components of a price such as `interval` and `interval_count`.
     pub recurring: UpdateSubscriptionSchedulePhasesItemsPriceDataRecurring,
     /// Only required if a [default tax behavior](https://stripe.com/docs/tax/products-prices-tax-categories-tax-behavior#setting-a-default-tax-behavior-(recommended)) was not provided in the Stripe Tax settings.
@@ -2633,18 +2669,18 @@ pub struct UpdateSubscriptionSchedulePhasesItemsPriceData<'a> {
     /// Same as `unit_amount`, but accepts a decimal value in cents (or local equivalent) with at most 12 decimal places.
     /// Only one of `unit_amount` and `unit_amount_decimal` can be set.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub unit_amount_decimal: Option<&'a str>,
+    pub unit_amount_decimal: Option<String>,
 }
-impl<'a> UpdateSubscriptionSchedulePhasesItemsPriceData<'a> {
+impl UpdateSubscriptionSchedulePhasesItemsPriceData {
     pub fn new(
-        currency: stripe_types::Currency,
-        product: &'a str,
-        recurring: UpdateSubscriptionSchedulePhasesItemsPriceDataRecurring,
+        currency: impl Into<stripe_types::Currency>,
+        product: impl Into<String>,
+        recurring: impl Into<UpdateSubscriptionSchedulePhasesItemsPriceDataRecurring>,
     ) -> Self {
         Self {
-            currency,
-            product,
-            recurring,
+            currency: currency.into(),
+            product: product.into(),
+            recurring: recurring.into(),
             tax_behavior: None,
             unit_amount: None,
             unit_amount_decimal: None,
@@ -2663,8 +2699,10 @@ pub struct UpdateSubscriptionSchedulePhasesItemsPriceDataRecurring {
     pub interval_count: Option<u64>,
 }
 impl UpdateSubscriptionSchedulePhasesItemsPriceDataRecurring {
-    pub fn new(interval: UpdateSubscriptionSchedulePhasesItemsPriceDataRecurringInterval) -> Self {
-        Self { interval, interval_count: None }
+    pub fn new(
+        interval: impl Into<UpdateSubscriptionSchedulePhasesItemsPriceDataRecurringInterval>,
+    ) -> Self {
+        Self { interval: interval.into(), interval_count: None }
     }
 }
 /// Specifies billing frequency. Either `day`, `week`, `month` or `year`.
@@ -2943,21 +2981,21 @@ impl<'de> serde::Deserialize<'de> for UpdateSubscriptionScheduleProrationBehavio
 }
 /// Updates an existing subscription schedule.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateSubscriptionSchedule<'a> {
-    inner: UpdateSubscriptionScheduleBuilder<'a>,
-    schedule: &'a stripe_shared::SubscriptionScheduleId,
+pub struct UpdateSubscriptionSchedule {
+    inner: UpdateSubscriptionScheduleBuilder,
+    schedule: stripe_shared::SubscriptionScheduleId,
 }
-impl<'a> UpdateSubscriptionSchedule<'a> {
+impl UpdateSubscriptionSchedule {
     /// Construct a new `UpdateSubscriptionSchedule`.
-    pub fn new(schedule: &'a stripe_shared::SubscriptionScheduleId) -> Self {
-        Self { schedule, inner: UpdateSubscriptionScheduleBuilder::new() }
+    pub fn new(schedule: impl Into<stripe_shared::SubscriptionScheduleId>) -> Self {
+        Self { schedule: schedule.into(), inner: UpdateSubscriptionScheduleBuilder::new() }
     }
     /// Object representing the subscription schedule's default settings.
     pub fn default_settings(
         mut self,
-        default_settings: UpdateSubscriptionScheduleDefaultSettings<'a>,
+        default_settings: impl Into<UpdateSubscriptionScheduleDefaultSettings>,
     ) -> Self {
-        self.inner.default_settings = Some(default_settings);
+        self.inner.default_settings = Some(default_settings.into());
         self
     }
     /// Behavior of the subscription schedule and underlying subscription when it ends.
@@ -2966,43 +3004,46 @@ impl<'a> UpdateSubscriptionSchedule<'a> {
     /// `cancel` will end the subscription schedule and cancel the underlying subscription.
     pub fn end_behavior(
         mut self,
-        end_behavior: stripe_shared::SubscriptionScheduleEndBehavior,
+        end_behavior: impl Into<stripe_shared::SubscriptionScheduleEndBehavior>,
     ) -> Self {
-        self.inner.end_behavior = Some(end_behavior);
+        self.inner.end_behavior = Some(end_behavior.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// List representing phases of the subscription schedule.
     /// Each phase can be customized to have different durations, plans, and coupons.
     /// If there are multiple phases, the `end_date` of one phase will always equal the `start_date` of the next phase.
     /// Note that past phases can be omitted.
-    pub fn phases(mut self, phases: &'a [UpdateSubscriptionSchedulePhases<'a>]) -> Self {
-        self.inner.phases = Some(phases);
+    pub fn phases(mut self, phases: impl Into<Vec<UpdateSubscriptionSchedulePhases>>) -> Self {
+        self.inner.phases = Some(phases.into());
         self
     }
     /// If the update changes the current phase, indicates whether the changes should be prorated.
     /// The default value is `create_prorations`.
     pub fn proration_behavior(
         mut self,
-        proration_behavior: UpdateSubscriptionScheduleProrationBehavior,
+        proration_behavior: impl Into<UpdateSubscriptionScheduleProrationBehavior>,
     ) -> Self {
-        self.inner.proration_behavior = Some(proration_behavior);
+        self.inner.proration_behavior = Some(proration_behavior.into());
         self
     }
 }
-impl UpdateSubscriptionSchedule<'_> {
+impl UpdateSubscriptionSchedule {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -3020,25 +3061,25 @@ impl UpdateSubscriptionSchedule<'_> {
     }
 }
 
-impl StripeRequest for UpdateSubscriptionSchedule<'_> {
+impl StripeRequest for UpdateSubscriptionSchedule {
     type Output = stripe_shared::SubscriptionSchedule;
 
     fn build(&self) -> RequestBuilder {
-        let schedule = self.schedule;
+        let schedule = &self.schedule;
         RequestBuilder::new(StripeMethod::Post, format!("/subscription_schedules/{schedule}"))
             .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CancelSubscriptionScheduleBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CancelSubscriptionScheduleBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     invoice_now: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     prorate: Option<bool>,
 }
-impl<'a> CancelSubscriptionScheduleBuilder<'a> {
+impl CancelSubscriptionScheduleBuilder {
     fn new() -> Self {
         Self { expand: None, invoice_now: None, prorate: None }
     }
@@ -3046,34 +3087,34 @@ impl<'a> CancelSubscriptionScheduleBuilder<'a> {
 /// Cancels a subscription schedule and its associated subscription immediately (if the subscription schedule has an active subscription).
 /// A subscription schedule can only be canceled if its status is `not_started` or `active`.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CancelSubscriptionSchedule<'a> {
-    inner: CancelSubscriptionScheduleBuilder<'a>,
-    schedule: &'a stripe_shared::SubscriptionScheduleId,
+pub struct CancelSubscriptionSchedule {
+    inner: CancelSubscriptionScheduleBuilder,
+    schedule: stripe_shared::SubscriptionScheduleId,
 }
-impl<'a> CancelSubscriptionSchedule<'a> {
+impl CancelSubscriptionSchedule {
     /// Construct a new `CancelSubscriptionSchedule`.
-    pub fn new(schedule: &'a stripe_shared::SubscriptionScheduleId) -> Self {
-        Self { schedule, inner: CancelSubscriptionScheduleBuilder::new() }
+    pub fn new(schedule: impl Into<stripe_shared::SubscriptionScheduleId>) -> Self {
+        Self { schedule: schedule.into(), inner: CancelSubscriptionScheduleBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// If the subscription schedule is `active`, indicates if a final invoice will be generated that contains any un-invoiced metered usage and new/pending proration invoice items.
     /// Defaults to `true`.
-    pub fn invoice_now(mut self, invoice_now: bool) -> Self {
-        self.inner.invoice_now = Some(invoice_now);
+    pub fn invoice_now(mut self, invoice_now: impl Into<bool>) -> Self {
+        self.inner.invoice_now = Some(invoice_now.into());
         self
     }
     /// If the subscription schedule is `active`, indicates if the cancellation should be prorated.
     /// Defaults to `true`.
-    pub fn prorate(mut self, prorate: bool) -> Self {
-        self.inner.prorate = Some(prorate);
+    pub fn prorate(mut self, prorate: impl Into<bool>) -> Self {
+        self.inner.prorate = Some(prorate.into());
         self
     }
 }
-impl CancelSubscriptionSchedule<'_> {
+impl CancelSubscriptionSchedule {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -3091,11 +3132,11 @@ impl CancelSubscriptionSchedule<'_> {
     }
 }
 
-impl StripeRequest for CancelSubscriptionSchedule<'_> {
+impl StripeRequest for CancelSubscriptionSchedule {
     type Output = stripe_shared::SubscriptionSchedule;
 
     fn build(&self) -> RequestBuilder {
-        let schedule = self.schedule;
+        let schedule = &self.schedule;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/subscription_schedules/{schedule}/cancel"),
@@ -3103,14 +3144,14 @@ impl StripeRequest for CancelSubscriptionSchedule<'_> {
         .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ReleaseSubscriptionScheduleBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ReleaseSubscriptionScheduleBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     preserve_cancel_date: Option<bool>,
 }
-impl<'a> ReleaseSubscriptionScheduleBuilder<'a> {
+impl ReleaseSubscriptionScheduleBuilder {
     fn new() -> Self {
         Self { expand: None, preserve_cancel_date: None }
     }
@@ -3119,27 +3160,27 @@ impl<'a> ReleaseSubscriptionScheduleBuilder<'a> {
 /// A schedule can only be released if its status is `not_started` or `active`.
 /// If the subscription schedule is currently associated with a subscription, releasing it will remove its `subscription` property and set the subscription’s ID to the `released_subscription` property.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ReleaseSubscriptionSchedule<'a> {
-    inner: ReleaseSubscriptionScheduleBuilder<'a>,
-    schedule: &'a stripe_shared::SubscriptionScheduleId,
+pub struct ReleaseSubscriptionSchedule {
+    inner: ReleaseSubscriptionScheduleBuilder,
+    schedule: stripe_shared::SubscriptionScheduleId,
 }
-impl<'a> ReleaseSubscriptionSchedule<'a> {
+impl ReleaseSubscriptionSchedule {
     /// Construct a new `ReleaseSubscriptionSchedule`.
-    pub fn new(schedule: &'a stripe_shared::SubscriptionScheduleId) -> Self {
-        Self { schedule, inner: ReleaseSubscriptionScheduleBuilder::new() }
+    pub fn new(schedule: impl Into<stripe_shared::SubscriptionScheduleId>) -> Self {
+        Self { schedule: schedule.into(), inner: ReleaseSubscriptionScheduleBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Keep any cancellation on the subscription that the schedule has set
-    pub fn preserve_cancel_date(mut self, preserve_cancel_date: bool) -> Self {
-        self.inner.preserve_cancel_date = Some(preserve_cancel_date);
+    pub fn preserve_cancel_date(mut self, preserve_cancel_date: impl Into<bool>) -> Self {
+        self.inner.preserve_cancel_date = Some(preserve_cancel_date.into());
         self
     }
 }
-impl ReleaseSubscriptionSchedule<'_> {
+impl ReleaseSubscriptionSchedule {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -3157,11 +3198,11 @@ impl ReleaseSubscriptionSchedule<'_> {
     }
 }
 
-impl StripeRequest for ReleaseSubscriptionSchedule<'_> {
+impl StripeRequest for ReleaseSubscriptionSchedule {
     type Output = stripe_shared::SubscriptionSchedule;
 
     fn build(&self) -> RequestBuilder {
-        let schedule = self.schedule;
+        let schedule = &self.schedule;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/subscription_schedules/{schedule}/release"),
@@ -3190,39 +3231,39 @@ impl Default for BillingThresholdsParam {
         Self::new()
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct TransferDataSpecs<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct TransferDataSpecs {
     /// A non-negative decimal between 0 and 100, with at most two decimal places.
     /// This represents the percentage of the subscription invoice total that will be transferred to the destination account.
     /// By default, the entire amount is transferred to the destination.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub amount_percent: Option<f64>,
     /// ID of an existing, connected Stripe account.
-    pub destination: &'a str,
+    pub destination: String,
 }
-impl<'a> TransferDataSpecs<'a> {
-    pub fn new(destination: &'a str) -> Self {
-        Self { amount_percent: None, destination }
+impl TransferDataSpecs {
+    pub fn new(destination: impl Into<String>) -> Self {
+        Self { amount_percent: None, destination: destination.into() }
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct DiscountsDataParam<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct DiscountsDataParam {
     /// ID of the coupon to create a new discount for.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub coupon: Option<&'a str>,
+    pub coupon: Option<String>,
     /// ID of an existing discount on the object (or one of its ancestors) to reuse.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub discount: Option<&'a str>,
+    pub discount: Option<String>,
     /// ID of the promotion code to create a new discount for.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub promotion_code: Option<&'a str>,
+    pub promotion_code: Option<String>,
 }
-impl<'a> DiscountsDataParam<'a> {
+impl DiscountsDataParam {
     pub fn new() -> Self {
         Self { coupon: None, discount: None, promotion_code: None }
     }
 }
-impl<'a> Default for DiscountsDataParam<'a> {
+impl Default for DiscountsDataParam {
     fn default() -> Self {
         Self::new()
     }
@@ -3233,7 +3274,7 @@ pub struct ItemBillingThresholdsParam {
     pub usage_gte: i64,
 }
 impl ItemBillingThresholdsParam {
-    pub fn new(usage_gte: i64) -> Self {
-        Self { usage_gte }
+    pub fn new(usage_gte: impl Into<i64>) -> Self {
+        Self { usage_gte: usage_gte.into() }
     }
 }

--- a/generated/async-stripe-billing/src/tax_id/requests.rs
+++ b/generated/async-stripe-billing/src/tax_id/requests.rs
@@ -4,17 +4,17 @@ use stripe_client_core::{
 
 /// Deletes an existing `tax_id` object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct DeleteCustomerTaxId<'a> {
-    customer: &'a stripe_shared::CustomerId,
-    id: &'a str,
+pub struct DeleteCustomerTaxId {
+    customer: stripe_shared::CustomerId,
+    id: String,
 }
-impl<'a> DeleteCustomerTaxId<'a> {
+impl DeleteCustomerTaxId {
     /// Construct a new `DeleteCustomerTaxId`.
-    pub fn new(customer: &'a stripe_shared::CustomerId, id: &'a str) -> Self {
-        Self { customer, id }
+    pub fn new(customer: impl Into<stripe_shared::CustomerId>, id: impl Into<String>) -> Self {
+        Self { customer: customer.into(), id: id.into() }
     }
 }
-impl DeleteCustomerTaxId<'_> {
+impl DeleteCustomerTaxId {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -32,27 +32,27 @@ impl DeleteCustomerTaxId<'_> {
     }
 }
 
-impl StripeRequest for DeleteCustomerTaxId<'_> {
+impl StripeRequest for DeleteCustomerTaxId {
     type Output = stripe_shared::DeletedTaxId;
 
     fn build(&self) -> RequestBuilder {
-        let customer = self.customer;
-        let id = self.id;
+        let customer = &self.customer;
+        let id = &self.id;
         RequestBuilder::new(StripeMethod::Delete, format!("/customers/{customer}/tax_ids/{id}"))
     }
 }
 /// Deletes an existing account or customer `tax_id` object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct DeleteIdTaxId<'a> {
-    id: &'a stripe_shared::TaxIdId,
+pub struct DeleteIdTaxId {
+    id: stripe_shared::TaxIdId,
 }
-impl<'a> DeleteIdTaxId<'a> {
+impl DeleteIdTaxId {
     /// Construct a new `DeleteIdTaxId`.
-    pub fn new(id: &'a stripe_shared::TaxIdId) -> Self {
-        Self { id }
+    pub fn new(id: impl Into<stripe_shared::TaxIdId>) -> Self {
+        Self { id: id.into() }
     }
 }
-impl DeleteIdTaxId<'_> {
+impl DeleteIdTaxId {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -70,68 +70,68 @@ impl DeleteIdTaxId<'_> {
     }
 }
 
-impl StripeRequest for DeleteIdTaxId<'_> {
+impl StripeRequest for DeleteIdTaxId {
     type Output = stripe_shared::DeletedTaxId;
 
     fn build(&self) -> RequestBuilder {
-        let id = self.id;
+        let id = &self.id;
         RequestBuilder::new(StripeMethod::Delete, format!("/tax_ids/{id}"))
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListCustomerTaxIdBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListCustomerTaxIdBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListCustomerTaxIdBuilder<'a> {
+impl ListCustomerTaxIdBuilder {
     fn new() -> Self {
         Self { ending_before: None, expand: None, limit: None, starting_after: None }
     }
 }
 /// Returns a list of tax IDs for a customer.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListCustomerTaxId<'a> {
-    inner: ListCustomerTaxIdBuilder<'a>,
-    customer: &'a stripe_shared::CustomerId,
+pub struct ListCustomerTaxId {
+    inner: ListCustomerTaxIdBuilder,
+    customer: stripe_shared::CustomerId,
 }
-impl<'a> ListCustomerTaxId<'a> {
+impl ListCustomerTaxId {
     /// Construct a new `ListCustomerTaxId`.
-    pub fn new(customer: &'a stripe_shared::CustomerId) -> Self {
-        Self { customer, inner: ListCustomerTaxIdBuilder::new() }
+    pub fn new(customer: impl Into<stripe_shared::CustomerId>) -> Self {
+        Self { customer: customer.into(), inner: ListCustomerTaxIdBuilder::new() }
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl ListCustomerTaxId<'_> {
+impl ListCustomerTaxId {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -151,53 +151,57 @@ impl ListCustomerTaxId<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::TaxId>> {
-        let customer = self.customer;
+        let customer = &self.customer;
 
         stripe_client_core::ListPaginator::new_list(
             format!("/customers/{customer}/tax_ids"),
-            self.inner,
+            &self.inner,
         )
     }
 }
 
-impl StripeRequest for ListCustomerTaxId<'_> {
+impl StripeRequest for ListCustomerTaxId {
     type Output = stripe_types::List<stripe_shared::TaxId>;
 
     fn build(&self) -> RequestBuilder {
-        let customer = self.customer;
+        let customer = &self.customer;
         RequestBuilder::new(StripeMethod::Get, format!("/customers/{customer}/tax_ids"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveCustomerTaxIdBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveCustomerTaxIdBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveCustomerTaxIdBuilder<'a> {
+impl RetrieveCustomerTaxIdBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves the `tax_id` object with the given identifier.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveCustomerTaxId<'a> {
-    inner: RetrieveCustomerTaxIdBuilder<'a>,
-    customer: &'a stripe_shared::CustomerId,
-    id: &'a str,
+pub struct RetrieveCustomerTaxId {
+    inner: RetrieveCustomerTaxIdBuilder,
+    customer: stripe_shared::CustomerId,
+    id: String,
 }
-impl<'a> RetrieveCustomerTaxId<'a> {
+impl RetrieveCustomerTaxId {
     /// Construct a new `RetrieveCustomerTaxId`.
-    pub fn new(customer: &'a stripe_shared::CustomerId, id: &'a str) -> Self {
-        Self { customer, id, inner: RetrieveCustomerTaxIdBuilder::new() }
+    pub fn new(customer: impl Into<stripe_shared::CustomerId>, id: impl Into<String>) -> Self {
+        Self {
+            customer: customer.into(),
+            id: id.into(),
+            inner: RetrieveCustomerTaxIdBuilder::new(),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveCustomerTaxId<'_> {
+impl RetrieveCustomerTaxId {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -215,50 +219,50 @@ impl RetrieveCustomerTaxId<'_> {
     }
 }
 
-impl StripeRequest for RetrieveCustomerTaxId<'_> {
+impl StripeRequest for RetrieveCustomerTaxId {
     type Output = stripe_shared::TaxId;
 
     fn build(&self) -> RequestBuilder {
-        let customer = self.customer;
-        let id = self.id;
+        let customer = &self.customer;
+        let id = &self.id;
         RequestBuilder::new(StripeMethod::Get, format!("/customers/{customer}/tax_ids/{id}"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListTaxIdBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListTaxIdBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    owner: Option<ListTaxIdOwner<'a>>,
+    owner: Option<ListTaxIdOwner>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListTaxIdBuilder<'a> {
+impl ListTaxIdBuilder {
     fn new() -> Self {
         Self { ending_before: None, expand: None, limit: None, owner: None, starting_after: None }
     }
 }
 /// The account or customer the tax ID belongs to. Defaults to `owner[type]=self`.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ListTaxIdOwner<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ListTaxIdOwner {
     /// Account the tax ID belongs to. Required when `type=account`
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account: Option<&'a str>,
+    pub account: Option<String>,
     /// Customer the tax ID belongs to. Required when `type=customer`
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub customer: Option<&'a str>,
+    pub customer: Option<String>,
     /// Type of owner referenced.
     #[serde(rename = "type")]
     pub type_: ListTaxIdOwnerType,
 }
-impl<'a> ListTaxIdOwner<'a> {
-    pub fn new(type_: ListTaxIdOwnerType) -> Self {
-        Self { account: None, customer: None, type_ }
+impl ListTaxIdOwner {
+    pub fn new(type_: impl Into<ListTaxIdOwnerType>) -> Self {
+        Self { account: None, customer: None, type_: type_.into() }
     }
 }
 /// Type of owner referenced.
@@ -324,10 +328,10 @@ impl<'de> serde::Deserialize<'de> for ListTaxIdOwnerType {
 }
 /// Returns a list of tax IDs.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListTaxId<'a> {
-    inner: ListTaxIdBuilder<'a>,
+pub struct ListTaxId {
+    inner: ListTaxIdBuilder,
 }
-impl<'a> ListTaxId<'a> {
+impl ListTaxId {
     /// Construct a new `ListTaxId`.
     pub fn new() -> Self {
         Self { inner: ListTaxIdBuilder::new() }
@@ -335,40 +339,40 @@ impl<'a> ListTaxId<'a> {
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// The account or customer the tax ID belongs to. Defaults to `owner[type]=self`.
-    pub fn owner(mut self, owner: ListTaxIdOwner<'a>) -> Self {
-        self.inner.owner = Some(owner);
+    pub fn owner(mut self, owner: impl Into<ListTaxIdOwner>) -> Self {
+        self.inner.owner = Some(owner.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl<'a> Default for ListTaxId<'a> {
+impl Default for ListTaxId {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListTaxId<'_> {
+impl ListTaxId {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -388,45 +392,45 @@ impl ListTaxId<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::TaxId>> {
-        stripe_client_core::ListPaginator::new_list("/tax_ids", self.inner)
+        stripe_client_core::ListPaginator::new_list("/tax_ids", &self.inner)
     }
 }
 
-impl StripeRequest for ListTaxId<'_> {
+impl StripeRequest for ListTaxId {
     type Output = stripe_types::List<stripe_shared::TaxId>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/tax_ids").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveIdTaxIdBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveIdTaxIdBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveIdTaxIdBuilder<'a> {
+impl RetrieveIdTaxIdBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves an account or customer `tax_id` object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveIdTaxId<'a> {
-    inner: RetrieveIdTaxIdBuilder<'a>,
-    id: &'a stripe_shared::TaxIdId,
+pub struct RetrieveIdTaxId {
+    inner: RetrieveIdTaxIdBuilder,
+    id: stripe_shared::TaxIdId,
 }
-impl<'a> RetrieveIdTaxId<'a> {
+impl RetrieveIdTaxId {
     /// Construct a new `RetrieveIdTaxId`.
-    pub fn new(id: &'a stripe_shared::TaxIdId) -> Self {
-        Self { id, inner: RetrieveIdTaxIdBuilder::new() }
+    pub fn new(id: impl Into<stripe_shared::TaxIdId>) -> Self {
+        Self { id: id.into(), inner: RetrieveIdTaxIdBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveIdTaxId<'_> {
+impl RetrieveIdTaxId {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -444,25 +448,25 @@ impl RetrieveIdTaxId<'_> {
     }
 }
 
-impl StripeRequest for RetrieveIdTaxId<'_> {
+impl StripeRequest for RetrieveIdTaxId {
     type Output = stripe_shared::TaxId;
 
     fn build(&self) -> RequestBuilder {
-        let id = self.id;
+        let id = &self.id;
         RequestBuilder::new(StripeMethod::Get, format!("/tax_ids/{id}")).query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateCustomerTaxIdBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateCustomerTaxIdBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(rename = "type")]
     type_: CreateCustomerTaxIdType,
-    value: &'a str,
+    value: String,
 }
-impl<'a> CreateCustomerTaxIdBuilder<'a> {
-    fn new(type_: CreateCustomerTaxIdType, value: &'a str) -> Self {
-        Self { expand: None, type_, value }
+impl CreateCustomerTaxIdBuilder {
+    fn new(type_: impl Into<CreateCustomerTaxIdType>, value: impl Into<String>) -> Self {
+        Self { expand: None, type_: type_.into(), value: value.into() }
     }
 }
 /// Type of the tax ID, one of `ad_nrt`, `ae_trn`, `ar_cuit`, `au_abn`, `au_arn`, `bg_uic`, `bh_vat`, `bo_tin`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `cn_tin`, `co_nit`, `cr_tin`, `do_rcn`, `ec_ruc`, `eg_tin`, `es_cif`, `eu_oss_vat`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `hu_tin`, `id_npwp`, `il_vat`, `in_gst`, `is_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `ke_pin`, `kr_brn`, `kz_bin`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `ng_tin`, `no_vat`, `no_voec`, `nz_gst`, `om_vat`, `pe_ruc`, `ph_tin`, `ro_tin`, `rs_pib`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `si_tin`, `sv_nit`, `th_vat`, `tr_tin`, `tw_vat`, `ua_vat`, `us_ein`, `uy_ruc`, `ve_rif`, `vn_tin`, or `za_vat`.
@@ -732,26 +736,29 @@ impl<'de> serde::Deserialize<'de> for CreateCustomerTaxIdType {
 }
 /// Creates a new `tax_id` object for a customer.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateCustomerTaxId<'a> {
-    inner: CreateCustomerTaxIdBuilder<'a>,
-    customer: &'a stripe_shared::CustomerId,
+pub struct CreateCustomerTaxId {
+    inner: CreateCustomerTaxIdBuilder,
+    customer: stripe_shared::CustomerId,
 }
-impl<'a> CreateCustomerTaxId<'a> {
+impl CreateCustomerTaxId {
     /// Construct a new `CreateCustomerTaxId`.
     pub fn new(
-        customer: &'a stripe_shared::CustomerId,
-        type_: CreateCustomerTaxIdType,
-        value: &'a str,
+        customer: impl Into<stripe_shared::CustomerId>,
+        type_: impl Into<CreateCustomerTaxIdType>,
+        value: impl Into<String>,
     ) -> Self {
-        Self { customer, inner: CreateCustomerTaxIdBuilder::new(type_, value) }
+        Self {
+            customer: customer.into(),
+            inner: CreateCustomerTaxIdBuilder::new(type_.into(), value.into()),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl CreateCustomerTaxId<'_> {
+impl CreateCustomerTaxId {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -769,46 +776,46 @@ impl CreateCustomerTaxId<'_> {
     }
 }
 
-impl StripeRequest for CreateCustomerTaxId<'_> {
+impl StripeRequest for CreateCustomerTaxId {
     type Output = stripe_shared::TaxId;
 
     fn build(&self) -> RequestBuilder {
-        let customer = self.customer;
+        let customer = &self.customer;
         RequestBuilder::new(StripeMethod::Post, format!("/customers/{customer}/tax_ids"))
             .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateTaxIdBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateTaxIdBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    owner: Option<CreateTaxIdOwner<'a>>,
+    owner: Option<CreateTaxIdOwner>,
     #[serde(rename = "type")]
     type_: CreateTaxIdType,
-    value: &'a str,
+    value: String,
 }
-impl<'a> CreateTaxIdBuilder<'a> {
-    fn new(type_: CreateTaxIdType, value: &'a str) -> Self {
-        Self { expand: None, owner: None, type_, value }
+impl CreateTaxIdBuilder {
+    fn new(type_: impl Into<CreateTaxIdType>, value: impl Into<String>) -> Self {
+        Self { expand: None, owner: None, type_: type_.into(), value: value.into() }
     }
 }
 /// The account or customer the tax ID belongs to. Defaults to `owner[type]=self`.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateTaxIdOwner<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateTaxIdOwner {
     /// Account the tax ID belongs to. Required when `type=account`
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account: Option<&'a str>,
+    pub account: Option<String>,
     /// Customer the tax ID belongs to. Required when `type=customer`
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub customer: Option<&'a str>,
+    pub customer: Option<String>,
     /// Type of owner referenced.
     #[serde(rename = "type")]
     pub type_: CreateTaxIdOwnerType,
 }
-impl<'a> CreateTaxIdOwner<'a> {
-    pub fn new(type_: CreateTaxIdOwnerType) -> Self {
-        Self { account: None, customer: None, type_ }
+impl CreateTaxIdOwner {
+    pub fn new(type_: impl Into<CreateTaxIdOwnerType>) -> Self {
+        Self { account: None, customer: None, type_: type_.into() }
     }
 }
 /// Type of owner referenced.
@@ -1139,26 +1146,26 @@ impl<'de> serde::Deserialize<'de> for CreateTaxIdType {
 }
 /// Creates a new account or customer `tax_id` object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateTaxId<'a> {
-    inner: CreateTaxIdBuilder<'a>,
+pub struct CreateTaxId {
+    inner: CreateTaxIdBuilder,
 }
-impl<'a> CreateTaxId<'a> {
+impl CreateTaxId {
     /// Construct a new `CreateTaxId`.
-    pub fn new(type_: CreateTaxIdType, value: &'a str) -> Self {
-        Self { inner: CreateTaxIdBuilder::new(type_, value) }
+    pub fn new(type_: impl Into<CreateTaxIdType>, value: impl Into<String>) -> Self {
+        Self { inner: CreateTaxIdBuilder::new(type_.into(), value.into()) }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// The account or customer the tax ID belongs to. Defaults to `owner[type]=self`.
-    pub fn owner(mut self, owner: CreateTaxIdOwner<'a>) -> Self {
-        self.inner.owner = Some(owner);
+    pub fn owner(mut self, owner: impl Into<CreateTaxIdOwner>) -> Self {
+        self.inner.owner = Some(owner.into());
         self
     }
 }
-impl CreateTaxId<'_> {
+impl CreateTaxId {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -1176,7 +1183,7 @@ impl CreateTaxId<'_> {
     }
 }
 
-impl StripeRequest for CreateTaxId<'_> {
+impl StripeRequest for CreateTaxId {
     type Output = stripe_shared::TaxId;
 
     fn build(&self) -> RequestBuilder {

--- a/generated/async-stripe-billing/src/test_helpers_test_clock/requests.rs
+++ b/generated/async-stripe-billing/src/test_helpers_test_clock/requests.rs
@@ -4,16 +4,16 @@ use stripe_client_core::{
 
 /// Deletes a test clock.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct DeleteTestHelpersTestClock<'a> {
-    test_clock: &'a stripe_shared::TestHelpersTestClockId,
+pub struct DeleteTestHelpersTestClock {
+    test_clock: stripe_shared::TestHelpersTestClockId,
 }
-impl<'a> DeleteTestHelpersTestClock<'a> {
+impl DeleteTestHelpersTestClock {
     /// Construct a new `DeleteTestHelpersTestClock`.
-    pub fn new(test_clock: &'a stripe_shared::TestHelpersTestClockId) -> Self {
-        Self { test_clock }
+    pub fn new(test_clock: impl Into<stripe_shared::TestHelpersTestClockId>) -> Self {
+        Self { test_clock: test_clock.into() }
     }
 }
-impl DeleteTestHelpersTestClock<'_> {
+impl DeleteTestHelpersTestClock {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -31,36 +31,36 @@ impl DeleteTestHelpersTestClock<'_> {
     }
 }
 
-impl StripeRequest for DeleteTestHelpersTestClock<'_> {
+impl StripeRequest for DeleteTestHelpersTestClock {
     type Output = stripe_shared::DeletedTestHelpersTestClock;
 
     fn build(&self) -> RequestBuilder {
-        let test_clock = self.test_clock;
+        let test_clock = &self.test_clock;
         RequestBuilder::new(StripeMethod::Delete, format!("/test_helpers/test_clocks/{test_clock}"))
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListTestHelpersTestClockBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListTestHelpersTestClockBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListTestHelpersTestClockBuilder<'a> {
+impl ListTestHelpersTestClockBuilder {
     fn new() -> Self {
         Self { ending_before: None, expand: None, limit: None, starting_after: None }
     }
 }
 /// Returns a list of your test clocks.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListTestHelpersTestClock<'a> {
-    inner: ListTestHelpersTestClockBuilder<'a>,
+pub struct ListTestHelpersTestClock {
+    inner: ListTestHelpersTestClockBuilder,
 }
-impl<'a> ListTestHelpersTestClock<'a> {
+impl ListTestHelpersTestClock {
     /// Construct a new `ListTestHelpersTestClock`.
     pub fn new() -> Self {
         Self { inner: ListTestHelpersTestClockBuilder::new() }
@@ -68,35 +68,35 @@ impl<'a> ListTestHelpersTestClock<'a> {
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl<'a> Default for ListTestHelpersTestClock<'a> {
+impl Default for ListTestHelpersTestClock {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListTestHelpersTestClock<'_> {
+impl ListTestHelpersTestClock {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -117,45 +117,45 @@ impl ListTestHelpersTestClock<'_> {
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::TestHelpersTestClock>>
     {
-        stripe_client_core::ListPaginator::new_list("/test_helpers/test_clocks", self.inner)
+        stripe_client_core::ListPaginator::new_list("/test_helpers/test_clocks", &self.inner)
     }
 }
 
-impl StripeRequest for ListTestHelpersTestClock<'_> {
+impl StripeRequest for ListTestHelpersTestClock {
     type Output = stripe_types::List<stripe_shared::TestHelpersTestClock>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/test_helpers/test_clocks").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveTestHelpersTestClockBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveTestHelpersTestClockBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveTestHelpersTestClockBuilder<'a> {
+impl RetrieveTestHelpersTestClockBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves a test clock.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveTestHelpersTestClock<'a> {
-    inner: RetrieveTestHelpersTestClockBuilder<'a>,
-    test_clock: &'a stripe_shared::TestHelpersTestClockId,
+pub struct RetrieveTestHelpersTestClock {
+    inner: RetrieveTestHelpersTestClockBuilder,
+    test_clock: stripe_shared::TestHelpersTestClockId,
 }
-impl<'a> RetrieveTestHelpersTestClock<'a> {
+impl RetrieveTestHelpersTestClock {
     /// Construct a new `RetrieveTestHelpersTestClock`.
-    pub fn new(test_clock: &'a stripe_shared::TestHelpersTestClockId) -> Self {
-        Self { test_clock, inner: RetrieveTestHelpersTestClockBuilder::new() }
+    pub fn new(test_clock: impl Into<stripe_shared::TestHelpersTestClockId>) -> Self {
+        Self { test_clock: test_clock.into(), inner: RetrieveTestHelpersTestClockBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveTestHelpersTestClock<'_> {
+impl RetrieveTestHelpersTestClock {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -173,50 +173,50 @@ impl RetrieveTestHelpersTestClock<'_> {
     }
 }
 
-impl StripeRequest for RetrieveTestHelpersTestClock<'_> {
+impl StripeRequest for RetrieveTestHelpersTestClock {
     type Output = stripe_shared::TestHelpersTestClock;
 
     fn build(&self) -> RequestBuilder {
-        let test_clock = self.test_clock;
+        let test_clock = &self.test_clock;
         RequestBuilder::new(StripeMethod::Get, format!("/test_helpers/test_clocks/{test_clock}"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateTestHelpersTestClockBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateTestHelpersTestClockBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     frozen_time: stripe_types::Timestamp,
     #[serde(skip_serializing_if = "Option::is_none")]
-    name: Option<&'a str>,
+    name: Option<String>,
 }
-impl<'a> CreateTestHelpersTestClockBuilder<'a> {
-    fn new(frozen_time: stripe_types::Timestamp) -> Self {
-        Self { expand: None, frozen_time, name: None }
+impl CreateTestHelpersTestClockBuilder {
+    fn new(frozen_time: impl Into<stripe_types::Timestamp>) -> Self {
+        Self { expand: None, frozen_time: frozen_time.into(), name: None }
     }
 }
 /// Creates a new test clock that can be attached to new customers and quotes.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateTestHelpersTestClock<'a> {
-    inner: CreateTestHelpersTestClockBuilder<'a>,
+pub struct CreateTestHelpersTestClock {
+    inner: CreateTestHelpersTestClockBuilder,
 }
-impl<'a> CreateTestHelpersTestClock<'a> {
+impl CreateTestHelpersTestClock {
     /// Construct a new `CreateTestHelpersTestClock`.
-    pub fn new(frozen_time: stripe_types::Timestamp) -> Self {
-        Self { inner: CreateTestHelpersTestClockBuilder::new(frozen_time) }
+    pub fn new(frozen_time: impl Into<stripe_types::Timestamp>) -> Self {
+        Self { inner: CreateTestHelpersTestClockBuilder::new(frozen_time.into()) }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// The name for this test clock.
-    pub fn name(mut self, name: &'a str) -> Self {
-        self.inner.name = Some(name);
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.inner.name = Some(name.into());
         self
     }
 }
-impl CreateTestHelpersTestClock<'_> {
+impl CreateTestHelpersTestClock {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -234,46 +234,49 @@ impl CreateTestHelpersTestClock<'_> {
     }
 }
 
-impl StripeRequest for CreateTestHelpersTestClock<'_> {
+impl StripeRequest for CreateTestHelpersTestClock {
     type Output = stripe_shared::TestHelpersTestClock;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Post, "/test_helpers/test_clocks").form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct AdvanceTestHelpersTestClockBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct AdvanceTestHelpersTestClockBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     frozen_time: stripe_types::Timestamp,
 }
-impl<'a> AdvanceTestHelpersTestClockBuilder<'a> {
-    fn new(frozen_time: stripe_types::Timestamp) -> Self {
-        Self { expand: None, frozen_time }
+impl AdvanceTestHelpersTestClockBuilder {
+    fn new(frozen_time: impl Into<stripe_types::Timestamp>) -> Self {
+        Self { expand: None, frozen_time: frozen_time.into() }
     }
 }
 /// Starts advancing a test clock to a specified time in the future.
 /// Advancement is done when status changes to `Ready`.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct AdvanceTestHelpersTestClock<'a> {
-    inner: AdvanceTestHelpersTestClockBuilder<'a>,
-    test_clock: &'a stripe_shared::TestHelpersTestClockId,
+pub struct AdvanceTestHelpersTestClock {
+    inner: AdvanceTestHelpersTestClockBuilder,
+    test_clock: stripe_shared::TestHelpersTestClockId,
 }
-impl<'a> AdvanceTestHelpersTestClock<'a> {
+impl AdvanceTestHelpersTestClock {
     /// Construct a new `AdvanceTestHelpersTestClock`.
     pub fn new(
-        test_clock: &'a stripe_shared::TestHelpersTestClockId,
-        frozen_time: stripe_types::Timestamp,
+        test_clock: impl Into<stripe_shared::TestHelpersTestClockId>,
+        frozen_time: impl Into<stripe_types::Timestamp>,
     ) -> Self {
-        Self { test_clock, inner: AdvanceTestHelpersTestClockBuilder::new(frozen_time) }
+        Self {
+            test_clock: test_clock.into(),
+            inner: AdvanceTestHelpersTestClockBuilder::new(frozen_time.into()),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl AdvanceTestHelpersTestClock<'_> {
+impl AdvanceTestHelpersTestClock {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -291,11 +294,11 @@ impl AdvanceTestHelpersTestClock<'_> {
     }
 }
 
-impl StripeRequest for AdvanceTestHelpersTestClock<'_> {
+impl StripeRequest for AdvanceTestHelpersTestClock {
     type Output = stripe_shared::TestHelpersTestClock;
 
     fn build(&self) -> RequestBuilder {
-        let test_clock = self.test_clock;
+        let test_clock = &self.test_clock;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/test_helpers/test_clocks/{test_clock}/advance"),

--- a/generated/async-stripe-billing/src/usage_record_summary/requests.rs
+++ b/generated/async-stripe-billing/src/usage_record_summary/requests.rs
@@ -2,18 +2,18 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListSubscriptionItemUsageRecordSummaryBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListSubscriptionItemUsageRecordSummaryBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListSubscriptionItemUsageRecordSummaryBuilder<'a> {
+impl ListSubscriptionItemUsageRecordSummaryBuilder {
     fn new() -> Self {
         Self { ending_before: None, expand: None, limit: None, starting_after: None }
     }
@@ -25,42 +25,45 @@ impl<'a> ListSubscriptionItemUsageRecordSummaryBuilder<'a> {
 /// The first list item represents the most current usage period that hasn’t ended yet.
 /// Since new usage records can still be added, the returned summary information for the subscription item’s ID should be seen as unstable until the subscription billing period ends.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListSubscriptionItemUsageRecordSummary<'a> {
-    inner: ListSubscriptionItemUsageRecordSummaryBuilder<'a>,
-    subscription_item: &'a stripe_shared::SubscriptionItemId,
+pub struct ListSubscriptionItemUsageRecordSummary {
+    inner: ListSubscriptionItemUsageRecordSummaryBuilder,
+    subscription_item: stripe_shared::SubscriptionItemId,
 }
-impl<'a> ListSubscriptionItemUsageRecordSummary<'a> {
+impl ListSubscriptionItemUsageRecordSummary {
     /// Construct a new `ListSubscriptionItemUsageRecordSummary`.
-    pub fn new(subscription_item: &'a stripe_shared::SubscriptionItemId) -> Self {
-        Self { subscription_item, inner: ListSubscriptionItemUsageRecordSummaryBuilder::new() }
+    pub fn new(subscription_item: impl Into<stripe_shared::SubscriptionItemId>) -> Self {
+        Self {
+            subscription_item: subscription_item.into(),
+            inner: ListSubscriptionItemUsageRecordSummaryBuilder::new(),
+        }
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl ListSubscriptionItemUsageRecordSummary<'_> {
+impl ListSubscriptionItemUsageRecordSummary {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -81,20 +84,20 @@ impl ListSubscriptionItemUsageRecordSummary<'_> {
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::UsageRecordSummary>>
     {
-        let subscription_item = self.subscription_item;
+        let subscription_item = &self.subscription_item;
 
         stripe_client_core::ListPaginator::new_list(
             format!("/subscription_items/{subscription_item}/usage_record_summaries"),
-            self.inner,
+            &self.inner,
         )
     }
 }
 
-impl StripeRequest for ListSubscriptionItemUsageRecordSummary<'_> {
+impl StripeRequest for ListSubscriptionItemUsageRecordSummary {
     type Output = stripe_types::List<stripe_shared::UsageRecordSummary>;
 
     fn build(&self) -> RequestBuilder {
-        let subscription_item = self.subscription_item;
+        let subscription_item = &self.subscription_item;
         RequestBuilder::new(
             StripeMethod::Get,
             format!("/subscription_items/{subscription_item}/usage_record_summaries"),

--- a/generated/async-stripe-checkout/src/checkout_session/requests.rs
+++ b/generated/async-stripe-checkout/src/checkout_session/requests.rs
@@ -2,32 +2,32 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListCheckoutSessionBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListCheckoutSessionBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     created: Option<stripe_types::RangeQueryTs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    customer: Option<&'a str>,
+    customer: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    customer_details: Option<ListCheckoutSessionCustomerDetails<'a>>,
+    customer_details: Option<ListCheckoutSessionCustomerDetails>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_intent: Option<&'a str>,
+    payment_intent: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_link: Option<&'a str>,
+    payment_link: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     status: Option<stripe_checkout::CheckoutSessionStatus>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    subscription: Option<&'a str>,
+    subscription: Option<String>,
 }
-impl<'a> ListCheckoutSessionBuilder<'a> {
+impl ListCheckoutSessionBuilder {
     fn new() -> Self {
         Self {
             created: None,
@@ -45,96 +45,96 @@ impl<'a> ListCheckoutSessionBuilder<'a> {
     }
 }
 /// Only return the Checkout Sessions for the Customer details specified.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ListCheckoutSessionCustomerDetails<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ListCheckoutSessionCustomerDetails {
     /// Customer's email address.
-    pub email: &'a str,
+    pub email: String,
 }
-impl<'a> ListCheckoutSessionCustomerDetails<'a> {
-    pub fn new(email: &'a str) -> Self {
-        Self { email }
+impl ListCheckoutSessionCustomerDetails {
+    pub fn new(email: impl Into<String>) -> Self {
+        Self { email: email.into() }
     }
 }
 /// Returns a list of Checkout Sessions.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListCheckoutSession<'a> {
-    inner: ListCheckoutSessionBuilder<'a>,
+pub struct ListCheckoutSession {
+    inner: ListCheckoutSessionBuilder,
 }
-impl<'a> ListCheckoutSession<'a> {
+impl ListCheckoutSession {
     /// Construct a new `ListCheckoutSession`.
     pub fn new() -> Self {
         Self { inner: ListCheckoutSessionBuilder::new() }
     }
     /// Only return Checkout Sessions that were created during the given date interval.
-    pub fn created(mut self, created: stripe_types::RangeQueryTs) -> Self {
-        self.inner.created = Some(created);
+    pub fn created(mut self, created: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.created = Some(created.into());
         self
     }
     /// Only return the Checkout Sessions for the Customer specified.
-    pub fn customer(mut self, customer: &'a str) -> Self {
-        self.inner.customer = Some(customer);
+    pub fn customer(mut self, customer: impl Into<String>) -> Self {
+        self.inner.customer = Some(customer.into());
         self
     }
     /// Only return the Checkout Sessions for the Customer details specified.
     pub fn customer_details(
         mut self,
-        customer_details: ListCheckoutSessionCustomerDetails<'a>,
+        customer_details: impl Into<ListCheckoutSessionCustomerDetails>,
     ) -> Self {
-        self.inner.customer_details = Some(customer_details);
+        self.inner.customer_details = Some(customer_details.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// Only return the Checkout Session for the PaymentIntent specified.
-    pub fn payment_intent(mut self, payment_intent: &'a str) -> Self {
-        self.inner.payment_intent = Some(payment_intent);
+    pub fn payment_intent(mut self, payment_intent: impl Into<String>) -> Self {
+        self.inner.payment_intent = Some(payment_intent.into());
         self
     }
     /// Only return the Checkout Sessions for the Payment Link specified.
-    pub fn payment_link(mut self, payment_link: &'a str) -> Self {
-        self.inner.payment_link = Some(payment_link);
+    pub fn payment_link(mut self, payment_link: impl Into<String>) -> Self {
+        self.inner.payment_link = Some(payment_link.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
     /// Only return the Checkout Sessions matching the given status.
-    pub fn status(mut self, status: stripe_checkout::CheckoutSessionStatus) -> Self {
-        self.inner.status = Some(status);
+    pub fn status(mut self, status: impl Into<stripe_checkout::CheckoutSessionStatus>) -> Self {
+        self.inner.status = Some(status.into());
         self
     }
     /// Only return the Checkout Session for the subscription specified.
-    pub fn subscription(mut self, subscription: &'a str) -> Self {
-        self.inner.subscription = Some(subscription);
+    pub fn subscription(mut self, subscription: impl Into<String>) -> Self {
+        self.inner.subscription = Some(subscription.into());
         self
     }
 }
-impl<'a> Default for ListCheckoutSession<'a> {
+impl Default for ListCheckoutSession {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListCheckoutSession<'_> {
+impl ListCheckoutSession {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -155,45 +155,45 @@ impl ListCheckoutSession<'_> {
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_checkout::CheckoutSession>>
     {
-        stripe_client_core::ListPaginator::new_list("/checkout/sessions", self.inner)
+        stripe_client_core::ListPaginator::new_list("/checkout/sessions", &self.inner)
     }
 }
 
-impl StripeRequest for ListCheckoutSession<'_> {
+impl StripeRequest for ListCheckoutSession {
     type Output = stripe_types::List<stripe_checkout::CheckoutSession>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/checkout/sessions").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveCheckoutSessionBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveCheckoutSessionBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveCheckoutSessionBuilder<'a> {
+impl RetrieveCheckoutSessionBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves a Session object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveCheckoutSession<'a> {
-    inner: RetrieveCheckoutSessionBuilder<'a>,
-    session: &'a stripe_checkout::CheckoutSessionId,
+pub struct RetrieveCheckoutSession {
+    inner: RetrieveCheckoutSessionBuilder,
+    session: stripe_checkout::CheckoutSessionId,
 }
-impl<'a> RetrieveCheckoutSession<'a> {
+impl RetrieveCheckoutSession {
     /// Construct a new `RetrieveCheckoutSession`.
-    pub fn new(session: &'a stripe_checkout::CheckoutSessionId) -> Self {
-        Self { session, inner: RetrieveCheckoutSessionBuilder::new() }
+    pub fn new(session: impl Into<stripe_checkout::CheckoutSessionId>) -> Self {
+        Self { session: session.into(), inner: RetrieveCheckoutSessionBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveCheckoutSession<'_> {
+impl RetrieveCheckoutSession {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -211,27 +211,27 @@ impl RetrieveCheckoutSession<'_> {
     }
 }
 
-impl StripeRequest for RetrieveCheckoutSession<'_> {
+impl StripeRequest for RetrieveCheckoutSession {
     type Output = stripe_checkout::CheckoutSession;
 
     fn build(&self) -> RequestBuilder {
-        let session = self.session;
+        let session = &self.session;
         RequestBuilder::new(StripeMethod::Get, format!("/checkout/sessions/{session}"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListLineItemsCheckoutSessionBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListLineItemsCheckoutSessionBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListLineItemsCheckoutSessionBuilder<'a> {
+impl ListLineItemsCheckoutSessionBuilder {
     fn new() -> Self {
         Self { ending_before: None, expand: None, limit: None, starting_after: None }
     }
@@ -239,42 +239,42 @@ impl<'a> ListLineItemsCheckoutSessionBuilder<'a> {
 /// When retrieving a Checkout Session, there is an includable **line_items** property containing the first handful of those items.
 /// There is also a URL where you can retrieve the full (paginated) list of line items.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListLineItemsCheckoutSession<'a> {
-    inner: ListLineItemsCheckoutSessionBuilder<'a>,
-    session: &'a stripe_checkout::CheckoutSessionId,
+pub struct ListLineItemsCheckoutSession {
+    inner: ListLineItemsCheckoutSessionBuilder,
+    session: stripe_checkout::CheckoutSessionId,
 }
-impl<'a> ListLineItemsCheckoutSession<'a> {
+impl ListLineItemsCheckoutSession {
     /// Construct a new `ListLineItemsCheckoutSession`.
-    pub fn new(session: &'a stripe_checkout::CheckoutSessionId) -> Self {
-        Self { session, inner: ListLineItemsCheckoutSessionBuilder::new() }
+    pub fn new(session: impl Into<stripe_checkout::CheckoutSessionId>) -> Self {
+        Self { session: session.into(), inner: ListLineItemsCheckoutSessionBuilder::new() }
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl ListLineItemsCheckoutSession<'_> {
+impl ListLineItemsCheckoutSession {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -295,108 +295,108 @@ impl ListLineItemsCheckoutSession<'_> {
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::CheckoutSessionItem>>
     {
-        let session = self.session;
+        let session = &self.session;
 
         stripe_client_core::ListPaginator::new_list(
             format!("/checkout/sessions/{session}/line_items"),
-            self.inner,
+            &self.inner,
         )
     }
 }
 
-impl StripeRequest for ListLineItemsCheckoutSession<'_> {
+impl StripeRequest for ListLineItemsCheckoutSession {
     type Output = stripe_types::List<stripe_shared::CheckoutSessionItem>;
 
     fn build(&self) -> RequestBuilder {
-        let session = self.session;
+        let session = &self.session;
         RequestBuilder::new(StripeMethod::Get, format!("/checkout/sessions/{session}/line_items"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateCheckoutSessionBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateCheckoutSessionBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     after_expiration: Option<CreateCheckoutSessionAfterExpiration>,
     #[serde(skip_serializing_if = "Option::is_none")]
     allow_promotion_codes: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    automatic_tax: Option<CreateCheckoutSessionAutomaticTax<'a>>,
+    automatic_tax: Option<CreateCheckoutSessionAutomaticTax>,
     #[serde(skip_serializing_if = "Option::is_none")]
     billing_address_collection: Option<stripe_checkout::CheckoutSessionBillingAddressCollection>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    cancel_url: Option<&'a str>,
+    cancel_url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    client_reference_id: Option<&'a str>,
+    client_reference_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     consent_collection: Option<CreateCheckoutSessionConsentCollection>,
     #[serde(skip_serializing_if = "Option::is_none")]
     currency: Option<stripe_types::Currency>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    custom_fields: Option<&'a [CreateCheckoutSessionCustomFields<'a>]>,
+    custom_fields: Option<Vec<CreateCheckoutSessionCustomFields>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    custom_text: Option<CreateCheckoutSessionCustomText<'a>>,
+    custom_text: Option<CreateCheckoutSessionCustomText>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    customer: Option<&'a str>,
+    customer: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     customer_creation: Option<CreateCheckoutSessionCustomerCreation>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    customer_email: Option<&'a str>,
+    customer_email: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     customer_update: Option<CreateCheckoutSessionCustomerUpdate>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    discounts: Option<&'a [CreateCheckoutSessionDiscounts<'a>]>,
+    discounts: Option<Vec<CreateCheckoutSessionDiscounts>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     expires_at: Option<stripe_types::Timestamp>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    invoice_creation: Option<CreateCheckoutSessionInvoiceCreation<'a>>,
+    invoice_creation: Option<CreateCheckoutSessionInvoiceCreation>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    line_items: Option<&'a [CreateCheckoutSessionLineItems<'a>]>,
+    line_items: Option<Vec<CreateCheckoutSessionLineItems>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     locale: Option<stripe_checkout::CheckoutSessionLocale>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     mode: Option<stripe_checkout::CheckoutSessionMode>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_intent_data: Option<CreateCheckoutSessionPaymentIntentData<'a>>,
+    payment_intent_data: Option<CreateCheckoutSessionPaymentIntentData>,
     #[serde(skip_serializing_if = "Option::is_none")]
     payment_method_collection: Option<CreateCheckoutSessionPaymentMethodCollection>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_method_configuration: Option<&'a str>,
+    payment_method_configuration: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     payment_method_data: Option<CreateCheckoutSessionPaymentMethodData>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_method_options: Option<CreateCheckoutSessionPaymentMethodOptions<'a>>,
+    payment_method_options: Option<CreateCheckoutSessionPaymentMethodOptions>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_method_types: Option<&'a [CreateCheckoutSessionPaymentMethodTypes]>,
+    payment_method_types: Option<Vec<CreateCheckoutSessionPaymentMethodTypes>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     phone_number_collection: Option<CreateCheckoutSessionPhoneNumberCollection>,
     #[serde(skip_serializing_if = "Option::is_none")]
     redirect_on_completion: Option<stripe_checkout::CheckoutSessionRedirectOnCompletion>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    return_url: Option<&'a str>,
+    return_url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    saved_payment_method_options: Option<CreateCheckoutSessionSavedPaymentMethodOptions<'a>>,
+    saved_payment_method_options: Option<CreateCheckoutSessionSavedPaymentMethodOptions>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    setup_intent_data: Option<CreateCheckoutSessionSetupIntentData<'a>>,
+    setup_intent_data: Option<CreateCheckoutSessionSetupIntentData>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    shipping_address_collection: Option<CreateCheckoutSessionShippingAddressCollection<'a>>,
+    shipping_address_collection: Option<CreateCheckoutSessionShippingAddressCollection>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    shipping_options: Option<&'a [CreateCheckoutSessionShippingOptions<'a>]>,
+    shipping_options: Option<Vec<CreateCheckoutSessionShippingOptions>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     submit_type: Option<stripe_checkout::CheckoutSessionSubmitType>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    subscription_data: Option<CreateCheckoutSessionSubscriptionData<'a>>,
+    subscription_data: Option<CreateCheckoutSessionSubscriptionData>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    success_url: Option<&'a str>,
+    success_url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tax_id_collection: Option<CreateCheckoutSessionTaxIdCollection>,
     #[serde(skip_serializing_if = "Option::is_none")]
     ui_mode: Option<stripe_checkout::CheckoutSessionUiMode>,
 }
-impl<'a> CreateCheckoutSessionBuilder<'a> {
+impl CreateCheckoutSessionBuilder {
     fn new() -> Self {
         Self {
             after_expiration: None,
@@ -471,41 +471,41 @@ pub struct CreateCheckoutSessionAfterExpirationRecovery {
     pub enabled: bool,
 }
 impl CreateCheckoutSessionAfterExpirationRecovery {
-    pub fn new(enabled: bool) -> Self {
-        Self { allow_promotion_codes: None, enabled }
+    pub fn new(enabled: impl Into<bool>) -> Self {
+        Self { allow_promotion_codes: None, enabled: enabled.into() }
     }
 }
 /// Settings for automatic tax lookup for this session and resulting payments, invoices, and subscriptions.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateCheckoutSessionAutomaticTax<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateCheckoutSessionAutomaticTax {
     /// Set to true to enable automatic taxes.
     pub enabled: bool,
     /// The account that's liable for tax.
     /// If set, the business address and tax registrations required to perform the tax calculation are loaded from this account.
     /// The tax transaction is returned in the report of the connected account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub liability: Option<CreateCheckoutSessionAutomaticTaxLiability<'a>>,
+    pub liability: Option<CreateCheckoutSessionAutomaticTaxLiability>,
 }
-impl<'a> CreateCheckoutSessionAutomaticTax<'a> {
-    pub fn new(enabled: bool) -> Self {
-        Self { enabled, liability: None }
+impl CreateCheckoutSessionAutomaticTax {
+    pub fn new(enabled: impl Into<bool>) -> Self {
+        Self { enabled: enabled.into(), liability: None }
     }
 }
 /// The account that's liable for tax.
 /// If set, the business address and tax registrations required to perform the tax calculation are loaded from this account.
 /// The tax transaction is returned in the report of the connected account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateCheckoutSessionAutomaticTaxLiability<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateCheckoutSessionAutomaticTaxLiability {
     /// The connected account being referenced when `type` is `account`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account: Option<&'a str>,
+    pub account: Option<String>,
     /// Type of the account referenced in the request.
     #[serde(rename = "type")]
     pub type_: CreateCheckoutSessionAutomaticTaxLiabilityType,
 }
-impl<'a> CreateCheckoutSessionAutomaticTaxLiability<'a> {
-    pub fn new(type_: CreateCheckoutSessionAutomaticTaxLiabilityType) -> Self {
-        Self { account: None, type_ }
+impl CreateCheckoutSessionAutomaticTaxLiability {
+    pub fn new(type_: impl Into<CreateCheckoutSessionAutomaticTaxLiabilityType>) -> Self {
+        Self { account: None, type_: type_.into() }
     }
 }
 /// Type of the account referenced in the request.
@@ -607,9 +607,9 @@ pub struct CreateCheckoutSessionConsentCollectionPaymentMethodReuseAgreement {
 }
 impl CreateCheckoutSessionConsentCollectionPaymentMethodReuseAgreement {
     pub fn new(
-        position: CreateCheckoutSessionConsentCollectionPaymentMethodReuseAgreementPosition,
+        position: impl Into<CreateCheckoutSessionConsentCollectionPaymentMethodReuseAgreementPosition>,
     ) -> Self {
-        Self { position }
+        Self { position: position.into() }
     }
 }
 /// Determines the position and visibility of the payment method reuse agreement in the UI.
@@ -799,16 +799,16 @@ impl<'de> serde::Deserialize<'de> for CreateCheckoutSessionConsentCollectionTerm
 }
 /// Collect additional information from your customer using custom fields.
 /// Up to 3 fields are supported.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateCheckoutSessionCustomFields<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateCheckoutSessionCustomFields {
     /// Configuration for `type=dropdown` fields.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub dropdown: Option<CreateCheckoutSessionCustomFieldsDropdown<'a>>,
+    pub dropdown: Option<CreateCheckoutSessionCustomFieldsDropdown>,
     /// String of your choice that your integration can use to reconcile this field.
     /// Must be unique to this field, alphanumeric, and up to 200 characters.
-    pub key: &'a str,
+    pub key: String,
     /// The label for the field, displayed to the customer.
-    pub label: CreateCheckoutSessionCustomFieldsLabel<'a>,
+    pub label: CreateCheckoutSessionCustomFieldsLabel,
     /// Configuration for `type=numeric` fields.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub numeric: Option<CreateCheckoutSessionCustomFieldsNumeric>,
@@ -823,52 +823,63 @@ pub struct CreateCheckoutSessionCustomFields<'a> {
     #[serde(rename = "type")]
     pub type_: CreateCheckoutSessionCustomFieldsType,
 }
-impl<'a> CreateCheckoutSessionCustomFields<'a> {
+impl CreateCheckoutSessionCustomFields {
     pub fn new(
-        key: &'a str,
-        label: CreateCheckoutSessionCustomFieldsLabel<'a>,
-        type_: CreateCheckoutSessionCustomFieldsType,
+        key: impl Into<String>,
+        label: impl Into<CreateCheckoutSessionCustomFieldsLabel>,
+        type_: impl Into<CreateCheckoutSessionCustomFieldsType>,
     ) -> Self {
-        Self { dropdown: None, key, label, numeric: None, optional: None, text: None, type_ }
+        Self {
+            dropdown: None,
+            key: key.into(),
+            label: label.into(),
+            numeric: None,
+            optional: None,
+            text: None,
+            type_: type_.into(),
+        }
     }
 }
 /// Configuration for `type=dropdown` fields.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateCheckoutSessionCustomFieldsDropdown<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateCheckoutSessionCustomFieldsDropdown {
     /// The options available for the customer to select. Up to 200 options allowed.
-    pub options: &'a [CreateCheckoutSessionCustomFieldsDropdownOptions<'a>],
+    pub options: Vec<CreateCheckoutSessionCustomFieldsDropdownOptions>,
 }
-impl<'a> CreateCheckoutSessionCustomFieldsDropdown<'a> {
-    pub fn new(options: &'a [CreateCheckoutSessionCustomFieldsDropdownOptions<'a>]) -> Self {
-        Self { options }
+impl CreateCheckoutSessionCustomFieldsDropdown {
+    pub fn new(options: impl Into<Vec<CreateCheckoutSessionCustomFieldsDropdownOptions>>) -> Self {
+        Self { options: options.into() }
     }
 }
 /// The options available for the customer to select. Up to 200 options allowed.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateCheckoutSessionCustomFieldsDropdownOptions<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateCheckoutSessionCustomFieldsDropdownOptions {
     /// The label for the option, displayed to the customer. Up to 100 characters.
-    pub label: &'a str,
+    pub label: String,
     /// The value for this option, not displayed to the customer, used by your integration to reconcile the option selected by the customer.
     /// Must be unique to this option, alphanumeric, and up to 100 characters.
-    pub value: &'a str,
+    pub value: String,
 }
-impl<'a> CreateCheckoutSessionCustomFieldsDropdownOptions<'a> {
-    pub fn new(label: &'a str, value: &'a str) -> Self {
-        Self { label, value }
+impl CreateCheckoutSessionCustomFieldsDropdownOptions {
+    pub fn new(label: impl Into<String>, value: impl Into<String>) -> Self {
+        Self { label: label.into(), value: value.into() }
     }
 }
 /// The label for the field, displayed to the customer.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateCheckoutSessionCustomFieldsLabel<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateCheckoutSessionCustomFieldsLabel {
     /// Custom text for the label, displayed to the customer. Up to 50 characters.
-    pub custom: &'a str,
+    pub custom: String,
     /// The type of the label.
     #[serde(rename = "type")]
     pub type_: CreateCheckoutSessionCustomFieldsLabelType,
 }
-impl<'a> CreateCheckoutSessionCustomFieldsLabel<'a> {
-    pub fn new(custom: &'a str, type_: CreateCheckoutSessionCustomFieldsLabelType) -> Self {
-        Self { custom, type_ }
+impl CreateCheckoutSessionCustomFieldsLabel {
+    pub fn new(
+        custom: impl Into<String>,
+        type_: impl Into<CreateCheckoutSessionCustomFieldsLabelType>,
+    ) -> Self {
+        Self { custom: custom.into(), type_: type_.into() }
     }
 }
 /// The type of the label.
@@ -1024,22 +1035,22 @@ impl<'de> serde::Deserialize<'de> for CreateCheckoutSessionCustomFieldsType {
     }
 }
 /// Display additional text for your customers using custom text.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateCheckoutSessionCustomText<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateCheckoutSessionCustomText {
     /// Custom text that should be displayed after the payment confirmation button.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub after_submit: Option<CustomTextPositionParam<'a>>,
+    pub after_submit: Option<CustomTextPositionParam>,
     /// Custom text that should be displayed alongside shipping address collection.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub shipping_address: Option<CustomTextPositionParam<'a>>,
+    pub shipping_address: Option<CustomTextPositionParam>,
     /// Custom text that should be displayed alongside the payment confirmation button.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub submit: Option<CustomTextPositionParam<'a>>,
+    pub submit: Option<CustomTextPositionParam>,
     /// Custom text that should be displayed in place of the default terms of service agreement text.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub terms_of_service_acceptance: Option<CustomTextPositionParam<'a>>,
+    pub terms_of_service_acceptance: Option<CustomTextPositionParam>,
 }
-impl<'a> CreateCheckoutSessionCustomText<'a> {
+impl CreateCheckoutSessionCustomText {
     pub fn new() -> Self {
         Self {
             after_submit: None,
@@ -1049,7 +1060,7 @@ impl<'a> CreateCheckoutSessionCustomText<'a> {
         }
     }
 }
-impl<'a> Default for CreateCheckoutSessionCustomText<'a> {
+impl Default for CreateCheckoutSessionCustomText {
     fn default() -> Self {
         Self::new()
     }
@@ -1318,70 +1329,69 @@ impl<'de> serde::Deserialize<'de> for CreateCheckoutSessionCustomerUpdateShippin
     }
 }
 /// The coupon or promotion code to apply to this Session. Currently, only up to one may be specified.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateCheckoutSessionDiscounts<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateCheckoutSessionDiscounts {
     /// The ID of the coupon to apply to this Session.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub coupon: Option<&'a str>,
+    pub coupon: Option<String>,
     /// The ID of a promotion code to apply to this Session.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub promotion_code: Option<&'a str>,
+    pub promotion_code: Option<String>,
 }
-impl<'a> CreateCheckoutSessionDiscounts<'a> {
+impl CreateCheckoutSessionDiscounts {
     pub fn new() -> Self {
         Self { coupon: None, promotion_code: None }
     }
 }
-impl<'a> Default for CreateCheckoutSessionDiscounts<'a> {
+impl Default for CreateCheckoutSessionDiscounts {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Generate a post-purchase Invoice for one-time payments.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateCheckoutSessionInvoiceCreation<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateCheckoutSessionInvoiceCreation {
     /// Set to `true` to enable invoice creation.
     pub enabled: bool,
     /// Parameters passed when creating invoices for payment-mode Checkout Sessions.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub invoice_data: Option<CreateCheckoutSessionInvoiceCreationInvoiceData<'a>>,
+    pub invoice_data: Option<CreateCheckoutSessionInvoiceCreationInvoiceData>,
 }
-impl<'a> CreateCheckoutSessionInvoiceCreation<'a> {
-    pub fn new(enabled: bool) -> Self {
-        Self { enabled, invoice_data: None }
+impl CreateCheckoutSessionInvoiceCreation {
+    pub fn new(enabled: impl Into<bool>) -> Self {
+        Self { enabled: enabled.into(), invoice_data: None }
     }
 }
 /// Parameters passed when creating invoices for payment-mode Checkout Sessions.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateCheckoutSessionInvoiceCreationInvoiceData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateCheckoutSessionInvoiceCreationInvoiceData {
     /// The account tax IDs associated with the invoice.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account_tax_ids: Option<&'a [&'a str]>,
+    pub account_tax_ids: Option<Vec<String>>,
     /// Default custom fields to be displayed on invoices for this customer.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub custom_fields:
-        Option<&'a [CreateCheckoutSessionInvoiceCreationInvoiceDataCustomFields<'a>]>,
+    pub custom_fields: Option<Vec<CreateCheckoutSessionInvoiceCreationInvoiceDataCustomFields>>,
     /// An arbitrary string attached to the object. Often useful for displaying to users.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<&'a str>,
+    pub description: Option<String>,
     /// Default footer to be displayed on invoices for this customer.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub footer: Option<&'a str>,
+    pub footer: Option<String>,
     /// The connected account that issues the invoice.
     /// The invoice is presented with the branding and support information of the specified account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub issuer: Option<CreateCheckoutSessionInvoiceCreationInvoiceDataIssuer<'a>>,
+    pub issuer: Option<CreateCheckoutSessionInvoiceCreationInvoiceDataIssuer>,
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// Default options for invoice PDF rendering for this customer.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rendering_options: Option<CreateCheckoutSessionInvoiceCreationInvoiceDataRenderingOptions>,
 }
-impl<'a> CreateCheckoutSessionInvoiceCreationInvoiceData<'a> {
+impl CreateCheckoutSessionInvoiceCreationInvoiceData {
     pub fn new() -> Self {
         Self {
             account_tax_ids: None,
@@ -1394,38 +1404,40 @@ impl<'a> CreateCheckoutSessionInvoiceCreationInvoiceData<'a> {
         }
     }
 }
-impl<'a> Default for CreateCheckoutSessionInvoiceCreationInvoiceData<'a> {
+impl Default for CreateCheckoutSessionInvoiceCreationInvoiceData {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Default custom fields to be displayed on invoices for this customer.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateCheckoutSessionInvoiceCreationInvoiceDataCustomFields<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateCheckoutSessionInvoiceCreationInvoiceDataCustomFields {
     /// The name of the custom field. This may be up to 40 characters.
-    pub name: &'a str,
+    pub name: String,
     /// The value of the custom field. This may be up to 140 characters.
-    pub value: &'a str,
+    pub value: String,
 }
-impl<'a> CreateCheckoutSessionInvoiceCreationInvoiceDataCustomFields<'a> {
-    pub fn new(name: &'a str, value: &'a str) -> Self {
-        Self { name, value }
+impl CreateCheckoutSessionInvoiceCreationInvoiceDataCustomFields {
+    pub fn new(name: impl Into<String>, value: impl Into<String>) -> Self {
+        Self { name: name.into(), value: value.into() }
     }
 }
 /// The connected account that issues the invoice.
 /// The invoice is presented with the branding and support information of the specified account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateCheckoutSessionInvoiceCreationInvoiceDataIssuer<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateCheckoutSessionInvoiceCreationInvoiceDataIssuer {
     /// The connected account being referenced when `type` is `account`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account: Option<&'a str>,
+    pub account: Option<String>,
     /// Type of the account referenced in the request.
     #[serde(rename = "type")]
     pub type_: CreateCheckoutSessionInvoiceCreationInvoiceDataIssuerType,
 }
-impl<'a> CreateCheckoutSessionInvoiceCreationInvoiceDataIssuer<'a> {
-    pub fn new(type_: CreateCheckoutSessionInvoiceCreationInvoiceDataIssuerType) -> Self {
-        Self { account: None, type_ }
+impl CreateCheckoutSessionInvoiceCreationInvoiceDataIssuer {
+    pub fn new(
+        type_: impl Into<CreateCheckoutSessionInvoiceCreationInvoiceDataIssuerType>,
+    ) -> Self {
+        Self { account: None, type_: type_.into() }
     }
 }
 /// Type of the account referenced in the request.
@@ -1581,32 +1593,32 @@ impl<'de> serde::Deserialize<'de>
 ///
 /// For `subscription` mode, there is a maximum of 20 line items with recurring Prices and 20 line items with one-time Prices.
 /// Line items with one-time Prices will be on the initial invoice only.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateCheckoutSessionLineItems<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateCheckoutSessionLineItems {
     /// When set, provides configuration for this item’s quantity to be adjusted by the customer during Checkout.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub adjustable_quantity: Option<CreateCheckoutSessionLineItemsAdjustableQuantity>,
     /// The [tax rates](https://stripe.com/docs/api/tax_rates) that will be applied to this line item depending on the customer's billing/shipping address.
     /// We currently support the following countries: US, GB, AU, and all countries in the EU.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub dynamic_tax_rates: Option<&'a [&'a str]>,
+    pub dynamic_tax_rates: Option<Vec<String>>,
     /// The ID of the [Price](https://stripe.com/docs/api/prices) or [Plan](https://stripe.com/docs/api/plans) object.
     /// One of `price` or `price_data` is required.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price: Option<&'a str>,
+    pub price: Option<String>,
     /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
     /// One of `price` or `price_data` is required.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub price_data: Option<CreateCheckoutSessionLineItemsPriceData<'a>>,
+    pub price_data: Option<CreateCheckoutSessionLineItemsPriceData>,
     /// The quantity of the line item being purchased.
     /// Quantity should not be defined when `recurring.usage_type=metered`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub quantity: Option<u64>,
     /// The [tax rates](https://stripe.com/docs/api/tax_rates) which apply to this line item.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_rates: Option<&'a [&'a str]>,
+    pub tax_rates: Option<Vec<String>>,
 }
-impl<'a> CreateCheckoutSessionLineItems<'a> {
+impl CreateCheckoutSessionLineItems {
     pub fn new() -> Self {
         Self {
             adjustable_quantity: None,
@@ -1618,7 +1630,7 @@ impl<'a> CreateCheckoutSessionLineItems<'a> {
         }
     }
 }
-impl<'a> Default for CreateCheckoutSessionLineItems<'a> {
+impl Default for CreateCheckoutSessionLineItems {
     fn default() -> Self {
         Self::new()
     }
@@ -1640,24 +1652,24 @@ pub struct CreateCheckoutSessionLineItemsAdjustableQuantity {
     pub minimum: Option<i64>,
 }
 impl CreateCheckoutSessionLineItemsAdjustableQuantity {
-    pub fn new(enabled: bool) -> Self {
-        Self { enabled, maximum: None, minimum: None }
+    pub fn new(enabled: impl Into<bool>) -> Self {
+        Self { enabled: enabled.into(), maximum: None, minimum: None }
     }
 }
 /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
 /// One of `price` or `price_data` is required.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateCheckoutSessionLineItemsPriceData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateCheckoutSessionLineItemsPriceData {
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     /// Must be a [supported currency](https://stripe.com/docs/currencies).
     pub currency: stripe_types::Currency,
     /// The ID of the product that this price will belong to.
     /// One of `product` or `product_data` is required.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub product: Option<&'a str>,
+    pub product: Option<String>,
     /// Data used to generate a new product object inline. One of `product` or `product_data` is required.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub product_data: Option<CreateCheckoutSessionLineItemsPriceDataProductData<'a>>,
+    pub product_data: Option<CreateCheckoutSessionLineItemsPriceDataProductData>,
     /// The recurring components of a price such as `interval` and `interval_count`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub recurring: Option<CreateCheckoutSessionLineItemsPriceDataRecurring>,
@@ -1674,12 +1686,12 @@ pub struct CreateCheckoutSessionLineItemsPriceData<'a> {
     /// Same as `unit_amount`, but accepts a decimal value in cents (or local equivalent) with at most 12 decimal places.
     /// Only one of `unit_amount` and `unit_amount_decimal` can be set.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub unit_amount_decimal: Option<&'a str>,
+    pub unit_amount_decimal: Option<String>,
 }
-impl<'a> CreateCheckoutSessionLineItemsPriceData<'a> {
-    pub fn new(currency: stripe_types::Currency) -> Self {
+impl CreateCheckoutSessionLineItemsPriceData {
+    pub fn new(currency: impl Into<stripe_types::Currency>) -> Self {
         Self {
-            currency,
+            currency: currency.into(),
             product: None,
             product_data: None,
             recurring: None,
@@ -1690,30 +1702,30 @@ impl<'a> CreateCheckoutSessionLineItemsPriceData<'a> {
     }
 }
 /// Data used to generate a new product object inline. One of `product` or `product_data` is required.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateCheckoutSessionLineItemsPriceDataProductData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateCheckoutSessionLineItemsPriceDataProductData {
     /// The product's description, meant to be displayable to the customer.
     /// Use this field to optionally store a long form explanation of the product being sold for your own rendering purposes.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<&'a str>,
+    pub description: Option<String>,
     /// A list of up to 8 URLs of images for this product, meant to be displayable to the customer.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub images: Option<&'a [&'a str]>,
+    pub images: Option<Vec<String>>,
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// The product's name, meant to be displayable to the customer.
-    pub name: &'a str,
+    pub name: String,
     /// A [tax code](https://stripe.com/docs/tax/tax-categories) ID.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_code: Option<&'a str>,
+    pub tax_code: Option<String>,
 }
-impl<'a> CreateCheckoutSessionLineItemsPriceDataProductData<'a> {
-    pub fn new(name: &'a str) -> Self {
-        Self { description: None, images: None, metadata: None, name, tax_code: None }
+impl CreateCheckoutSessionLineItemsPriceDataProductData {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self { description: None, images: None, metadata: None, name: name.into(), tax_code: None }
     }
 }
 /// The recurring components of a price such as `interval` and `interval_count`.
@@ -1728,8 +1740,10 @@ pub struct CreateCheckoutSessionLineItemsPriceDataRecurring {
     pub interval_count: Option<u64>,
 }
 impl CreateCheckoutSessionLineItemsPriceDataRecurring {
-    pub fn new(interval: CreateCheckoutSessionLineItemsPriceDataRecurringInterval) -> Self {
-        Self { interval, interval_count: None }
+    pub fn new(
+        interval: impl Into<CreateCheckoutSessionLineItemsPriceDataRecurringInterval>,
+    ) -> Self {
+        Self { interval: interval.into(), interval_count: None }
     }
 }
 /// Specifies billing frequency. Either `day`, `week`, `month` or `year`.
@@ -1861,8 +1875,8 @@ impl<'de> serde::Deserialize<'de> for CreateCheckoutSessionLineItemsPriceDataTax
     }
 }
 /// A subset of parameters to be passed to PaymentIntent creation for Checkout Sessions in `payment` mode.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateCheckoutSessionPaymentIntentData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateCheckoutSessionPaymentIntentData {
     /// The amount of the application fee (if any) that will be requested to be applied to the payment and transferred to the application owner's Stripe account.
     /// The amount of the application fee collected will be capped at the total payment amount.
     /// For more information, see the PaymentIntents [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts).
@@ -1873,22 +1887,22 @@ pub struct CreateCheckoutSessionPaymentIntentData<'a> {
     pub capture_method: Option<CreateCheckoutSessionPaymentIntentDataCaptureMethod>,
     /// An arbitrary string attached to the object. Often useful for displaying to users.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<&'a str>,
+    pub description: Option<String>,
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// The Stripe account ID for which these funds are intended. For details,
     /// see the PaymentIntents [use case for connected
     /// accounts](/docs/payments/connected-accounts).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub on_behalf_of: Option<&'a str>,
+    pub on_behalf_of: Option<String>,
     /// Email address that the receipt for the resulting payment will be sent to.
     /// If `receipt_email` is specified for a payment in live mode, a receipt will be sent regardless of your [email settings](https://dashboard.stripe.com/account/emails).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub receipt_email: Option<&'a str>,
+    pub receipt_email: Option<String>,
     /// Indicates that you intend to [make future payments](https://stripe.com/docs/payments/payment-intents#future-usage) with the payment.
     /// method collected by this Checkout Session.
     ///
@@ -1913,26 +1927,26 @@ pub struct CreateCheckoutSessionPaymentIntentData<'a> {
     pub setup_future_usage: Option<CreateCheckoutSessionPaymentIntentDataSetupFutureUsage>,
     /// Shipping information for this payment.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub shipping: Option<CreateCheckoutSessionPaymentIntentDataShipping<'a>>,
+    pub shipping: Option<CreateCheckoutSessionPaymentIntentDataShipping>,
     /// Extra information about the payment. This will appear on your
     /// customer's statement when this payment succeeds in creating a charge.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub statement_descriptor: Option<&'a str>,
+    pub statement_descriptor: Option<String>,
     /// Provides information about the charge that customers see on their statements. Concatenated with the
     /// prefix (shortened descriptor) or statement descriptor that’s set on the account to form the complete.
     /// statement descriptor. Maximum 22 characters for the concatenated descriptor.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub statement_descriptor_suffix: Option<&'a str>,
+    pub statement_descriptor_suffix: Option<String>,
     /// The parameters used to automatically create a Transfer when the payment succeeds.
     /// For more information, see the PaymentIntents [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub transfer_data: Option<CreateCheckoutSessionPaymentIntentDataTransferData<'a>>,
+    pub transfer_data: Option<CreateCheckoutSessionPaymentIntentDataTransferData>,
     /// A string that identifies the resulting payment as part of a group.
     /// See the PaymentIntents [use case for connected accounts](https://stripe.com/docs/connect/separate-charges-and-transfers) for details.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub transfer_group: Option<&'a str>,
+    pub transfer_group: Option<String>,
 }
-impl<'a> CreateCheckoutSessionPaymentIntentData<'a> {
+impl CreateCheckoutSessionPaymentIntentData {
     pub fn new() -> Self {
         Self {
             application_fee_amount: None,
@@ -1950,7 +1964,7 @@ impl<'a> CreateCheckoutSessionPaymentIntentData<'a> {
         }
     }
 }
-impl<'a> Default for CreateCheckoutSessionPaymentIntentData<'a> {
+impl Default for CreateCheckoutSessionPaymentIntentData {
     fn default() -> Self {
         Self::new()
     }
@@ -2094,61 +2108,74 @@ impl<'de> serde::Deserialize<'de> for CreateCheckoutSessionPaymentIntentDataSetu
     }
 }
 /// Shipping information for this payment.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateCheckoutSessionPaymentIntentDataShipping<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateCheckoutSessionPaymentIntentDataShipping {
     /// Shipping address.
-    pub address: CreateCheckoutSessionPaymentIntentDataShippingAddress<'a>,
+    pub address: CreateCheckoutSessionPaymentIntentDataShippingAddress,
     /// The delivery service that shipped a physical product, such as Fedex, UPS, USPS, etc.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub carrier: Option<&'a str>,
+    pub carrier: Option<String>,
     /// Recipient name.
-    pub name: &'a str,
+    pub name: String,
     /// Recipient phone (including extension).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub phone: Option<&'a str>,
+    pub phone: Option<String>,
     /// The tracking number for a physical product, obtained from the delivery service.
     /// If multiple tracking numbers were generated for this purchase, please separate them with commas.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tracking_number: Option<&'a str>,
+    pub tracking_number: Option<String>,
 }
-impl<'a> CreateCheckoutSessionPaymentIntentDataShipping<'a> {
+impl CreateCheckoutSessionPaymentIntentDataShipping {
     pub fn new(
-        address: CreateCheckoutSessionPaymentIntentDataShippingAddress<'a>,
-        name: &'a str,
+        address: impl Into<CreateCheckoutSessionPaymentIntentDataShippingAddress>,
+        name: impl Into<String>,
     ) -> Self {
-        Self { address, carrier: None, name, phone: None, tracking_number: None }
+        Self {
+            address: address.into(),
+            carrier: None,
+            name: name.into(),
+            phone: None,
+            tracking_number: None,
+        }
     }
 }
 /// Shipping address.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateCheckoutSessionPaymentIntentDataShippingAddress<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateCheckoutSessionPaymentIntentDataShippingAddress {
     /// City, district, suburb, town, or village.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<&'a str>,
+    pub city: Option<String>,
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub country: Option<&'a str>,
+    pub country: Option<String>,
     /// Address line 1 (e.g., street, PO Box, or company name).
-    pub line1: &'a str,
+    pub line1: String,
     /// Address line 2 (e.g., apartment, suite, unit, or building).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line2: Option<&'a str>,
+    pub line2: Option<String>,
     /// ZIP or postal code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<&'a str>,
+    pub postal_code: Option<String>,
     /// State, county, province, or region.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
 }
-impl<'a> CreateCheckoutSessionPaymentIntentDataShippingAddress<'a> {
-    pub fn new(line1: &'a str) -> Self {
-        Self { city: None, country: None, line1, line2: None, postal_code: None, state: None }
+impl CreateCheckoutSessionPaymentIntentDataShippingAddress {
+    pub fn new(line1: impl Into<String>) -> Self {
+        Self {
+            city: None,
+            country: None,
+            line1: line1.into(),
+            line2: None,
+            postal_code: None,
+            state: None,
+        }
     }
 }
 /// The parameters used to automatically create a Transfer when the payment succeeds.
 /// For more information, see the PaymentIntents [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts).
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateCheckoutSessionPaymentIntentDataTransferData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateCheckoutSessionPaymentIntentDataTransferData {
     /// The amount that will be transferred automatically when a charge succeeds.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub amount: Option<i64>,
@@ -2156,11 +2183,11 @@ pub struct CreateCheckoutSessionPaymentIntentDataTransferData<'a> {
     /// account for tax reporting, and the funds from charges will be transferred
     /// to the destination account. The ID of the resulting transfer will be
     /// returned on the successful charge's `transfer` field.
-    pub destination: &'a str,
+    pub destination: String,
 }
-impl<'a> CreateCheckoutSessionPaymentIntentDataTransferData<'a> {
-    pub fn new(destination: &'a str) -> Self {
-        Self { amount: None, destination }
+impl CreateCheckoutSessionPaymentIntentDataTransferData {
+    pub fn new(destination: impl Into<String>) -> Self {
+        Self { amount: None, destination: destination.into() }
     }
 }
 /// Specify whether Checkout should collect a payment method.
@@ -2308,11 +2335,11 @@ impl<'de> serde::Deserialize<'de> for CreateCheckoutSessionPaymentMethodDataAllo
     }
 }
 /// Payment-method-specific configuration.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateCheckoutSessionPaymentMethodOptions<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateCheckoutSessionPaymentMethodOptions {
     /// contains details about the ACSS Debit payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub acss_debit: Option<CreateCheckoutSessionPaymentMethodOptionsAcssDebit<'a>>,
+    pub acss_debit: Option<CreateCheckoutSessionPaymentMethodOptionsAcssDebit>,
     /// contains details about the Affirm payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub affirm: Option<CreateCheckoutSessionPaymentMethodOptionsAffirm>,
@@ -2339,13 +2366,13 @@ pub struct CreateCheckoutSessionPaymentMethodOptions<'a> {
     pub boleto: Option<CreateCheckoutSessionPaymentMethodOptionsBoleto>,
     /// contains details about the Card payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub card: Option<CreateCheckoutSessionPaymentMethodOptionsCard<'a>>,
+    pub card: Option<CreateCheckoutSessionPaymentMethodOptionsCard>,
     /// contains details about the Cashapp Pay payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cashapp: Option<CreateCheckoutSessionPaymentMethodOptionsCashapp>,
     /// contains details about the Customer Balance payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub customer_balance: Option<CreateCheckoutSessionPaymentMethodOptionsCustomerBalance<'a>>,
+    pub customer_balance: Option<CreateCheckoutSessionPaymentMethodOptionsCustomerBalance>,
     /// contains details about the EPS payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub eps: Option<CreateCheckoutSessionPaymentMethodOptionsEps>,
@@ -2384,7 +2411,7 @@ pub struct CreateCheckoutSessionPaymentMethodOptions<'a> {
     pub paynow: Option<CreateCheckoutSessionPaymentMethodOptionsPaynow>,
     /// contains details about the PayPal payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub paypal: Option<CreateCheckoutSessionPaymentMethodOptionsPaypal<'a>>,
+    pub paypal: Option<CreateCheckoutSessionPaymentMethodOptionsPaypal>,
     /// contains details about the Pix payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pix: Option<CreateCheckoutSessionPaymentMethodOptionsPix>,
@@ -2399,15 +2426,15 @@ pub struct CreateCheckoutSessionPaymentMethodOptions<'a> {
     pub sofort: Option<CreateCheckoutSessionPaymentMethodOptionsSofort>,
     /// contains details about the Swish payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub swish: Option<CreateCheckoutSessionPaymentMethodOptionsSwish<'a>>,
+    pub swish: Option<CreateCheckoutSessionPaymentMethodOptionsSwish>,
     /// contains details about the Us Bank Account payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub us_bank_account: Option<CreateCheckoutSessionPaymentMethodOptionsUsBankAccount<'a>>,
+    pub us_bank_account: Option<CreateCheckoutSessionPaymentMethodOptionsUsBankAccount>,
     /// contains details about the WeChat Pay payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub wechat_pay: Option<CreateCheckoutSessionPaymentMethodOptionsWechatPay<'a>>,
+    pub wechat_pay: Option<CreateCheckoutSessionPaymentMethodOptionsWechatPay>,
 }
-impl<'a> CreateCheckoutSessionPaymentMethodOptions<'a> {
+impl CreateCheckoutSessionPaymentMethodOptions {
     pub fn new() -> Self {
         Self {
             acss_debit: None,
@@ -2445,14 +2472,14 @@ impl<'a> CreateCheckoutSessionPaymentMethodOptions<'a> {
         }
     }
 }
-impl<'a> Default for CreateCheckoutSessionPaymentMethodOptions<'a> {
+impl Default for CreateCheckoutSessionPaymentMethodOptions {
     fn default() -> Self {
         Self::new()
     }
 }
 /// contains details about the ACSS Debit payment method options.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateCheckoutSessionPaymentMethodOptionsAcssDebit<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateCheckoutSessionPaymentMethodOptionsAcssDebit {
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     /// Must be a [supported currency](https://stripe.com/docs/currencies).
     /// This is only accepted for Checkout Sessions in `setup` mode.
@@ -2460,8 +2487,7 @@ pub struct CreateCheckoutSessionPaymentMethodOptionsAcssDebit<'a> {
     pub currency: Option<CreateCheckoutSessionPaymentMethodOptionsAcssDebitCurrency>,
     /// Additional fields for Mandate creation
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub mandate_options:
-        Option<CreateCheckoutSessionPaymentMethodOptionsAcssDebitMandateOptions<'a>>,
+    pub mandate_options: Option<CreateCheckoutSessionPaymentMethodOptionsAcssDebitMandateOptions>,
     /// Indicates that you intend to make future payments with this PaymentIntent's payment method.
     ///
     /// Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete.
@@ -2476,7 +2502,7 @@ pub struct CreateCheckoutSessionPaymentMethodOptionsAcssDebit<'a> {
     pub verification_method:
         Option<CreateCheckoutSessionPaymentMethodOptionsAcssDebitVerificationMethod>,
 }
-impl<'a> CreateCheckoutSessionPaymentMethodOptionsAcssDebit<'a> {
+impl CreateCheckoutSessionPaymentMethodOptionsAcssDebit {
     pub fn new() -> Self {
         Self {
             currency: None,
@@ -2486,7 +2512,7 @@ impl<'a> CreateCheckoutSessionPaymentMethodOptionsAcssDebit<'a> {
         }
     }
 }
-impl<'a> Default for CreateCheckoutSessionPaymentMethodOptionsAcssDebit<'a> {
+impl Default for CreateCheckoutSessionPaymentMethodOptionsAcssDebit {
     fn default() -> Self {
         Self::new()
     }
@@ -2552,22 +2578,22 @@ impl<'de> serde::Deserialize<'de> for CreateCheckoutSessionPaymentMethodOptionsA
     }
 }
 /// Additional fields for Mandate creation
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateCheckoutSessionPaymentMethodOptionsAcssDebitMandateOptions<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateCheckoutSessionPaymentMethodOptionsAcssDebitMandateOptions {
     /// A URL for custom mandate text to render during confirmation step.
     /// The URL will be rendered with additional GET parameters `payment_intent` and `payment_intent_client_secret` when confirming a Payment Intent,.
     /// or `setup_intent` and `setup_intent_client_secret` when confirming a Setup Intent.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub custom_mandate_url: Option<&'a str>,
+    pub custom_mandate_url: Option<String>,
     /// List of Stripe products where this mandate can be selected automatically.
     /// Only usable in `setup` mode.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_for:
-        Option<&'a [CreateCheckoutSessionPaymentMethodOptionsAcssDebitMandateOptionsDefaultFor]>,
+        Option<Vec<CreateCheckoutSessionPaymentMethodOptionsAcssDebitMandateOptionsDefaultFor>>,
     /// Description of the mandate interval.
     /// Only required if 'payment_schedule' parameter is 'interval' or 'combined'.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub interval_description: Option<&'a str>,
+    pub interval_description: Option<String>,
     /// Payment schedule for the mandate.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub payment_schedule:
@@ -2577,7 +2603,7 @@ pub struct CreateCheckoutSessionPaymentMethodOptionsAcssDebitMandateOptions<'a> 
     pub transaction_type:
         Option<CreateCheckoutSessionPaymentMethodOptionsAcssDebitMandateOptionsTransactionType>,
 }
-impl<'a> CreateCheckoutSessionPaymentMethodOptionsAcssDebitMandateOptions<'a> {
+impl CreateCheckoutSessionPaymentMethodOptionsAcssDebitMandateOptions {
     pub fn new() -> Self {
         Self {
             custom_mandate_url: None,
@@ -2588,7 +2614,7 @@ impl<'a> CreateCheckoutSessionPaymentMethodOptionsAcssDebitMandateOptions<'a> {
         }
     }
 }
-impl<'a> Default for CreateCheckoutSessionPaymentMethodOptionsAcssDebitMandateOptions<'a> {
+impl Default for CreateCheckoutSessionPaymentMethodOptionsAcssDebitMandateOptions {
     fn default() -> Self {
         Self::new()
     }
@@ -3595,8 +3621,8 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// contains details about the Card payment method options.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateCheckoutSessionPaymentMethodOptionsCard<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateCheckoutSessionPaymentMethodOptionsCard {
     /// Installment options for card payments
     #[serde(skip_serializing_if = "Option::is_none")]
     pub installments: Option<CreateCheckoutSessionPaymentMethodOptionsCardInstallments>,
@@ -3620,15 +3646,15 @@ pub struct CreateCheckoutSessionPaymentMethodOptionsCard<'a> {
     /// Maximum 22 characters.
     /// On card statements, the *concatenation* of both prefix and suffix (including separators) will appear truncated to 22 characters.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub statement_descriptor_suffix_kana: Option<&'a str>,
+    pub statement_descriptor_suffix_kana: Option<String>,
     /// Provides information about a card payment that customers see on their statements.
     /// Concatenated with the Kanji prefix (shortened Kanji descriptor) or Kanji statement descriptor that’s set on the account to form the complete statement descriptor.
     /// Maximum 17 characters.
     /// On card statements, the *concatenation* of both prefix and suffix (including separators) will appear truncated to 17 characters.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub statement_descriptor_suffix_kanji: Option<&'a str>,
+    pub statement_descriptor_suffix_kanji: Option<String>,
 }
-impl<'a> CreateCheckoutSessionPaymentMethodOptionsCard<'a> {
+impl CreateCheckoutSessionPaymentMethodOptionsCard {
     pub fn new() -> Self {
         Self {
             installments: None,
@@ -3639,7 +3665,7 @@ impl<'a> CreateCheckoutSessionPaymentMethodOptionsCard<'a> {
         }
     }
 }
-impl<'a> Default for CreateCheckoutSessionPaymentMethodOptionsCard<'a> {
+impl Default for CreateCheckoutSessionPaymentMethodOptionsCard {
     fn default() -> Self {
         Self::new()
     }
@@ -3877,12 +3903,11 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// contains details about the Customer Balance payment method options.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateCheckoutSessionPaymentMethodOptionsCustomerBalance<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateCheckoutSessionPaymentMethodOptionsCustomerBalance {
     /// Configuration for the bank transfer funding type, if the `funding_type` is set to `bank_transfer`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub bank_transfer:
-        Option<CreateCheckoutSessionPaymentMethodOptionsCustomerBalanceBankTransfer<'a>>,
+    pub bank_transfer: Option<CreateCheckoutSessionPaymentMethodOptionsCustomerBalanceBankTransfer>,
     /// The funding method type to be used when there are not enough funds in the customer balance.
     /// Permitted values include: `bank_transfer`.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -3897,50 +3922,50 @@ pub struct CreateCheckoutSessionPaymentMethodOptionsCustomerBalance<'a> {
     pub setup_future_usage:
         Option<CreateCheckoutSessionPaymentMethodOptionsCustomerBalanceSetupFutureUsage>,
 }
-impl<'a> CreateCheckoutSessionPaymentMethodOptionsCustomerBalance<'a> {
+impl CreateCheckoutSessionPaymentMethodOptionsCustomerBalance {
     pub fn new() -> Self {
         Self { bank_transfer: None, funding_type: None, setup_future_usage: None }
     }
 }
-impl<'a> Default for CreateCheckoutSessionPaymentMethodOptionsCustomerBalance<'a> {
+impl Default for CreateCheckoutSessionPaymentMethodOptionsCustomerBalance {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Configuration for the bank transfer funding type, if the `funding_type` is set to `bank_transfer`.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateCheckoutSessionPaymentMethodOptionsCustomerBalanceBankTransfer<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateCheckoutSessionPaymentMethodOptionsCustomerBalanceBankTransfer {
     /// Configuration for eu_bank_transfer funding type.
 #[serde(skip_serializing_if = "Option::is_none")]
-pub eu_bank_transfer: Option<CreateCheckoutSessionPaymentMethodOptionsCustomerBalanceBankTransferEuBankTransfer<'a>>,
+pub eu_bank_transfer: Option<CreateCheckoutSessionPaymentMethodOptionsCustomerBalanceBankTransferEuBankTransfer>,
         /// List of address types that should be returned in the financial_addresses response.
     /// If not specified, all valid types will be returned.
     ///
     /// Permitted values include: `sort_code`, `zengin`, `iban`, or `spei`.
 #[serde(skip_serializing_if = "Option::is_none")]
-pub requested_address_types: Option<&'a [CreateCheckoutSessionPaymentMethodOptionsCustomerBalanceBankTransferRequestedAddressTypes]>,
+pub requested_address_types: Option<Vec<CreateCheckoutSessionPaymentMethodOptionsCustomerBalanceBankTransferRequestedAddressTypes>>,
     /// The list of bank transfer types that this PaymentIntent is allowed to use for funding.
 #[serde(rename = "type")]
 pub type_: CreateCheckoutSessionPaymentMethodOptionsCustomerBalanceBankTransferType,
 
 }
-impl<'a> CreateCheckoutSessionPaymentMethodOptionsCustomerBalanceBankTransfer<'a> {
+impl CreateCheckoutSessionPaymentMethodOptionsCustomerBalanceBankTransfer {
     pub fn new(
-        type_: CreateCheckoutSessionPaymentMethodOptionsCustomerBalanceBankTransferType,
+        type_: impl Into<CreateCheckoutSessionPaymentMethodOptionsCustomerBalanceBankTransferType>,
     ) -> Self {
-        Self { eu_bank_transfer: None, requested_address_types: None, type_ }
+        Self { eu_bank_transfer: None, requested_address_types: None, type_: type_.into() }
     }
 }
 /// Configuration for eu_bank_transfer funding type.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateCheckoutSessionPaymentMethodOptionsCustomerBalanceBankTransferEuBankTransfer<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateCheckoutSessionPaymentMethodOptionsCustomerBalanceBankTransferEuBankTransfer {
     /// The desired country code of the bank account information.
     /// Permitted values include: `BE`, `DE`, `ES`, `FR`, `IE`, or `NL`.
-    pub country: &'a str,
+    pub country: String,
 }
-impl<'a> CreateCheckoutSessionPaymentMethodOptionsCustomerBalanceBankTransferEuBankTransfer<'a> {
-    pub fn new(country: &'a str) -> Self {
-        Self { country }
+impl CreateCheckoutSessionPaymentMethodOptionsCustomerBalanceBankTransferEuBankTransfer {
+    pub fn new(country: impl Into<String>) -> Self {
+        Self { country: country.into() }
     }
 }
 /// List of address types that should be returned in the financial_addresses response.
@@ -5216,8 +5241,8 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// contains details about the PayPal payment method options.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateCheckoutSessionPaymentMethodOptionsPaypal<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateCheckoutSessionPaymentMethodOptionsPaypal {
     /// Controls when the funds will be captured from the customer's account.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub capture_method: Option<CreateCheckoutSessionPaymentMethodOptionsPaypalCaptureMethod>,
@@ -5227,10 +5252,10 @@ pub struct CreateCheckoutSessionPaymentMethodOptionsPaypal<'a> {
     /// A reference of the PayPal transaction visible to customer which is mapped to PayPal's invoice ID.
     /// This must be a globally unique ID if you have configured in your PayPal settings to block multiple payments per invoice ID.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reference: Option<&'a str>,
+    pub reference: Option<String>,
     /// The risk correlation ID for an on-session payment using a saved PayPal payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub risk_correlation_id: Option<&'a str>,
+    pub risk_correlation_id: Option<String>,
     /// Indicates that you intend to make future payments with this PaymentIntent's payment method.
     ///
     /// Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete.
@@ -5242,7 +5267,7 @@ pub struct CreateCheckoutSessionPaymentMethodOptionsPaypal<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub setup_future_usage: Option<CreateCheckoutSessionPaymentMethodOptionsPaypalSetupFutureUsage>,
 }
-impl<'a> CreateCheckoutSessionPaymentMethodOptionsPaypal<'a> {
+impl CreateCheckoutSessionPaymentMethodOptionsPaypal {
     pub fn new() -> Self {
         Self {
             capture_method: None,
@@ -5253,7 +5278,7 @@ impl<'a> CreateCheckoutSessionPaymentMethodOptionsPaypal<'a> {
         }
     }
 }
-impl<'a> Default for CreateCheckoutSessionPaymentMethodOptionsPaypal<'a> {
+impl Default for CreateCheckoutSessionPaymentMethodOptionsPaypal {
     fn default() -> Self {
         Self::new()
     }
@@ -5771,30 +5796,30 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// contains details about the Swish payment method options.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateCheckoutSessionPaymentMethodOptionsSwish<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateCheckoutSessionPaymentMethodOptionsSwish {
     /// The order reference that will be displayed to customers in the Swish application.
     /// Defaults to the `id` of the Payment Intent.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reference: Option<&'a str>,
+    pub reference: Option<String>,
 }
-impl<'a> CreateCheckoutSessionPaymentMethodOptionsSwish<'a> {
+impl CreateCheckoutSessionPaymentMethodOptionsSwish {
     pub fn new() -> Self {
         Self { reference: None }
     }
 }
-impl<'a> Default for CreateCheckoutSessionPaymentMethodOptionsSwish<'a> {
+impl Default for CreateCheckoutSessionPaymentMethodOptionsSwish {
     fn default() -> Self {
         Self::new()
     }
 }
 /// contains details about the Us Bank Account payment method options.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateCheckoutSessionPaymentMethodOptionsUsBankAccount<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateCheckoutSessionPaymentMethodOptionsUsBankAccount {
     /// Additional fields for Financial Connections Session creation
     #[serde(skip_serializing_if = "Option::is_none")]
     pub financial_connections:
-        Option<CreateCheckoutSessionPaymentMethodOptionsUsBankAccountFinancialConnections<'a>>,
+        Option<CreateCheckoutSessionPaymentMethodOptionsUsBankAccountFinancialConnections>,
     /// Indicates that you intend to make future payments with this PaymentIntent's payment method.
     ///
     /// Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete.
@@ -5809,37 +5834,38 @@ pub struct CreateCheckoutSessionPaymentMethodOptionsUsBankAccount<'a> {
     pub verification_method:
         Option<CreateCheckoutSessionPaymentMethodOptionsUsBankAccountVerificationMethod>,
 }
-impl<'a> CreateCheckoutSessionPaymentMethodOptionsUsBankAccount<'a> {
+impl CreateCheckoutSessionPaymentMethodOptionsUsBankAccount {
     pub fn new() -> Self {
         Self { financial_connections: None, setup_future_usage: None, verification_method: None }
     }
 }
-impl<'a> Default for CreateCheckoutSessionPaymentMethodOptionsUsBankAccount<'a> {
+impl Default for CreateCheckoutSessionPaymentMethodOptionsUsBankAccount {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Additional fields for Financial Connections Session creation
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateCheckoutSessionPaymentMethodOptionsUsBankAccountFinancialConnections<'a> {
-        /// The list of permissions to request.
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateCheckoutSessionPaymentMethodOptionsUsBankAccountFinancialConnections {
+    /// The list of permissions to request.
     /// If this parameter is passed, the `payment_method` permission must be included.
     /// Valid permissions include: `balances`, `ownership`, `payment_method`, and `transactions`.
-#[serde(skip_serializing_if = "Option::is_none")]
-pub permissions: Option<&'a [CreateCheckoutSessionPaymentMethodOptionsUsBankAccountFinancialConnectionsPermissions]>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub permissions: Option<
+        Vec<CreateCheckoutSessionPaymentMethodOptionsUsBankAccountFinancialConnectionsPermissions>,
+    >,
     /// List of data features that you would like to retrieve upon account creation.
-#[serde(skip_serializing_if = "Option::is_none")]
-pub prefetch: Option<&'a [CreateCheckoutSessionPaymentMethodOptionsUsBankAccountFinancialConnectionsPrefetch]>,
-
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prefetch: Option<
+        Vec<CreateCheckoutSessionPaymentMethodOptionsUsBankAccountFinancialConnectionsPrefetch>,
+    >,
 }
-impl<'a> CreateCheckoutSessionPaymentMethodOptionsUsBankAccountFinancialConnections<'a> {
+impl CreateCheckoutSessionPaymentMethodOptionsUsBankAccountFinancialConnections {
     pub fn new() -> Self {
         Self { permissions: None, prefetch: None }
     }
 }
-impl<'a> Default
-    for CreateCheckoutSessionPaymentMethodOptionsUsBankAccountFinancialConnections<'a>
-{
+impl Default for CreateCheckoutSessionPaymentMethodOptionsUsBankAccountFinancialConnections {
     fn default() -> Self {
         Self::new()
     }
@@ -6108,11 +6134,11 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// contains details about the WeChat Pay payment method options.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateCheckoutSessionPaymentMethodOptionsWechatPay<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateCheckoutSessionPaymentMethodOptionsWechatPay {
     /// The app ID registered with WeChat Pay. Only required when client is ios or android.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub app_id: Option<&'a str>,
+    pub app_id: Option<String>,
     /// The client type that the end customer will pay from
     pub client: CreateCheckoutSessionPaymentMethodOptionsWechatPayClient,
     /// Indicates that you intend to make future payments with this PaymentIntent's payment method.
@@ -6125,9 +6151,11 @@ pub struct CreateCheckoutSessionPaymentMethodOptionsWechatPay<'a> {
     pub setup_future_usage:
         Option<CreateCheckoutSessionPaymentMethodOptionsWechatPaySetupFutureUsage>,
 }
-impl<'a> CreateCheckoutSessionPaymentMethodOptionsWechatPay<'a> {
-    pub fn new(client: CreateCheckoutSessionPaymentMethodOptionsWechatPayClient) -> Self {
-        Self { app_id: None, client, setup_future_usage: None }
+impl CreateCheckoutSessionPaymentMethodOptionsWechatPay {
+    pub fn new(
+        client: impl Into<CreateCheckoutSessionPaymentMethodOptionsWechatPayClient>,
+    ) -> Self {
+        Self { app_id: None, client: client.into(), setup_future_usage: None }
     }
 }
 /// The client type that the end customer will pay from
@@ -6427,30 +6455,30 @@ pub struct CreateCheckoutSessionPhoneNumberCollection {
     pub enabled: bool,
 }
 impl CreateCheckoutSessionPhoneNumberCollection {
-    pub fn new(enabled: bool) -> Self {
-        Self { enabled }
+    pub fn new(enabled: impl Into<bool>) -> Self {
+        Self { enabled: enabled.into() }
     }
 }
 /// Controls saved payment method settings for the session.
 /// Only available in `payment` and `subscription` mode.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateCheckoutSessionSavedPaymentMethodOptions<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateCheckoutSessionSavedPaymentMethodOptions {
     /// Controls which payment methods are eligible to be redisplayed to returning customers.
     /// Corresponds to `allow_redisplay` on the payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allow_redisplay_filters:
-        Option<&'a [CreateCheckoutSessionSavedPaymentMethodOptionsAllowRedisplayFilters]>,
+        Option<Vec<CreateCheckoutSessionSavedPaymentMethodOptionsAllowRedisplayFilters>>,
     /// Enable customers to choose if they wish to save their payment method for future use.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub payment_method_save:
         Option<CreateCheckoutSessionSavedPaymentMethodOptionsPaymentMethodSave>,
 }
-impl<'a> CreateCheckoutSessionSavedPaymentMethodOptions<'a> {
+impl CreateCheckoutSessionSavedPaymentMethodOptions {
     pub fn new() -> Self {
         Self { allow_redisplay_filters: None, payment_method_save: None }
     }
 }
-impl<'a> Default for CreateCheckoutSessionSavedPaymentMethodOptions<'a> {
+impl Default for CreateCheckoutSessionSavedPaymentMethodOptions {
     fn default() -> Self {
         Self::new()
     }
@@ -6576,44 +6604,46 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// A subset of parameters to be passed to SetupIntent creation for Checkout Sessions in `setup` mode.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateCheckoutSessionSetupIntentData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateCheckoutSessionSetupIntentData {
     /// An arbitrary string attached to the object. Often useful for displaying to users.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<&'a str>,
+    pub description: Option<String>,
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// The Stripe account for which the setup is intended.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub on_behalf_of: Option<&'a str>,
+    pub on_behalf_of: Option<String>,
 }
-impl<'a> CreateCheckoutSessionSetupIntentData<'a> {
+impl CreateCheckoutSessionSetupIntentData {
     pub fn new() -> Self {
         Self { description: None, metadata: None, on_behalf_of: None }
     }
 }
-impl<'a> Default for CreateCheckoutSessionSetupIntentData<'a> {
+impl Default for CreateCheckoutSessionSetupIntentData {
     fn default() -> Self {
         Self::new()
     }
 }
 /// When set, provides configuration for Checkout to collect a shipping address from a customer.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateCheckoutSessionShippingAddressCollection<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateCheckoutSessionShippingAddressCollection {
     /// An array of two-letter ISO country codes representing which countries Checkout should provide as options for.
     /// shipping locations.
     /// Unsupported country codes: `AS, CX, CC, CU, HM, IR, KP, MH, FM, NF, MP, PW, SD, SY, UM, VI`.
-    pub allowed_countries: &'a [CreateCheckoutSessionShippingAddressCollectionAllowedCountries],
+    pub allowed_countries: Vec<CreateCheckoutSessionShippingAddressCollectionAllowedCountries>,
 }
-impl<'a> CreateCheckoutSessionShippingAddressCollection<'a> {
+impl CreateCheckoutSessionShippingAddressCollection {
     pub fn new(
-        allowed_countries: &'a [CreateCheckoutSessionShippingAddressCollectionAllowedCountries],
+        allowed_countries: impl Into<
+            Vec<CreateCheckoutSessionShippingAddressCollectionAllowedCountries>,
+        >,
     ) -> Self {
-        Self { allowed_countries }
+        Self { allowed_countries: allowed_countries.into() }
     }
 }
 /// An array of two-letter ISO country codes representing which countries Checkout should provide as options for.
@@ -7384,28 +7414,28 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// The shipping rate options to apply to this Session. Up to a maximum of 5.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateCheckoutSessionShippingOptions<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateCheckoutSessionShippingOptions {
     /// The ID of the Shipping Rate to use for this shipping option.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub shipping_rate: Option<&'a str>,
+    pub shipping_rate: Option<String>,
     /// Parameters to be passed to Shipping Rate creation for this shipping option
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub shipping_rate_data: Option<CreateCheckoutSessionShippingOptionsShippingRateData<'a>>,
+    pub shipping_rate_data: Option<CreateCheckoutSessionShippingOptionsShippingRateData>,
 }
-impl<'a> CreateCheckoutSessionShippingOptions<'a> {
+impl CreateCheckoutSessionShippingOptions {
     pub fn new() -> Self {
         Self { shipping_rate: None, shipping_rate_data: None }
     }
 }
-impl<'a> Default for CreateCheckoutSessionShippingOptions<'a> {
+impl Default for CreateCheckoutSessionShippingOptions {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Parameters to be passed to Shipping Rate creation for this shipping option
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateCheckoutSessionShippingOptionsShippingRateData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateCheckoutSessionShippingOptionsShippingRateData {
     /// The estimated range for how long shipping will take, meant to be displayable to the customer.
     /// This will appear on CheckoutSessions.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -7413,16 +7443,16 @@ pub struct CreateCheckoutSessionShippingOptionsShippingRateData<'a> {
         Option<CreateCheckoutSessionShippingOptionsShippingRateDataDeliveryEstimate>,
     /// The name of the shipping rate, meant to be displayable to the customer.
     /// This will appear on CheckoutSessions.
-    pub display_name: &'a str,
+    pub display_name: String,
     /// Describes a fixed amount to charge for shipping. Must be present if type is `fixed_amount`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub fixed_amount: Option<CreateCheckoutSessionShippingOptionsShippingRateDataFixedAmount<'a>>,
+    pub fixed_amount: Option<CreateCheckoutSessionShippingOptionsShippingRateDataFixedAmount>,
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// Specifies whether the rate is considered inclusive of taxes or exclusive of taxes.
     /// One of `inclusive`, `exclusive`, or `unspecified`.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -7430,17 +7460,17 @@ pub struct CreateCheckoutSessionShippingOptionsShippingRateData<'a> {
     /// A [tax code](https://stripe.com/docs/tax/tax-categories) ID.
     /// The Shipping tax code is `txcd_92010001`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_code: Option<&'a str>,
+    pub tax_code: Option<String>,
     /// The type of calculation to use on the shipping rate. Can only be `fixed_amount` for now.
     #[serde(rename = "type")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub type_: Option<CreateCheckoutSessionShippingOptionsShippingRateDataType>,
 }
-impl<'a> CreateCheckoutSessionShippingOptionsShippingRateData<'a> {
-    pub fn new(display_name: &'a str) -> Self {
+impl CreateCheckoutSessionShippingOptionsShippingRateData {
+    pub fn new(display_name: impl Into<String>) -> Self {
         Self {
             delivery_estimate: None,
-            display_name,
+            display_name: display_name.into(),
             fixed_amount: None,
             metadata: None,
             tax_behavior: None,
@@ -7482,10 +7512,10 @@ pub struct CreateCheckoutSessionShippingOptionsShippingRateDataDeliveryEstimateM
 }
 impl CreateCheckoutSessionShippingOptionsShippingRateDataDeliveryEstimateMaximum {
     pub fn new(
-        unit: CreateCheckoutSessionShippingOptionsShippingRateDataDeliveryEstimateMaximumUnit,
-        value: i64,
+        unit: impl Into<CreateCheckoutSessionShippingOptionsShippingRateDataDeliveryEstimateMaximumUnit>,
+        value: impl Into<i64>,
     ) -> Self {
-        Self { unit, value }
+        Self { unit: unit.into(), value: value.into() }
     }
 }
 /// A unit of time.
@@ -7571,10 +7601,10 @@ pub struct CreateCheckoutSessionShippingOptionsShippingRateDataDeliveryEstimateM
 }
 impl CreateCheckoutSessionShippingOptionsShippingRateDataDeliveryEstimateMinimum {
     pub fn new(
-        unit: CreateCheckoutSessionShippingOptionsShippingRateDataDeliveryEstimateMinimumUnit,
-        value: i64,
+        unit: impl Into<CreateCheckoutSessionShippingOptionsShippingRateDataDeliveryEstimateMinimumUnit>,
+        value: impl Into<i64>,
     ) -> Self {
-        Self { unit, value }
+        Self { unit: unit.into(), value: value.into() }
     }
 }
 /// A unit of time.
@@ -7651,8 +7681,8 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// Describes a fixed amount to charge for shipping. Must be present if type is `fixed_amount`.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateCheckoutSessionShippingOptionsShippingRateDataFixedAmount<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateCheckoutSessionShippingOptionsShippingRateDataFixedAmount {
     /// A non-negative integer in cents representing how much to charge.
     pub amount: i64,
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
@@ -7662,15 +7692,15 @@ pub struct CreateCheckoutSessionShippingOptionsShippingRateDataFixedAmount<'a> {
     /// Each key must be a three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html) and a [supported currency](https://stripe.com/docs/currencies).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub currency_options: Option<
-        &'a std::collections::HashMap<
+        std::collections::HashMap<
             stripe_types::Currency,
             CreateCheckoutSessionShippingOptionsShippingRateDataFixedAmountCurrencyOptions,
         >,
     >,
 }
-impl<'a> CreateCheckoutSessionShippingOptionsShippingRateDataFixedAmount<'a> {
-    pub fn new(amount: i64, currency: stripe_types::Currency) -> Self {
-        Self { amount, currency, currency_options: None }
+impl CreateCheckoutSessionShippingOptionsShippingRateDataFixedAmount {
+    pub fn new(amount: impl Into<i64>, currency: impl Into<stripe_types::Currency>) -> Self {
+        Self { amount: amount.into(), currency: currency.into(), currency_options: None }
     }
 }
 /// Shipping rates defined in each available currency option.
@@ -7687,8 +7717,8 @@ pub struct CreateCheckoutSessionShippingOptionsShippingRateDataFixedAmountCurren
     >,
 }
 impl CreateCheckoutSessionShippingOptionsShippingRateDataFixedAmountCurrencyOptions {
-    pub fn new(amount: i64) -> Self {
-        Self { amount, tax_behavior: None }
+    pub fn new(amount: impl Into<i64>) -> Self {
+        Self { amount: amount.into(), tax_behavior: None }
     }
 }
 /// Specifies whether the rate is considered inclusive of taxes or exclusive of taxes.
@@ -7879,8 +7909,8 @@ impl<'de> serde::Deserialize<'de> for CreateCheckoutSessionShippingOptionsShippi
     }
 }
 /// A subset of parameters to be passed to subscription creation for Checkout Sessions in `subscription` mode.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateCheckoutSessionSubscriptionData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateCheckoutSessionSubscriptionData {
     /// A non-negative decimal between 0 and 100, with at most two decimal places.
     /// This represents the percentage of the subscription invoice total that will be transferred to the application owner's Stripe account.
     /// To use an application fee percent, the request must be made on behalf of another account, using the `Stripe-Account` header or an OAuth key.
@@ -7894,31 +7924,31 @@ pub struct CreateCheckoutSessionSubscriptionData<'a> {
     /// `tax_rates` set. Invoices created will have their `default_tax_rates` populated
     /// from the subscription.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub default_tax_rates: Option<&'a [&'a str]>,
+    pub default_tax_rates: Option<Vec<String>>,
     /// The subscription's description, meant to be displayable to the customer.
     /// Use this field to optionally store an explanation of the subscription
     /// for rendering in the [customer portal](https://stripe.com/docs/customer-management).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<&'a str>,
+    pub description: Option<String>,
     /// All invoices will be billed using the specified settings.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub invoice_settings: Option<CreateCheckoutSessionSubscriptionDataInvoiceSettings<'a>>,
+    pub invoice_settings: Option<CreateCheckoutSessionSubscriptionDataInvoiceSettings>,
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// The account on behalf of which to charge, for each of the subscription's invoices.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub on_behalf_of: Option<&'a str>,
+    pub on_behalf_of: Option<String>,
     /// Determines how to handle prorations resulting from the `billing_cycle_anchor`.
     /// If no value is passed, the default is `create_prorations`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub proration_behavior: Option<CreateCheckoutSessionSubscriptionDataProrationBehavior>,
     /// If specified, the funds from the subscription's invoices will be transferred to the destination and the ID of the resulting transfers will be found on the resulting charges.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub transfer_data: Option<CreateCheckoutSessionSubscriptionDataTransferData<'a>>,
+    pub transfer_data: Option<CreateCheckoutSessionSubscriptionDataTransferData>,
     /// Unix timestamp representing the end of the trial period the customer
     /// will get before being charged for the first time. Has to be at least
     /// 48 hours in the future.
@@ -7932,7 +7962,7 @@ pub struct CreateCheckoutSessionSubscriptionData<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub trial_settings: Option<CreateCheckoutSessionSubscriptionDataTrialSettings>,
 }
-impl<'a> CreateCheckoutSessionSubscriptionData<'a> {
+impl CreateCheckoutSessionSubscriptionData {
     pub fn new() -> Self {
         Self {
             application_fee_percent: None,
@@ -7950,43 +7980,45 @@ impl<'a> CreateCheckoutSessionSubscriptionData<'a> {
         }
     }
 }
-impl<'a> Default for CreateCheckoutSessionSubscriptionData<'a> {
+impl Default for CreateCheckoutSessionSubscriptionData {
     fn default() -> Self {
         Self::new()
     }
 }
 /// All invoices will be billed using the specified settings.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateCheckoutSessionSubscriptionDataInvoiceSettings<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateCheckoutSessionSubscriptionDataInvoiceSettings {
     /// The connected account that issues the invoice.
     /// The invoice is presented with the branding and support information of the specified account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub issuer: Option<CreateCheckoutSessionSubscriptionDataInvoiceSettingsIssuer<'a>>,
+    pub issuer: Option<CreateCheckoutSessionSubscriptionDataInvoiceSettingsIssuer>,
 }
-impl<'a> CreateCheckoutSessionSubscriptionDataInvoiceSettings<'a> {
+impl CreateCheckoutSessionSubscriptionDataInvoiceSettings {
     pub fn new() -> Self {
         Self { issuer: None }
     }
 }
-impl<'a> Default for CreateCheckoutSessionSubscriptionDataInvoiceSettings<'a> {
+impl Default for CreateCheckoutSessionSubscriptionDataInvoiceSettings {
     fn default() -> Self {
         Self::new()
     }
 }
 /// The connected account that issues the invoice.
 /// The invoice is presented with the branding and support information of the specified account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateCheckoutSessionSubscriptionDataInvoiceSettingsIssuer<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateCheckoutSessionSubscriptionDataInvoiceSettingsIssuer {
     /// The connected account being referenced when `type` is `account`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account: Option<&'a str>,
+    pub account: Option<String>,
     /// Type of the account referenced in the request.
     #[serde(rename = "type")]
     pub type_: CreateCheckoutSessionSubscriptionDataInvoiceSettingsIssuerType,
 }
-impl<'a> CreateCheckoutSessionSubscriptionDataInvoiceSettingsIssuer<'a> {
-    pub fn new(type_: CreateCheckoutSessionSubscriptionDataInvoiceSettingsIssuerType) -> Self {
-        Self { account: None, type_ }
+impl CreateCheckoutSessionSubscriptionDataInvoiceSettingsIssuer {
+    pub fn new(
+        type_: impl Into<CreateCheckoutSessionSubscriptionDataInvoiceSettingsIssuerType>,
+    ) -> Self {
+        Self { account: None, type_: type_.into() }
     }
 }
 /// Type of the account referenced in the request.
@@ -8109,19 +8141,19 @@ impl<'de> serde::Deserialize<'de> for CreateCheckoutSessionSubscriptionDataProra
     }
 }
 /// If specified, the funds from the subscription's invoices will be transferred to the destination and the ID of the resulting transfers will be found on the resulting charges.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateCheckoutSessionSubscriptionDataTransferData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateCheckoutSessionSubscriptionDataTransferData {
     /// A non-negative decimal between 0 and 100, with at most two decimal places.
     /// This represents the percentage of the subscription invoice total that will be transferred to the destination account.
     /// By default, the entire amount is transferred to the destination.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub amount_percent: Option<f64>,
     /// ID of an existing, connected Stripe account.
-    pub destination: &'a str,
+    pub destination: String,
 }
-impl<'a> CreateCheckoutSessionSubscriptionDataTransferData<'a> {
-    pub fn new(destination: &'a str) -> Self {
-        Self { amount_percent: None, destination }
+impl CreateCheckoutSessionSubscriptionDataTransferData {
+    pub fn new(destination: impl Into<String>) -> Self {
+        Self { amount_percent: None, destination: destination.into() }
     }
 }
 /// Settings related to subscription trials.
@@ -8132,9 +8164,9 @@ pub struct CreateCheckoutSessionSubscriptionDataTrialSettings {
 }
 impl CreateCheckoutSessionSubscriptionDataTrialSettings {
     pub fn new(
-        end_behavior: CreateCheckoutSessionSubscriptionDataTrialSettingsEndBehavior,
+        end_behavior: impl Into<CreateCheckoutSessionSubscriptionDataTrialSettingsEndBehavior>,
     ) -> Self {
-        Self { end_behavior }
+        Self { end_behavior: end_behavior.into() }
     }
 }
 /// Defines how the subscription should behave when the user's free trial ends.
@@ -8146,9 +8178,11 @@ pub struct CreateCheckoutSessionSubscriptionDataTrialSettingsEndBehavior {
 }
 impl CreateCheckoutSessionSubscriptionDataTrialSettingsEndBehavior {
     pub fn new(
-        missing_payment_method: CreateCheckoutSessionSubscriptionDataTrialSettingsEndBehaviorMissingPaymentMethod,
+        missing_payment_method: impl Into<
+            CreateCheckoutSessionSubscriptionDataTrialSettingsEndBehaviorMissingPaymentMethod,
+        >,
     ) -> Self {
-        Self { missing_payment_method }
+        Self { missing_payment_method: missing_payment_method.into() }
     }
 }
 /// Indicates how the subscription should change when the trial ends if the user did not provide a payment method.
@@ -8225,16 +8259,16 @@ pub struct CreateCheckoutSessionTaxIdCollection {
     pub enabled: bool,
 }
 impl CreateCheckoutSessionTaxIdCollection {
-    pub fn new(enabled: bool) -> Self {
-        Self { enabled }
+    pub fn new(enabled: impl Into<bool>) -> Self {
+        Self { enabled: enabled.into() }
     }
 }
 /// Creates a Session object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateCheckoutSession<'a> {
-    inner: CreateCheckoutSessionBuilder<'a>,
+pub struct CreateCheckoutSession {
+    inner: CreateCheckoutSessionBuilder,
 }
-impl<'a> CreateCheckoutSession<'a> {
+impl CreateCheckoutSession {
     /// Construct a new `CreateCheckoutSession`.
     pub fn new() -> Self {
         Self { inner: CreateCheckoutSessionBuilder::new() }
@@ -8242,68 +8276,71 @@ impl<'a> CreateCheckoutSession<'a> {
     /// Configure actions after a Checkout Session has expired.
     pub fn after_expiration(
         mut self,
-        after_expiration: CreateCheckoutSessionAfterExpiration,
+        after_expiration: impl Into<CreateCheckoutSessionAfterExpiration>,
     ) -> Self {
-        self.inner.after_expiration = Some(after_expiration);
+        self.inner.after_expiration = Some(after_expiration.into());
         self
     }
     /// Enables user redeemable promotion codes.
-    pub fn allow_promotion_codes(mut self, allow_promotion_codes: bool) -> Self {
-        self.inner.allow_promotion_codes = Some(allow_promotion_codes);
+    pub fn allow_promotion_codes(mut self, allow_promotion_codes: impl Into<bool>) -> Self {
+        self.inner.allow_promotion_codes = Some(allow_promotion_codes.into());
         self
     }
     /// Settings for automatic tax lookup for this session and resulting payments, invoices, and subscriptions.
-    pub fn automatic_tax(mut self, automatic_tax: CreateCheckoutSessionAutomaticTax<'a>) -> Self {
-        self.inner.automatic_tax = Some(automatic_tax);
+    pub fn automatic_tax(
+        mut self,
+        automatic_tax: impl Into<CreateCheckoutSessionAutomaticTax>,
+    ) -> Self {
+        self.inner.automatic_tax = Some(automatic_tax.into());
         self
     }
     /// Specify whether Checkout should collect the customer's billing address. Defaults to `auto`.
     pub fn billing_address_collection(
         mut self,
-        billing_address_collection: stripe_checkout::CheckoutSessionBillingAddressCollection,
+        billing_address_collection: impl Into<stripe_checkout::CheckoutSessionBillingAddressCollection>,
     ) -> Self {
-        self.inner.billing_address_collection = Some(billing_address_collection);
+        self.inner.billing_address_collection = Some(billing_address_collection.into());
         self
     }
     /// If set, Checkout displays a back button and customers will be directed to this URL if they decide to cancel payment and return to your website.
-    pub fn cancel_url(mut self, cancel_url: &'a str) -> Self {
-        self.inner.cancel_url = Some(cancel_url);
+    pub fn cancel_url(mut self, cancel_url: impl Into<String>) -> Self {
+        self.inner.cancel_url = Some(cancel_url.into());
         self
     }
     /// A unique string to reference the Checkout Session. This can be a
     /// customer ID, a cart ID, or similar, and can be used to reconcile the
     /// session with your internal systems.
-    pub fn client_reference_id(mut self, client_reference_id: &'a str) -> Self {
-        self.inner.client_reference_id = Some(client_reference_id);
+    pub fn client_reference_id(mut self, client_reference_id: impl Into<String>) -> Self {
+        self.inner.client_reference_id = Some(client_reference_id.into());
         self
     }
     /// Configure fields for the Checkout Session to gather active consent from customers.
     pub fn consent_collection(
         mut self,
-        consent_collection: CreateCheckoutSessionConsentCollection,
+        consent_collection: impl Into<CreateCheckoutSessionConsentCollection>,
     ) -> Self {
-        self.inner.consent_collection = Some(consent_collection);
+        self.inner.consent_collection = Some(consent_collection.into());
         self
     }
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     /// Must be a [supported currency](https://stripe.com/docs/currencies).
     /// Required in `setup` mode when `payment_method_types` is not set.
-    pub fn currency(mut self, currency: stripe_types::Currency) -> Self {
-        self.inner.currency = Some(currency);
+    pub fn currency(mut self, currency: impl Into<stripe_types::Currency>) -> Self {
+        self.inner.currency = Some(currency.into());
         self
     }
     /// Collect additional information from your customer using custom fields.
     /// Up to 3 fields are supported.
     pub fn custom_fields(
         mut self,
-        custom_fields: &'a [CreateCheckoutSessionCustomFields<'a>],
+        custom_fields: impl Into<Vec<CreateCheckoutSessionCustomFields>>,
     ) -> Self {
-        self.inner.custom_fields = Some(custom_fields);
+        self.inner.custom_fields = Some(custom_fields.into());
         self
     }
     /// Display additional text for your customers using custom text.
-    pub fn custom_text(mut self, custom_text: CreateCheckoutSessionCustomText<'a>) -> Self {
-        self.inner.custom_text = Some(custom_text);
+    pub fn custom_text(mut self, custom_text: impl Into<CreateCheckoutSessionCustomText>) -> Self {
+        self.inner.custom_text = Some(custom_text.into());
         self
     }
     /// ID of an existing Customer, if one exists.
@@ -8320,8 +8357,8 @@ impl<'a> CreateCheckoutSession<'a> {
     /// If blank for Checkout Sessions in `subscription` mode or with `customer_creation` set as `always` in `payment` mode, Checkout will create a new Customer object based on information provided during the payment flow.
     ///
     /// You can set [`payment_intent_data.setup_future_usage`](https://stripe.com/docs/api/checkout/sessions/create#create_checkout_session-payment_intent_data-setup_future_usage) to have Checkout automatically attach the payment method to the Customer you pass in for future reuse.
-    pub fn customer(mut self, customer: &'a str) -> Self {
-        self.inner.customer = Some(customer);
+    pub fn customer(mut self, customer: impl Into<String>) -> Self {
+        self.inner.customer = Some(customer.into());
         self
     }
     /// Configure whether a Checkout Session creates a [Customer](https://stripe.com/docs/api/customers) during Session confirmation.
@@ -8336,9 +8373,9 @@ impl<'a> CreateCheckoutSession<'a> {
     /// Can only be set in `payment` and `setup` mode.
     pub fn customer_creation(
         mut self,
-        customer_creation: CreateCheckoutSessionCustomerCreation,
+        customer_creation: impl Into<CreateCheckoutSessionCustomerCreation>,
     ) -> Self {
-        self.inner.customer_creation = Some(customer_creation);
+        self.inner.customer_creation = Some(customer_creation.into());
         self
     }
     /// If provided, this value will be used when the Customer object is created.
@@ -8346,39 +8383,42 @@ impl<'a> CreateCheckoutSession<'a> {
     /// Use this parameter to prefill customer data if you already have an email
     /// on file. To access information about the customer once a session is
     /// complete, use the `customer` field.
-    pub fn customer_email(mut self, customer_email: &'a str) -> Self {
-        self.inner.customer_email = Some(customer_email);
+    pub fn customer_email(mut self, customer_email: impl Into<String>) -> Self {
+        self.inner.customer_email = Some(customer_email.into());
         self
     }
     /// Controls what fields on Customer can be updated by the Checkout Session.
     /// Can only be provided when `customer` is provided.
-    pub fn customer_update(mut self, customer_update: CreateCheckoutSessionCustomerUpdate) -> Self {
-        self.inner.customer_update = Some(customer_update);
+    pub fn customer_update(
+        mut self,
+        customer_update: impl Into<CreateCheckoutSessionCustomerUpdate>,
+    ) -> Self {
+        self.inner.customer_update = Some(customer_update.into());
         self
     }
     /// The coupon or promotion code to apply to this Session. Currently, only up to one may be specified.
-    pub fn discounts(mut self, discounts: &'a [CreateCheckoutSessionDiscounts<'a>]) -> Self {
-        self.inner.discounts = Some(discounts);
+    pub fn discounts(mut self, discounts: impl Into<Vec<CreateCheckoutSessionDiscounts>>) -> Self {
+        self.inner.discounts = Some(discounts.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// The Epoch time in seconds at which the Checkout Session will expire.
     /// It can be anywhere from 30 minutes to 24 hours after Checkout Session creation.
     /// By default, this value is 24 hours from creation.
-    pub fn expires_at(mut self, expires_at: stripe_types::Timestamp) -> Self {
-        self.inner.expires_at = Some(expires_at);
+    pub fn expires_at(mut self, expires_at: impl Into<stripe_types::Timestamp>) -> Self {
+        self.inner.expires_at = Some(expires_at.into());
         self
     }
     /// Generate a post-purchase Invoice for one-time payments.
     pub fn invoice_creation(
         mut self,
-        invoice_creation: CreateCheckoutSessionInvoiceCreation<'a>,
+        invoice_creation: impl Into<CreateCheckoutSessionInvoiceCreation>,
     ) -> Self {
-        self.inner.invoice_creation = Some(invoice_creation);
+        self.inner.invoice_creation = Some(invoice_creation.into());
         self
     }
     /// A list of items the customer is purchasing.
@@ -8388,36 +8428,42 @@ impl<'a> CreateCheckoutSession<'a> {
     ///
     /// For `subscription` mode, there is a maximum of 20 line items with recurring Prices and 20 line items with one-time Prices.
     /// Line items with one-time Prices will be on the initial invoice only.
-    pub fn line_items(mut self, line_items: &'a [CreateCheckoutSessionLineItems<'a>]) -> Self {
-        self.inner.line_items = Some(line_items);
+    pub fn line_items(
+        mut self,
+        line_items: impl Into<Vec<CreateCheckoutSessionLineItems>>,
+    ) -> Self {
+        self.inner.line_items = Some(line_items.into());
         self
     }
     /// The IETF language tag of the locale Checkout is displayed in.
     /// If blank or `auto`, the browser's locale is used.
-    pub fn locale(mut self, locale: stripe_checkout::CheckoutSessionLocale) -> Self {
-        self.inner.locale = Some(locale);
+    pub fn locale(mut self, locale: impl Into<stripe_checkout::CheckoutSessionLocale>) -> Self {
+        self.inner.locale = Some(locale.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// The mode of the Checkout Session.
     /// Pass `subscription` if the Checkout Session includes at least one recurring item.
-    pub fn mode(mut self, mode: stripe_checkout::CheckoutSessionMode) -> Self {
-        self.inner.mode = Some(mode);
+    pub fn mode(mut self, mode: impl Into<stripe_checkout::CheckoutSessionMode>) -> Self {
+        self.inner.mode = Some(mode.into());
         self
     }
     /// A subset of parameters to be passed to PaymentIntent creation for Checkout Sessions in `payment` mode.
     pub fn payment_intent_data(
         mut self,
-        payment_intent_data: CreateCheckoutSessionPaymentIntentData<'a>,
+        payment_intent_data: impl Into<CreateCheckoutSessionPaymentIntentData>,
     ) -> Self {
-        self.inner.payment_intent_data = Some(payment_intent_data);
+        self.inner.payment_intent_data = Some(payment_intent_data.into());
         self
     }
     /// Specify whether Checkout should collect a payment method.
@@ -8429,30 +8475,33 @@ impl<'a> CreateCheckoutSession<'a> {
     /// If you'd like information on how to collect a payment method outside of Checkout, read the guide on configuring [subscriptions with a free trial](https://stripe.com/docs/payments/checkout/free-trials).
     pub fn payment_method_collection(
         mut self,
-        payment_method_collection: CreateCheckoutSessionPaymentMethodCollection,
+        payment_method_collection: impl Into<CreateCheckoutSessionPaymentMethodCollection>,
     ) -> Self {
-        self.inner.payment_method_collection = Some(payment_method_collection);
+        self.inner.payment_method_collection = Some(payment_method_collection.into());
         self
     }
     /// The ID of the payment method configuration to use with this Checkout session.
-    pub fn payment_method_configuration(mut self, payment_method_configuration: &'a str) -> Self {
-        self.inner.payment_method_configuration = Some(payment_method_configuration);
+    pub fn payment_method_configuration(
+        mut self,
+        payment_method_configuration: impl Into<String>,
+    ) -> Self {
+        self.inner.payment_method_configuration = Some(payment_method_configuration.into());
         self
     }
     /// This parameter allows you to set some attributes on the payment method created during a Checkout session.
     pub fn payment_method_data(
         mut self,
-        payment_method_data: CreateCheckoutSessionPaymentMethodData,
+        payment_method_data: impl Into<CreateCheckoutSessionPaymentMethodData>,
     ) -> Self {
-        self.inner.payment_method_data = Some(payment_method_data);
+        self.inner.payment_method_data = Some(payment_method_data.into());
         self
     }
     /// Payment-method-specific configuration.
     pub fn payment_method_options(
         mut self,
-        payment_method_options: CreateCheckoutSessionPaymentMethodOptions<'a>,
+        payment_method_options: impl Into<CreateCheckoutSessionPaymentMethodOptions>,
     ) -> Self {
-        self.inner.payment_method_options = Some(payment_method_options);
+        self.inner.payment_method_options = Some(payment_method_options.into());
         self
     }
     /// A list of the types of payment methods (e.g., `card`) this Checkout Session can accept.
@@ -8468,9 +8517,9 @@ impl<'a> CreateCheckoutSession<'a> {
     /// other characteristics.
     pub fn payment_method_types(
         mut self,
-        payment_method_types: &'a [CreateCheckoutSessionPaymentMethodTypes],
+        payment_method_types: impl Into<Vec<CreateCheckoutSessionPaymentMethodTypes>>,
     ) -> Self {
-        self.inner.payment_method_types = Some(payment_method_types);
+        self.inner.payment_method_types = Some(payment_method_types.into());
         self
     }
     /// Controls phone number collection settings for the session.
@@ -8480,9 +8529,9 @@ impl<'a> CreateCheckoutSession<'a> {
     /// Learn more about [collecting phone numbers with Checkout](https://stripe.com/docs/payments/checkout/phone-numbers).
     pub fn phone_number_collection(
         mut self,
-        phone_number_collection: CreateCheckoutSessionPhoneNumberCollection,
+        phone_number_collection: impl Into<CreateCheckoutSessionPhoneNumberCollection>,
     ) -> Self {
-        self.inner.phone_number_collection = Some(phone_number_collection);
+        self.inner.phone_number_collection = Some(phone_number_collection.into());
         self
     }
     /// This parameter applies to `ui_mode: embedded`.
@@ -8490,64 +8539,67 @@ impl<'a> CreateCheckoutSession<'a> {
     /// Defaults to `always`.
     pub fn redirect_on_completion(
         mut self,
-        redirect_on_completion: stripe_checkout::CheckoutSessionRedirectOnCompletion,
+        redirect_on_completion: impl Into<stripe_checkout::CheckoutSessionRedirectOnCompletion>,
     ) -> Self {
-        self.inner.redirect_on_completion = Some(redirect_on_completion);
+        self.inner.redirect_on_completion = Some(redirect_on_completion.into());
         self
     }
     /// The URL to redirect your customer back to after they authenticate or cancel their payment on the
     /// payment method's app or site. This parameter is required if ui_mode is `embedded`
     /// and redirect-based payment methods are enabled on the session.
-    pub fn return_url(mut self, return_url: &'a str) -> Self {
-        self.inner.return_url = Some(return_url);
+    pub fn return_url(mut self, return_url: impl Into<String>) -> Self {
+        self.inner.return_url = Some(return_url.into());
         self
     }
     /// Controls saved payment method settings for the session.
     /// Only available in `payment` and `subscription` mode.
     pub fn saved_payment_method_options(
         mut self,
-        saved_payment_method_options: CreateCheckoutSessionSavedPaymentMethodOptions<'a>,
+        saved_payment_method_options: impl Into<CreateCheckoutSessionSavedPaymentMethodOptions>,
     ) -> Self {
-        self.inner.saved_payment_method_options = Some(saved_payment_method_options);
+        self.inner.saved_payment_method_options = Some(saved_payment_method_options.into());
         self
     }
     /// A subset of parameters to be passed to SetupIntent creation for Checkout Sessions in `setup` mode.
     pub fn setup_intent_data(
         mut self,
-        setup_intent_data: CreateCheckoutSessionSetupIntentData<'a>,
+        setup_intent_data: impl Into<CreateCheckoutSessionSetupIntentData>,
     ) -> Self {
-        self.inner.setup_intent_data = Some(setup_intent_data);
+        self.inner.setup_intent_data = Some(setup_intent_data.into());
         self
     }
     /// When set, provides configuration for Checkout to collect a shipping address from a customer.
     pub fn shipping_address_collection(
         mut self,
-        shipping_address_collection: CreateCheckoutSessionShippingAddressCollection<'a>,
+        shipping_address_collection: impl Into<CreateCheckoutSessionShippingAddressCollection>,
     ) -> Self {
-        self.inner.shipping_address_collection = Some(shipping_address_collection);
+        self.inner.shipping_address_collection = Some(shipping_address_collection.into());
         self
     }
     /// The shipping rate options to apply to this Session. Up to a maximum of 5.
     pub fn shipping_options(
         mut self,
-        shipping_options: &'a [CreateCheckoutSessionShippingOptions<'a>],
+        shipping_options: impl Into<Vec<CreateCheckoutSessionShippingOptions>>,
     ) -> Self {
-        self.inner.shipping_options = Some(shipping_options);
+        self.inner.shipping_options = Some(shipping_options.into());
         self
     }
     /// Describes the type of transaction being performed by Checkout in order to customize
     /// relevant text on the page, such as the submit button. `submit_type` can only be
     /// specified on Checkout Sessions in `payment` mode. If blank or `auto`, `pay` is used.
-    pub fn submit_type(mut self, submit_type: stripe_checkout::CheckoutSessionSubmitType) -> Self {
-        self.inner.submit_type = Some(submit_type);
+    pub fn submit_type(
+        mut self,
+        submit_type: impl Into<stripe_checkout::CheckoutSessionSubmitType>,
+    ) -> Self {
+        self.inner.submit_type = Some(submit_type.into());
         self
     }
     /// A subset of parameters to be passed to subscription creation for Checkout Sessions in `subscription` mode.
     pub fn subscription_data(
         mut self,
-        subscription_data: CreateCheckoutSessionSubscriptionData<'a>,
+        subscription_data: impl Into<CreateCheckoutSessionSubscriptionData>,
     ) -> Self {
-        self.inner.subscription_data = Some(subscription_data);
+        self.inner.subscription_data = Some(subscription_data.into());
         self
     }
     /// The URL to which Stripe should send customers when payment or setup
@@ -8555,30 +8607,30 @@ impl<'a> CreateCheckoutSession<'a> {
     /// This parameter is not allowed if ui_mode is `embedded`. If you’d like to use
     /// information from the successful Checkout Session on your page, read the
     /// guide on [customizing your success page](https://stripe.com/docs/payments/checkout/custom-success-page).
-    pub fn success_url(mut self, success_url: &'a str) -> Self {
-        self.inner.success_url = Some(success_url);
+    pub fn success_url(mut self, success_url: impl Into<String>) -> Self {
+        self.inner.success_url = Some(success_url.into());
         self
     }
     /// Controls tax ID collection settings for the session.
     pub fn tax_id_collection(
         mut self,
-        tax_id_collection: CreateCheckoutSessionTaxIdCollection,
+        tax_id_collection: impl Into<CreateCheckoutSessionTaxIdCollection>,
     ) -> Self {
-        self.inner.tax_id_collection = Some(tax_id_collection);
+        self.inner.tax_id_collection = Some(tax_id_collection.into());
         self
     }
     /// The UI mode of the Session. Defaults to `hosted`.
-    pub fn ui_mode(mut self, ui_mode: stripe_checkout::CheckoutSessionUiMode) -> Self {
-        self.inner.ui_mode = Some(ui_mode);
+    pub fn ui_mode(mut self, ui_mode: impl Into<stripe_checkout::CheckoutSessionUiMode>) -> Self {
+        self.inner.ui_mode = Some(ui_mode.into());
         self
     }
 }
-impl<'a> Default for CreateCheckoutSession<'a> {
+impl Default for CreateCheckoutSession {
     fn default() -> Self {
         Self::new()
     }
 }
-impl CreateCheckoutSession<'_> {
+impl CreateCheckoutSession {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -8596,19 +8648,19 @@ impl CreateCheckoutSession<'_> {
     }
 }
 
-impl StripeRequest for CreateCheckoutSession<'_> {
+impl StripeRequest for CreateCheckoutSession {
     type Output = stripe_checkout::CheckoutSession;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Post, "/checkout/sessions").form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ExpireCheckoutSessionBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ExpireCheckoutSessionBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> ExpireCheckoutSessionBuilder<'a> {
+impl ExpireCheckoutSessionBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
@@ -8617,22 +8669,22 @@ impl<'a> ExpireCheckoutSessionBuilder<'a> {
 ///
 /// After it expires, a customer can’t complete a Session and customers loading the Session see a message saying the Session is expired.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ExpireCheckoutSession<'a> {
-    inner: ExpireCheckoutSessionBuilder<'a>,
-    session: &'a stripe_checkout::CheckoutSessionId,
+pub struct ExpireCheckoutSession {
+    inner: ExpireCheckoutSessionBuilder,
+    session: stripe_checkout::CheckoutSessionId,
 }
-impl<'a> ExpireCheckoutSession<'a> {
+impl ExpireCheckoutSession {
     /// Construct a new `ExpireCheckoutSession`.
-    pub fn new(session: &'a stripe_checkout::CheckoutSessionId) -> Self {
-        Self { session, inner: ExpireCheckoutSessionBuilder::new() }
+    pub fn new(session: impl Into<stripe_checkout::CheckoutSessionId>) -> Self {
+        Self { session: session.into(), inner: ExpireCheckoutSessionBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl ExpireCheckoutSession<'_> {
+impl ExpireCheckoutSession {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -8650,23 +8702,23 @@ impl ExpireCheckoutSession<'_> {
     }
 }
 
-impl StripeRequest for ExpireCheckoutSession<'_> {
+impl StripeRequest for ExpireCheckoutSession {
     type Output = stripe_checkout::CheckoutSession;
 
     fn build(&self) -> RequestBuilder {
-        let session = self.session;
+        let session = &self.session;
         RequestBuilder::new(StripeMethod::Post, format!("/checkout/sessions/{session}/expire"))
             .form(&self.inner)
     }
 }
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CustomTextPositionParam<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CustomTextPositionParam {
     /// Text may be up to 1200 characters in length.
-    pub message: &'a str,
+    pub message: String,
 }
-impl<'a> CustomTextPositionParam<'a> {
-    pub fn new(message: &'a str) -> Self {
-        Self { message }
+impl CustomTextPositionParam {
+    pub fn new(message: impl Into<String>) -> Self {
+        Self { message: message.into() }
     }
 }

--- a/generated/async-stripe-connect/src/account/requests.rs
+++ b/generated/async-stripe-connect/src/account/requests.rs
@@ -11,16 +11,16 @@ use stripe_client_core::{
 ///
 /// If you want to delete your own account, use the [account information tab in your account settings](https://dashboard.stripe.com/settings/account) instead.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct DeleteAccount<'a> {
-    account: &'a stripe_shared::AccountId,
+pub struct DeleteAccount {
+    account: stripe_shared::AccountId,
 }
-impl<'a> DeleteAccount<'a> {
+impl DeleteAccount {
     /// Construct a new `DeleteAccount`.
-    pub fn new(account: &'a stripe_shared::AccountId) -> Self {
-        Self { account }
+    pub fn new(account: impl Into<stripe_shared::AccountId>) -> Self {
+        Self { account: account.into() }
     }
 }
-impl DeleteAccount<'_> {
+impl DeleteAccount {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -38,46 +38,46 @@ impl DeleteAccount<'_> {
     }
 }
 
-impl StripeRequest for DeleteAccount<'_> {
+impl StripeRequest for DeleteAccount {
     type Output = stripe_shared::DeletedAccount;
 
     fn build(&self) -> RequestBuilder {
-        let account = self.account;
+        let account = &self.account;
         RequestBuilder::new(StripeMethod::Delete, format!("/accounts/{account}"))
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveForMyAccountAccountBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveForMyAccountAccountBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveForMyAccountAccountBuilder<'a> {
+impl RetrieveForMyAccountAccountBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves the details of an account.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveForMyAccountAccount<'a> {
-    inner: RetrieveForMyAccountAccountBuilder<'a>,
+pub struct RetrieveForMyAccountAccount {
+    inner: RetrieveForMyAccountAccountBuilder,
 }
-impl<'a> RetrieveForMyAccountAccount<'a> {
+impl RetrieveForMyAccountAccount {
     /// Construct a new `RetrieveForMyAccountAccount`.
     pub fn new() -> Self {
         Self { inner: RetrieveForMyAccountAccountBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl<'a> Default for RetrieveForMyAccountAccount<'a> {
+impl Default for RetrieveForMyAccountAccount {
     fn default() -> Self {
         Self::new()
     }
 }
-impl RetrieveForMyAccountAccount<'_> {
+impl RetrieveForMyAccountAccount {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -95,27 +95,27 @@ impl RetrieveForMyAccountAccount<'_> {
     }
 }
 
-impl StripeRequest for RetrieveForMyAccountAccount<'_> {
+impl StripeRequest for RetrieveForMyAccountAccount {
     type Output = stripe_shared::Account;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/account").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListAccountBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListAccountBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     created: Option<stripe_types::RangeQueryTs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListAccountBuilder<'a> {
+impl ListAccountBuilder {
     fn new() -> Self {
         Self { created: None, ending_before: None, expand: None, limit: None, starting_after: None }
     }
@@ -123,51 +123,51 @@ impl<'a> ListAccountBuilder<'a> {
 /// Returns a list of accounts connected to your platform via [Connect](https://stripe.com/docs/connect).
 /// If you’re not a platform, the list is empty.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListAccount<'a> {
-    inner: ListAccountBuilder<'a>,
+pub struct ListAccount {
+    inner: ListAccountBuilder,
 }
-impl<'a> ListAccount<'a> {
+impl ListAccount {
     /// Construct a new `ListAccount`.
     pub fn new() -> Self {
         Self { inner: ListAccountBuilder::new() }
     }
     /// Only return connected accounts that were created during the given date interval.
-    pub fn created(mut self, created: stripe_types::RangeQueryTs) -> Self {
-        self.inner.created = Some(created);
+    pub fn created(mut self, created: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.created = Some(created.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl<'a> Default for ListAccount<'a> {
+impl Default for ListAccount {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListAccount<'_> {
+impl ListAccount {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -187,45 +187,45 @@ impl ListAccount<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::Account>> {
-        stripe_client_core::ListPaginator::new_list("/accounts", self.inner)
+        stripe_client_core::ListPaginator::new_list("/accounts", &self.inner)
     }
 }
 
-impl StripeRequest for ListAccount<'_> {
+impl StripeRequest for ListAccount {
     type Output = stripe_types::List<stripe_shared::Account>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/accounts").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveAccountBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveAccountBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveAccountBuilder<'a> {
+impl RetrieveAccountBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves the details of an account.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveAccount<'a> {
-    inner: RetrieveAccountBuilder<'a>,
-    account: &'a stripe_shared::AccountId,
+pub struct RetrieveAccount {
+    inner: RetrieveAccountBuilder,
+    account: stripe_shared::AccountId,
 }
-impl<'a> RetrieveAccount<'a> {
+impl RetrieveAccount {
     /// Construct a new `RetrieveAccount`.
-    pub fn new(account: &'a stripe_shared::AccountId) -> Self {
-        Self { account, inner: RetrieveAccountBuilder::new() }
+    pub fn new(account: impl Into<stripe_shared::AccountId>) -> Self {
+        Self { account: account.into(), inner: RetrieveAccountBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveAccount<'_> {
+impl RetrieveAccount {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -243,20 +243,20 @@ impl RetrieveAccount<'_> {
     }
 }
 
-impl StripeRequest for RetrieveAccount<'_> {
+impl StripeRequest for RetrieveAccount {
     type Output = stripe_shared::Account;
 
     fn build(&self) -> RequestBuilder {
-        let account = self.account;
+        let account = &self.account;
         RequestBuilder::new(StripeMethod::Get, format!("/accounts/{account}")).query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CapabilitiesAccountBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CapabilitiesAccountBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> CapabilitiesAccountBuilder<'a> {
+impl CapabilitiesAccountBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
@@ -264,22 +264,22 @@ impl<'a> CapabilitiesAccountBuilder<'a> {
 /// Returns a list of capabilities associated with the account.
 /// The capabilities are returned sorted by creation date, with the most recent capability appearing first.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CapabilitiesAccount<'a> {
-    inner: CapabilitiesAccountBuilder<'a>,
-    account: &'a stripe_shared::AccountId,
+pub struct CapabilitiesAccount {
+    inner: CapabilitiesAccountBuilder,
+    account: stripe_shared::AccountId,
 }
-impl<'a> CapabilitiesAccount<'a> {
+impl CapabilitiesAccount {
     /// Construct a new `CapabilitiesAccount`.
-    pub fn new(account: &'a stripe_shared::AccountId) -> Self {
-        Self { account, inner: CapabilitiesAccountBuilder::new() }
+    pub fn new(account: impl Into<stripe_shared::AccountId>) -> Self {
+        Self { account: account.into(), inner: CapabilitiesAccountBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl CapabilitiesAccount<'_> {
+impl CapabilitiesAccount {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -299,38 +299,38 @@ impl CapabilitiesAccount<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::Capability>> {
-        let account = self.account;
+        let account = &self.account;
 
         stripe_client_core::ListPaginator::new_list(
             format!("/accounts/{account}/capabilities"),
-            self.inner,
+            &self.inner,
         )
     }
 }
 
-impl StripeRequest for CapabilitiesAccount<'_> {
+impl StripeRequest for CapabilitiesAccount {
     type Output = stripe_types::List<stripe_shared::Capability>;
 
     fn build(&self) -> RequestBuilder {
-        let account = self.account;
+        let account = &self.account;
         RequestBuilder::new(StripeMethod::Get, format!("/accounts/{account}/capabilities"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct PersonsAccountBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct PersonsAccountBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     relationship: Option<PersonsAccountRelationship>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> PersonsAccountBuilder<'a> {
+impl PersonsAccountBuilder {
     fn new() -> Self {
         Self {
             ending_before: None,
@@ -379,47 +379,47 @@ impl Default for PersonsAccountRelationship {
 /// Returns a list of people associated with the account’s legal entity.
 /// The people are returned sorted by creation date, with the most recent people appearing first.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct PersonsAccount<'a> {
-    inner: PersonsAccountBuilder<'a>,
-    account: &'a stripe_shared::AccountId,
+pub struct PersonsAccount {
+    inner: PersonsAccountBuilder,
+    account: stripe_shared::AccountId,
 }
-impl<'a> PersonsAccount<'a> {
+impl PersonsAccount {
     /// Construct a new `PersonsAccount`.
-    pub fn new(account: &'a stripe_shared::AccountId) -> Self {
-        Self { account, inner: PersonsAccountBuilder::new() }
+    pub fn new(account: impl Into<stripe_shared::AccountId>) -> Self {
+        Self { account: account.into(), inner: PersonsAccountBuilder::new() }
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// Filters on the list of people returned based on the person's relationship to the account's company.
-    pub fn relationship(mut self, relationship: PersonsAccountRelationship) -> Self {
-        self.inner.relationship = Some(relationship);
+    pub fn relationship(mut self, relationship: impl Into<PersonsAccountRelationship>) -> Self {
+        self.inner.relationship = Some(relationship.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl PersonsAccount<'_> {
+impl PersonsAccount {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -439,63 +439,63 @@ impl PersonsAccount<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::Person>> {
-        let account = self.account;
+        let account = &self.account;
 
         stripe_client_core::ListPaginator::new_list(
             format!("/accounts/{account}/persons"),
-            self.inner,
+            &self.inner,
         )
     }
 }
 
-impl StripeRequest for PersonsAccount<'_> {
+impl StripeRequest for PersonsAccount {
     type Output = stripe_types::List<stripe_shared::Person>;
 
     fn build(&self) -> RequestBuilder {
-        let account = self.account;
+        let account = &self.account;
         RequestBuilder::new(StripeMethod::Get, format!("/accounts/{account}/persons"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateAccountBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateAccountBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    account_token: Option<&'a str>,
+    account_token: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    business_profile: Option<BusinessProfileSpecs<'a>>,
+    business_profile: Option<BusinessProfileSpecs>,
     #[serde(skip_serializing_if = "Option::is_none")]
     business_type: Option<stripe_shared::AccountBusinessType>,
     #[serde(skip_serializing_if = "Option::is_none")]
     capabilities: Option<CapabilitiesParam>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    company: Option<CreateAccountCompany<'a>>,
+    company: Option<CreateAccountCompany>,
     #[serde(skip_serializing_if = "Option::is_none")]
     controller: Option<CreateAccountController>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    country: Option<&'a str>,
+    country: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     default_currency: Option<stripe_types::Currency>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    documents: Option<DocumentsSpecs<'a>>,
+    documents: Option<DocumentsSpecs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    email: Option<&'a str>,
+    email: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    external_account: Option<&'a str>,
+    external_account: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    individual: Option<CreateAccountIndividual<'a>>,
+    individual: Option<CreateAccountIndividual>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    settings: Option<CreateAccountSettings<'a>>,
+    settings: Option<CreateAccountSettings>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    tos_acceptance: Option<TosAcceptanceSpecs<'a>>,
+    tos_acceptance: Option<TosAcceptanceSpecs>,
     #[serde(rename = "type")]
     #[serde(skip_serializing_if = "Option::is_none")]
     type_: Option<CreateAccountType>,
 }
-impl<'a> CreateAccountBuilder<'a> {
+impl CreateAccountBuilder {
     fn new() -> Self {
         Self {
             account_token: None,
@@ -521,17 +521,17 @@ impl<'a> CreateAccountBuilder<'a> {
 /// Information about the company or business.
 /// This field is available for any `business_type`.
 /// Once you create an [Account Link](/api/account_links) or [Account Session](/api/account_sessions), this property can only be updated for accounts where [controller.requirement_collection](/api/accounts/object#account_object-controller-requirement_collection) is `application`, which includes Custom accounts.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateAccountCompany<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateAccountCompany {
     /// The company's primary address.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub address: Option<AddressSpecs<'a>>,
+    pub address: Option<AddressSpecs>,
     /// The Kana variation of the company's primary address (Japan only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub address_kana: Option<CreateAccountCompanyAddressKana<'a>>,
+    pub address_kana: Option<CreateAccountCompanyAddressKana>,
     /// The Kanji variation of the company's primary address (Japan only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub address_kanji: Option<CreateAccountCompanyAddressKanji<'a>>,
+    pub address_kanji: Option<CreateAccountCompanyAddressKanji>,
     /// Whether the company's directors have been provided.
     /// Set this Boolean to `true` after creating all the company's directors with [the Persons API](https://docs.stripe.com/api/persons) for accounts with a `relationship.director` requirement.
     /// This value is not automatically set to `true` after creating directors, so it needs to be updated to indicate all directors have been provided.
@@ -543,33 +543,33 @@ pub struct CreateAccountCompany<'a> {
     pub executives_provided: Option<bool>,
     /// The export license ID number of the company, also referred as Import Export Code (India only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub export_license_id: Option<&'a str>,
+    pub export_license_id: Option<String>,
     /// The purpose code to use for export transactions (India only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub export_purpose_code: Option<&'a str>,
+    pub export_purpose_code: Option<String>,
     /// The company's legal name.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<&'a str>,
+    pub name: Option<String>,
     /// The Kana variation of the company's legal name (Japan only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub name_kana: Option<&'a str>,
+    pub name_kana: Option<String>,
     /// The Kanji variation of the company's legal name (Japan only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub name_kanji: Option<&'a str>,
+    pub name_kanji: Option<String>,
     /// Whether the company's owners have been provided.
     /// Set this Boolean to `true` after creating all the company's owners with [the Persons API](https://docs.stripe.com/api/persons) for accounts with a `relationship.owner` requirement.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub owners_provided: Option<bool>,
     /// This hash is used to attest that the beneficial owner information provided to Stripe is both current and correct.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ownership_declaration: Option<CompanyOwnershipDeclaration<'a>>,
+    pub ownership_declaration: Option<CompanyOwnershipDeclaration>,
     /// The company's phone number (used for verification).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub phone: Option<&'a str>,
+    pub phone: Option<String>,
     /// The identification number given to a company when it is registered or incorporated, if distinct from the identification number used for filing taxes.
     /// (Examples are the CIN for companies and LLP IN for partnerships in India, and the Company Registration Number in Hong Kong).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub registration_number: Option<&'a str>,
+    pub registration_number: Option<String>,
     /// The category identifying the legal structure of the company or legal entity.
     /// See [Business structure](https://docs.stripe.com/connect/identity-verification#business-structure) for more details.
     /// Pass an empty string to unset this value.
@@ -578,18 +578,18 @@ pub struct CreateAccountCompany<'a> {
     /// The business ID number of the company, as appropriate for the company’s country.
     /// (Examples are an Employer ID Number in the U.S., a Business Number in Canada, or a Company Number in the UK.).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_id: Option<&'a str>,
+    pub tax_id: Option<String>,
     /// The jurisdiction in which the `tax_id` is registered (Germany-based companies only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_id_registrar: Option<&'a str>,
+    pub tax_id_registrar: Option<String>,
     /// The VAT number of the company.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub vat_id: Option<&'a str>,
+    pub vat_id: Option<String>,
     /// Information on the verification state of the company.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub verification: Option<VerificationSpecs<'a>>,
+    pub verification: Option<VerificationSpecs>,
 }
-impl<'a> CreateAccountCompany<'a> {
+impl CreateAccountCompany {
     pub fn new() -> Self {
         Self {
             address: None,
@@ -614,37 +614,37 @@ impl<'a> CreateAccountCompany<'a> {
         }
     }
 }
-impl<'a> Default for CreateAccountCompany<'a> {
+impl Default for CreateAccountCompany {
     fn default() -> Self {
         Self::new()
     }
 }
 /// The Kana variation of the company's primary address (Japan only).
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateAccountCompanyAddressKana<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateAccountCompanyAddressKana {
     /// City or ward.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<&'a str>,
+    pub city: Option<String>,
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub country: Option<&'a str>,
+    pub country: Option<String>,
     /// Block or building number.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line1: Option<&'a str>,
+    pub line1: Option<String>,
     /// Building details.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line2: Option<&'a str>,
+    pub line2: Option<String>,
     /// Postal code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<&'a str>,
+    pub postal_code: Option<String>,
     /// Prefecture.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
     /// Town or cho-me.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub town: Option<&'a str>,
+    pub town: Option<String>,
 }
-impl<'a> CreateAccountCompanyAddressKana<'a> {
+impl CreateAccountCompanyAddressKana {
     pub fn new() -> Self {
         Self {
             city: None,
@@ -657,37 +657,37 @@ impl<'a> CreateAccountCompanyAddressKana<'a> {
         }
     }
 }
-impl<'a> Default for CreateAccountCompanyAddressKana<'a> {
+impl Default for CreateAccountCompanyAddressKana {
     fn default() -> Self {
         Self::new()
     }
 }
 /// The Kanji variation of the company's primary address (Japan only).
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateAccountCompanyAddressKanji<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateAccountCompanyAddressKanji {
     /// City or ward.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<&'a str>,
+    pub city: Option<String>,
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub country: Option<&'a str>,
+    pub country: Option<String>,
     /// Block or building number.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line1: Option<&'a str>,
+    pub line1: Option<String>,
     /// Building details.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line2: Option<&'a str>,
+    pub line2: Option<String>,
     /// Postal code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<&'a str>,
+    pub postal_code: Option<String>,
     /// Prefecture.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
     /// Town or cho-me.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub town: Option<&'a str>,
+    pub town: Option<String>,
 }
-impl<'a> CreateAccountCompanyAddressKanji<'a> {
+impl CreateAccountCompanyAddressKanji {
     pub fn new() -> Self {
         Self {
             city: None,
@@ -700,7 +700,7 @@ impl<'a> CreateAccountCompanyAddressKanji<'a> {
         }
     }
 }
-impl<'a> Default for CreateAccountCompanyAddressKanji<'a> {
+impl Default for CreateAccountCompanyAddressKanji {
     fn default() -> Self {
         Self::new()
     }
@@ -1148,86 +1148,86 @@ impl<'de> serde::Deserialize<'de> for CreateAccountControllerStripeDashboardType
 /// Information about the person represented by the account.
 /// This field is null unless `business_type` is set to `individual`.
 /// Once you create an [Account Link](/api/account_links) or [Account Session](/api/account_sessions), this property can only be updated for accounts where [controller.requirement_collection](/api/accounts/object#account_object-controller-requirement_collection) is `application`, which includes Custom accounts.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateAccountIndividual<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateAccountIndividual {
     /// The individual's primary address.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub address: Option<AddressSpecs<'a>>,
+    pub address: Option<AddressSpecs>,
     /// The Kana variation of the the individual's primary address (Japan only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub address_kana: Option<CreateAccountIndividualAddressKana<'a>>,
+    pub address_kana: Option<CreateAccountIndividualAddressKana>,
     /// The Kanji variation of the the individual's primary address (Japan only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub address_kanji: Option<CreateAccountIndividualAddressKanji<'a>>,
+    pub address_kanji: Option<CreateAccountIndividualAddressKanji>,
     /// The individual's date of birth.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dob: Option<DateOfBirthSpecs>,
     /// The individual's email address.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub email: Option<&'a str>,
+    pub email: Option<String>,
     /// The individual's first name.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub first_name: Option<&'a str>,
+    pub first_name: Option<String>,
     /// The Kana variation of the the individual's first name (Japan only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub first_name_kana: Option<&'a str>,
+    pub first_name_kana: Option<String>,
     /// The Kanji variation of the individual's first name (Japan only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub first_name_kanji: Option<&'a str>,
+    pub first_name_kanji: Option<String>,
     /// A list of alternate names or aliases that the individual is known by.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub full_name_aliases: Option<&'a [&'a str]>,
+    pub full_name_aliases: Option<Vec<String>>,
     /// The individual's gender (International regulations require either "male" or "female").
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub gender: Option<&'a str>,
+    pub gender: Option<String>,
     /// The government-issued ID number of the individual, as appropriate for the representative's country.
     /// (Examples are a Social Security Number in the U.S., or a Social Insurance Number in Canada).
     /// Instead of the number itself, you can also provide a [PII token created with Stripe.js](https://docs.stripe.com/js/tokens/create_token?type=pii).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub id_number: Option<&'a str>,
+    pub id_number: Option<String>,
     /// The government-issued secondary ID number of the individual, as appropriate for the representative's country, will be used for enhanced verification checks.
     /// In Thailand, this would be the laser code found on the back of an ID card.
     /// Instead of the number itself, you can also provide a [PII token created with Stripe.js](https://docs.stripe.com/js/tokens/create_token?type=pii).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub id_number_secondary: Option<&'a str>,
+    pub id_number_secondary: Option<String>,
     /// The individual's last name.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub last_name: Option<&'a str>,
+    pub last_name: Option<String>,
     /// The Kana variation of the individual's last name (Japan only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub last_name_kana: Option<&'a str>,
+    pub last_name_kana: Option<String>,
     /// The Kanji variation of the individual's last name (Japan only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub last_name_kanji: Option<&'a str>,
+    pub last_name_kanji: Option<String>,
     /// The individual's maiden name.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub maiden_name: Option<&'a str>,
+    pub maiden_name: Option<String>,
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// The individual's phone number.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub phone: Option<&'a str>,
+    pub phone: Option<String>,
     /// Indicates if the person or any of their representatives, family members, or other closely related persons, declares that they hold or have held an important public job or function, in any jurisdiction.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub political_exposure: Option<CreateAccountIndividualPoliticalExposure>,
     /// The individual's registered address.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub registered_address: Option<AddressSpecs<'a>>,
+    pub registered_address: Option<AddressSpecs>,
     /// Describes the person’s relationship to the account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub relationship: Option<IndividualRelationshipSpecs<'a>>,
+    pub relationship: Option<IndividualRelationshipSpecs>,
     /// The last four digits of the individual's Social Security Number (U.S. only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ssn_last_4: Option<&'a str>,
+    pub ssn_last_4: Option<String>,
     /// The individual's verification document information.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub verification: Option<PersonVerificationSpecs<'a>>,
+    pub verification: Option<PersonVerificationSpecs>,
 }
-impl<'a> CreateAccountIndividual<'a> {
+impl CreateAccountIndividual {
     pub fn new() -> Self {
         Self {
             address: None,
@@ -1256,37 +1256,37 @@ impl<'a> CreateAccountIndividual<'a> {
         }
     }
 }
-impl<'a> Default for CreateAccountIndividual<'a> {
+impl Default for CreateAccountIndividual {
     fn default() -> Self {
         Self::new()
     }
 }
 /// The Kana variation of the the individual's primary address (Japan only).
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateAccountIndividualAddressKana<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateAccountIndividualAddressKana {
     /// City or ward.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<&'a str>,
+    pub city: Option<String>,
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub country: Option<&'a str>,
+    pub country: Option<String>,
     /// Block or building number.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line1: Option<&'a str>,
+    pub line1: Option<String>,
     /// Building details.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line2: Option<&'a str>,
+    pub line2: Option<String>,
     /// Postal code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<&'a str>,
+    pub postal_code: Option<String>,
     /// Prefecture.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
     /// Town or cho-me.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub town: Option<&'a str>,
+    pub town: Option<String>,
 }
-impl<'a> CreateAccountIndividualAddressKana<'a> {
+impl CreateAccountIndividualAddressKana {
     pub fn new() -> Self {
         Self {
             city: None,
@@ -1299,37 +1299,37 @@ impl<'a> CreateAccountIndividualAddressKana<'a> {
         }
     }
 }
-impl<'a> Default for CreateAccountIndividualAddressKana<'a> {
+impl Default for CreateAccountIndividualAddressKana {
     fn default() -> Self {
         Self::new()
     }
 }
 /// The Kanji variation of the the individual's primary address (Japan only).
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateAccountIndividualAddressKanji<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateAccountIndividualAddressKanji {
     /// City or ward.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<&'a str>,
+    pub city: Option<String>,
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub country: Option<&'a str>,
+    pub country: Option<String>,
     /// Block or building number.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line1: Option<&'a str>,
+    pub line1: Option<String>,
     /// Building details.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line2: Option<&'a str>,
+    pub line2: Option<String>,
     /// Postal code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<&'a str>,
+    pub postal_code: Option<String>,
     /// Prefecture.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
     /// Town or cho-me.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub town: Option<&'a str>,
+    pub town: Option<String>,
 }
-impl<'a> CreateAccountIndividualAddressKanji<'a> {
+impl CreateAccountIndividualAddressKanji {
     pub fn new() -> Self {
         Self {
             city: None,
@@ -1342,7 +1342,7 @@ impl<'a> CreateAccountIndividualAddressKanji<'a> {
         }
     }
 }
-impl<'a> Default for CreateAccountIndividualAddressKanji<'a> {
+impl Default for CreateAccountIndividualAddressKanji {
     fn default() -> Self {
         Self::new()
     }
@@ -1404,31 +1404,31 @@ impl<'de> serde::Deserialize<'de> for CreateAccountIndividualPoliticalExposure {
     }
 }
 /// Options for customizing how the account functions within Stripe.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateAccountSettings<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateAccountSettings {
     /// Settings specific to Bacs Direct Debit.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub bacs_debit_payments: Option<BacsDebitPaymentsSpecs<'a>>,
+    pub bacs_debit_payments: Option<BacsDebitPaymentsSpecs>,
     /// Settings used to apply the account's branding to email receipts, invoices, Checkout, and other products.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub branding: Option<BrandingSettingsSpecs<'a>>,
+    pub branding: Option<BrandingSettingsSpecs>,
     /// Settings specific to the account's use of the Card Issuing product.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub card_issuing: Option<CardIssuingSettingsSpecs<'a>>,
+    pub card_issuing: Option<CardIssuingSettingsSpecs>,
     /// Settings specific to card charging on the account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub card_payments: Option<CardPaymentsSettingsSpecs<'a>>,
+    pub card_payments: Option<CardPaymentsSettingsSpecs>,
     /// Settings that apply across payment methods for charging on the account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub payments: Option<PaymentsSettingsSpecs<'a>>,
+    pub payments: Option<PaymentsSettingsSpecs>,
     /// Settings specific to the account's payouts.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub payouts: Option<CreateAccountSettingsPayouts<'a>>,
+    pub payouts: Option<CreateAccountSettingsPayouts>,
     /// Settings specific to the account's Treasury FinancialAccounts.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub treasury: Option<TreasurySettingsSpecs<'a>>,
+    pub treasury: Option<TreasurySettingsSpecs>,
 }
-impl<'a> CreateAccountSettings<'a> {
+impl CreateAccountSettings {
     pub fn new() -> Self {
         Self {
             bacs_debit_payments: None,
@@ -1441,14 +1441,14 @@ impl<'a> CreateAccountSettings<'a> {
         }
     }
 }
-impl<'a> Default for CreateAccountSettings<'a> {
+impl Default for CreateAccountSettings {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Settings specific to the account's payouts.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateAccountSettingsPayouts<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateAccountSettingsPayouts {
     /// A Boolean indicating whether Stripe should try to reclaim negative balances from an attached bank account.
     /// For details, see [Understanding Connect Account Balances](https://docs.stripe.com/connect/account-balances).
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1460,14 +1460,14 @@ pub struct CreateAccountSettingsPayouts<'a> {
     /// The text that appears on the bank account statement for payouts.
     /// If not set, this defaults to the platform's bank descriptor as set in the Dashboard.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub statement_descriptor: Option<&'a str>,
+    pub statement_descriptor: Option<String>,
 }
-impl<'a> CreateAccountSettingsPayouts<'a> {
+impl CreateAccountSettingsPayouts {
     pub fn new() -> Self {
         Self { debit_negative_balances: None, schedule: None, statement_descriptor: None }
     }
 }
-impl<'a> Default for CreateAccountSettingsPayouts<'a> {
+impl Default for CreateAccountSettingsPayouts {
     fn default() -> Self {
         Self::new()
     }
@@ -1726,28 +1726,31 @@ impl<'de> serde::Deserialize<'de> for CreateAccountType {
 /// Connect Onboarding won’t ask for the prefilled information during account onboarding.
 /// You can prefill any information on the account.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateAccount<'a> {
-    inner: CreateAccountBuilder<'a>,
+pub struct CreateAccount {
+    inner: CreateAccountBuilder,
 }
-impl<'a> CreateAccount<'a> {
+impl CreateAccount {
     /// Construct a new `CreateAccount`.
     pub fn new() -> Self {
         Self { inner: CreateAccountBuilder::new() }
     }
     /// An [account token](https://stripe.com/docs/api#create_account_token), used to securely provide details to the account.
-    pub fn account_token(mut self, account_token: &'a str) -> Self {
-        self.inner.account_token = Some(account_token);
+    pub fn account_token(mut self, account_token: impl Into<String>) -> Self {
+        self.inner.account_token = Some(account_token.into());
         self
     }
     /// Business information about the account.
-    pub fn business_profile(mut self, business_profile: BusinessProfileSpecs<'a>) -> Self {
-        self.inner.business_profile = Some(business_profile);
+    pub fn business_profile(mut self, business_profile: impl Into<BusinessProfileSpecs>) -> Self {
+        self.inner.business_profile = Some(business_profile.into());
         self
     }
     /// The business type.
     /// Once you create an [Account Link](/api/account_links) or [Account Session](/api/account_sessions), this property can only be updated for accounts where [controller.requirement_collection](/api/accounts/object#account_object-controller-requirement_collection) is `application`, which includes Custom accounts.
-    pub fn business_type(mut self, business_type: stripe_shared::AccountBusinessType) -> Self {
-        self.inner.business_type = Some(business_type);
+    pub fn business_type(
+        mut self,
+        business_type: impl Into<stripe_shared::AccountBusinessType>,
+    ) -> Self {
+        self.inner.business_type = Some(business_type.into());
         self
     }
     /// Each key of the dictionary represents a capability, and each capability
@@ -1758,51 +1761,51 @@ impl<'a> CreateAccount<'a> {
     ///
     /// Required when [account.controller.stripe_dashboard.type](/api/accounts/create#create_account-controller-dashboard-type).
     /// is `none`, which includes Custom accounts.
-    pub fn capabilities(mut self, capabilities: CapabilitiesParam) -> Self {
-        self.inner.capabilities = Some(capabilities);
+    pub fn capabilities(mut self, capabilities: impl Into<CapabilitiesParam>) -> Self {
+        self.inner.capabilities = Some(capabilities.into());
         self
     }
     /// Information about the company or business.
     /// This field is available for any `business_type`.
     /// Once you create an [Account Link](/api/account_links) or [Account Session](/api/account_sessions), this property can only be updated for accounts where [controller.requirement_collection](/api/accounts/object#account_object-controller-requirement_collection) is `application`, which includes Custom accounts.
-    pub fn company(mut self, company: CreateAccountCompany<'a>) -> Self {
-        self.inner.company = Some(company);
+    pub fn company(mut self, company: impl Into<CreateAccountCompany>) -> Self {
+        self.inner.company = Some(company.into());
         self
     }
     /// A hash of configuration describing the account controller's attributes.
-    pub fn controller(mut self, controller: CreateAccountController) -> Self {
-        self.inner.controller = Some(controller);
+    pub fn controller(mut self, controller: impl Into<CreateAccountController>) -> Self {
+        self.inner.controller = Some(controller.into());
         self
     }
     /// The country in which the account holder resides, or in which the business is legally established.
     /// This should be an ISO 3166-1 alpha-2 country code.
     /// For example, if you are in the United States and the business for which you're creating an account is legally represented in Canada, you would use `CA` as the country for the account being created.
     /// Available countries include [Stripe's global markets](https://stripe.com/global) as well as countries where [cross-border payouts](https://stripe.com/docs/connect/cross-border-payouts) are supported.
-    pub fn country(mut self, country: &'a str) -> Self {
-        self.inner.country = Some(country);
+    pub fn country(mut self, country: impl Into<String>) -> Self {
+        self.inner.country = Some(country.into());
         self
     }
     /// Three-letter ISO currency code representing the default currency for the account.
     /// This must be a currency that [Stripe supports in the account's country](https://docs.stripe.com/payouts).
-    pub fn default_currency(mut self, default_currency: stripe_types::Currency) -> Self {
-        self.inner.default_currency = Some(default_currency);
+    pub fn default_currency(mut self, default_currency: impl Into<stripe_types::Currency>) -> Self {
+        self.inner.default_currency = Some(default_currency.into());
         self
     }
     /// Documents that may be submitted to satisfy various informational requests.
-    pub fn documents(mut self, documents: DocumentsSpecs<'a>) -> Self {
-        self.inner.documents = Some(documents);
+    pub fn documents(mut self, documents: impl Into<DocumentsSpecs>) -> Self {
+        self.inner.documents = Some(documents.into());
         self
     }
     /// The email address of the account holder.
     /// This is only to make the account easier to identify to you.
     /// If [controller.requirement_collection](/api/accounts/object#account_object-controller-requirement_collection) is `application`, which includes Custom accounts, Stripe doesn't email the account without your consent.
-    pub fn email(mut self, email: &'a str) -> Self {
-        self.inner.email = Some(email);
+    pub fn email(mut self, email: impl Into<String>) -> Self {
+        self.inner.email = Some(email.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A card or bank account to attach to the account for receiving [payouts](/connect/bank-debit-card-payouts) (you won’t be able to use it for top-ups).
@@ -1812,48 +1815,51 @@ impl<'a> CreateAccount<'a> {
     /// By default, providing an external account sets it as the new default external account for its currency, and deletes the old default if one exists.
     /// To add additional external accounts without replacing the existing default for the currency, use the [bank account](/api#account_create_bank_account) or [card creation](/api#account_create_card) APIs.
     /// After you create an [Account Link](/api/account_links) or [Account Session](/api/account_sessions), this property can only be updated for accounts where [controller.requirement_collection](/api/accounts/object#account_object-controller-requirement_collection) is `application`, which includes Custom accounts.
-    pub fn external_account(mut self, external_account: &'a str) -> Self {
-        self.inner.external_account = Some(external_account);
+    pub fn external_account(mut self, external_account: impl Into<String>) -> Self {
+        self.inner.external_account = Some(external_account.into());
         self
     }
     /// Information about the person represented by the account.
     /// This field is null unless `business_type` is set to `individual`.
     /// Once you create an [Account Link](/api/account_links) or [Account Session](/api/account_sessions), this property can only be updated for accounts where [controller.requirement_collection](/api/accounts/object#account_object-controller-requirement_collection) is `application`, which includes Custom accounts.
-    pub fn individual(mut self, individual: CreateAccountIndividual<'a>) -> Self {
-        self.inner.individual = Some(individual);
+    pub fn individual(mut self, individual: impl Into<CreateAccountIndividual>) -> Self {
+        self.inner.individual = Some(individual.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// Options for customizing how the account functions within Stripe.
-    pub fn settings(mut self, settings: CreateAccountSettings<'a>) -> Self {
-        self.inner.settings = Some(settings);
+    pub fn settings(mut self, settings: impl Into<CreateAccountSettings>) -> Self {
+        self.inner.settings = Some(settings.into());
         self
     }
     /// Details on the account's acceptance of the [Stripe Services Agreement](/connect/updating-accounts#tos-acceptance).
     /// This property can only be updated for accounts where [controller.requirement_collection](/api/accounts/object#account_object-controller-requirement_collection) is `application`, which includes Custom accounts.
-    pub fn tos_acceptance(mut self, tos_acceptance: TosAcceptanceSpecs<'a>) -> Self {
-        self.inner.tos_acceptance = Some(tos_acceptance);
+    pub fn tos_acceptance(mut self, tos_acceptance: impl Into<TosAcceptanceSpecs>) -> Self {
+        self.inner.tos_acceptance = Some(tos_acceptance.into());
         self
     }
     /// The type of Stripe account to create. May be one of `custom`, `express` or `standard`.
-    pub fn type_(mut self, type_: CreateAccountType) -> Self {
-        self.inner.type_ = Some(type_);
+    pub fn type_(mut self, type_: impl Into<CreateAccountType>) -> Self {
+        self.inner.type_ = Some(type_.into());
         self
     }
 }
-impl<'a> Default for CreateAccount<'a> {
+impl Default for CreateAccount {
     fn default() -> Self {
         Self::new()
     }
 }
-impl CreateAccount<'_> {
+impl CreateAccount {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -1871,45 +1877,45 @@ impl CreateAccount<'_> {
     }
 }
 
-impl StripeRequest for CreateAccount<'_> {
+impl StripeRequest for CreateAccount {
     type Output = stripe_shared::Account;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Post, "/accounts").form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdateAccountBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdateAccountBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    account_token: Option<&'a str>,
+    account_token: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    business_profile: Option<BusinessProfileSpecs<'a>>,
+    business_profile: Option<BusinessProfileSpecs>,
     #[serde(skip_serializing_if = "Option::is_none")]
     business_type: Option<stripe_shared::AccountBusinessType>,
     #[serde(skip_serializing_if = "Option::is_none")]
     capabilities: Option<CapabilitiesParam>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    company: Option<UpdateAccountCompany<'a>>,
+    company: Option<UpdateAccountCompany>,
     #[serde(skip_serializing_if = "Option::is_none")]
     default_currency: Option<stripe_types::Currency>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    documents: Option<DocumentsSpecs<'a>>,
+    documents: Option<DocumentsSpecs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    email: Option<&'a str>,
+    email: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    external_account: Option<&'a str>,
+    external_account: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    individual: Option<UpdateAccountIndividual<'a>>,
+    individual: Option<UpdateAccountIndividual>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    settings: Option<UpdateAccountSettings<'a>>,
+    settings: Option<UpdateAccountSettings>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    tos_acceptance: Option<TosAcceptanceSpecs<'a>>,
+    tos_acceptance: Option<TosAcceptanceSpecs>,
 }
-impl<'a> UpdateAccountBuilder<'a> {
+impl UpdateAccountBuilder {
     fn new() -> Self {
         Self {
             account_token: None,
@@ -1932,17 +1938,17 @@ impl<'a> UpdateAccountBuilder<'a> {
 /// Information about the company or business.
 /// This field is available for any `business_type`.
 /// Once you create an [Account Link](/api/account_links) or [Account Session](/api/account_sessions), this property can only be updated for accounts where [controller.requirement_collection](/api/accounts/object#account_object-controller-requirement_collection) is `application`, which includes Custom accounts.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateAccountCompany<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateAccountCompany {
     /// The company's primary address.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub address: Option<AddressSpecs<'a>>,
+    pub address: Option<AddressSpecs>,
     /// The Kana variation of the company's primary address (Japan only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub address_kana: Option<UpdateAccountCompanyAddressKana<'a>>,
+    pub address_kana: Option<UpdateAccountCompanyAddressKana>,
     /// The Kanji variation of the company's primary address (Japan only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub address_kanji: Option<UpdateAccountCompanyAddressKanji<'a>>,
+    pub address_kanji: Option<UpdateAccountCompanyAddressKanji>,
     /// Whether the company's directors have been provided.
     /// Set this Boolean to `true` after creating all the company's directors with [the Persons API](https://docs.stripe.com/api/persons) for accounts with a `relationship.director` requirement.
     /// This value is not automatically set to `true` after creating directors, so it needs to be updated to indicate all directors have been provided.
@@ -1954,33 +1960,33 @@ pub struct UpdateAccountCompany<'a> {
     pub executives_provided: Option<bool>,
     /// The export license ID number of the company, also referred as Import Export Code (India only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub export_license_id: Option<&'a str>,
+    pub export_license_id: Option<String>,
     /// The purpose code to use for export transactions (India only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub export_purpose_code: Option<&'a str>,
+    pub export_purpose_code: Option<String>,
     /// The company's legal name.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<&'a str>,
+    pub name: Option<String>,
     /// The Kana variation of the company's legal name (Japan only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub name_kana: Option<&'a str>,
+    pub name_kana: Option<String>,
     /// The Kanji variation of the company's legal name (Japan only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub name_kanji: Option<&'a str>,
+    pub name_kanji: Option<String>,
     /// Whether the company's owners have been provided.
     /// Set this Boolean to `true` after creating all the company's owners with [the Persons API](https://docs.stripe.com/api/persons) for accounts with a `relationship.owner` requirement.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub owners_provided: Option<bool>,
     /// This hash is used to attest that the beneficial owner information provided to Stripe is both current and correct.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ownership_declaration: Option<CompanyOwnershipDeclaration<'a>>,
+    pub ownership_declaration: Option<CompanyOwnershipDeclaration>,
     /// The company's phone number (used for verification).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub phone: Option<&'a str>,
+    pub phone: Option<String>,
     /// The identification number given to a company when it is registered or incorporated, if distinct from the identification number used for filing taxes.
     /// (Examples are the CIN for companies and LLP IN for partnerships in India, and the Company Registration Number in Hong Kong).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub registration_number: Option<&'a str>,
+    pub registration_number: Option<String>,
     /// The category identifying the legal structure of the company or legal entity.
     /// See [Business structure](https://docs.stripe.com/connect/identity-verification#business-structure) for more details.
     /// Pass an empty string to unset this value.
@@ -1989,18 +1995,18 @@ pub struct UpdateAccountCompany<'a> {
     /// The business ID number of the company, as appropriate for the company’s country.
     /// (Examples are an Employer ID Number in the U.S., a Business Number in Canada, or a Company Number in the UK.).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_id: Option<&'a str>,
+    pub tax_id: Option<String>,
     /// The jurisdiction in which the `tax_id` is registered (Germany-based companies only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_id_registrar: Option<&'a str>,
+    pub tax_id_registrar: Option<String>,
     /// The VAT number of the company.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub vat_id: Option<&'a str>,
+    pub vat_id: Option<String>,
     /// Information on the verification state of the company.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub verification: Option<VerificationSpecs<'a>>,
+    pub verification: Option<VerificationSpecs>,
 }
-impl<'a> UpdateAccountCompany<'a> {
+impl UpdateAccountCompany {
     pub fn new() -> Self {
         Self {
             address: None,
@@ -2025,37 +2031,37 @@ impl<'a> UpdateAccountCompany<'a> {
         }
     }
 }
-impl<'a> Default for UpdateAccountCompany<'a> {
+impl Default for UpdateAccountCompany {
     fn default() -> Self {
         Self::new()
     }
 }
 /// The Kana variation of the company's primary address (Japan only).
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateAccountCompanyAddressKana<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateAccountCompanyAddressKana {
     /// City or ward.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<&'a str>,
+    pub city: Option<String>,
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub country: Option<&'a str>,
+    pub country: Option<String>,
     /// Block or building number.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line1: Option<&'a str>,
+    pub line1: Option<String>,
     /// Building details.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line2: Option<&'a str>,
+    pub line2: Option<String>,
     /// Postal code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<&'a str>,
+    pub postal_code: Option<String>,
     /// Prefecture.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
     /// Town or cho-me.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub town: Option<&'a str>,
+    pub town: Option<String>,
 }
-impl<'a> UpdateAccountCompanyAddressKana<'a> {
+impl UpdateAccountCompanyAddressKana {
     pub fn new() -> Self {
         Self {
             city: None,
@@ -2068,37 +2074,37 @@ impl<'a> UpdateAccountCompanyAddressKana<'a> {
         }
     }
 }
-impl<'a> Default for UpdateAccountCompanyAddressKana<'a> {
+impl Default for UpdateAccountCompanyAddressKana {
     fn default() -> Self {
         Self::new()
     }
 }
 /// The Kanji variation of the company's primary address (Japan only).
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateAccountCompanyAddressKanji<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateAccountCompanyAddressKanji {
     /// City or ward.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<&'a str>,
+    pub city: Option<String>,
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub country: Option<&'a str>,
+    pub country: Option<String>,
     /// Block or building number.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line1: Option<&'a str>,
+    pub line1: Option<String>,
     /// Building details.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line2: Option<&'a str>,
+    pub line2: Option<String>,
     /// Postal code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<&'a str>,
+    pub postal_code: Option<String>,
     /// Prefecture.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
     /// Town or cho-me.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub town: Option<&'a str>,
+    pub town: Option<String>,
 }
-impl<'a> UpdateAccountCompanyAddressKanji<'a> {
+impl UpdateAccountCompanyAddressKanji {
     pub fn new() -> Self {
         Self {
             city: None,
@@ -2111,7 +2117,7 @@ impl<'a> UpdateAccountCompanyAddressKanji<'a> {
         }
     }
 }
-impl<'a> Default for UpdateAccountCompanyAddressKanji<'a> {
+impl Default for UpdateAccountCompanyAddressKanji {
     fn default() -> Self {
         Self::new()
     }
@@ -2242,86 +2248,86 @@ impl<'de> serde::Deserialize<'de> for UpdateAccountCompanyStructure {
 /// Information about the person represented by the account.
 /// This field is null unless `business_type` is set to `individual`.
 /// Once you create an [Account Link](/api/account_links) or [Account Session](/api/account_sessions), this property can only be updated for accounts where [controller.requirement_collection](/api/accounts/object#account_object-controller-requirement_collection) is `application`, which includes Custom accounts.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateAccountIndividual<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateAccountIndividual {
     /// The individual's primary address.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub address: Option<AddressSpecs<'a>>,
+    pub address: Option<AddressSpecs>,
     /// The Kana variation of the the individual's primary address (Japan only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub address_kana: Option<UpdateAccountIndividualAddressKana<'a>>,
+    pub address_kana: Option<UpdateAccountIndividualAddressKana>,
     /// The Kanji variation of the the individual's primary address (Japan only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub address_kanji: Option<UpdateAccountIndividualAddressKanji<'a>>,
+    pub address_kanji: Option<UpdateAccountIndividualAddressKanji>,
     /// The individual's date of birth.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dob: Option<DateOfBirthSpecs>,
     /// The individual's email address.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub email: Option<&'a str>,
+    pub email: Option<String>,
     /// The individual's first name.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub first_name: Option<&'a str>,
+    pub first_name: Option<String>,
     /// The Kana variation of the the individual's first name (Japan only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub first_name_kana: Option<&'a str>,
+    pub first_name_kana: Option<String>,
     /// The Kanji variation of the individual's first name (Japan only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub first_name_kanji: Option<&'a str>,
+    pub first_name_kanji: Option<String>,
     /// A list of alternate names or aliases that the individual is known by.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub full_name_aliases: Option<&'a [&'a str]>,
+    pub full_name_aliases: Option<Vec<String>>,
     /// The individual's gender (International regulations require either "male" or "female").
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub gender: Option<&'a str>,
+    pub gender: Option<String>,
     /// The government-issued ID number of the individual, as appropriate for the representative's country.
     /// (Examples are a Social Security Number in the U.S., or a Social Insurance Number in Canada).
     /// Instead of the number itself, you can also provide a [PII token created with Stripe.js](https://docs.stripe.com/js/tokens/create_token?type=pii).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub id_number: Option<&'a str>,
+    pub id_number: Option<String>,
     /// The government-issued secondary ID number of the individual, as appropriate for the representative's country, will be used for enhanced verification checks.
     /// In Thailand, this would be the laser code found on the back of an ID card.
     /// Instead of the number itself, you can also provide a [PII token created with Stripe.js](https://docs.stripe.com/js/tokens/create_token?type=pii).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub id_number_secondary: Option<&'a str>,
+    pub id_number_secondary: Option<String>,
     /// The individual's last name.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub last_name: Option<&'a str>,
+    pub last_name: Option<String>,
     /// The Kana variation of the individual's last name (Japan only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub last_name_kana: Option<&'a str>,
+    pub last_name_kana: Option<String>,
     /// The Kanji variation of the individual's last name (Japan only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub last_name_kanji: Option<&'a str>,
+    pub last_name_kanji: Option<String>,
     /// The individual's maiden name.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub maiden_name: Option<&'a str>,
+    pub maiden_name: Option<String>,
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// The individual's phone number.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub phone: Option<&'a str>,
+    pub phone: Option<String>,
     /// Indicates if the person or any of their representatives, family members, or other closely related persons, declares that they hold or have held an important public job or function, in any jurisdiction.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub political_exposure: Option<UpdateAccountIndividualPoliticalExposure>,
     /// The individual's registered address.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub registered_address: Option<AddressSpecs<'a>>,
+    pub registered_address: Option<AddressSpecs>,
     /// Describes the person’s relationship to the account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub relationship: Option<IndividualRelationshipSpecs<'a>>,
+    pub relationship: Option<IndividualRelationshipSpecs>,
     /// The last four digits of the individual's Social Security Number (U.S. only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ssn_last_4: Option<&'a str>,
+    pub ssn_last_4: Option<String>,
     /// The individual's verification document information.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub verification: Option<PersonVerificationSpecs<'a>>,
+    pub verification: Option<PersonVerificationSpecs>,
 }
-impl<'a> UpdateAccountIndividual<'a> {
+impl UpdateAccountIndividual {
     pub fn new() -> Self {
         Self {
             address: None,
@@ -2350,37 +2356,37 @@ impl<'a> UpdateAccountIndividual<'a> {
         }
     }
 }
-impl<'a> Default for UpdateAccountIndividual<'a> {
+impl Default for UpdateAccountIndividual {
     fn default() -> Self {
         Self::new()
     }
 }
 /// The Kana variation of the the individual's primary address (Japan only).
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateAccountIndividualAddressKana<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateAccountIndividualAddressKana {
     /// City or ward.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<&'a str>,
+    pub city: Option<String>,
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub country: Option<&'a str>,
+    pub country: Option<String>,
     /// Block or building number.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line1: Option<&'a str>,
+    pub line1: Option<String>,
     /// Building details.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line2: Option<&'a str>,
+    pub line2: Option<String>,
     /// Postal code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<&'a str>,
+    pub postal_code: Option<String>,
     /// Prefecture.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
     /// Town or cho-me.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub town: Option<&'a str>,
+    pub town: Option<String>,
 }
-impl<'a> UpdateAccountIndividualAddressKana<'a> {
+impl UpdateAccountIndividualAddressKana {
     pub fn new() -> Self {
         Self {
             city: None,
@@ -2393,37 +2399,37 @@ impl<'a> UpdateAccountIndividualAddressKana<'a> {
         }
     }
 }
-impl<'a> Default for UpdateAccountIndividualAddressKana<'a> {
+impl Default for UpdateAccountIndividualAddressKana {
     fn default() -> Self {
         Self::new()
     }
 }
 /// The Kanji variation of the the individual's primary address (Japan only).
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateAccountIndividualAddressKanji<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateAccountIndividualAddressKanji {
     /// City or ward.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<&'a str>,
+    pub city: Option<String>,
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub country: Option<&'a str>,
+    pub country: Option<String>,
     /// Block or building number.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line1: Option<&'a str>,
+    pub line1: Option<String>,
     /// Building details.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line2: Option<&'a str>,
+    pub line2: Option<String>,
     /// Postal code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<&'a str>,
+    pub postal_code: Option<String>,
     /// Prefecture.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
     /// Town or cho-me.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub town: Option<&'a str>,
+    pub town: Option<String>,
 }
-impl<'a> UpdateAccountIndividualAddressKanji<'a> {
+impl UpdateAccountIndividualAddressKanji {
     pub fn new() -> Self {
         Self {
             city: None,
@@ -2436,7 +2442,7 @@ impl<'a> UpdateAccountIndividualAddressKanji<'a> {
         }
     }
 }
-impl<'a> Default for UpdateAccountIndividualAddressKanji<'a> {
+impl Default for UpdateAccountIndividualAddressKanji {
     fn default() -> Self {
         Self::new()
     }
@@ -2498,34 +2504,34 @@ impl<'de> serde::Deserialize<'de> for UpdateAccountIndividualPoliticalExposure {
     }
 }
 /// Options for customizing how the account functions within Stripe.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateAccountSettings<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateAccountSettings {
     /// Settings specific to Bacs Direct Debit payments.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub bacs_debit_payments: Option<BacsDebitPaymentsSpecs<'a>>,
+    pub bacs_debit_payments: Option<BacsDebitPaymentsSpecs>,
     /// Settings used to apply the account's branding to email receipts, invoices, Checkout, and other products.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub branding: Option<BrandingSettingsSpecs<'a>>,
+    pub branding: Option<BrandingSettingsSpecs>,
     /// Settings specific to the account's use of the Card Issuing product.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub card_issuing: Option<CardIssuingSettingsSpecs<'a>>,
+    pub card_issuing: Option<CardIssuingSettingsSpecs>,
     /// Settings specific to card charging on the account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub card_payments: Option<CardPaymentsSettingsSpecs<'a>>,
+    pub card_payments: Option<CardPaymentsSettingsSpecs>,
     /// Settings specific to the account's use of Invoices.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub invoices: Option<UpdateAccountSettingsInvoices<'a>>,
+    pub invoices: Option<UpdateAccountSettingsInvoices>,
     /// Settings that apply across payment methods for charging on the account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub payments: Option<PaymentsSettingsSpecs<'a>>,
+    pub payments: Option<PaymentsSettingsSpecs>,
     /// Settings specific to the account's payouts.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub payouts: Option<UpdateAccountSettingsPayouts<'a>>,
+    pub payouts: Option<UpdateAccountSettingsPayouts>,
     /// Settings specific to the account's Treasury FinancialAccounts.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub treasury: Option<TreasurySettingsSpecs<'a>>,
+    pub treasury: Option<TreasurySettingsSpecs>,
 }
-impl<'a> UpdateAccountSettings<'a> {
+impl UpdateAccountSettings {
     pub fn new() -> Self {
         Self {
             bacs_debit_payments: None,
@@ -2539,32 +2545,32 @@ impl<'a> UpdateAccountSettings<'a> {
         }
     }
 }
-impl<'a> Default for UpdateAccountSettings<'a> {
+impl Default for UpdateAccountSettings {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Settings specific to the account's use of Invoices.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateAccountSettingsInvoices<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateAccountSettingsInvoices {
     /// The list of default Account Tax IDs to automatically include on invoices.
     /// Account Tax IDs get added when an invoice is finalized.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub default_account_tax_ids: Option<&'a [&'a str]>,
+    pub default_account_tax_ids: Option<Vec<String>>,
 }
-impl<'a> UpdateAccountSettingsInvoices<'a> {
+impl UpdateAccountSettingsInvoices {
     pub fn new() -> Self {
         Self { default_account_tax_ids: None }
     }
 }
-impl<'a> Default for UpdateAccountSettingsInvoices<'a> {
+impl Default for UpdateAccountSettingsInvoices {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Settings specific to the account's payouts.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateAccountSettingsPayouts<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateAccountSettingsPayouts {
     /// A Boolean indicating whether Stripe should try to reclaim negative balances from an attached bank account.
     /// For details, see [Understanding Connect Account Balances](https://docs.stripe.com/connect/account-balances).
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2576,14 +2582,14 @@ pub struct UpdateAccountSettingsPayouts<'a> {
     /// The text that appears on the bank account statement for payouts.
     /// If not set, this defaults to the platform's bank descriptor as set in the Dashboard.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub statement_descriptor: Option<&'a str>,
+    pub statement_descriptor: Option<String>,
 }
-impl<'a> UpdateAccountSettingsPayouts<'a> {
+impl UpdateAccountSettingsPayouts {
     pub fn new() -> Self {
         Self { debit_negative_balances: None, schedule: None, statement_descriptor: None }
     }
 }
-impl<'a> Default for UpdateAccountSettingsPayouts<'a> {
+impl Default for UpdateAccountSettingsPayouts {
     fn default() -> Self {
         Self::new()
     }
@@ -2792,29 +2798,32 @@ impl<'de> serde::Deserialize<'de> for UpdateAccountSettingsPayoutsScheduleWeekly
 /// Refer to our.
 /// [Connect](https://stripe.com/docs/connect/updating-accounts) documentation to learn more about updating accounts.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateAccount<'a> {
-    inner: UpdateAccountBuilder<'a>,
-    account: &'a stripe_shared::AccountId,
+pub struct UpdateAccount {
+    inner: UpdateAccountBuilder,
+    account: stripe_shared::AccountId,
 }
-impl<'a> UpdateAccount<'a> {
+impl UpdateAccount {
     /// Construct a new `UpdateAccount`.
-    pub fn new(account: &'a stripe_shared::AccountId) -> Self {
-        Self { account, inner: UpdateAccountBuilder::new() }
+    pub fn new(account: impl Into<stripe_shared::AccountId>) -> Self {
+        Self { account: account.into(), inner: UpdateAccountBuilder::new() }
     }
     /// An [account token](https://stripe.com/docs/api#create_account_token), used to securely provide details to the account.
-    pub fn account_token(mut self, account_token: &'a str) -> Self {
-        self.inner.account_token = Some(account_token);
+    pub fn account_token(mut self, account_token: impl Into<String>) -> Self {
+        self.inner.account_token = Some(account_token.into());
         self
     }
     /// Business information about the account.
-    pub fn business_profile(mut self, business_profile: BusinessProfileSpecs<'a>) -> Self {
-        self.inner.business_profile = Some(business_profile);
+    pub fn business_profile(mut self, business_profile: impl Into<BusinessProfileSpecs>) -> Self {
+        self.inner.business_profile = Some(business_profile.into());
         self
     }
     /// The business type.
     /// Once you create an [Account Link](/api/account_links) or [Account Session](/api/account_sessions), this property can only be updated for accounts where [controller.requirement_collection](/api/accounts/object#account_object-controller-requirement_collection) is `application`, which includes Custom accounts.
-    pub fn business_type(mut self, business_type: stripe_shared::AccountBusinessType) -> Self {
-        self.inner.business_type = Some(business_type);
+    pub fn business_type(
+        mut self,
+        business_type: impl Into<stripe_shared::AccountBusinessType>,
+    ) -> Self {
+        self.inner.business_type = Some(business_type.into());
         self
     }
     /// Each key of the dictionary represents a capability, and each capability
@@ -2825,38 +2834,38 @@ impl<'a> UpdateAccount<'a> {
     ///
     /// Required when [account.controller.stripe_dashboard.type](/api/accounts/create#create_account-controller-dashboard-type).
     /// is `none`, which includes Custom accounts.
-    pub fn capabilities(mut self, capabilities: CapabilitiesParam) -> Self {
-        self.inner.capabilities = Some(capabilities);
+    pub fn capabilities(mut self, capabilities: impl Into<CapabilitiesParam>) -> Self {
+        self.inner.capabilities = Some(capabilities.into());
         self
     }
     /// Information about the company or business.
     /// This field is available for any `business_type`.
     /// Once you create an [Account Link](/api/account_links) or [Account Session](/api/account_sessions), this property can only be updated for accounts where [controller.requirement_collection](/api/accounts/object#account_object-controller-requirement_collection) is `application`, which includes Custom accounts.
-    pub fn company(mut self, company: UpdateAccountCompany<'a>) -> Self {
-        self.inner.company = Some(company);
+    pub fn company(mut self, company: impl Into<UpdateAccountCompany>) -> Self {
+        self.inner.company = Some(company.into());
         self
     }
     /// Three-letter ISO currency code representing the default currency for the account.
     /// This must be a currency that [Stripe supports in the account's country](https://docs.stripe.com/payouts).
-    pub fn default_currency(mut self, default_currency: stripe_types::Currency) -> Self {
-        self.inner.default_currency = Some(default_currency);
+    pub fn default_currency(mut self, default_currency: impl Into<stripe_types::Currency>) -> Self {
+        self.inner.default_currency = Some(default_currency.into());
         self
     }
     /// Documents that may be submitted to satisfy various informational requests.
-    pub fn documents(mut self, documents: DocumentsSpecs<'a>) -> Self {
-        self.inner.documents = Some(documents);
+    pub fn documents(mut self, documents: impl Into<DocumentsSpecs>) -> Self {
+        self.inner.documents = Some(documents.into());
         self
     }
     /// The email address of the account holder.
     /// This is only to make the account easier to identify to you.
     /// If [controller.requirement_collection](/api/accounts/object#account_object-controller-requirement_collection) is `application`, which includes Custom accounts, Stripe doesn't email the account without your consent.
-    pub fn email(mut self, email: &'a str) -> Self {
-        self.inner.email = Some(email);
+    pub fn email(mut self, email: impl Into<String>) -> Self {
+        self.inner.email = Some(email.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A card or bank account to attach to the account for receiving [payouts](/connect/bank-debit-card-payouts) (you won’t be able to use it for top-ups).
@@ -2866,38 +2875,41 @@ impl<'a> UpdateAccount<'a> {
     /// By default, providing an external account sets it as the new default external account for its currency, and deletes the old default if one exists.
     /// To add additional external accounts without replacing the existing default for the currency, use the [bank account](/api#account_create_bank_account) or [card creation](/api#account_create_card) APIs.
     /// After you create an [Account Link](/api/account_links) or [Account Session](/api/account_sessions), this property can only be updated for accounts where [controller.requirement_collection](/api/accounts/object#account_object-controller-requirement_collection) is `application`, which includes Custom accounts.
-    pub fn external_account(mut self, external_account: &'a str) -> Self {
-        self.inner.external_account = Some(external_account);
+    pub fn external_account(mut self, external_account: impl Into<String>) -> Self {
+        self.inner.external_account = Some(external_account.into());
         self
     }
     /// Information about the person represented by the account.
     /// This field is null unless `business_type` is set to `individual`.
     /// Once you create an [Account Link](/api/account_links) or [Account Session](/api/account_sessions), this property can only be updated for accounts where [controller.requirement_collection](/api/accounts/object#account_object-controller-requirement_collection) is `application`, which includes Custom accounts.
-    pub fn individual(mut self, individual: UpdateAccountIndividual<'a>) -> Self {
-        self.inner.individual = Some(individual);
+    pub fn individual(mut self, individual: impl Into<UpdateAccountIndividual>) -> Self {
+        self.inner.individual = Some(individual.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// Options for customizing how the account functions within Stripe.
-    pub fn settings(mut self, settings: UpdateAccountSettings<'a>) -> Self {
-        self.inner.settings = Some(settings);
+    pub fn settings(mut self, settings: impl Into<UpdateAccountSettings>) -> Self {
+        self.inner.settings = Some(settings.into());
         self
     }
     /// Details on the account's acceptance of the [Stripe Services Agreement](/connect/updating-accounts#tos-acceptance).
     /// This property can only be updated for accounts where [controller.requirement_collection](/api/accounts/object#account_object-controller-requirement_collection) is `application`, which includes Custom accounts.
-    pub fn tos_acceptance(mut self, tos_acceptance: TosAcceptanceSpecs<'a>) -> Self {
-        self.inner.tos_acceptance = Some(tos_acceptance);
+    pub fn tos_acceptance(mut self, tos_acceptance: impl Into<TosAcceptanceSpecs>) -> Self {
+        self.inner.tos_acceptance = Some(tos_acceptance.into());
         self
     }
 }
-impl UpdateAccount<'_> {
+impl UpdateAccount {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -2915,23 +2927,23 @@ impl UpdateAccount<'_> {
     }
 }
 
-impl StripeRequest for UpdateAccount<'_> {
+impl StripeRequest for UpdateAccount {
     type Output = stripe_shared::Account;
 
     fn build(&self) -> RequestBuilder {
-        let account = self.account;
+        let account = &self.account;
         RequestBuilder::new(StripeMethod::Post, format!("/accounts/{account}")).form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RejectAccountBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RejectAccountBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
-    reason: &'a str,
+    expand: Option<Vec<String>>,
+    reason: String,
 }
-impl<'a> RejectAccountBuilder<'a> {
-    fn new(reason: &'a str) -> Self {
-        Self { expand: None, reason }
+impl RejectAccountBuilder {
+    fn new(reason: impl Into<String>) -> Self {
+        Self { expand: None, reason: reason.into() }
     }
 }
 /// With <a href="/connect">Connect</a>, you can reject accounts that you have flagged as suspicious.
@@ -2940,22 +2952,22 @@ impl<'a> RejectAccountBuilder<'a> {
 /// Test-mode accounts can be rejected at any time.
 /// Live-mode accounts can only be rejected after all balances are zero.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RejectAccount<'a> {
-    inner: RejectAccountBuilder<'a>,
-    account: &'a stripe_shared::AccountId,
+pub struct RejectAccount {
+    inner: RejectAccountBuilder,
+    account: stripe_shared::AccountId,
 }
-impl<'a> RejectAccount<'a> {
+impl RejectAccount {
     /// Construct a new `RejectAccount`.
-    pub fn new(account: &'a stripe_shared::AccountId, reason: &'a str) -> Self {
-        Self { account, inner: RejectAccountBuilder::new(reason) }
+    pub fn new(account: impl Into<stripe_shared::AccountId>, reason: impl Into<String>) -> Self {
+        Self { account: account.into(), inner: RejectAccountBuilder::new(reason.into()) }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RejectAccount<'_> {
+impl RejectAccount {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -2973,18 +2985,18 @@ impl RejectAccount<'_> {
     }
 }
 
-impl StripeRequest for RejectAccount<'_> {
+impl StripeRequest for RejectAccount {
     type Output = stripe_shared::Account;
 
     fn build(&self) -> RequestBuilder {
-        let account = self.account;
+        let account = &self.account;
         RequestBuilder::new(StripeMethod::Post, format!("/accounts/{account}/reject"))
             .form(&self.inner)
     }
 }
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct AnnualRevenueSpecs<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct AnnualRevenueSpecs {
     /// A non-negative integer representing the amount in the [smallest currency unit](https://docs.stripe.com/currencies#zero-decimal).
     pub amount: i64,
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
@@ -2993,11 +3005,19 @@ pub struct AnnualRevenueSpecs<'a> {
     /// The close-out date of the preceding fiscal year in ISO 8601 format.
     /// E.g.
     /// 2023-12-31 for the 31st of December, 2023.
-    pub fiscal_year_end: &'a str,
+    pub fiscal_year_end: String,
 }
-impl<'a> AnnualRevenueSpecs<'a> {
-    pub fn new(amount: i64, currency: stripe_types::Currency, fiscal_year_end: &'a str) -> Self {
-        Self { amount, currency, fiscal_year_end }
+impl AnnualRevenueSpecs {
+    pub fn new(
+        amount: impl Into<i64>,
+        currency: impl Into<stripe_types::Currency>,
+        fiscal_year_end: impl Into<String>,
+    ) -> Self {
+        Self {
+            amount: amount.into(),
+            currency: currency.into(),
+            fiscal_year_end: fiscal_year_end.into(),
+        }
     }
 }
 #[derive(Copy, Clone, Debug, serde::Serialize)]
@@ -3009,37 +3029,37 @@ pub struct MonthlyEstimatedRevenueSpecs {
     pub currency: stripe_types::Currency,
 }
 impl MonthlyEstimatedRevenueSpecs {
-    pub fn new(amount: i64, currency: stripe_types::Currency) -> Self {
-        Self { amount, currency }
+    pub fn new(amount: impl Into<i64>, currency: impl Into<stripe_types::Currency>) -> Self {
+        Self { amount: amount.into(), currency: currency.into() }
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct AddressSpecs<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct AddressSpecs {
     /// City, district, suburb, town, or village.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<&'a str>,
+    pub city: Option<String>,
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub country: Option<&'a str>,
+    pub country: Option<String>,
     /// Address line 1 (e.g., street, PO Box, or company name).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line1: Option<&'a str>,
+    pub line1: Option<String>,
     /// Address line 2 (e.g., apartment, suite, unit, or building).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line2: Option<&'a str>,
+    pub line2: Option<String>,
     /// ZIP or postal code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<&'a str>,
+    pub postal_code: Option<String>,
     /// State, county, province, or region.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
 }
-impl<'a> AddressSpecs<'a> {
+impl AddressSpecs {
     pub fn new() -> Self {
         Self { city: None, country: None, line1: None, line2: None, postal_code: None, state: None }
     }
 }
-impl<'a> Default for AddressSpecs<'a> {
+impl Default for AddressSpecs {
     fn default() -> Self {
         Self::new()
     }
@@ -3062,61 +3082,61 @@ impl Default for CapabilityParam {
         Self::new()
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CompanyOwnershipDeclaration<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CompanyOwnershipDeclaration {
     /// The Unix timestamp marking when the beneficial owner attestation was made.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub date: Option<stripe_types::Timestamp>,
     /// The IP address from which the beneficial owner attestation was made.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ip: Option<&'a str>,
+    pub ip: Option<String>,
     /// The user agent of the browser from which the beneficial owner attestation was made.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user_agent: Option<&'a str>,
+    pub user_agent: Option<String>,
 }
-impl<'a> CompanyOwnershipDeclaration<'a> {
+impl CompanyOwnershipDeclaration {
     pub fn new() -> Self {
         Self { date: None, ip: None, user_agent: None }
     }
 }
-impl<'a> Default for CompanyOwnershipDeclaration<'a> {
+impl Default for CompanyOwnershipDeclaration {
     fn default() -> Self {
         Self::new()
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct VerificationDocumentSpecs<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct VerificationDocumentSpecs {
     /// The back of a document returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `additional_verification`.
     /// The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG, PNG, or PDF format, and less than 10 MB in size.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub back: Option<&'a str>,
+    pub back: Option<String>,
     /// The front of a document returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `additional_verification`.
     /// The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG, PNG, or PDF format, and less than 10 MB in size.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub front: Option<&'a str>,
+    pub front: Option<String>,
 }
-impl<'a> VerificationDocumentSpecs<'a> {
+impl VerificationDocumentSpecs {
     pub fn new() -> Self {
         Self { back: None, front: None }
     }
 }
-impl<'a> Default for VerificationDocumentSpecs<'a> {
+impl Default for VerificationDocumentSpecs {
     fn default() -> Self {
         Self::new()
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct DocumentsParam<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct DocumentsParam {
     /// One or more document ids returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `account_requirement`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub files: Option<&'a [&'a str]>,
+    pub files: Option<Vec<String>>,
 }
-impl<'a> DocumentsParam<'a> {
+impl DocumentsParam {
     pub fn new() -> Self {
         Self { files: None }
     }
 }
-impl<'a> Default for DocumentsParam<'a> {
+impl Default for DocumentsParam {
     fn default() -> Self {
         Self::new()
     }
@@ -3131,12 +3151,12 @@ pub struct DateOfBirthSpecs {
     pub year: i64,
 }
 impl DateOfBirthSpecs {
-    pub fn new(day: i64, month: i64, year: i64) -> Self {
-        Self { day, month, year }
+    pub fn new(day: impl Into<i64>, month: impl Into<i64>, year: impl Into<i64>) -> Self {
+        Self { day: day.into(), month: month.into(), year: year.into() }
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct IndividualRelationshipSpecs<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct IndividualRelationshipSpecs {
     /// Whether the person is a director of the account's legal entity.
     /// Directors are typically members of the governing board of the company, or responsible for ensuring the company meets its regulatory obligations.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -3152,41 +3172,41 @@ pub struct IndividualRelationshipSpecs<'a> {
     pub percent_ownership: Option<f64>,
     /// The person's title (e.g., CEO, Support Engineer).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub title: Option<&'a str>,
+    pub title: Option<String>,
 }
-impl<'a> IndividualRelationshipSpecs<'a> {
+impl IndividualRelationshipSpecs {
     pub fn new() -> Self {
         Self { director: None, executive: None, owner: None, percent_ownership: None, title: None }
     }
 }
-impl<'a> Default for IndividualRelationshipSpecs<'a> {
+impl Default for IndividualRelationshipSpecs {
     fn default() -> Self {
         Self::new()
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct PersonVerificationDocumentSpecs<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct PersonVerificationDocumentSpecs {
     /// The back of an ID returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `identity_document`.
     /// The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG, PNG, or PDF format, and less than 10 MB in size.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub back: Option<&'a str>,
+    pub back: Option<String>,
     /// The front of an ID returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `identity_document`.
     /// The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG, PNG, or PDF format, and less than 10 MB in size.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub front: Option<&'a str>,
+    pub front: Option<String>,
 }
-impl<'a> PersonVerificationDocumentSpecs<'a> {
+impl PersonVerificationDocumentSpecs {
     pub fn new() -> Self {
         Self { back: None, front: None }
     }
 }
-impl<'a> Default for PersonVerificationDocumentSpecs<'a> {
+impl Default for PersonVerificationDocumentSpecs {
     fn default() -> Self {
         Self::new()
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct BacsDebitPaymentsSpecs<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct BacsDebitPaymentsSpecs {
     /// The Bacs Direct Debit Display Name for this account.
     /// For payments made with Bacs Direct Debit, this name appears on the mandate as the statement descriptor.
     /// Mobile banking apps display it as the name of the business.
@@ -3194,63 +3214,63 @@ pub struct BacsDebitPaymentsSpecs<'a> {
     /// Custom branding incurs an additional monthly fee for the platform.
     /// If you don't set the display name before requesting Bacs capability, it's automatically set as "Stripe" and the account is onboarded to Stripe branding, which is free.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub display_name: Option<&'a str>,
+    pub display_name: Option<String>,
 }
-impl<'a> BacsDebitPaymentsSpecs<'a> {
+impl BacsDebitPaymentsSpecs {
     pub fn new() -> Self {
         Self { display_name: None }
     }
 }
-impl<'a> Default for BacsDebitPaymentsSpecs<'a> {
+impl Default for BacsDebitPaymentsSpecs {
     fn default() -> Self {
         Self::new()
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct BrandingSettingsSpecs<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct BrandingSettingsSpecs {
     /// (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) An icon for the account.
     /// Must be square and at least 128px x 128px.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub icon: Option<&'a str>,
+    pub icon: Option<String>,
     /// (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) A logo for the account that will be used in Checkout instead of the icon and without the account's name next to it if provided.
     /// Must be at least 128px x 128px.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub logo: Option<&'a str>,
+    pub logo: Option<String>,
     /// A CSS hex color value representing the primary branding color for this account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub primary_color: Option<&'a str>,
+    pub primary_color: Option<String>,
     /// A CSS hex color value representing the secondary branding color for this account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub secondary_color: Option<&'a str>,
+    pub secondary_color: Option<String>,
 }
-impl<'a> BrandingSettingsSpecs<'a> {
+impl BrandingSettingsSpecs {
     pub fn new() -> Self {
         Self { icon: None, logo: None, primary_color: None, secondary_color: None }
     }
 }
-impl<'a> Default for BrandingSettingsSpecs<'a> {
+impl Default for BrandingSettingsSpecs {
     fn default() -> Self {
         Self::new()
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct SettingsTermsOfServiceSpecs<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct SettingsTermsOfServiceSpecs {
     /// The Unix timestamp marking when the account representative accepted the service agreement.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub date: Option<stripe_types::Timestamp>,
     /// The IP address from which the account representative accepted the service agreement.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ip: Option<&'a str>,
+    pub ip: Option<String>,
     /// The user agent of the browser from which the account representative accepted the service agreement.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user_agent: Option<&'a str>,
+    pub user_agent: Option<String>,
 }
-impl<'a> SettingsTermsOfServiceSpecs<'a> {
+impl SettingsTermsOfServiceSpecs {
     pub fn new() -> Self {
         Self { date: None, ip: None, user_agent: None }
     }
 }
-impl<'a> Default for SettingsTermsOfServiceSpecs<'a> {
+impl Default for SettingsTermsOfServiceSpecs {
     fn default() -> Self {
         Self::new()
     }
@@ -3276,20 +3296,20 @@ impl Default for DeclineChargeOnSpecs {
         Self::new()
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct PaymentsSettingsSpecs<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct PaymentsSettingsSpecs {
     /// The default text that appears on credit card statements when a charge is made.
     /// This field prefixes any dynamic `statement_descriptor` specified on the charge.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub statement_descriptor: Option<&'a str>,
+    pub statement_descriptor: Option<String>,
     /// The Kana variation of the default text that appears on credit card statements when a charge is made (Japan only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub statement_descriptor_kana: Option<&'a str>,
+    pub statement_descriptor_kana: Option<String>,
     /// The Kanji variation of the default text that appears on credit card statements when a charge is made (Japan only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub statement_descriptor_kanji: Option<&'a str>,
+    pub statement_descriptor_kanji: Option<String>,
 }
-impl<'a> PaymentsSettingsSpecs<'a> {
+impl PaymentsSettingsSpecs {
     pub fn new() -> Self {
         Self {
             statement_descriptor: None,
@@ -3298,41 +3318,41 @@ impl<'a> PaymentsSettingsSpecs<'a> {
         }
     }
 }
-impl<'a> Default for PaymentsSettingsSpecs<'a> {
+impl Default for PaymentsSettingsSpecs {
     fn default() -> Self {
         Self::new()
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct TosAcceptanceSpecs<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct TosAcceptanceSpecs {
     /// The Unix timestamp marking when the account representative accepted their service agreement.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub date: Option<stripe_types::Timestamp>,
     /// The IP address from which the account representative accepted their service agreement.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ip: Option<&'a str>,
+    pub ip: Option<String>,
     /// The user's service agreement type.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub service_agreement: Option<&'a str>,
+    pub service_agreement: Option<String>,
     /// The user agent of the browser from which the account representative accepted their service agreement.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user_agent: Option<&'a str>,
+    pub user_agent: Option<String>,
 }
-impl<'a> TosAcceptanceSpecs<'a> {
+impl TosAcceptanceSpecs {
     pub fn new() -> Self {
         Self { date: None, ip: None, service_agreement: None, user_agent: None }
     }
 }
-impl<'a> Default for TosAcceptanceSpecs<'a> {
+impl Default for TosAcceptanceSpecs {
     fn default() -> Self {
         Self::new()
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct BusinessProfileSpecs<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct BusinessProfileSpecs {
     /// The applicant's gross annual revenue for its preceding fiscal year.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub annual_revenue: Option<AnnualRevenueSpecs<'a>>,
+    pub annual_revenue: Option<AnnualRevenueSpecs>,
     /// An estimated upper bound of employees, contractors, vendors, etc.
     /// currently working for the business.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -3340,34 +3360,34 @@ pub struct BusinessProfileSpecs<'a> {
     /// [The merchant category code for the account](https://docs.stripe.com/connect/setting-mcc).
     /// MCCs are used to classify businesses based on the goods or services they provide.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub mcc: Option<&'a str>,
+    pub mcc: Option<String>,
     /// An estimate of the monthly revenue of the business. Only accepted for accounts in Brazil and India.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub monthly_estimated_revenue: Option<MonthlyEstimatedRevenueSpecs>,
     /// The customer-facing business name.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<&'a str>,
+    pub name: Option<String>,
     /// Internal-only description of the product sold by, or service provided by, the business.
     /// Used by Stripe for risk and underwriting purposes.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub product_description: Option<&'a str>,
+    pub product_description: Option<String>,
     /// A publicly available mailing address for sending support issues to.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub support_address: Option<AddressSpecs<'a>>,
+    pub support_address: Option<AddressSpecs>,
     /// A publicly available email address for sending support issues to.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub support_email: Option<&'a str>,
+    pub support_email: Option<String>,
     /// A publicly available phone number to call with support issues.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub support_phone: Option<&'a str>,
+    pub support_phone: Option<String>,
     /// A publicly available website for handling support issues.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub support_url: Option<&'a str>,
+    pub support_url: Option<String>,
     /// The business's publicly available website.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub url: Option<&'a str>,
+    pub url: Option<String>,
 }
-impl<'a> BusinessProfileSpecs<'a> {
+impl BusinessProfileSpecs {
     pub fn new() -> Self {
         Self {
             annual_revenue: None,
@@ -3384,7 +3404,7 @@ impl<'a> BusinessProfileSpecs<'a> {
         }
     }
 }
-impl<'a> Default for BusinessProfileSpecs<'a> {
+impl Default for BusinessProfileSpecs {
     fn default() -> Self {
         Self::new()
     }
@@ -3563,48 +3583,48 @@ impl Default for CapabilitiesParam {
         Self::new()
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct VerificationSpecs<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct VerificationSpecs {
     /// A document verifying the business.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub document: Option<VerificationDocumentSpecs<'a>>,
+    pub document: Option<VerificationDocumentSpecs>,
 }
-impl<'a> VerificationSpecs<'a> {
+impl VerificationSpecs {
     pub fn new() -> Self {
         Self { document: None }
     }
 }
-impl<'a> Default for VerificationSpecs<'a> {
+impl Default for VerificationSpecs {
     fn default() -> Self {
         Self::new()
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct DocumentsSpecs<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct DocumentsSpecs {
     /// One or more documents that support the [Bank account ownership verification](https://support.stripe.com/questions/bank-account-ownership-verification) requirement.
     /// Must be a document associated with the account’s primary active bank account that displays the last 4 digits of the account number, either a statement or a voided check.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub bank_account_ownership_verification: Option<DocumentsParam<'a>>,
+    pub bank_account_ownership_verification: Option<DocumentsParam>,
     /// One or more documents that demonstrate proof of a company's license to operate.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub company_license: Option<DocumentsParam<'a>>,
+    pub company_license: Option<DocumentsParam>,
     /// One or more documents showing the company's Memorandum of Association.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub company_memorandum_of_association: Option<DocumentsParam<'a>>,
+    pub company_memorandum_of_association: Option<DocumentsParam>,
     /// (Certain countries only) One or more documents showing the ministerial decree legalizing the company's establishment.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub company_ministerial_decree: Option<DocumentsParam<'a>>,
+    pub company_ministerial_decree: Option<DocumentsParam>,
     /// One or more documents that demonstrate proof of a company's registration with the appropriate local authorities.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub company_registration_verification: Option<DocumentsParam<'a>>,
+    pub company_registration_verification: Option<DocumentsParam>,
     /// One or more documents that demonstrate proof of a company's tax ID.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub company_tax_id_verification: Option<DocumentsParam<'a>>,
+    pub company_tax_id_verification: Option<DocumentsParam>,
     /// One or more documents showing the company’s proof of registration with the national business registry.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub proof_of_registration: Option<DocumentsParam<'a>>,
+    pub proof_of_registration: Option<DocumentsParam>,
 }
-impl<'a> DocumentsSpecs<'a> {
+impl DocumentsSpecs {
     pub fn new() -> Self {
         Self {
             bank_account_ownership_verification: None,
@@ -3617,48 +3637,48 @@ impl<'a> DocumentsSpecs<'a> {
         }
     }
 }
-impl<'a> Default for DocumentsSpecs<'a> {
+impl Default for DocumentsSpecs {
     fn default() -> Self {
         Self::new()
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct PersonVerificationSpecs<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct PersonVerificationSpecs {
     /// A document showing address, either a passport, local ID card, or utility bill from a well-known utility company.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub additional_document: Option<PersonVerificationDocumentSpecs<'a>>,
+    pub additional_document: Option<PersonVerificationDocumentSpecs>,
     /// An identifying document, either a passport or local ID card.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub document: Option<PersonVerificationDocumentSpecs<'a>>,
+    pub document: Option<PersonVerificationDocumentSpecs>,
 }
-impl<'a> PersonVerificationSpecs<'a> {
+impl PersonVerificationSpecs {
     pub fn new() -> Self {
         Self { additional_document: None, document: None }
     }
 }
-impl<'a> Default for PersonVerificationSpecs<'a> {
+impl Default for PersonVerificationSpecs {
     fn default() -> Self {
         Self::new()
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CardIssuingSettingsSpecs<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CardIssuingSettingsSpecs {
     /// Details on the account's acceptance of the [Stripe Issuing Terms and Disclosures](https://docs.stripe.com/issuing/connect/tos_acceptance).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tos_acceptance: Option<SettingsTermsOfServiceSpecs<'a>>,
+    pub tos_acceptance: Option<SettingsTermsOfServiceSpecs>,
 }
-impl<'a> CardIssuingSettingsSpecs<'a> {
+impl CardIssuingSettingsSpecs {
     pub fn new() -> Self {
         Self { tos_acceptance: None }
     }
 }
-impl<'a> Default for CardIssuingSettingsSpecs<'a> {
+impl Default for CardIssuingSettingsSpecs {
     fn default() -> Self {
         Self::new()
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CardPaymentsSettingsSpecs<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CardPaymentsSettingsSpecs {
     /// Automatically declines certain charge types regardless of whether the card issuer accepted or declined the charge.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub decline_on: Option<DeclineChargeOnSpecs>,
@@ -3666,19 +3686,19 @@ pub struct CardPaymentsSettingsSpecs<'a> {
     /// This field prefixes any dynamic `statement_descriptor` specified on the charge.
     /// `statement_descriptor_prefix` is useful for maximizing descriptor space for the dynamic portion.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub statement_descriptor_prefix: Option<&'a str>,
+    pub statement_descriptor_prefix: Option<String>,
     /// The Kana variation of the default text that appears on credit card statements when a charge is made (Japan only).
     /// This field prefixes any dynamic `statement_descriptor_suffix_kana` specified on the charge.
     /// `statement_descriptor_prefix_kana` is useful for maximizing descriptor space for the dynamic portion.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub statement_descriptor_prefix_kana: Option<&'a str>,
+    pub statement_descriptor_prefix_kana: Option<String>,
     /// The Kanji variation of the default text that appears on credit card statements when a charge is made (Japan only).
     /// This field prefixes any dynamic `statement_descriptor_suffix_kanji` specified on the charge.
     /// `statement_descriptor_prefix_kanji` is useful for maximizing descriptor space for the dynamic portion.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub statement_descriptor_prefix_kanji: Option<&'a str>,
+    pub statement_descriptor_prefix_kanji: Option<String>,
 }
-impl<'a> CardPaymentsSettingsSpecs<'a> {
+impl CardPaymentsSettingsSpecs {
     pub fn new() -> Self {
         Self {
             decline_on: None,
@@ -3688,23 +3708,23 @@ impl<'a> CardPaymentsSettingsSpecs<'a> {
         }
     }
 }
-impl<'a> Default for CardPaymentsSettingsSpecs<'a> {
+impl Default for CardPaymentsSettingsSpecs {
     fn default() -> Self {
         Self::new()
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct TreasurySettingsSpecs<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct TreasurySettingsSpecs {
     /// Details on the account's acceptance of the Stripe Treasury Services Agreement.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tos_acceptance: Option<SettingsTermsOfServiceSpecs<'a>>,
+    pub tos_acceptance: Option<SettingsTermsOfServiceSpecs>,
 }
-impl<'a> TreasurySettingsSpecs<'a> {
+impl TreasurySettingsSpecs {
     pub fn new() -> Self {
         Self { tos_acceptance: None }
     }
 }
-impl<'a> Default for TreasurySettingsSpecs<'a> {
+impl Default for TreasurySettingsSpecs {
     fn default() -> Self {
         Self::new()
     }

--- a/generated/async-stripe-connect/src/account_link/requests.rs
+++ b/generated/async-stripe-connect/src/account_link/requests.rs
@@ -2,32 +2,32 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateAccountLinkBuilder<'a> {
-    account: &'a str,
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateAccountLinkBuilder {
+    account: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     collect: Option<CreateAccountLinkCollect>,
     #[serde(skip_serializing_if = "Option::is_none")]
     collection_options: Option<CreateAccountLinkCollectionOptions>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    refresh_url: Option<&'a str>,
+    refresh_url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    return_url: Option<&'a str>,
+    return_url: Option<String>,
     #[serde(rename = "type")]
     type_: CreateAccountLinkType,
 }
-impl<'a> CreateAccountLinkBuilder<'a> {
-    fn new(account: &'a str, type_: CreateAccountLinkType) -> Self {
+impl CreateAccountLinkBuilder {
+    fn new(account: impl Into<String>, type_: impl Into<CreateAccountLinkType>) -> Self {
         Self {
-            account,
+            account: account.into(),
             collect: None,
             collection_options: None,
             expand: None,
             refresh_url: None,
             return_url: None,
-            type_,
+            type_: type_.into(),
         }
     }
 }
@@ -98,8 +98,8 @@ pub struct CreateAccountLinkCollectionOptions {
     pub future_requirements: Option<CreateAccountLinkCollectionOptionsFutureRequirements>,
 }
 impl CreateAccountLinkCollectionOptions {
-    pub fn new(fields: CreateAccountLinkCollectionOptionsFields) -> Self {
-        Self { fields, future_requirements: None }
+    pub fn new(fields: impl Into<CreateAccountLinkCollectionOptionsFields>) -> Self {
+        Self { fields: fields.into(), future_requirements: None }
     }
 }
 /// Specifies whether the platform collects only currently_due requirements (`currently_due`) or both currently_due and eventually_due requirements (`eventually_due`).
@@ -276,46 +276,46 @@ impl<'de> serde::Deserialize<'de> for CreateAccountLinkType {
 }
 /// Creates an AccountLink object that includes a single-use Stripe URL that the platform can redirect their user to in order to take them through the Connect Onboarding flow.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateAccountLink<'a> {
-    inner: CreateAccountLinkBuilder<'a>,
+pub struct CreateAccountLink {
+    inner: CreateAccountLinkBuilder,
 }
-impl<'a> CreateAccountLink<'a> {
+impl CreateAccountLink {
     /// Construct a new `CreateAccountLink`.
-    pub fn new(account: &'a str, type_: CreateAccountLinkType) -> Self {
-        Self { inner: CreateAccountLinkBuilder::new(account, type_) }
+    pub fn new(account: impl Into<String>, type_: impl Into<CreateAccountLinkType>) -> Self {
+        Self { inner: CreateAccountLinkBuilder::new(account.into(), type_.into()) }
     }
     /// The collect parameter is deprecated. Use `collection_options` instead.
-    pub fn collect(mut self, collect: CreateAccountLinkCollect) -> Self {
-        self.inner.collect = Some(collect);
+    pub fn collect(mut self, collect: impl Into<CreateAccountLinkCollect>) -> Self {
+        self.inner.collect = Some(collect.into());
         self
     }
     /// Specifies the requirements that Stripe collects from connected accounts in the Connect Onboarding flow.
     pub fn collection_options(
         mut self,
-        collection_options: CreateAccountLinkCollectionOptions,
+        collection_options: impl Into<CreateAccountLinkCollectionOptions>,
     ) -> Self {
-        self.inner.collection_options = Some(collection_options);
+        self.inner.collection_options = Some(collection_options.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// The URL the user will be redirected to if the account link is expired, has been previously-visited, or is otherwise invalid.
     /// The URL you specify should attempt to generate a new account link with the same parameters used to create the original account link, then redirect the user to the new account link's URL so they can continue with Connect Onboarding.
     /// If a new account link cannot be generated or the redirect fails you should display a useful error to the user.
-    pub fn refresh_url(mut self, refresh_url: &'a str) -> Self {
-        self.inner.refresh_url = Some(refresh_url);
+    pub fn refresh_url(mut self, refresh_url: impl Into<String>) -> Self {
+        self.inner.refresh_url = Some(refresh_url.into());
         self
     }
     /// The URL that the user will be redirected to upon leaving or completing the linked flow.
-    pub fn return_url(mut self, return_url: &'a str) -> Self {
-        self.inner.return_url = Some(return_url);
+    pub fn return_url(mut self, return_url: impl Into<String>) -> Self {
+        self.inner.return_url = Some(return_url.into());
         self
     }
 }
-impl CreateAccountLink<'_> {
+impl CreateAccountLink {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -333,7 +333,7 @@ impl CreateAccountLink<'_> {
     }
 }
 
-impl StripeRequest for CreateAccountLink<'_> {
+impl StripeRequest for CreateAccountLink {
     type Output = stripe_connect::AccountLink;
 
     fn build(&self) -> RequestBuilder {

--- a/generated/async-stripe-connect/src/account_session/requests.rs
+++ b/generated/async-stripe-connect/src/account_session/requests.rs
@@ -3,15 +3,18 @@ use stripe_client_core::{
 };
 
 #[derive(Clone, Debug, serde::Serialize)]
-struct CreateAccountSessionBuilder<'a> {
-    account: &'a str,
+struct CreateAccountSessionBuilder {
+    account: String,
     components: CreateAccountSessionComponents,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> CreateAccountSessionBuilder<'a> {
-    fn new(account: &'a str, components: CreateAccountSessionComponents) -> Self {
-        Self { account, components, expand: None }
+impl CreateAccountSessionBuilder {
+    fn new(
+        account: impl Into<String>,
+        components: impl Into<CreateAccountSessionComponents>,
+    ) -> Self {
+        Self { account: account.into(), components: components.into(), expand: None }
     }
 }
 /// Each key of the dictionary represents an embedded component, and each embedded component maps to its configuration (e.g.
@@ -68,21 +71,24 @@ impl Default for CreateAccountSessionComponents {
 }
 /// Creates a AccountSession object that includes a single-use token that the platform can use on their front-end to grant client-side API access.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateAccountSession<'a> {
-    inner: CreateAccountSessionBuilder<'a>,
+pub struct CreateAccountSession {
+    inner: CreateAccountSessionBuilder,
 }
-impl<'a> CreateAccountSession<'a> {
+impl CreateAccountSession {
     /// Construct a new `CreateAccountSession`.
-    pub fn new(account: &'a str, components: CreateAccountSessionComponents) -> Self {
-        Self { inner: CreateAccountSessionBuilder::new(account, components) }
+    pub fn new(
+        account: impl Into<String>,
+        components: impl Into<CreateAccountSessionComponents>,
+    ) -> Self {
+        Self { inner: CreateAccountSessionBuilder::new(account.into(), components.into()) }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl CreateAccountSession<'_> {
+impl CreateAccountSession {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -100,7 +106,7 @@ impl CreateAccountSession<'_> {
     }
 }
 
-impl StripeRequest for CreateAccountSession<'_> {
+impl StripeRequest for CreateAccountSession {
     type Output = stripe_connect::AccountSession;
 
     fn build(&self) -> RequestBuilder {
@@ -161,8 +167,8 @@ pub struct BaseConfigParam {
     pub features: Option<miniserde::json::Value>,
 }
 impl BaseConfigParam {
-    pub fn new(enabled: bool) -> Self {
-        Self { enabled, features: None }
+    pub fn new(enabled: impl Into<bool>) -> Self {
+        Self { enabled: enabled.into(), features: None }
     }
 }
 #[derive(Copy, Clone, Debug, serde::Serialize)]
@@ -206,8 +212,8 @@ pub struct AccountConfigParam {
     pub features: Option<AccountFeaturesParam>,
 }
 impl AccountConfigParam {
-    pub fn new(enabled: bool) -> Self {
-        Self { enabled, features: None }
+    pub fn new(enabled: impl Into<bool>) -> Self {
+        Self { enabled: enabled.into(), features: None }
     }
 }
 #[derive(Copy, Clone, Debug, serde::Serialize)]
@@ -219,8 +225,8 @@ pub struct PayoutsConfigParam {
     pub features: Option<PayoutsFeaturesParam>,
 }
 impl PayoutsConfigParam {
-    pub fn new(enabled: bool) -> Self {
-        Self { enabled, features: None }
+    pub fn new(enabled: impl Into<bool>) -> Self {
+        Self { enabled: enabled.into(), features: None }
     }
 }
 #[derive(Copy, Clone, Debug, serde::Serialize)]
@@ -232,7 +238,7 @@ pub struct PaymentsConfigParam {
     pub features: Option<PaymentsFeaturesParam>,
 }
 impl PaymentsConfigParam {
-    pub fn new(enabled: bool) -> Self {
-        Self { enabled, features: None }
+    pub fn new(enabled: impl Into<bool>) -> Self {
+        Self { enabled: enabled.into(), features: None }
     }
 }

--- a/generated/async-stripe-connect/src/application_fee/requests.rs
+++ b/generated/async-stripe-connect/src/application_fee/requests.rs
@@ -2,22 +2,22 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListApplicationFeeBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListApplicationFeeBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    charge: Option<&'a str>,
+    charge: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     created: Option<stripe_types::RangeQueryTs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListApplicationFeeBuilder<'a> {
+impl ListApplicationFeeBuilder {
     fn new() -> Self {
         Self {
             charge: None,
@@ -32,56 +32,56 @@ impl<'a> ListApplicationFeeBuilder<'a> {
 /// Returns a list of application fees you’ve previously collected.
 /// The application fees are returned in sorted order, with the most recent fees appearing first.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListApplicationFee<'a> {
-    inner: ListApplicationFeeBuilder<'a>,
+pub struct ListApplicationFee {
+    inner: ListApplicationFeeBuilder,
 }
-impl<'a> ListApplicationFee<'a> {
+impl ListApplicationFee {
     /// Construct a new `ListApplicationFee`.
     pub fn new() -> Self {
         Self { inner: ListApplicationFeeBuilder::new() }
     }
     /// Only return application fees for the charge specified by this charge ID.
-    pub fn charge(mut self, charge: &'a str) -> Self {
-        self.inner.charge = Some(charge);
+    pub fn charge(mut self, charge: impl Into<String>) -> Self {
+        self.inner.charge = Some(charge.into());
         self
     }
     /// Only return applications fees that were created during the given date interval.
-    pub fn created(mut self, created: stripe_types::RangeQueryTs) -> Self {
-        self.inner.created = Some(created);
+    pub fn created(mut self, created: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.created = Some(created.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl<'a> Default for ListApplicationFee<'a> {
+impl Default for ListApplicationFee {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListApplicationFee<'_> {
+impl ListApplicationFee {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -101,23 +101,23 @@ impl ListApplicationFee<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::ApplicationFee>> {
-        stripe_client_core::ListPaginator::new_list("/application_fees", self.inner)
+        stripe_client_core::ListPaginator::new_list("/application_fees", &self.inner)
     }
 }
 
-impl StripeRequest for ListApplicationFee<'_> {
+impl StripeRequest for ListApplicationFee {
     type Output = stripe_types::List<stripe_shared::ApplicationFee>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/application_fees").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveApplicationFeeBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveApplicationFeeBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveApplicationFeeBuilder<'a> {
+impl RetrieveApplicationFeeBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
@@ -125,22 +125,22 @@ impl<'a> RetrieveApplicationFeeBuilder<'a> {
 /// Retrieves the details of an application fee that your account has collected.
 /// The same information is returned when refunding the application fee.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveApplicationFee<'a> {
-    inner: RetrieveApplicationFeeBuilder<'a>,
-    id: &'a stripe_shared::ApplicationFeeId,
+pub struct RetrieveApplicationFee {
+    inner: RetrieveApplicationFeeBuilder,
+    id: stripe_shared::ApplicationFeeId,
 }
-impl<'a> RetrieveApplicationFee<'a> {
+impl RetrieveApplicationFee {
     /// Construct a new `RetrieveApplicationFee`.
-    pub fn new(id: &'a stripe_shared::ApplicationFeeId) -> Self {
-        Self { id, inner: RetrieveApplicationFeeBuilder::new() }
+    pub fn new(id: impl Into<stripe_shared::ApplicationFeeId>) -> Self {
+        Self { id: id.into(), inner: RetrieveApplicationFeeBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveApplicationFee<'_> {
+impl RetrieveApplicationFee {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -158,11 +158,11 @@ impl RetrieveApplicationFee<'_> {
     }
 }
 
-impl StripeRequest for RetrieveApplicationFee<'_> {
+impl StripeRequest for RetrieveApplicationFee {
     type Output = stripe_shared::ApplicationFee;
 
     fn build(&self) -> RequestBuilder {
-        let id = self.id;
+        let id = &self.id;
         RequestBuilder::new(StripeMethod::Get, format!("/application_fees/{id}")).query(&self.inner)
     }
 }

--- a/generated/async-stripe-connect/src/application_fee_refund/requests.rs
+++ b/generated/async-stripe-connect/src/application_fee_refund/requests.rs
@@ -2,35 +2,35 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveApplicationFeeRefundBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveApplicationFeeRefundBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveApplicationFeeRefundBuilder<'a> {
+impl RetrieveApplicationFeeRefundBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// By default, you can see the 10 most recent refunds stored directly on the application fee object, but you can also retrieve details about a specific refund stored on the application fee.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveApplicationFeeRefund<'a> {
-    inner: RetrieveApplicationFeeRefundBuilder<'a>,
-    fee: &'a stripe_shared::ApplicationFeeId,
-    id: &'a str,
+pub struct RetrieveApplicationFeeRefund {
+    inner: RetrieveApplicationFeeRefundBuilder,
+    fee: stripe_shared::ApplicationFeeId,
+    id: String,
 }
-impl<'a> RetrieveApplicationFeeRefund<'a> {
+impl RetrieveApplicationFeeRefund {
     /// Construct a new `RetrieveApplicationFeeRefund`.
-    pub fn new(fee: &'a stripe_shared::ApplicationFeeId, id: &'a str) -> Self {
-        Self { fee, id, inner: RetrieveApplicationFeeRefundBuilder::new() }
+    pub fn new(fee: impl Into<stripe_shared::ApplicationFeeId>, id: impl Into<String>) -> Self {
+        Self { fee: fee.into(), id: id.into(), inner: RetrieveApplicationFeeRefundBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveApplicationFeeRefund<'_> {
+impl RetrieveApplicationFeeRefund {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -48,28 +48,28 @@ impl RetrieveApplicationFeeRefund<'_> {
     }
 }
 
-impl StripeRequest for RetrieveApplicationFeeRefund<'_> {
+impl StripeRequest for RetrieveApplicationFeeRefund {
     type Output = stripe_shared::ApplicationFeeRefund;
 
     fn build(&self) -> RequestBuilder {
-        let fee = self.fee;
-        let id = self.id;
+        let fee = &self.fee;
+        let id = &self.id;
         RequestBuilder::new(StripeMethod::Get, format!("/application_fees/{fee}/refunds/{id}"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListIdApplicationFeeRefundBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListIdApplicationFeeRefundBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListIdApplicationFeeRefundBuilder<'a> {
+impl ListIdApplicationFeeRefundBuilder {
     fn new() -> Self {
         Self { ending_before: None, expand: None, limit: None, starting_after: None }
     }
@@ -78,42 +78,42 @@ impl<'a> ListIdApplicationFeeRefundBuilder<'a> {
 /// Note that the 10 most recent refunds are always available by default on the application fee object.
 /// If you need more than those 10, you can use this API method and the `limit` and `starting_after` parameters to page through additional refunds.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListIdApplicationFeeRefund<'a> {
-    inner: ListIdApplicationFeeRefundBuilder<'a>,
-    id: &'a stripe_shared::ApplicationFeeId,
+pub struct ListIdApplicationFeeRefund {
+    inner: ListIdApplicationFeeRefundBuilder,
+    id: stripe_shared::ApplicationFeeId,
 }
-impl<'a> ListIdApplicationFeeRefund<'a> {
+impl ListIdApplicationFeeRefund {
     /// Construct a new `ListIdApplicationFeeRefund`.
-    pub fn new(id: &'a stripe_shared::ApplicationFeeId) -> Self {
-        Self { id, inner: ListIdApplicationFeeRefundBuilder::new() }
+    pub fn new(id: impl Into<stripe_shared::ApplicationFeeId>) -> Self {
+        Self { id: id.into(), inner: ListIdApplicationFeeRefundBuilder::new() }
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl ListIdApplicationFeeRefund<'_> {
+impl ListIdApplicationFeeRefund {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -134,32 +134,32 @@ impl ListIdApplicationFeeRefund<'_> {
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::ApplicationFeeRefund>>
     {
-        let id = self.id;
+        let id = &self.id;
 
         stripe_client_core::ListPaginator::new_list(
             format!("/application_fees/{id}/refunds"),
-            self.inner,
+            &self.inner,
         )
     }
 }
 
-impl StripeRequest for ListIdApplicationFeeRefund<'_> {
+impl StripeRequest for ListIdApplicationFeeRefund {
     type Output = stripe_types::List<stripe_shared::ApplicationFeeRefund>;
 
     fn build(&self) -> RequestBuilder {
-        let id = self.id;
+        let id = &self.id;
         RequestBuilder::new(StripeMethod::Get, format!("/application_fees/{id}/refunds"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdateApplicationFeeRefundBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdateApplicationFeeRefundBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
 }
-impl<'a> UpdateApplicationFeeRefundBuilder<'a> {
+impl UpdateApplicationFeeRefundBuilder {
     fn new() -> Self {
         Self { expand: None, metadata: None }
     }
@@ -169,31 +169,34 @@ impl<'a> UpdateApplicationFeeRefundBuilder<'a> {
 ///
 /// This request only accepts metadata as an argument.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateApplicationFeeRefund<'a> {
-    inner: UpdateApplicationFeeRefundBuilder<'a>,
-    fee: &'a stripe_shared::ApplicationFeeId,
-    id: &'a str,
+pub struct UpdateApplicationFeeRefund {
+    inner: UpdateApplicationFeeRefundBuilder,
+    fee: stripe_shared::ApplicationFeeId,
+    id: String,
 }
-impl<'a> UpdateApplicationFeeRefund<'a> {
+impl UpdateApplicationFeeRefund {
     /// Construct a new `UpdateApplicationFeeRefund`.
-    pub fn new(fee: &'a stripe_shared::ApplicationFeeId, id: &'a str) -> Self {
-        Self { fee, id, inner: UpdateApplicationFeeRefundBuilder::new() }
+    pub fn new(fee: impl Into<stripe_shared::ApplicationFeeId>, id: impl Into<String>) -> Self {
+        Self { fee: fee.into(), id: id.into(), inner: UpdateApplicationFeeRefundBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
 }
-impl UpdateApplicationFeeRefund<'_> {
+impl UpdateApplicationFeeRefund {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -211,26 +214,26 @@ impl UpdateApplicationFeeRefund<'_> {
     }
 }
 
-impl StripeRequest for UpdateApplicationFeeRefund<'_> {
+impl StripeRequest for UpdateApplicationFeeRefund {
     type Output = stripe_shared::ApplicationFeeRefund;
 
     fn build(&self) -> RequestBuilder {
-        let fee = self.fee;
-        let id = self.id;
+        let fee = &self.fee;
+        let id = &self.id;
         RequestBuilder::new(StripeMethod::Post, format!("/application_fees/{fee}/refunds/{id}"))
             .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateIdApplicationFeeRefundBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateIdApplicationFeeRefundBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     amount: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
 }
-impl<'a> CreateIdApplicationFeeRefundBuilder<'a> {
+impl CreateIdApplicationFeeRefundBuilder {
     fn new() -> Self {
         Self { amount: None, expand: None, metadata: None }
     }
@@ -245,36 +248,39 @@ impl<'a> CreateIdApplicationFeeRefundBuilder<'a> {
 /// This method will raise an error when called on an already-refunded application fee,
 /// or when trying to refund more money than is left on an application fee.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateIdApplicationFeeRefund<'a> {
-    inner: CreateIdApplicationFeeRefundBuilder<'a>,
-    id: &'a stripe_shared::ApplicationFeeId,
+pub struct CreateIdApplicationFeeRefund {
+    inner: CreateIdApplicationFeeRefundBuilder,
+    id: stripe_shared::ApplicationFeeId,
 }
-impl<'a> CreateIdApplicationFeeRefund<'a> {
+impl CreateIdApplicationFeeRefund {
     /// Construct a new `CreateIdApplicationFeeRefund`.
-    pub fn new(id: &'a stripe_shared::ApplicationFeeId) -> Self {
-        Self { id, inner: CreateIdApplicationFeeRefundBuilder::new() }
+    pub fn new(id: impl Into<stripe_shared::ApplicationFeeId>) -> Self {
+        Self { id: id.into(), inner: CreateIdApplicationFeeRefundBuilder::new() }
     }
     /// A positive integer, in _cents (or local equivalent)_, representing how much of this fee to refund.
     /// Can refund only up to the remaining unrefunded amount of the fee.
-    pub fn amount(mut self, amount: i64) -> Self {
-        self.inner.amount = Some(amount);
+    pub fn amount(mut self, amount: impl Into<i64>) -> Self {
+        self.inner.amount = Some(amount.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
 }
-impl CreateIdApplicationFeeRefund<'_> {
+impl CreateIdApplicationFeeRefund {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -292,11 +298,11 @@ impl CreateIdApplicationFeeRefund<'_> {
     }
 }
 
-impl StripeRequest for CreateIdApplicationFeeRefund<'_> {
+impl StripeRequest for CreateIdApplicationFeeRefund {
     type Output = stripe_shared::ApplicationFeeRefund;
 
     fn build(&self) -> RequestBuilder {
-        let id = self.id;
+        let id = &self.id;
         RequestBuilder::new(StripeMethod::Post, format!("/application_fees/{id}/refunds"))
             .form(&self.inner)
     }

--- a/generated/async-stripe-connect/src/apps_secret/requests.rs
+++ b/generated/async-stripe-connect/src/apps_secret/requests.rs
@@ -2,38 +2,44 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListAppsSecretBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListAppsSecretBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
-    scope: ListAppsSecretScope<'a>,
+    scope: ListAppsSecretScope,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListAppsSecretBuilder<'a> {
-    fn new(scope: ListAppsSecretScope<'a>) -> Self {
-        Self { ending_before: None, expand: None, limit: None, scope, starting_after: None }
+impl ListAppsSecretBuilder {
+    fn new(scope: impl Into<ListAppsSecretScope>) -> Self {
+        Self {
+            ending_before: None,
+            expand: None,
+            limit: None,
+            scope: scope.into(),
+            starting_after: None,
+        }
     }
 }
 /// Specifies the scoping of the secret.
 /// Requests originating from UI extensions can only access account-scoped secrets or secrets scoped to their own user.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ListAppsSecretScope<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ListAppsSecretScope {
     /// The secret scope type.
     #[serde(rename = "type")]
     pub type_: ListAppsSecretScopeType,
     /// The user ID.
     /// This field is required if `type` is set to `user`, and should not be provided if `type` is set to `account`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user: Option<&'a str>,
+    pub user: Option<String>,
 }
-impl<'a> ListAppsSecretScope<'a> {
-    pub fn new(type_: ListAppsSecretScopeType) -> Self {
-        Self { type_, user: None }
+impl ListAppsSecretScope {
+    pub fn new(type_: impl Into<ListAppsSecretScopeType>) -> Self {
+        Self { type_: type_.into(), user: None }
     }
 }
 /// The secret scope type.
@@ -93,41 +99,41 @@ impl<'de> serde::Deserialize<'de> for ListAppsSecretScopeType {
 }
 /// List all secrets stored on the given scope.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListAppsSecret<'a> {
-    inner: ListAppsSecretBuilder<'a>,
+pub struct ListAppsSecret {
+    inner: ListAppsSecretBuilder,
 }
-impl<'a> ListAppsSecret<'a> {
+impl ListAppsSecret {
     /// Construct a new `ListAppsSecret`.
-    pub fn new(scope: ListAppsSecretScope<'a>) -> Self {
-        Self { inner: ListAppsSecretBuilder::new(scope) }
+    pub fn new(scope: impl Into<ListAppsSecretScope>) -> Self {
+        Self { inner: ListAppsSecretBuilder::new(scope.into()) }
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl ListAppsSecret<'_> {
+impl ListAppsSecret {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -147,44 +153,44 @@ impl ListAppsSecret<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_connect::AppsSecret>> {
-        stripe_client_core::ListPaginator::new_list("/apps/secrets", self.inner)
+        stripe_client_core::ListPaginator::new_list("/apps/secrets", &self.inner)
     }
 }
 
-impl StripeRequest for ListAppsSecret<'_> {
+impl StripeRequest for ListAppsSecret {
     type Output = stripe_types::List<stripe_connect::AppsSecret>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/apps/secrets").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct FindAppsSecretBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct FindAppsSecretBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
-    name: &'a str,
-    scope: FindAppsSecretScope<'a>,
+    expand: Option<Vec<String>>,
+    name: String,
+    scope: FindAppsSecretScope,
 }
-impl<'a> FindAppsSecretBuilder<'a> {
-    fn new(name: &'a str, scope: FindAppsSecretScope<'a>) -> Self {
-        Self { expand: None, name, scope }
+impl FindAppsSecretBuilder {
+    fn new(name: impl Into<String>, scope: impl Into<FindAppsSecretScope>) -> Self {
+        Self { expand: None, name: name.into(), scope: scope.into() }
     }
 }
 /// Specifies the scoping of the secret.
 /// Requests originating from UI extensions can only access account-scoped secrets or secrets scoped to their own user.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct FindAppsSecretScope<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct FindAppsSecretScope {
     /// The secret scope type.
     #[serde(rename = "type")]
     pub type_: FindAppsSecretScopeType,
     /// The user ID.
     /// This field is required if `type` is set to `user`, and should not be provided if `type` is set to `account`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user: Option<&'a str>,
+    pub user: Option<String>,
 }
-impl<'a> FindAppsSecretScope<'a> {
-    pub fn new(type_: FindAppsSecretScopeType) -> Self {
-        Self { type_, user: None }
+impl FindAppsSecretScope {
+    pub fn new(type_: impl Into<FindAppsSecretScopeType>) -> Self {
+        Self { type_: type_.into(), user: None }
     }
 }
 /// The secret scope type.
@@ -244,21 +250,21 @@ impl<'de> serde::Deserialize<'de> for FindAppsSecretScopeType {
 }
 /// Finds a secret in the secret store by name and scope.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct FindAppsSecret<'a> {
-    inner: FindAppsSecretBuilder<'a>,
+pub struct FindAppsSecret {
+    inner: FindAppsSecretBuilder,
 }
-impl<'a> FindAppsSecret<'a> {
+impl FindAppsSecret {
     /// Construct a new `FindAppsSecret`.
-    pub fn new(name: &'a str, scope: FindAppsSecretScope<'a>) -> Self {
-        Self { inner: FindAppsSecretBuilder::new(name, scope) }
+    pub fn new(name: impl Into<String>, scope: impl Into<FindAppsSecretScope>) -> Self {
+        Self { inner: FindAppsSecretBuilder::new(name.into(), scope.into()) }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl FindAppsSecret<'_> {
+impl FindAppsSecret {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -276,43 +282,53 @@ impl FindAppsSecret<'_> {
     }
 }
 
-impl StripeRequest for FindAppsSecret<'_> {
+impl StripeRequest for FindAppsSecret {
     type Output = stripe_connect::AppsSecret;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/apps/secrets/find").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateAppsSecretBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateAppsSecretBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     expires_at: Option<stripe_types::Timestamp>,
-    name: &'a str,
-    payload: &'a str,
-    scope: CreateAppsSecretScope<'a>,
+    name: String,
+    payload: String,
+    scope: CreateAppsSecretScope,
 }
-impl<'a> CreateAppsSecretBuilder<'a> {
-    fn new(name: &'a str, payload: &'a str, scope: CreateAppsSecretScope<'a>) -> Self {
-        Self { expand: None, expires_at: None, name, payload, scope }
+impl CreateAppsSecretBuilder {
+    fn new(
+        name: impl Into<String>,
+        payload: impl Into<String>,
+        scope: impl Into<CreateAppsSecretScope>,
+    ) -> Self {
+        Self {
+            expand: None,
+            expires_at: None,
+            name: name.into(),
+            payload: payload.into(),
+            scope: scope.into(),
+        }
     }
 }
 /// Specifies the scoping of the secret.
 /// Requests originating from UI extensions can only access account-scoped secrets or secrets scoped to their own user.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateAppsSecretScope<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateAppsSecretScope {
     /// The secret scope type.
     #[serde(rename = "type")]
     pub type_: CreateAppsSecretScopeType,
     /// The user ID.
     /// This field is required if `type` is set to `user`, and should not be provided if `type` is set to `account`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user: Option<&'a str>,
+    pub user: Option<String>,
 }
-impl<'a> CreateAppsSecretScope<'a> {
-    pub fn new(type_: CreateAppsSecretScopeType) -> Self {
-        Self { type_, user: None }
+impl CreateAppsSecretScope {
+    pub fn new(type_: impl Into<CreateAppsSecretScopeType>) -> Self {
+        Self { type_: type_.into(), user: None }
     }
 }
 /// The secret scope type.
@@ -372,26 +388,30 @@ impl<'de> serde::Deserialize<'de> for CreateAppsSecretScopeType {
 }
 /// Create or replace a secret in the secret store.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateAppsSecret<'a> {
-    inner: CreateAppsSecretBuilder<'a>,
+pub struct CreateAppsSecret {
+    inner: CreateAppsSecretBuilder,
 }
-impl<'a> CreateAppsSecret<'a> {
+impl CreateAppsSecret {
     /// Construct a new `CreateAppsSecret`.
-    pub fn new(name: &'a str, payload: &'a str, scope: CreateAppsSecretScope<'a>) -> Self {
-        Self { inner: CreateAppsSecretBuilder::new(name, payload, scope) }
+    pub fn new(
+        name: impl Into<String>,
+        payload: impl Into<String>,
+        scope: impl Into<CreateAppsSecretScope>,
+    ) -> Self {
+        Self { inner: CreateAppsSecretBuilder::new(name.into(), payload.into(), scope.into()) }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// The Unix timestamp for the expiry time of the secret, after which the secret deletes.
-    pub fn expires_at(mut self, expires_at: stripe_types::Timestamp) -> Self {
-        self.inner.expires_at = Some(expires_at);
+    pub fn expires_at(mut self, expires_at: impl Into<stripe_types::Timestamp>) -> Self {
+        self.inner.expires_at = Some(expires_at.into());
         self
     }
 }
-impl CreateAppsSecret<'_> {
+impl CreateAppsSecret {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -409,40 +429,40 @@ impl CreateAppsSecret<'_> {
     }
 }
 
-impl StripeRequest for CreateAppsSecret<'_> {
+impl StripeRequest for CreateAppsSecret {
     type Output = stripe_connect::AppsSecret;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Post, "/apps/secrets").form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct DeleteWhereAppsSecretBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct DeleteWhereAppsSecretBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
-    name: &'a str,
-    scope: DeleteWhereAppsSecretScope<'a>,
+    expand: Option<Vec<String>>,
+    name: String,
+    scope: DeleteWhereAppsSecretScope,
 }
-impl<'a> DeleteWhereAppsSecretBuilder<'a> {
-    fn new(name: &'a str, scope: DeleteWhereAppsSecretScope<'a>) -> Self {
-        Self { expand: None, name, scope }
+impl DeleteWhereAppsSecretBuilder {
+    fn new(name: impl Into<String>, scope: impl Into<DeleteWhereAppsSecretScope>) -> Self {
+        Self { expand: None, name: name.into(), scope: scope.into() }
     }
 }
 /// Specifies the scoping of the secret.
 /// Requests originating from UI extensions can only access account-scoped secrets or secrets scoped to their own user.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct DeleteWhereAppsSecretScope<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct DeleteWhereAppsSecretScope {
     /// The secret scope type.
     #[serde(rename = "type")]
     pub type_: DeleteWhereAppsSecretScopeType,
     /// The user ID.
     /// This field is required if `type` is set to `user`, and should not be provided if `type` is set to `account`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user: Option<&'a str>,
+    pub user: Option<String>,
 }
-impl<'a> DeleteWhereAppsSecretScope<'a> {
-    pub fn new(type_: DeleteWhereAppsSecretScopeType) -> Self {
-        Self { type_, user: None }
+impl DeleteWhereAppsSecretScope {
+    pub fn new(type_: impl Into<DeleteWhereAppsSecretScopeType>) -> Self {
+        Self { type_: type_.into(), user: None }
     }
 }
 /// The secret scope type.
@@ -503,21 +523,21 @@ impl<'de> serde::Deserialize<'de> for DeleteWhereAppsSecretScopeType {
 }
 /// Deletes a secret from the secret store by name and scope.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct DeleteWhereAppsSecret<'a> {
-    inner: DeleteWhereAppsSecretBuilder<'a>,
+pub struct DeleteWhereAppsSecret {
+    inner: DeleteWhereAppsSecretBuilder,
 }
-impl<'a> DeleteWhereAppsSecret<'a> {
+impl DeleteWhereAppsSecret {
     /// Construct a new `DeleteWhereAppsSecret`.
-    pub fn new(name: &'a str, scope: DeleteWhereAppsSecretScope<'a>) -> Self {
-        Self { inner: DeleteWhereAppsSecretBuilder::new(name, scope) }
+    pub fn new(name: impl Into<String>, scope: impl Into<DeleteWhereAppsSecretScope>) -> Self {
+        Self { inner: DeleteWhereAppsSecretBuilder::new(name.into(), scope.into()) }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl DeleteWhereAppsSecret<'_> {
+impl DeleteWhereAppsSecret {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -535,7 +555,7 @@ impl DeleteWhereAppsSecret<'_> {
     }
 }
 
-impl StripeRequest for DeleteWhereAppsSecret<'_> {
+impl StripeRequest for DeleteWhereAppsSecret {
     type Output = stripe_connect::AppsSecret;
 
     fn build(&self) -> RequestBuilder {

--- a/generated/async-stripe-connect/src/country_spec/requests.rs
+++ b/generated/async-stripe-connect/src/country_spec/requests.rs
@@ -2,28 +2,28 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListCountrySpecBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListCountrySpecBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListCountrySpecBuilder<'a> {
+impl ListCountrySpecBuilder {
     fn new() -> Self {
         Self { ending_before: None, expand: None, limit: None, starting_after: None }
     }
 }
 /// Lists all Country Spec objects available in the API.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListCountrySpec<'a> {
-    inner: ListCountrySpecBuilder<'a>,
+pub struct ListCountrySpec {
+    inner: ListCountrySpecBuilder,
 }
-impl<'a> ListCountrySpec<'a> {
+impl ListCountrySpec {
     /// Construct a new `ListCountrySpec`.
     pub fn new() -> Self {
         Self { inner: ListCountrySpecBuilder::new() }
@@ -31,35 +31,35 @@ impl<'a> ListCountrySpec<'a> {
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl<'a> Default for ListCountrySpec<'a> {
+impl Default for ListCountrySpec {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListCountrySpec<'_> {
+impl ListCountrySpec {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -79,45 +79,45 @@ impl ListCountrySpec<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_connect::CountrySpec>> {
-        stripe_client_core::ListPaginator::new_list("/country_specs", self.inner)
+        stripe_client_core::ListPaginator::new_list("/country_specs", &self.inner)
     }
 }
 
-impl StripeRequest for ListCountrySpec<'_> {
+impl StripeRequest for ListCountrySpec {
     type Output = stripe_types::List<stripe_connect::CountrySpec>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/country_specs").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveCountrySpecBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveCountrySpecBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveCountrySpecBuilder<'a> {
+impl RetrieveCountrySpecBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Returns a Country Spec for a given Country code.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveCountrySpec<'a> {
-    inner: RetrieveCountrySpecBuilder<'a>,
-    country: &'a stripe_connect::CountrySpecId,
+pub struct RetrieveCountrySpec {
+    inner: RetrieveCountrySpecBuilder,
+    country: stripe_connect::CountrySpecId,
 }
-impl<'a> RetrieveCountrySpec<'a> {
+impl RetrieveCountrySpec {
     /// Construct a new `RetrieveCountrySpec`.
-    pub fn new(country: &'a stripe_connect::CountrySpecId) -> Self {
-        Self { country, inner: RetrieveCountrySpecBuilder::new() }
+    pub fn new(country: impl Into<stripe_connect::CountrySpecId>) -> Self {
+        Self { country: country.into(), inner: RetrieveCountrySpecBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveCountrySpec<'_> {
+impl RetrieveCountrySpec {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -135,11 +135,11 @@ impl RetrieveCountrySpec<'_> {
     }
 }
 
-impl StripeRequest for RetrieveCountrySpec<'_> {
+impl StripeRequest for RetrieveCountrySpec {
     type Output = stripe_connect::CountrySpec;
 
     fn build(&self) -> RequestBuilder {
-        let country = self.country;
+        let country = &self.country;
         RequestBuilder::new(StripeMethod::Get, format!("/country_specs/{country}"))
             .query(&self.inner)
     }

--- a/generated/async-stripe-connect/src/external_account/requests.rs
+++ b/generated/async-stripe-connect/src/external_account/requests.rs
@@ -4,17 +4,17 @@ use stripe_client_core::{
 
 /// Delete a specified external account for a given account.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct DeleteExternalAccount<'a> {
-    account: &'a stripe_shared::AccountId,
-    id: &'a str,
+pub struct DeleteExternalAccount {
+    account: stripe_shared::AccountId,
+    id: String,
 }
-impl<'a> DeleteExternalAccount<'a> {
+impl DeleteExternalAccount {
     /// Construct a new `DeleteExternalAccount`.
-    pub fn new(account: &'a stripe_shared::AccountId, id: &'a str) -> Self {
-        Self { account, id }
+    pub fn new(account: impl Into<stripe_shared::AccountId>, id: impl Into<String>) -> Self {
+        Self { account: account.into(), id: id.into() }
     }
 }
-impl DeleteExternalAccount<'_> {
+impl DeleteExternalAccount {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -32,32 +32,32 @@ impl DeleteExternalAccount<'_> {
     }
 }
 
-impl StripeRequest for DeleteExternalAccount<'_> {
+impl StripeRequest for DeleteExternalAccount {
     type Output = stripe_shared::DeletedExternalAccount;
 
     fn build(&self) -> RequestBuilder {
-        let account = self.account;
-        let id = self.id;
+        let account = &self.account;
+        let id = &self.id;
         RequestBuilder::new(
             StripeMethod::Delete,
             format!("/accounts/{account}/external_accounts/{id}"),
         )
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListAccountExternalAccountBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListAccountExternalAccountBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     object: Option<ListAccountExternalAccountObject>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListAccountExternalAccountBuilder<'a> {
+impl ListAccountExternalAccountBuilder {
     fn new() -> Self {
         Self { ending_before: None, expand: None, limit: None, object: None, starting_after: None }
     }
@@ -120,47 +120,47 @@ impl<'de> serde::Deserialize<'de> for ListAccountExternalAccountObject {
 }
 /// List external accounts for an account.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListAccountExternalAccount<'a> {
-    inner: ListAccountExternalAccountBuilder<'a>,
-    account: &'a stripe_shared::AccountId,
+pub struct ListAccountExternalAccount {
+    inner: ListAccountExternalAccountBuilder,
+    account: stripe_shared::AccountId,
 }
-impl<'a> ListAccountExternalAccount<'a> {
+impl ListAccountExternalAccount {
     /// Construct a new `ListAccountExternalAccount`.
-    pub fn new(account: &'a stripe_shared::AccountId) -> Self {
-        Self { account, inner: ListAccountExternalAccountBuilder::new() }
+    pub fn new(account: impl Into<stripe_shared::AccountId>) -> Self {
+        Self { account: account.into(), inner: ListAccountExternalAccountBuilder::new() }
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// Filter external accounts according to a particular object type.
-    pub fn object(mut self, object: ListAccountExternalAccountObject) -> Self {
-        self.inner.object = Some(object);
+    pub fn object(mut self, object: impl Into<ListAccountExternalAccountObject>) -> Self {
+        self.inner.object = Some(object.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl ListAccountExternalAccount<'_> {
+impl ListAccountExternalAccount {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -180,53 +180,57 @@ impl ListAccountExternalAccount<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::ExternalAccount>> {
-        let account = self.account;
+        let account = &self.account;
 
         stripe_client_core::ListPaginator::new_list(
             format!("/accounts/{account}/external_accounts"),
-            self.inner,
+            &self.inner,
         )
     }
 }
 
-impl StripeRequest for ListAccountExternalAccount<'_> {
+impl StripeRequest for ListAccountExternalAccount {
     type Output = stripe_types::List<stripe_shared::ExternalAccount>;
 
     fn build(&self) -> RequestBuilder {
-        let account = self.account;
+        let account = &self.account;
         RequestBuilder::new(StripeMethod::Get, format!("/accounts/{account}/external_accounts"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveExternalAccountBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveExternalAccountBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveExternalAccountBuilder<'a> {
+impl RetrieveExternalAccountBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieve a specified external account for a given account.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveExternalAccount<'a> {
-    inner: RetrieveExternalAccountBuilder<'a>,
-    account: &'a stripe_shared::AccountId,
-    id: &'a str,
+pub struct RetrieveExternalAccount {
+    inner: RetrieveExternalAccountBuilder,
+    account: stripe_shared::AccountId,
+    id: String,
 }
-impl<'a> RetrieveExternalAccount<'a> {
+impl RetrieveExternalAccount {
     /// Construct a new `RetrieveExternalAccount`.
-    pub fn new(account: &'a stripe_shared::AccountId, id: &'a str) -> Self {
-        Self { account, id, inner: RetrieveExternalAccountBuilder::new() }
+    pub fn new(account: impl Into<stripe_shared::AccountId>, id: impl Into<String>) -> Self {
+        Self {
+            account: account.into(),
+            id: id.into(),
+            inner: RetrieveExternalAccountBuilder::new(),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveExternalAccount<'_> {
+impl RetrieveExternalAccount {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -244,12 +248,12 @@ impl RetrieveExternalAccount<'_> {
     }
 }
 
-impl StripeRequest for RetrieveExternalAccount<'_> {
+impl StripeRequest for RetrieveExternalAccount {
     type Output = stripe_shared::ExternalAccount;
 
     fn build(&self) -> RequestBuilder {
-        let account = self.account;
-        let id = self.id;
+        let account = &self.account;
+        let id = &self.id;
         RequestBuilder::new(
             StripeMethod::Get,
             format!("/accounts/{account}/external_accounts/{id}"),
@@ -257,52 +261,66 @@ impl StripeRequest for RetrieveExternalAccount<'_> {
         .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateAccountExternalAccountBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateAccountExternalAccountBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     default_for_currency: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
-    external_account: &'a str,
+    expand: Option<Vec<String>>,
+    external_account: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
 }
-impl<'a> CreateAccountExternalAccountBuilder<'a> {
-    fn new(external_account: &'a str) -> Self {
-        Self { default_for_currency: None, expand: None, external_account, metadata: None }
+impl CreateAccountExternalAccountBuilder {
+    fn new(external_account: impl Into<String>) -> Self {
+        Self {
+            default_for_currency: None,
+            expand: None,
+            external_account: external_account.into(),
+            metadata: None,
+        }
     }
 }
 /// Create an external account for a given account.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateAccountExternalAccount<'a> {
-    inner: CreateAccountExternalAccountBuilder<'a>,
-    account: &'a stripe_shared::AccountId,
+pub struct CreateAccountExternalAccount {
+    inner: CreateAccountExternalAccountBuilder,
+    account: stripe_shared::AccountId,
 }
-impl<'a> CreateAccountExternalAccount<'a> {
+impl CreateAccountExternalAccount {
     /// Construct a new `CreateAccountExternalAccount`.
-    pub fn new(account: &'a stripe_shared::AccountId, external_account: &'a str) -> Self {
-        Self { account, inner: CreateAccountExternalAccountBuilder::new(external_account) }
+    pub fn new(
+        account: impl Into<stripe_shared::AccountId>,
+        external_account: impl Into<String>,
+    ) -> Self {
+        Self {
+            account: account.into(),
+            inner: CreateAccountExternalAccountBuilder::new(external_account.into()),
+        }
     }
     /// When set to true, or if this is the first external account added in this currency, this account becomes the default external account for its currency.
-    pub fn default_for_currency(mut self, default_for_currency: bool) -> Self {
-        self.inner.default_for_currency = Some(default_for_currency);
+    pub fn default_for_currency(mut self, default_for_currency: impl Into<bool>) -> Self {
+        self.inner.default_for_currency = Some(default_for_currency.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
 }
-impl CreateAccountExternalAccount<'_> {
+impl CreateAccountExternalAccount {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -320,51 +338,51 @@ impl CreateAccountExternalAccount<'_> {
     }
 }
 
-impl StripeRequest for CreateAccountExternalAccount<'_> {
+impl StripeRequest for CreateAccountExternalAccount {
     type Output = stripe_shared::ExternalAccount;
 
     fn build(&self) -> RequestBuilder {
-        let account = self.account;
+        let account = &self.account;
         RequestBuilder::new(StripeMethod::Post, format!("/accounts/{account}/external_accounts"))
             .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdateExternalAccountBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdateExternalAccountBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    account_holder_name: Option<&'a str>,
+    account_holder_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     account_holder_type: Option<UpdateExternalAccountAccountHolderType>,
     #[serde(skip_serializing_if = "Option::is_none")]
     account_type: Option<UpdateExternalAccountAccountType>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    address_city: Option<&'a str>,
+    address_city: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    address_country: Option<&'a str>,
+    address_country: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    address_line1: Option<&'a str>,
+    address_line1: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    address_line2: Option<&'a str>,
+    address_line2: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    address_state: Option<&'a str>,
+    address_state: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    address_zip: Option<&'a str>,
+    address_zip: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     default_for_currency: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    documents: Option<UpdateExternalAccountDocuments<'a>>,
+    documents: Option<UpdateExternalAccountDocuments>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    exp_month: Option<&'a str>,
+    exp_month: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    exp_year: Option<&'a str>,
+    exp_year: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    name: Option<&'a str>,
+    name: Option<String>,
 }
-impl<'a> UpdateExternalAccountBuilder<'a> {
+impl UpdateExternalAccountBuilder {
     fn new() -> Self {
         Self {
             account_holder_name: None,
@@ -507,38 +525,38 @@ impl<'de> serde::Deserialize<'de> for UpdateExternalAccountAccountType {
     }
 }
 /// Documents that may be submitted to satisfy various informational requests.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateExternalAccountDocuments<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateExternalAccountDocuments {
     /// One or more documents that support the [Bank account ownership verification](https://support.stripe.com/questions/bank-account-ownership-verification) requirement.
     /// Must be a document associated with the bank account that displays the last 4 digits of the account number, either a statement or a voided check.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bank_account_ownership_verification:
-        Option<UpdateExternalAccountDocumentsBankAccountOwnershipVerification<'a>>,
+        Option<UpdateExternalAccountDocumentsBankAccountOwnershipVerification>,
 }
-impl<'a> UpdateExternalAccountDocuments<'a> {
+impl UpdateExternalAccountDocuments {
     pub fn new() -> Self {
         Self { bank_account_ownership_verification: None }
     }
 }
-impl<'a> Default for UpdateExternalAccountDocuments<'a> {
+impl Default for UpdateExternalAccountDocuments {
     fn default() -> Self {
         Self::new()
     }
 }
 /// One or more documents that support the [Bank account ownership verification](https://support.stripe.com/questions/bank-account-ownership-verification) requirement.
 /// Must be a document associated with the bank account that displays the last 4 digits of the account number, either a statement or a voided check.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateExternalAccountDocumentsBankAccountOwnershipVerification<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateExternalAccountDocumentsBankAccountOwnershipVerification {
     /// One or more document ids returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `account_requirement`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub files: Option<&'a [&'a str]>,
+    pub files: Option<Vec<String>>,
 }
-impl<'a> UpdateExternalAccountDocumentsBankAccountOwnershipVerification<'a> {
+impl UpdateExternalAccountDocumentsBankAccountOwnershipVerification {
     pub fn new() -> Self {
         Self { files: None }
     }
 }
-impl<'a> Default for UpdateExternalAccountDocumentsBankAccountOwnershipVerification<'a> {
+impl Default for UpdateExternalAccountDocumentsBankAccountOwnershipVerification {
     fn default() -> Self {
         Self::new()
     }
@@ -552,106 +570,112 @@ impl<'a> Default for UpdateExternalAccountDocumentsBankAccountOwnershipVerificat
 /// You can re-enable a disabled bank account by performing an update call without providing any
 /// arguments or changes.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateExternalAccount<'a> {
-    inner: UpdateExternalAccountBuilder<'a>,
-    account: &'a stripe_shared::AccountId,
-    id: &'a str,
+pub struct UpdateExternalAccount {
+    inner: UpdateExternalAccountBuilder,
+    account: stripe_shared::AccountId,
+    id: String,
 }
-impl<'a> UpdateExternalAccount<'a> {
+impl UpdateExternalAccount {
     /// Construct a new `UpdateExternalAccount`.
-    pub fn new(account: &'a stripe_shared::AccountId, id: &'a str) -> Self {
-        Self { account, id, inner: UpdateExternalAccountBuilder::new() }
+    pub fn new(account: impl Into<stripe_shared::AccountId>, id: impl Into<String>) -> Self {
+        Self { account: account.into(), id: id.into(), inner: UpdateExternalAccountBuilder::new() }
     }
     /// The name of the person or business that owns the bank account.
-    pub fn account_holder_name(mut self, account_holder_name: &'a str) -> Self {
-        self.inner.account_holder_name = Some(account_holder_name);
+    pub fn account_holder_name(mut self, account_holder_name: impl Into<String>) -> Self {
+        self.inner.account_holder_name = Some(account_holder_name.into());
         self
     }
     /// The type of entity that holds the account. This can be either `individual` or `company`.
     pub fn account_holder_type(
         mut self,
-        account_holder_type: UpdateExternalAccountAccountHolderType,
+        account_holder_type: impl Into<UpdateExternalAccountAccountHolderType>,
     ) -> Self {
-        self.inner.account_holder_type = Some(account_holder_type);
+        self.inner.account_holder_type = Some(account_holder_type.into());
         self
     }
     /// The bank account type.
     /// This can only be `checking` or `savings` in most countries.
     /// In Japan, this can only be `futsu` or `toza`.
-    pub fn account_type(mut self, account_type: UpdateExternalAccountAccountType) -> Self {
-        self.inner.account_type = Some(account_type);
+    pub fn account_type(
+        mut self,
+        account_type: impl Into<UpdateExternalAccountAccountType>,
+    ) -> Self {
+        self.inner.account_type = Some(account_type.into());
         self
     }
     /// City/District/Suburb/Town/Village.
-    pub fn address_city(mut self, address_city: &'a str) -> Self {
-        self.inner.address_city = Some(address_city);
+    pub fn address_city(mut self, address_city: impl Into<String>) -> Self {
+        self.inner.address_city = Some(address_city.into());
         self
     }
     /// Billing address country, if provided when creating card.
-    pub fn address_country(mut self, address_country: &'a str) -> Self {
-        self.inner.address_country = Some(address_country);
+    pub fn address_country(mut self, address_country: impl Into<String>) -> Self {
+        self.inner.address_country = Some(address_country.into());
         self
     }
     /// Address line 1 (Street address/PO Box/Company name).
-    pub fn address_line1(mut self, address_line1: &'a str) -> Self {
-        self.inner.address_line1 = Some(address_line1);
+    pub fn address_line1(mut self, address_line1: impl Into<String>) -> Self {
+        self.inner.address_line1 = Some(address_line1.into());
         self
     }
     /// Address line 2 (Apartment/Suite/Unit/Building).
-    pub fn address_line2(mut self, address_line2: &'a str) -> Self {
-        self.inner.address_line2 = Some(address_line2);
+    pub fn address_line2(mut self, address_line2: impl Into<String>) -> Self {
+        self.inner.address_line2 = Some(address_line2.into());
         self
     }
     /// State/County/Province/Region.
-    pub fn address_state(mut self, address_state: &'a str) -> Self {
-        self.inner.address_state = Some(address_state);
+    pub fn address_state(mut self, address_state: impl Into<String>) -> Self {
+        self.inner.address_state = Some(address_state.into());
         self
     }
     /// ZIP or postal code.
-    pub fn address_zip(mut self, address_zip: &'a str) -> Self {
-        self.inner.address_zip = Some(address_zip);
+    pub fn address_zip(mut self, address_zip: impl Into<String>) -> Self {
+        self.inner.address_zip = Some(address_zip.into());
         self
     }
     /// When set to true, this becomes the default external account for its currency.
-    pub fn default_for_currency(mut self, default_for_currency: bool) -> Self {
-        self.inner.default_for_currency = Some(default_for_currency);
+    pub fn default_for_currency(mut self, default_for_currency: impl Into<bool>) -> Self {
+        self.inner.default_for_currency = Some(default_for_currency.into());
         self
     }
     /// Documents that may be submitted to satisfy various informational requests.
-    pub fn documents(mut self, documents: UpdateExternalAccountDocuments<'a>) -> Self {
-        self.inner.documents = Some(documents);
+    pub fn documents(mut self, documents: impl Into<UpdateExternalAccountDocuments>) -> Self {
+        self.inner.documents = Some(documents.into());
         self
     }
     /// Two digit number representing the card’s expiration month.
-    pub fn exp_month(mut self, exp_month: &'a str) -> Self {
-        self.inner.exp_month = Some(exp_month);
+    pub fn exp_month(mut self, exp_month: impl Into<String>) -> Self {
+        self.inner.exp_month = Some(exp_month.into());
         self
     }
     /// Four digit number representing the card’s expiration year.
-    pub fn exp_year(mut self, exp_year: &'a str) -> Self {
-        self.inner.exp_year = Some(exp_year);
+    pub fn exp_year(mut self, exp_year: impl Into<String>) -> Self {
+        self.inner.exp_year = Some(exp_year.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// Cardholder name.
-    pub fn name(mut self, name: &'a str) -> Self {
-        self.inner.name = Some(name);
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.inner.name = Some(name.into());
         self
     }
 }
-impl UpdateExternalAccount<'_> {
+impl UpdateExternalAccount {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -669,12 +693,12 @@ impl UpdateExternalAccount<'_> {
     }
 }
 
-impl StripeRequest for UpdateExternalAccount<'_> {
+impl StripeRequest for UpdateExternalAccount {
     type Output = stripe_shared::ExternalAccount;
 
     fn build(&self) -> RequestBuilder {
-        let account = self.account;
-        let id = self.id;
+        let account = &self.account;
+        let id = &self.id;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/accounts/{account}/external_accounts/{id}"),

--- a/generated/async-stripe-connect/src/person/requests.rs
+++ b/generated/async-stripe-connect/src/person/requests.rs
@@ -6,17 +6,17 @@ use stripe_client_core::{
 /// Any person with a relationship for an account can be deleted through the API, except if the person is the `account_opener`.
 /// If your integration is using the `executive` parameter, you cannot delete the only verified `executive` on file.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct DeletePerson<'a> {
-    account: &'a stripe_shared::AccountId,
-    person: &'a str,
+pub struct DeletePerson {
+    account: stripe_shared::AccountId,
+    person: String,
 }
-impl<'a> DeletePerson<'a> {
+impl DeletePerson {
     /// Construct a new `DeletePerson`.
-    pub fn new(account: &'a stripe_shared::AccountId, person: &'a str) -> Self {
-        Self { account, person }
+    pub fn new(account: impl Into<stripe_shared::AccountId>, person: impl Into<String>) -> Self {
+        Self { account: account.into(), person: person.into() }
     }
 }
-impl DeletePerson<'_> {
+impl DeletePerson {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -34,29 +34,29 @@ impl DeletePerson<'_> {
     }
 }
 
-impl StripeRequest for DeletePerson<'_> {
+impl StripeRequest for DeletePerson {
     type Output = stripe_shared::DeletedPerson;
 
     fn build(&self) -> RequestBuilder {
-        let account = self.account;
-        let person = self.person;
+        let account = &self.account;
+        let person = &self.person;
         RequestBuilder::new(StripeMethod::Delete, format!("/accounts/{account}/persons/{person}"))
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListAccountPersonBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListAccountPersonBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     relationship: Option<ListAccountPersonRelationship>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListAccountPersonBuilder<'a> {
+impl ListAccountPersonBuilder {
     fn new() -> Self {
         Self {
             ending_before: None,
@@ -105,47 +105,47 @@ impl Default for ListAccountPersonRelationship {
 /// Returns a list of people associated with the account’s legal entity.
 /// The people are returned sorted by creation date, with the most recent people appearing first.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListAccountPerson<'a> {
-    inner: ListAccountPersonBuilder<'a>,
-    account: &'a stripe_shared::AccountId,
+pub struct ListAccountPerson {
+    inner: ListAccountPersonBuilder,
+    account: stripe_shared::AccountId,
 }
-impl<'a> ListAccountPerson<'a> {
+impl ListAccountPerson {
     /// Construct a new `ListAccountPerson`.
-    pub fn new(account: &'a stripe_shared::AccountId) -> Self {
-        Self { account, inner: ListAccountPersonBuilder::new() }
+    pub fn new(account: impl Into<stripe_shared::AccountId>) -> Self {
+        Self { account: account.into(), inner: ListAccountPersonBuilder::new() }
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// Filters on the list of people returned based on the person's relationship to the account's company.
-    pub fn relationship(mut self, relationship: ListAccountPersonRelationship) -> Self {
-        self.inner.relationship = Some(relationship);
+    pub fn relationship(mut self, relationship: impl Into<ListAccountPersonRelationship>) -> Self {
+        self.inner.relationship = Some(relationship.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl ListAccountPerson<'_> {
+impl ListAccountPerson {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -165,53 +165,53 @@ impl ListAccountPerson<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::Person>> {
-        let account = self.account;
+        let account = &self.account;
 
         stripe_client_core::ListPaginator::new_list(
             format!("/accounts/{account}/persons"),
-            self.inner,
+            &self.inner,
         )
     }
 }
 
-impl StripeRequest for ListAccountPerson<'_> {
+impl StripeRequest for ListAccountPerson {
     type Output = stripe_types::List<stripe_shared::Person>;
 
     fn build(&self) -> RequestBuilder {
-        let account = self.account;
+        let account = &self.account;
         RequestBuilder::new(StripeMethod::Get, format!("/accounts/{account}/persons"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrievePersonBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrievePersonBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrievePersonBuilder<'a> {
+impl RetrievePersonBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves an existing person.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrievePerson<'a> {
-    inner: RetrievePersonBuilder<'a>,
-    account: &'a stripe_shared::AccountId,
-    person: &'a str,
+pub struct RetrievePerson {
+    inner: RetrievePersonBuilder,
+    account: stripe_shared::AccountId,
+    person: String,
 }
-impl<'a> RetrievePerson<'a> {
+impl RetrievePerson {
     /// Construct a new `RetrievePerson`.
-    pub fn new(account: &'a stripe_shared::AccountId, person: &'a str) -> Self {
-        Self { account, person, inner: RetrievePersonBuilder::new() }
+    pub fn new(account: impl Into<stripe_shared::AccountId>, person: impl Into<String>) -> Self {
+        Self { account: account.into(), person: person.into(), inner: RetrievePersonBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrievePerson<'_> {
+impl RetrievePerson {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -229,76 +229,76 @@ impl RetrievePerson<'_> {
     }
 }
 
-impl StripeRequest for RetrievePerson<'_> {
+impl StripeRequest for RetrievePerson {
     type Output = stripe_shared::Person;
 
     fn build(&self) -> RequestBuilder {
-        let account = self.account;
-        let person = self.person;
+        let account = &self.account;
+        let person = &self.person;
         RequestBuilder::new(StripeMethod::Get, format!("/accounts/{account}/persons/{person}"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateAccountPersonBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateAccountPersonBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    additional_tos_acceptances: Option<PersonAdditionalTosAcceptancesSpecs<'a>>,
+    additional_tos_acceptances: Option<PersonAdditionalTosAcceptancesSpecs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    address: Option<AddressSpecs<'a>>,
+    address: Option<AddressSpecs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    address_kana: Option<CreateAccountPersonAddressKana<'a>>,
+    address_kana: Option<CreateAccountPersonAddressKana>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    address_kanji: Option<CreateAccountPersonAddressKanji<'a>>,
+    address_kanji: Option<CreateAccountPersonAddressKanji>,
     #[serde(skip_serializing_if = "Option::is_none")]
     dob: Option<DateOfBirthSpecs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    documents: Option<PersonDocumentsSpecs<'a>>,
+    documents: Option<PersonDocumentsSpecs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    email: Option<&'a str>,
+    email: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    first_name: Option<&'a str>,
+    first_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    first_name_kana: Option<&'a str>,
+    first_name_kana: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    first_name_kanji: Option<&'a str>,
+    first_name_kanji: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    full_name_aliases: Option<&'a [&'a str]>,
+    full_name_aliases: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    gender: Option<&'a str>,
+    gender: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    id_number: Option<&'a str>,
+    id_number: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    id_number_secondary: Option<&'a str>,
+    id_number_secondary: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    last_name: Option<&'a str>,
+    last_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    last_name_kana: Option<&'a str>,
+    last_name_kana: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    last_name_kanji: Option<&'a str>,
+    last_name_kanji: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    maiden_name: Option<&'a str>,
+    maiden_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    nationality: Option<&'a str>,
+    nationality: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    person_token: Option<&'a str>,
+    person_token: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    phone: Option<&'a str>,
+    phone: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    political_exposure: Option<&'a str>,
+    political_exposure: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    registered_address: Option<AddressSpecs<'a>>,
+    registered_address: Option<AddressSpecs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    relationship: Option<RelationshipSpecs<'a>>,
+    relationship: Option<RelationshipSpecs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ssn_last_4: Option<&'a str>,
+    ssn_last_4: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    verification: Option<PersonVerificationSpecs<'a>>,
+    verification: Option<PersonVerificationSpecs>,
 }
-impl<'a> CreateAccountPersonBuilder<'a> {
+impl CreateAccountPersonBuilder {
     fn new() -> Self {
         Self {
             additional_tos_acceptances: None,
@@ -333,31 +333,31 @@ impl<'a> CreateAccountPersonBuilder<'a> {
     }
 }
 /// The Kana variation of the person's address (Japan only).
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateAccountPersonAddressKana<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateAccountPersonAddressKana {
     /// City or ward.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<&'a str>,
+    pub city: Option<String>,
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub country: Option<&'a str>,
+    pub country: Option<String>,
     /// Block or building number.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line1: Option<&'a str>,
+    pub line1: Option<String>,
     /// Building details.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line2: Option<&'a str>,
+    pub line2: Option<String>,
     /// Postal code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<&'a str>,
+    pub postal_code: Option<String>,
     /// Prefecture.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
     /// Town or cho-me.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub town: Option<&'a str>,
+    pub town: Option<String>,
 }
-impl<'a> CreateAccountPersonAddressKana<'a> {
+impl CreateAccountPersonAddressKana {
     pub fn new() -> Self {
         Self {
             city: None,
@@ -370,37 +370,37 @@ impl<'a> CreateAccountPersonAddressKana<'a> {
         }
     }
 }
-impl<'a> Default for CreateAccountPersonAddressKana<'a> {
+impl Default for CreateAccountPersonAddressKana {
     fn default() -> Self {
         Self::new()
     }
 }
 /// The Kanji variation of the person's address (Japan only).
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateAccountPersonAddressKanji<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateAccountPersonAddressKanji {
     /// City or ward.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<&'a str>,
+    pub city: Option<String>,
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub country: Option<&'a str>,
+    pub country: Option<String>,
     /// Block or building number.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line1: Option<&'a str>,
+    pub line1: Option<String>,
     /// Building details.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line2: Option<&'a str>,
+    pub line2: Option<String>,
     /// Postal code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<&'a str>,
+    pub postal_code: Option<String>,
     /// Prefecture.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
     /// Town or cho-me.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub town: Option<&'a str>,
+    pub town: Option<String>,
 }
-impl<'a> CreateAccountPersonAddressKanji<'a> {
+impl CreateAccountPersonAddressKanji {
     pub fn new() -> Self {
         Self {
             city: None,
@@ -413,175 +413,181 @@ impl<'a> CreateAccountPersonAddressKanji<'a> {
         }
     }
 }
-impl<'a> Default for CreateAccountPersonAddressKanji<'a> {
+impl Default for CreateAccountPersonAddressKanji {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Creates a new person.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateAccountPerson<'a> {
-    inner: CreateAccountPersonBuilder<'a>,
-    account: &'a stripe_shared::AccountId,
+pub struct CreateAccountPerson {
+    inner: CreateAccountPersonBuilder,
+    account: stripe_shared::AccountId,
 }
-impl<'a> CreateAccountPerson<'a> {
+impl CreateAccountPerson {
     /// Construct a new `CreateAccountPerson`.
-    pub fn new(account: &'a stripe_shared::AccountId) -> Self {
-        Self { account, inner: CreateAccountPersonBuilder::new() }
+    pub fn new(account: impl Into<stripe_shared::AccountId>) -> Self {
+        Self { account: account.into(), inner: CreateAccountPersonBuilder::new() }
     }
     /// Details on the legal guardian's acceptance of the required Stripe agreements.
     pub fn additional_tos_acceptances(
         mut self,
-        additional_tos_acceptances: PersonAdditionalTosAcceptancesSpecs<'a>,
+        additional_tos_acceptances: impl Into<PersonAdditionalTosAcceptancesSpecs>,
     ) -> Self {
-        self.inner.additional_tos_acceptances = Some(additional_tos_acceptances);
+        self.inner.additional_tos_acceptances = Some(additional_tos_acceptances.into());
         self
     }
     /// The person's address.
-    pub fn address(mut self, address: AddressSpecs<'a>) -> Self {
-        self.inner.address = Some(address);
+    pub fn address(mut self, address: impl Into<AddressSpecs>) -> Self {
+        self.inner.address = Some(address.into());
         self
     }
     /// The Kana variation of the person's address (Japan only).
-    pub fn address_kana(mut self, address_kana: CreateAccountPersonAddressKana<'a>) -> Self {
-        self.inner.address_kana = Some(address_kana);
+    pub fn address_kana(mut self, address_kana: impl Into<CreateAccountPersonAddressKana>) -> Self {
+        self.inner.address_kana = Some(address_kana.into());
         self
     }
     /// The Kanji variation of the person's address (Japan only).
-    pub fn address_kanji(mut self, address_kanji: CreateAccountPersonAddressKanji<'a>) -> Self {
-        self.inner.address_kanji = Some(address_kanji);
+    pub fn address_kanji(
+        mut self,
+        address_kanji: impl Into<CreateAccountPersonAddressKanji>,
+    ) -> Self {
+        self.inner.address_kanji = Some(address_kanji.into());
         self
     }
     /// The person's date of birth.
-    pub fn dob(mut self, dob: DateOfBirthSpecs) -> Self {
-        self.inner.dob = Some(dob);
+    pub fn dob(mut self, dob: impl Into<DateOfBirthSpecs>) -> Self {
+        self.inner.dob = Some(dob.into());
         self
     }
     /// Documents that may be submitted to satisfy various informational requests.
-    pub fn documents(mut self, documents: PersonDocumentsSpecs<'a>) -> Self {
-        self.inner.documents = Some(documents);
+    pub fn documents(mut self, documents: impl Into<PersonDocumentsSpecs>) -> Self {
+        self.inner.documents = Some(documents.into());
         self
     }
     /// The person's email address.
-    pub fn email(mut self, email: &'a str) -> Self {
-        self.inner.email = Some(email);
+    pub fn email(mut self, email: impl Into<String>) -> Self {
+        self.inner.email = Some(email.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// The person's first name.
-    pub fn first_name(mut self, first_name: &'a str) -> Self {
-        self.inner.first_name = Some(first_name);
+    pub fn first_name(mut self, first_name: impl Into<String>) -> Self {
+        self.inner.first_name = Some(first_name.into());
         self
     }
     /// The Kana variation of the person's first name (Japan only).
-    pub fn first_name_kana(mut self, first_name_kana: &'a str) -> Self {
-        self.inner.first_name_kana = Some(first_name_kana);
+    pub fn first_name_kana(mut self, first_name_kana: impl Into<String>) -> Self {
+        self.inner.first_name_kana = Some(first_name_kana.into());
         self
     }
     /// The Kanji variation of the person's first name (Japan only).
-    pub fn first_name_kanji(mut self, first_name_kanji: &'a str) -> Self {
-        self.inner.first_name_kanji = Some(first_name_kanji);
+    pub fn first_name_kanji(mut self, first_name_kanji: impl Into<String>) -> Self {
+        self.inner.first_name_kanji = Some(first_name_kanji.into());
         self
     }
     /// A list of alternate names or aliases that the person is known by.
-    pub fn full_name_aliases(mut self, full_name_aliases: &'a [&'a str]) -> Self {
-        self.inner.full_name_aliases = Some(full_name_aliases);
+    pub fn full_name_aliases(mut self, full_name_aliases: impl Into<Vec<String>>) -> Self {
+        self.inner.full_name_aliases = Some(full_name_aliases.into());
         self
     }
     /// The person's gender (International regulations require either "male" or "female").
-    pub fn gender(mut self, gender: &'a str) -> Self {
-        self.inner.gender = Some(gender);
+    pub fn gender(mut self, gender: impl Into<String>) -> Self {
+        self.inner.gender = Some(gender.into());
         self
     }
     /// The person's ID number, as appropriate for their country.
     /// For example, a social security number in the U.S., social insurance number in Canada, etc.
     /// Instead of the number itself, you can also provide a [PII token provided by Stripe.js](https://docs.stripe.com/js/tokens/create_token?type=pii).
-    pub fn id_number(mut self, id_number: &'a str) -> Self {
-        self.inner.id_number = Some(id_number);
+    pub fn id_number(mut self, id_number: impl Into<String>) -> Self {
+        self.inner.id_number = Some(id_number.into());
         self
     }
     /// The person's secondary ID number, as appropriate for their country, will be used for enhanced verification checks.
     /// In Thailand, this would be the laser code found on the back of an ID card.
     /// Instead of the number itself, you can also provide a [PII token provided by Stripe.js](https://docs.stripe.com/js/tokens/create_token?type=pii).
-    pub fn id_number_secondary(mut self, id_number_secondary: &'a str) -> Self {
-        self.inner.id_number_secondary = Some(id_number_secondary);
+    pub fn id_number_secondary(mut self, id_number_secondary: impl Into<String>) -> Self {
+        self.inner.id_number_secondary = Some(id_number_secondary.into());
         self
     }
     /// The person's last name.
-    pub fn last_name(mut self, last_name: &'a str) -> Self {
-        self.inner.last_name = Some(last_name);
+    pub fn last_name(mut self, last_name: impl Into<String>) -> Self {
+        self.inner.last_name = Some(last_name.into());
         self
     }
     /// The Kana variation of the person's last name (Japan only).
-    pub fn last_name_kana(mut self, last_name_kana: &'a str) -> Self {
-        self.inner.last_name_kana = Some(last_name_kana);
+    pub fn last_name_kana(mut self, last_name_kana: impl Into<String>) -> Self {
+        self.inner.last_name_kana = Some(last_name_kana.into());
         self
     }
     /// The Kanji variation of the person's last name (Japan only).
-    pub fn last_name_kanji(mut self, last_name_kanji: &'a str) -> Self {
-        self.inner.last_name_kanji = Some(last_name_kanji);
+    pub fn last_name_kanji(mut self, last_name_kanji: impl Into<String>) -> Self {
+        self.inner.last_name_kanji = Some(last_name_kanji.into());
         self
     }
     /// The person's maiden name.
-    pub fn maiden_name(mut self, maiden_name: &'a str) -> Self {
-        self.inner.maiden_name = Some(maiden_name);
+    pub fn maiden_name(mut self, maiden_name: impl Into<String>) -> Self {
+        self.inner.maiden_name = Some(maiden_name.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// The country where the person is a national.
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)), or "XX" if unavailable.
-    pub fn nationality(mut self, nationality: &'a str) -> Self {
-        self.inner.nationality = Some(nationality);
+    pub fn nationality(mut self, nationality: impl Into<String>) -> Self {
+        self.inner.nationality = Some(nationality.into());
         self
     }
     /// A [person token](https://docs.stripe.com/connect/account-tokens), used to securely provide details to the person.
-    pub fn person_token(mut self, person_token: &'a str) -> Self {
-        self.inner.person_token = Some(person_token);
+    pub fn person_token(mut self, person_token: impl Into<String>) -> Self {
+        self.inner.person_token = Some(person_token.into());
         self
     }
     /// The person's phone number.
-    pub fn phone(mut self, phone: &'a str) -> Self {
-        self.inner.phone = Some(phone);
+    pub fn phone(mut self, phone: impl Into<String>) -> Self {
+        self.inner.phone = Some(phone.into());
         self
     }
     /// Indicates if the person or any of their representatives, family members, or other closely related persons, declares that they hold or have held an important public job or function, in any jurisdiction.
-    pub fn political_exposure(mut self, political_exposure: &'a str) -> Self {
-        self.inner.political_exposure = Some(political_exposure);
+    pub fn political_exposure(mut self, political_exposure: impl Into<String>) -> Self {
+        self.inner.political_exposure = Some(political_exposure.into());
         self
     }
     /// The person's registered address.
-    pub fn registered_address(mut self, registered_address: AddressSpecs<'a>) -> Self {
-        self.inner.registered_address = Some(registered_address);
+    pub fn registered_address(mut self, registered_address: impl Into<AddressSpecs>) -> Self {
+        self.inner.registered_address = Some(registered_address.into());
         self
     }
     /// The relationship that this person has with the account's legal entity.
-    pub fn relationship(mut self, relationship: RelationshipSpecs<'a>) -> Self {
-        self.inner.relationship = Some(relationship);
+    pub fn relationship(mut self, relationship: impl Into<RelationshipSpecs>) -> Self {
+        self.inner.relationship = Some(relationship.into());
         self
     }
     /// The last four digits of the person's Social Security number (U.S. only).
-    pub fn ssn_last_4(mut self, ssn_last_4: &'a str) -> Self {
-        self.inner.ssn_last_4 = Some(ssn_last_4);
+    pub fn ssn_last_4(mut self, ssn_last_4: impl Into<String>) -> Self {
+        self.inner.ssn_last_4 = Some(ssn_last_4.into());
         self
     }
     /// The person's verification status.
-    pub fn verification(mut self, verification: PersonVerificationSpecs<'a>) -> Self {
-        self.inner.verification = Some(verification);
+    pub fn verification(mut self, verification: impl Into<PersonVerificationSpecs>) -> Self {
+        self.inner.verification = Some(verification.into());
         self
     }
 }
-impl CreateAccountPerson<'_> {
+impl CreateAccountPerson {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -599,75 +605,75 @@ impl CreateAccountPerson<'_> {
     }
 }
 
-impl StripeRequest for CreateAccountPerson<'_> {
+impl StripeRequest for CreateAccountPerson {
     type Output = stripe_shared::Person;
 
     fn build(&self) -> RequestBuilder {
-        let account = self.account;
+        let account = &self.account;
         RequestBuilder::new(StripeMethod::Post, format!("/accounts/{account}/persons"))
             .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdatePersonBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdatePersonBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    additional_tos_acceptances: Option<PersonAdditionalTosAcceptancesSpecs<'a>>,
+    additional_tos_acceptances: Option<PersonAdditionalTosAcceptancesSpecs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    address: Option<AddressSpecs<'a>>,
+    address: Option<AddressSpecs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    address_kana: Option<UpdatePersonAddressKana<'a>>,
+    address_kana: Option<UpdatePersonAddressKana>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    address_kanji: Option<UpdatePersonAddressKanji<'a>>,
+    address_kanji: Option<UpdatePersonAddressKanji>,
     #[serde(skip_serializing_if = "Option::is_none")]
     dob: Option<DateOfBirthSpecs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    documents: Option<PersonDocumentsSpecs<'a>>,
+    documents: Option<PersonDocumentsSpecs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    email: Option<&'a str>,
+    email: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    first_name: Option<&'a str>,
+    first_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    first_name_kana: Option<&'a str>,
+    first_name_kana: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    first_name_kanji: Option<&'a str>,
+    first_name_kanji: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    full_name_aliases: Option<&'a [&'a str]>,
+    full_name_aliases: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    gender: Option<&'a str>,
+    gender: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    id_number: Option<&'a str>,
+    id_number: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    id_number_secondary: Option<&'a str>,
+    id_number_secondary: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    last_name: Option<&'a str>,
+    last_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    last_name_kana: Option<&'a str>,
+    last_name_kana: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    last_name_kanji: Option<&'a str>,
+    last_name_kanji: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    maiden_name: Option<&'a str>,
+    maiden_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    nationality: Option<&'a str>,
+    nationality: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    person_token: Option<&'a str>,
+    person_token: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    phone: Option<&'a str>,
+    phone: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    political_exposure: Option<&'a str>,
+    political_exposure: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    registered_address: Option<AddressSpecs<'a>>,
+    registered_address: Option<AddressSpecs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    relationship: Option<RelationshipSpecs<'a>>,
+    relationship: Option<RelationshipSpecs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ssn_last_4: Option<&'a str>,
+    ssn_last_4: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    verification: Option<PersonVerificationSpecs<'a>>,
+    verification: Option<PersonVerificationSpecs>,
 }
-impl<'a> UpdatePersonBuilder<'a> {
+impl UpdatePersonBuilder {
     fn new() -> Self {
         Self {
             additional_tos_acceptances: None,
@@ -702,31 +708,31 @@ impl<'a> UpdatePersonBuilder<'a> {
     }
 }
 /// The Kana variation of the person's address (Japan only).
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdatePersonAddressKana<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdatePersonAddressKana {
     /// City or ward.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<&'a str>,
+    pub city: Option<String>,
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub country: Option<&'a str>,
+    pub country: Option<String>,
     /// Block or building number.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line1: Option<&'a str>,
+    pub line1: Option<String>,
     /// Building details.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line2: Option<&'a str>,
+    pub line2: Option<String>,
     /// Postal code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<&'a str>,
+    pub postal_code: Option<String>,
     /// Prefecture.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
     /// Town or cho-me.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub town: Option<&'a str>,
+    pub town: Option<String>,
 }
-impl<'a> UpdatePersonAddressKana<'a> {
+impl UpdatePersonAddressKana {
     pub fn new() -> Self {
         Self {
             city: None,
@@ -739,37 +745,37 @@ impl<'a> UpdatePersonAddressKana<'a> {
         }
     }
 }
-impl<'a> Default for UpdatePersonAddressKana<'a> {
+impl Default for UpdatePersonAddressKana {
     fn default() -> Self {
         Self::new()
     }
 }
 /// The Kanji variation of the person's address (Japan only).
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdatePersonAddressKanji<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdatePersonAddressKanji {
     /// City or ward.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<&'a str>,
+    pub city: Option<String>,
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub country: Option<&'a str>,
+    pub country: Option<String>,
     /// Block or building number.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line1: Option<&'a str>,
+    pub line1: Option<String>,
     /// Building details.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line2: Option<&'a str>,
+    pub line2: Option<String>,
     /// Postal code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<&'a str>,
+    pub postal_code: Option<String>,
     /// Prefecture.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
     /// Town or cho-me.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub town: Option<&'a str>,
+    pub town: Option<String>,
 }
-impl<'a> UpdatePersonAddressKanji<'a> {
+impl UpdatePersonAddressKanji {
     pub fn new() -> Self {
         Self {
             city: None,
@@ -782,176 +788,179 @@ impl<'a> UpdatePersonAddressKanji<'a> {
         }
     }
 }
-impl<'a> Default for UpdatePersonAddressKanji<'a> {
+impl Default for UpdatePersonAddressKanji {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Updates an existing person.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdatePerson<'a> {
-    inner: UpdatePersonBuilder<'a>,
-    account: &'a stripe_shared::AccountId,
-    person: &'a str,
+pub struct UpdatePerson {
+    inner: UpdatePersonBuilder,
+    account: stripe_shared::AccountId,
+    person: String,
 }
-impl<'a> UpdatePerson<'a> {
+impl UpdatePerson {
     /// Construct a new `UpdatePerson`.
-    pub fn new(account: &'a stripe_shared::AccountId, person: &'a str) -> Self {
-        Self { account, person, inner: UpdatePersonBuilder::new() }
+    pub fn new(account: impl Into<stripe_shared::AccountId>, person: impl Into<String>) -> Self {
+        Self { account: account.into(), person: person.into(), inner: UpdatePersonBuilder::new() }
     }
     /// Details on the legal guardian's acceptance of the required Stripe agreements.
     pub fn additional_tos_acceptances(
         mut self,
-        additional_tos_acceptances: PersonAdditionalTosAcceptancesSpecs<'a>,
+        additional_tos_acceptances: impl Into<PersonAdditionalTosAcceptancesSpecs>,
     ) -> Self {
-        self.inner.additional_tos_acceptances = Some(additional_tos_acceptances);
+        self.inner.additional_tos_acceptances = Some(additional_tos_acceptances.into());
         self
     }
     /// The person's address.
-    pub fn address(mut self, address: AddressSpecs<'a>) -> Self {
-        self.inner.address = Some(address);
+    pub fn address(mut self, address: impl Into<AddressSpecs>) -> Self {
+        self.inner.address = Some(address.into());
         self
     }
     /// The Kana variation of the person's address (Japan only).
-    pub fn address_kana(mut self, address_kana: UpdatePersonAddressKana<'a>) -> Self {
-        self.inner.address_kana = Some(address_kana);
+    pub fn address_kana(mut self, address_kana: impl Into<UpdatePersonAddressKana>) -> Self {
+        self.inner.address_kana = Some(address_kana.into());
         self
     }
     /// The Kanji variation of the person's address (Japan only).
-    pub fn address_kanji(mut self, address_kanji: UpdatePersonAddressKanji<'a>) -> Self {
-        self.inner.address_kanji = Some(address_kanji);
+    pub fn address_kanji(mut self, address_kanji: impl Into<UpdatePersonAddressKanji>) -> Self {
+        self.inner.address_kanji = Some(address_kanji.into());
         self
     }
     /// The person's date of birth.
-    pub fn dob(mut self, dob: DateOfBirthSpecs) -> Self {
-        self.inner.dob = Some(dob);
+    pub fn dob(mut self, dob: impl Into<DateOfBirthSpecs>) -> Self {
+        self.inner.dob = Some(dob.into());
         self
     }
     /// Documents that may be submitted to satisfy various informational requests.
-    pub fn documents(mut self, documents: PersonDocumentsSpecs<'a>) -> Self {
-        self.inner.documents = Some(documents);
+    pub fn documents(mut self, documents: impl Into<PersonDocumentsSpecs>) -> Self {
+        self.inner.documents = Some(documents.into());
         self
     }
     /// The person's email address.
-    pub fn email(mut self, email: &'a str) -> Self {
-        self.inner.email = Some(email);
+    pub fn email(mut self, email: impl Into<String>) -> Self {
+        self.inner.email = Some(email.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// The person's first name.
-    pub fn first_name(mut self, first_name: &'a str) -> Self {
-        self.inner.first_name = Some(first_name);
+    pub fn first_name(mut self, first_name: impl Into<String>) -> Self {
+        self.inner.first_name = Some(first_name.into());
         self
     }
     /// The Kana variation of the person's first name (Japan only).
-    pub fn first_name_kana(mut self, first_name_kana: &'a str) -> Self {
-        self.inner.first_name_kana = Some(first_name_kana);
+    pub fn first_name_kana(mut self, first_name_kana: impl Into<String>) -> Self {
+        self.inner.first_name_kana = Some(first_name_kana.into());
         self
     }
     /// The Kanji variation of the person's first name (Japan only).
-    pub fn first_name_kanji(mut self, first_name_kanji: &'a str) -> Self {
-        self.inner.first_name_kanji = Some(first_name_kanji);
+    pub fn first_name_kanji(mut self, first_name_kanji: impl Into<String>) -> Self {
+        self.inner.first_name_kanji = Some(first_name_kanji.into());
         self
     }
     /// A list of alternate names or aliases that the person is known by.
-    pub fn full_name_aliases(mut self, full_name_aliases: &'a [&'a str]) -> Self {
-        self.inner.full_name_aliases = Some(full_name_aliases);
+    pub fn full_name_aliases(mut self, full_name_aliases: impl Into<Vec<String>>) -> Self {
+        self.inner.full_name_aliases = Some(full_name_aliases.into());
         self
     }
     /// The person's gender (International regulations require either "male" or "female").
-    pub fn gender(mut self, gender: &'a str) -> Self {
-        self.inner.gender = Some(gender);
+    pub fn gender(mut self, gender: impl Into<String>) -> Self {
+        self.inner.gender = Some(gender.into());
         self
     }
     /// The person's ID number, as appropriate for their country.
     /// For example, a social security number in the U.S., social insurance number in Canada, etc.
     /// Instead of the number itself, you can also provide a [PII token provided by Stripe.js](https://docs.stripe.com/js/tokens/create_token?type=pii).
-    pub fn id_number(mut self, id_number: &'a str) -> Self {
-        self.inner.id_number = Some(id_number);
+    pub fn id_number(mut self, id_number: impl Into<String>) -> Self {
+        self.inner.id_number = Some(id_number.into());
         self
     }
     /// The person's secondary ID number, as appropriate for their country, will be used for enhanced verification checks.
     /// In Thailand, this would be the laser code found on the back of an ID card.
     /// Instead of the number itself, you can also provide a [PII token provided by Stripe.js](https://docs.stripe.com/js/tokens/create_token?type=pii).
-    pub fn id_number_secondary(mut self, id_number_secondary: &'a str) -> Self {
-        self.inner.id_number_secondary = Some(id_number_secondary);
+    pub fn id_number_secondary(mut self, id_number_secondary: impl Into<String>) -> Self {
+        self.inner.id_number_secondary = Some(id_number_secondary.into());
         self
     }
     /// The person's last name.
-    pub fn last_name(mut self, last_name: &'a str) -> Self {
-        self.inner.last_name = Some(last_name);
+    pub fn last_name(mut self, last_name: impl Into<String>) -> Self {
+        self.inner.last_name = Some(last_name.into());
         self
     }
     /// The Kana variation of the person's last name (Japan only).
-    pub fn last_name_kana(mut self, last_name_kana: &'a str) -> Self {
-        self.inner.last_name_kana = Some(last_name_kana);
+    pub fn last_name_kana(mut self, last_name_kana: impl Into<String>) -> Self {
+        self.inner.last_name_kana = Some(last_name_kana.into());
         self
     }
     /// The Kanji variation of the person's last name (Japan only).
-    pub fn last_name_kanji(mut self, last_name_kanji: &'a str) -> Self {
-        self.inner.last_name_kanji = Some(last_name_kanji);
+    pub fn last_name_kanji(mut self, last_name_kanji: impl Into<String>) -> Self {
+        self.inner.last_name_kanji = Some(last_name_kanji.into());
         self
     }
     /// The person's maiden name.
-    pub fn maiden_name(mut self, maiden_name: &'a str) -> Self {
-        self.inner.maiden_name = Some(maiden_name);
+    pub fn maiden_name(mut self, maiden_name: impl Into<String>) -> Self {
+        self.inner.maiden_name = Some(maiden_name.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// The country where the person is a national.
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)), or "XX" if unavailable.
-    pub fn nationality(mut self, nationality: &'a str) -> Self {
-        self.inner.nationality = Some(nationality);
+    pub fn nationality(mut self, nationality: impl Into<String>) -> Self {
+        self.inner.nationality = Some(nationality.into());
         self
     }
     /// A [person token](https://docs.stripe.com/connect/account-tokens), used to securely provide details to the person.
-    pub fn person_token(mut self, person_token: &'a str) -> Self {
-        self.inner.person_token = Some(person_token);
+    pub fn person_token(mut self, person_token: impl Into<String>) -> Self {
+        self.inner.person_token = Some(person_token.into());
         self
     }
     /// The person's phone number.
-    pub fn phone(mut self, phone: &'a str) -> Self {
-        self.inner.phone = Some(phone);
+    pub fn phone(mut self, phone: impl Into<String>) -> Self {
+        self.inner.phone = Some(phone.into());
         self
     }
     /// Indicates if the person or any of their representatives, family members, or other closely related persons, declares that they hold or have held an important public job or function, in any jurisdiction.
-    pub fn political_exposure(mut self, political_exposure: &'a str) -> Self {
-        self.inner.political_exposure = Some(political_exposure);
+    pub fn political_exposure(mut self, political_exposure: impl Into<String>) -> Self {
+        self.inner.political_exposure = Some(political_exposure.into());
         self
     }
     /// The person's registered address.
-    pub fn registered_address(mut self, registered_address: AddressSpecs<'a>) -> Self {
-        self.inner.registered_address = Some(registered_address);
+    pub fn registered_address(mut self, registered_address: impl Into<AddressSpecs>) -> Self {
+        self.inner.registered_address = Some(registered_address.into());
         self
     }
     /// The relationship that this person has with the account's legal entity.
-    pub fn relationship(mut self, relationship: RelationshipSpecs<'a>) -> Self {
-        self.inner.relationship = Some(relationship);
+    pub fn relationship(mut self, relationship: impl Into<RelationshipSpecs>) -> Self {
+        self.inner.relationship = Some(relationship.into());
         self
     }
     /// The last four digits of the person's Social Security number (U.S. only).
-    pub fn ssn_last_4(mut self, ssn_last_4: &'a str) -> Self {
-        self.inner.ssn_last_4 = Some(ssn_last_4);
+    pub fn ssn_last_4(mut self, ssn_last_4: impl Into<String>) -> Self {
+        self.inner.ssn_last_4 = Some(ssn_last_4.into());
         self
     }
     /// The person's verification status.
-    pub fn verification(mut self, verification: PersonVerificationSpecs<'a>) -> Self {
-        self.inner.verification = Some(verification);
+    pub fn verification(mut self, verification: impl Into<PersonVerificationSpecs>) -> Self {
+        self.inner.verification = Some(verification.into());
         self
     }
 }
-impl UpdatePerson<'_> {
+impl UpdatePerson {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -969,66 +978,66 @@ impl UpdatePerson<'_> {
     }
 }
 
-impl StripeRequest for UpdatePerson<'_> {
+impl StripeRequest for UpdatePerson {
     type Output = stripe_shared::Person;
 
     fn build(&self) -> RequestBuilder {
-        let account = self.account;
-        let person = self.person;
+        let account = &self.account;
+        let person = &self.person;
         RequestBuilder::new(StripeMethod::Post, format!("/accounts/{account}/persons/{person}"))
             .form(&self.inner)
     }
 }
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct SettingsTermsOfServiceSpecs<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct SettingsTermsOfServiceSpecs {
     /// The Unix timestamp marking when the account representative accepted the service agreement.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub date: Option<stripe_types::Timestamp>,
     /// The IP address from which the account representative accepted the service agreement.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ip: Option<&'a str>,
+    pub ip: Option<String>,
     /// The user agent of the browser from which the account representative accepted the service agreement.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user_agent: Option<&'a str>,
+    pub user_agent: Option<String>,
 }
-impl<'a> SettingsTermsOfServiceSpecs<'a> {
+impl SettingsTermsOfServiceSpecs {
     pub fn new() -> Self {
         Self { date: None, ip: None, user_agent: None }
     }
 }
-impl<'a> Default for SettingsTermsOfServiceSpecs<'a> {
+impl Default for SettingsTermsOfServiceSpecs {
     fn default() -> Self {
         Self::new()
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct AddressSpecs<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct AddressSpecs {
     /// City, district, suburb, town, or village.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<&'a str>,
+    pub city: Option<String>,
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub country: Option<&'a str>,
+    pub country: Option<String>,
     /// Address line 1 (e.g., street, PO Box, or company name).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line1: Option<&'a str>,
+    pub line1: Option<String>,
     /// Address line 2 (e.g., apartment, suite, unit, or building).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line2: Option<&'a str>,
+    pub line2: Option<String>,
     /// ZIP or postal code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<&'a str>,
+    pub postal_code: Option<String>,
     /// State, county, province, or region.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
 }
-impl<'a> AddressSpecs<'a> {
+impl AddressSpecs {
     pub fn new() -> Self {
         Self { city: None, country: None, line1: None, line2: None, postal_code: None, state: None }
     }
 }
-impl<'a> Default for AddressSpecs<'a> {
+impl Default for AddressSpecs {
     fn default() -> Self {
         Self::new()
     }
@@ -1043,28 +1052,28 @@ pub struct DateOfBirthSpecs {
     pub year: i64,
 }
 impl DateOfBirthSpecs {
-    pub fn new(day: i64, month: i64, year: i64) -> Self {
-        Self { day, month, year }
+    pub fn new(day: impl Into<i64>, month: impl Into<i64>, year: impl Into<i64>) -> Self {
+        Self { day: day.into(), month: month.into(), year: year.into() }
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct DocumentsParam<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct DocumentsParam {
     /// One or more document ids returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `account_requirement`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub files: Option<&'a [&'a str]>,
+    pub files: Option<Vec<String>>,
 }
-impl<'a> DocumentsParam<'a> {
+impl DocumentsParam {
     pub fn new() -> Self {
         Self { files: None }
     }
 }
-impl<'a> Default for DocumentsParam<'a> {
+impl Default for DocumentsParam {
     fn default() -> Self {
         Self::new()
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct RelationshipSpecs<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct RelationshipSpecs {
     /// Whether the person is a director of the account's legal entity.
     /// Directors are typically members of the governing board of the company, or responsible for ensuring the company meets its regulatory obligations.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1089,9 +1098,9 @@ pub struct RelationshipSpecs<'a> {
     pub representative: Option<bool>,
     /// The person's title (e.g., CEO, Support Engineer).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub title: Option<&'a str>,
+    pub title: Option<String>,
 }
-impl<'a> RelationshipSpecs<'a> {
+impl RelationshipSpecs {
     pub fn new() -> Self {
         Self {
             director: None,
@@ -1104,85 +1113,85 @@ impl<'a> RelationshipSpecs<'a> {
         }
     }
 }
-impl<'a> Default for RelationshipSpecs<'a> {
+impl Default for RelationshipSpecs {
     fn default() -> Self {
         Self::new()
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct PersonVerificationDocumentSpecs<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct PersonVerificationDocumentSpecs {
     /// The back of an ID returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `identity_document`.
     /// The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG, PNG, or PDF format, and less than 10 MB in size.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub back: Option<&'a str>,
+    pub back: Option<String>,
     /// The front of an ID returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `identity_document`.
     /// The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG, PNG, or PDF format, and less than 10 MB in size.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub front: Option<&'a str>,
+    pub front: Option<String>,
 }
-impl<'a> PersonVerificationDocumentSpecs<'a> {
+impl PersonVerificationDocumentSpecs {
     pub fn new() -> Self {
         Self { back: None, front: None }
     }
 }
-impl<'a> Default for PersonVerificationDocumentSpecs<'a> {
+impl Default for PersonVerificationDocumentSpecs {
     fn default() -> Self {
         Self::new()
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct PersonAdditionalTosAcceptancesSpecs<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct PersonAdditionalTosAcceptancesSpecs {
     /// Details on the legal guardian's acceptance of the main Stripe service agreement.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account: Option<SettingsTermsOfServiceSpecs<'a>>,
+    pub account: Option<SettingsTermsOfServiceSpecs>,
 }
-impl<'a> PersonAdditionalTosAcceptancesSpecs<'a> {
+impl PersonAdditionalTosAcceptancesSpecs {
     pub fn new() -> Self {
         Self { account: None }
     }
 }
-impl<'a> Default for PersonAdditionalTosAcceptancesSpecs<'a> {
+impl Default for PersonAdditionalTosAcceptancesSpecs {
     fn default() -> Self {
         Self::new()
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct PersonDocumentsSpecs<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct PersonDocumentsSpecs {
     /// One or more documents that demonstrate proof that this person is authorized to represent the company.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub company_authorization: Option<DocumentsParam<'a>>,
+    pub company_authorization: Option<DocumentsParam>,
     /// One or more documents showing the person's passport page with photo and personal data.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub passport: Option<DocumentsParam<'a>>,
+    pub passport: Option<DocumentsParam>,
     /// One or more documents showing the person's visa required for living in the country where they are residing.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub visa: Option<DocumentsParam<'a>>,
+    pub visa: Option<DocumentsParam>,
 }
-impl<'a> PersonDocumentsSpecs<'a> {
+impl PersonDocumentsSpecs {
     pub fn new() -> Self {
         Self { company_authorization: None, passport: None, visa: None }
     }
 }
-impl<'a> Default for PersonDocumentsSpecs<'a> {
+impl Default for PersonDocumentsSpecs {
     fn default() -> Self {
         Self::new()
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct PersonVerificationSpecs<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct PersonVerificationSpecs {
     /// A document showing address, either a passport, local ID card, or utility bill from a well-known utility company.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub additional_document: Option<PersonVerificationDocumentSpecs<'a>>,
+    pub additional_document: Option<PersonVerificationDocumentSpecs>,
     /// An identifying document, either a passport or local ID card.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub document: Option<PersonVerificationDocumentSpecs<'a>>,
+    pub document: Option<PersonVerificationDocumentSpecs>,
 }
-impl<'a> PersonVerificationSpecs<'a> {
+impl PersonVerificationSpecs {
     pub fn new() -> Self {
         Self { additional_document: None, document: None }
     }
 }
-impl<'a> Default for PersonVerificationSpecs<'a> {
+impl Default for PersonVerificationSpecs {
     fn default() -> Self {
         Self::new()
     }

--- a/generated/async-stripe-connect/src/topup/requests.rs
+++ b/generated/async-stripe-connect/src/topup/requests.rs
@@ -2,24 +2,24 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListTopupBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListTopupBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     amount: Option<stripe_types::RangeQueryTs>,
     #[serde(skip_serializing_if = "Option::is_none")]
     created: Option<stripe_types::RangeQueryTs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     status: Option<ListTopupStatus>,
 }
-impl<'a> ListTopupBuilder<'a> {
+impl ListTopupBuilder {
     fn new() -> Self {
         Self {
             amount: None,
@@ -96,63 +96,63 @@ impl<'de> serde::Deserialize<'de> for ListTopupStatus {
 }
 /// Returns a list of top-ups.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListTopup<'a> {
-    inner: ListTopupBuilder<'a>,
+pub struct ListTopup {
+    inner: ListTopupBuilder,
 }
-impl<'a> ListTopup<'a> {
+impl ListTopup {
     /// Construct a new `ListTopup`.
     pub fn new() -> Self {
         Self { inner: ListTopupBuilder::new() }
     }
     /// A positive integer representing how much to transfer.
-    pub fn amount(mut self, amount: stripe_types::RangeQueryTs) -> Self {
-        self.inner.amount = Some(amount);
+    pub fn amount(mut self, amount: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.amount = Some(amount.into());
         self
     }
     /// A filter on the list, based on the object `created` field.
     /// The value can be a string with an integer Unix timestamp, or it can be a dictionary with a number of different query options.
-    pub fn created(mut self, created: stripe_types::RangeQueryTs) -> Self {
-        self.inner.created = Some(created);
+    pub fn created(mut self, created: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.created = Some(created.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
     /// Only return top-ups that have the given status.
     /// One of `canceled`, `failed`, `pending` or `succeeded`.
-    pub fn status(mut self, status: ListTopupStatus) -> Self {
-        self.inner.status = Some(status);
+    pub fn status(mut self, status: impl Into<ListTopupStatus>) -> Self {
+        self.inner.status = Some(status.into());
         self
     }
 }
-impl<'a> Default for ListTopup<'a> {
+impl Default for ListTopup {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListTopup<'_> {
+impl ListTopup {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -172,23 +172,23 @@ impl ListTopup<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::Topup>> {
-        stripe_client_core::ListPaginator::new_list("/topups", self.inner)
+        stripe_client_core::ListPaginator::new_list("/topups", &self.inner)
     }
 }
 
-impl StripeRequest for ListTopup<'_> {
+impl StripeRequest for ListTopup {
     type Output = stripe_types::List<stripe_shared::Topup>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/topups").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveTopupBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveTopupBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveTopupBuilder<'a> {
+impl RetrieveTopupBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
@@ -196,22 +196,22 @@ impl<'a> RetrieveTopupBuilder<'a> {
 /// Retrieves the details of a top-up that has previously been created.
 /// Supply the unique top-up ID that was returned from your previous request, and Stripe will return the corresponding top-up information.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveTopup<'a> {
-    inner: RetrieveTopupBuilder<'a>,
-    topup: &'a stripe_shared::TopupId,
+pub struct RetrieveTopup {
+    inner: RetrieveTopupBuilder,
+    topup: stripe_shared::TopupId,
 }
-impl<'a> RetrieveTopup<'a> {
+impl RetrieveTopup {
     /// Construct a new `RetrieveTopup`.
-    pub fn new(topup: &'a stripe_shared::TopupId) -> Self {
-        Self { topup, inner: RetrieveTopupBuilder::new() }
+    pub fn new(topup: impl Into<stripe_shared::TopupId>) -> Self {
+        Self { topup: topup.into(), inner: RetrieveTopupBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveTopup<'_> {
+impl RetrieveTopup {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -229,36 +229,36 @@ impl RetrieveTopup<'_> {
     }
 }
 
-impl StripeRequest for RetrieveTopup<'_> {
+impl StripeRequest for RetrieveTopup {
     type Output = stripe_shared::Topup;
 
     fn build(&self) -> RequestBuilder {
-        let topup = self.topup;
+        let topup = &self.topup;
         RequestBuilder::new(StripeMethod::Get, format!("/topups/{topup}")).query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateTopupBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateTopupBuilder {
     amount: i64,
     currency: stripe_types::Currency,
     #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<&'a str>,
+    description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    source: Option<&'a str>,
+    source: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    statement_descriptor: Option<&'a str>,
+    statement_descriptor: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    transfer_group: Option<&'a str>,
+    transfer_group: Option<String>,
 }
-impl<'a> CreateTopupBuilder<'a> {
-    fn new(amount: i64, currency: stripe_types::Currency) -> Self {
+impl CreateTopupBuilder {
+    fn new(amount: impl Into<i64>, currency: impl Into<stripe_types::Currency>) -> Self {
         Self {
-            amount,
-            currency,
+            amount: amount.into(),
+            currency: currency.into(),
             description: None,
             expand: None,
             metadata: None,
@@ -270,51 +270,54 @@ impl<'a> CreateTopupBuilder<'a> {
 }
 /// Top up the balance of an account
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateTopup<'a> {
-    inner: CreateTopupBuilder<'a>,
+pub struct CreateTopup {
+    inner: CreateTopupBuilder,
 }
-impl<'a> CreateTopup<'a> {
+impl CreateTopup {
     /// Construct a new `CreateTopup`.
-    pub fn new(amount: i64, currency: stripe_types::Currency) -> Self {
-        Self { inner: CreateTopupBuilder::new(amount, currency) }
+    pub fn new(amount: impl Into<i64>, currency: impl Into<stripe_types::Currency>) -> Self {
+        Self { inner: CreateTopupBuilder::new(amount.into(), currency.into()) }
     }
     /// An arbitrary string attached to the object. Often useful for displaying to users.
-    pub fn description(mut self, description: &'a str) -> Self {
-        self.inner.description = Some(description);
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.inner.description = Some(description.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// The ID of a source to transfer funds from.
     /// For most users, this should be left unspecified which will use the bank account that was set up in the dashboard for the specified currency.
     /// In test mode, this can be a test bank token (see [Testing Top-ups](https://stripe.com/docs/connect/testing#testing-top-ups)).
-    pub fn source(mut self, source: &'a str) -> Self {
-        self.inner.source = Some(source);
+    pub fn source(mut self, source: impl Into<String>) -> Self {
+        self.inner.source = Some(source.into());
         self
     }
     /// Extra information about a top-up for the source's bank statement. Limited to 15 ASCII characters.
-    pub fn statement_descriptor(mut self, statement_descriptor: &'a str) -> Self {
-        self.inner.statement_descriptor = Some(statement_descriptor);
+    pub fn statement_descriptor(mut self, statement_descriptor: impl Into<String>) -> Self {
+        self.inner.statement_descriptor = Some(statement_descriptor.into());
         self
     }
     /// A string that identifies this top-up as part of a group.
-    pub fn transfer_group(mut self, transfer_group: &'a str) -> Self {
-        self.inner.transfer_group = Some(transfer_group);
+    pub fn transfer_group(mut self, transfer_group: impl Into<String>) -> Self {
+        self.inner.transfer_group = Some(transfer_group.into());
         self
     }
 }
-impl CreateTopup<'_> {
+impl CreateTopup {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -332,58 +335,61 @@ impl CreateTopup<'_> {
     }
 }
 
-impl StripeRequest for CreateTopup<'_> {
+impl StripeRequest for CreateTopup {
     type Output = stripe_shared::Topup;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Post, "/topups").form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdateTopupBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdateTopupBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<&'a str>,
+    description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
 }
-impl<'a> UpdateTopupBuilder<'a> {
+impl UpdateTopupBuilder {
     fn new() -> Self {
         Self { description: None, expand: None, metadata: None }
     }
 }
 /// Updates the metadata of a top-up. Other top-up details are not editable by design.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateTopup<'a> {
-    inner: UpdateTopupBuilder<'a>,
-    topup: &'a stripe_shared::TopupId,
+pub struct UpdateTopup {
+    inner: UpdateTopupBuilder,
+    topup: stripe_shared::TopupId,
 }
-impl<'a> UpdateTopup<'a> {
+impl UpdateTopup {
     /// Construct a new `UpdateTopup`.
-    pub fn new(topup: &'a stripe_shared::TopupId) -> Self {
-        Self { topup, inner: UpdateTopupBuilder::new() }
+    pub fn new(topup: impl Into<stripe_shared::TopupId>) -> Self {
+        Self { topup: topup.into(), inner: UpdateTopupBuilder::new() }
     }
     /// An arbitrary string attached to the object. Often useful for displaying to users.
-    pub fn description(mut self, description: &'a str) -> Self {
-        self.inner.description = Some(description);
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.inner.description = Some(description.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
 }
-impl UpdateTopup<'_> {
+impl UpdateTopup {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -401,42 +407,42 @@ impl UpdateTopup<'_> {
     }
 }
 
-impl StripeRequest for UpdateTopup<'_> {
+impl StripeRequest for UpdateTopup {
     type Output = stripe_shared::Topup;
 
     fn build(&self) -> RequestBuilder {
-        let topup = self.topup;
+        let topup = &self.topup;
         RequestBuilder::new(StripeMethod::Post, format!("/topups/{topup}")).form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CancelTopupBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CancelTopupBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> CancelTopupBuilder<'a> {
+impl CancelTopupBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Cancels a top-up. Only pending top-ups can be canceled.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CancelTopup<'a> {
-    inner: CancelTopupBuilder<'a>,
-    topup: &'a stripe_shared::TopupId,
+pub struct CancelTopup {
+    inner: CancelTopupBuilder,
+    topup: stripe_shared::TopupId,
 }
-impl<'a> CancelTopup<'a> {
+impl CancelTopup {
     /// Construct a new `CancelTopup`.
-    pub fn new(topup: &'a stripe_shared::TopupId) -> Self {
-        Self { topup, inner: CancelTopupBuilder::new() }
+    pub fn new(topup: impl Into<stripe_shared::TopupId>) -> Self {
+        Self { topup: topup.into(), inner: CancelTopupBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl CancelTopup<'_> {
+impl CancelTopup {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -454,11 +460,11 @@ impl CancelTopup<'_> {
     }
 }
 
-impl StripeRequest for CancelTopup<'_> {
+impl StripeRequest for CancelTopup {
     type Output = stripe_shared::Topup;
 
     fn build(&self) -> RequestBuilder {
-        let topup = self.topup;
+        let topup = &self.topup;
         RequestBuilder::new(StripeMethod::Post, format!("/topups/{topup}/cancel")).form(&self.inner)
     }
 }

--- a/generated/async-stripe-connect/src/transfer/requests.rs
+++ b/generated/async-stripe-connect/src/transfer/requests.rs
@@ -2,24 +2,24 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListTransferBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListTransferBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     created: Option<stripe_types::RangeQueryTs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    destination: Option<&'a str>,
+    destination: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    transfer_group: Option<&'a str>,
+    transfer_group: Option<String>,
 }
-impl<'a> ListTransferBuilder<'a> {
+impl ListTransferBuilder {
     fn new() -> Self {
         Self {
             created: None,
@@ -35,61 +35,61 @@ impl<'a> ListTransferBuilder<'a> {
 /// Returns a list of existing transfers sent to connected accounts.
 /// The transfers are returned in sorted order, with the most recently created transfers appearing first.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListTransfer<'a> {
-    inner: ListTransferBuilder<'a>,
+pub struct ListTransfer {
+    inner: ListTransferBuilder,
 }
-impl<'a> ListTransfer<'a> {
+impl ListTransfer {
     /// Construct a new `ListTransfer`.
     pub fn new() -> Self {
         Self { inner: ListTransferBuilder::new() }
     }
     /// Only return transfers that were created during the given date interval.
-    pub fn created(mut self, created: stripe_types::RangeQueryTs) -> Self {
-        self.inner.created = Some(created);
+    pub fn created(mut self, created: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.created = Some(created.into());
         self
     }
     /// Only return transfers for the destination specified by this account ID.
-    pub fn destination(mut self, destination: &'a str) -> Self {
-        self.inner.destination = Some(destination);
+    pub fn destination(mut self, destination: impl Into<String>) -> Self {
+        self.inner.destination = Some(destination.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
     /// Only return transfers with the specified transfer group.
-    pub fn transfer_group(mut self, transfer_group: &'a str) -> Self {
-        self.inner.transfer_group = Some(transfer_group);
+    pub fn transfer_group(mut self, transfer_group: impl Into<String>) -> Self {
+        self.inner.transfer_group = Some(transfer_group.into());
         self
     }
 }
-impl<'a> Default for ListTransfer<'a> {
+impl Default for ListTransfer {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListTransfer<'_> {
+impl ListTransfer {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -109,23 +109,23 @@ impl ListTransfer<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::Transfer>> {
-        stripe_client_core::ListPaginator::new_list("/transfers", self.inner)
+        stripe_client_core::ListPaginator::new_list("/transfers", &self.inner)
     }
 }
 
-impl StripeRequest for ListTransfer<'_> {
+impl StripeRequest for ListTransfer {
     type Output = stripe_types::List<stripe_shared::Transfer>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/transfers").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveTransferBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveTransferBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveTransferBuilder<'a> {
+impl RetrieveTransferBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
@@ -133,22 +133,22 @@ impl<'a> RetrieveTransferBuilder<'a> {
 /// Retrieves the details of an existing transfer.
 /// Supply the unique transfer ID from either a transfer creation request or the transfer list, and Stripe will return the corresponding transfer information.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveTransfer<'a> {
-    inner: RetrieveTransferBuilder<'a>,
-    transfer: &'a stripe_shared::TransferId,
+pub struct RetrieveTransfer {
+    inner: RetrieveTransferBuilder,
+    transfer: stripe_shared::TransferId,
 }
-impl<'a> RetrieveTransfer<'a> {
+impl RetrieveTransfer {
     /// Construct a new `RetrieveTransfer`.
-    pub fn new(transfer: &'a stripe_shared::TransferId) -> Self {
-        Self { transfer, inner: RetrieveTransferBuilder::new() }
+    pub fn new(transfer: impl Into<stripe_shared::TransferId>) -> Self {
+        Self { transfer: transfer.into(), inner: RetrieveTransferBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveTransfer<'_> {
+impl RetrieveTransfer {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -166,40 +166,40 @@ impl RetrieveTransfer<'_> {
     }
 }
 
-impl StripeRequest for RetrieveTransfer<'_> {
+impl StripeRequest for RetrieveTransfer {
     type Output = stripe_shared::Transfer;
 
     fn build(&self) -> RequestBuilder {
-        let transfer = self.transfer;
+        let transfer = &self.transfer;
         RequestBuilder::new(StripeMethod::Get, format!("/transfers/{transfer}")).query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateTransferBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateTransferBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     amount: Option<i64>,
     currency: stripe_types::Currency,
     #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<&'a str>,
-    destination: &'a str,
+    description: Option<String>,
+    destination: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    source_transaction: Option<&'a str>,
+    source_transaction: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     source_type: Option<CreateTransferSourceType>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    transfer_group: Option<&'a str>,
+    transfer_group: Option<String>,
 }
-impl<'a> CreateTransferBuilder<'a> {
-    fn new(currency: stripe_types::Currency, destination: &'a str) -> Self {
+impl CreateTransferBuilder {
+    fn new(currency: impl Into<stripe_types::Currency>, destination: impl Into<String>) -> Self {
         Self {
             amount: None,
-            currency,
+            currency: currency.into(),
             description: None,
-            destination,
+            destination: destination.into(),
             expand: None,
             metadata: None,
             source_transaction: None,
@@ -271,59 +271,65 @@ impl<'de> serde::Deserialize<'de> for CreateTransferSourceType {
 /// To send funds from your Stripe account to a connected account, you create a new transfer object.
 /// Your [Stripe balance](https://stripe.com/docs/api#balance) must be able to cover the transfer amount, or you’ll receive an “Insufficient Funds” error.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateTransfer<'a> {
-    inner: CreateTransferBuilder<'a>,
+pub struct CreateTransfer {
+    inner: CreateTransferBuilder,
 }
-impl<'a> CreateTransfer<'a> {
+impl CreateTransfer {
     /// Construct a new `CreateTransfer`.
-    pub fn new(currency: stripe_types::Currency, destination: &'a str) -> Self {
-        Self { inner: CreateTransferBuilder::new(currency, destination) }
+    pub fn new(
+        currency: impl Into<stripe_types::Currency>,
+        destination: impl Into<String>,
+    ) -> Self {
+        Self { inner: CreateTransferBuilder::new(currency.into(), destination.into()) }
     }
     /// A positive integer in cents (or local equivalent) representing how much to transfer.
-    pub fn amount(mut self, amount: i64) -> Self {
-        self.inner.amount = Some(amount);
+    pub fn amount(mut self, amount: impl Into<i64>) -> Self {
+        self.inner.amount = Some(amount.into());
         self
     }
     /// An arbitrary string attached to the object. Often useful for displaying to users.
-    pub fn description(mut self, description: &'a str) -> Self {
-        self.inner.description = Some(description);
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.inner.description = Some(description.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// You can use this parameter to transfer funds from a charge before they are added to your available balance.
     /// A pending balance will transfer immediately but the funds will not become available until the original charge becomes available.
     /// [See the Connect documentation](https://stripe.com/docs/connect/separate-charges-and-transfers#transfer-availability) for details.
-    pub fn source_transaction(mut self, source_transaction: &'a str) -> Self {
-        self.inner.source_transaction = Some(source_transaction);
+    pub fn source_transaction(mut self, source_transaction: impl Into<String>) -> Self {
+        self.inner.source_transaction = Some(source_transaction.into());
         self
     }
     /// The source balance to use for this transfer.
     /// One of `bank_account`, `card`, or `fpx`.
     /// For most users, this will default to `card`.
-    pub fn source_type(mut self, source_type: CreateTransferSourceType) -> Self {
-        self.inner.source_type = Some(source_type);
+    pub fn source_type(mut self, source_type: impl Into<CreateTransferSourceType>) -> Self {
+        self.inner.source_type = Some(source_type.into());
         self
     }
     /// A string that identifies this transaction as part of a group.
     /// See the [Connect documentation](https://stripe.com/docs/connect/separate-charges-and-transfers#transfer-options) for details.
-    pub fn transfer_group(mut self, transfer_group: &'a str) -> Self {
-        self.inner.transfer_group = Some(transfer_group);
+    pub fn transfer_group(mut self, transfer_group: impl Into<String>) -> Self {
+        self.inner.transfer_group = Some(transfer_group.into());
         self
     }
 }
-impl CreateTransfer<'_> {
+impl CreateTransfer {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -341,23 +347,23 @@ impl CreateTransfer<'_> {
     }
 }
 
-impl StripeRequest for CreateTransfer<'_> {
+impl StripeRequest for CreateTransfer {
     type Output = stripe_shared::Transfer;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Post, "/transfers").form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdateTransferBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdateTransferBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<&'a str>,
+    description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
 }
-impl<'a> UpdateTransferBuilder<'a> {
+impl UpdateTransferBuilder {
     fn new() -> Self {
         Self { description: None, expand: None, metadata: None }
     }
@@ -367,35 +373,38 @@ impl<'a> UpdateTransferBuilder<'a> {
 ///
 /// This request accepts only metadata as an argument.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateTransfer<'a> {
-    inner: UpdateTransferBuilder<'a>,
-    transfer: &'a stripe_shared::TransferId,
+pub struct UpdateTransfer {
+    inner: UpdateTransferBuilder,
+    transfer: stripe_shared::TransferId,
 }
-impl<'a> UpdateTransfer<'a> {
+impl UpdateTransfer {
     /// Construct a new `UpdateTransfer`.
-    pub fn new(transfer: &'a stripe_shared::TransferId) -> Self {
-        Self { transfer, inner: UpdateTransferBuilder::new() }
+    pub fn new(transfer: impl Into<stripe_shared::TransferId>) -> Self {
+        Self { transfer: transfer.into(), inner: UpdateTransferBuilder::new() }
     }
     /// An arbitrary string attached to the object. Often useful for displaying to users.
-    pub fn description(mut self, description: &'a str) -> Self {
-        self.inner.description = Some(description);
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.inner.description = Some(description.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
 }
-impl UpdateTransfer<'_> {
+impl UpdateTransfer {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -413,11 +422,11 @@ impl UpdateTransfer<'_> {
     }
 }
 
-impl StripeRequest for UpdateTransfer<'_> {
+impl StripeRequest for UpdateTransfer {
     type Output = stripe_shared::Transfer;
 
     fn build(&self) -> RequestBuilder {
-        let transfer = self.transfer;
+        let transfer = &self.transfer;
         RequestBuilder::new(StripeMethod::Post, format!("/transfers/{transfer}")).form(&self.inner)
     }
 }

--- a/generated/async-stripe-connect/src/transfer_reversal/requests.rs
+++ b/generated/async-stripe-connect/src/transfer_reversal/requests.rs
@@ -2,18 +2,18 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListIdTransferReversalBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListIdTransferReversalBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListIdTransferReversalBuilder<'a> {
+impl ListIdTransferReversalBuilder {
     fn new() -> Self {
         Self { ending_before: None, expand: None, limit: None, starting_after: None }
     }
@@ -22,42 +22,42 @@ impl<'a> ListIdTransferReversalBuilder<'a> {
 /// Note that the 10 most recent reversals are always available by default on the transfer object.
 /// If you need more than those 10, you can use this API method and the `limit` and `starting_after` parameters to page through additional reversals.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListIdTransferReversal<'a> {
-    inner: ListIdTransferReversalBuilder<'a>,
-    id: &'a stripe_shared::TransferId,
+pub struct ListIdTransferReversal {
+    inner: ListIdTransferReversalBuilder,
+    id: stripe_shared::TransferId,
 }
-impl<'a> ListIdTransferReversal<'a> {
+impl ListIdTransferReversal {
     /// Construct a new `ListIdTransferReversal`.
-    pub fn new(id: &'a stripe_shared::TransferId) -> Self {
-        Self { id, inner: ListIdTransferReversalBuilder::new() }
+    pub fn new(id: impl Into<stripe_shared::TransferId>) -> Self {
+        Self { id: id.into(), inner: ListIdTransferReversalBuilder::new() }
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl ListIdTransferReversal<'_> {
+impl ListIdTransferReversal {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -78,53 +78,57 @@ impl ListIdTransferReversal<'_> {
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::TransferReversal>>
     {
-        let id = self.id;
+        let id = &self.id;
 
         stripe_client_core::ListPaginator::new_list(
             format!("/transfers/{id}/reversals"),
-            self.inner,
+            &self.inner,
         )
     }
 }
 
-impl StripeRequest for ListIdTransferReversal<'_> {
+impl StripeRequest for ListIdTransferReversal {
     type Output = stripe_types::List<stripe_shared::TransferReversal>;
 
     fn build(&self) -> RequestBuilder {
-        let id = self.id;
+        let id = &self.id;
         RequestBuilder::new(StripeMethod::Get, format!("/transfers/{id}/reversals"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveTransferReversalBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveTransferReversalBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveTransferReversalBuilder<'a> {
+impl RetrieveTransferReversalBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// By default, you can see the 10 most recent reversals stored directly on the transfer object, but you can also retrieve details about a specific reversal stored on the transfer.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveTransferReversal<'a> {
-    inner: RetrieveTransferReversalBuilder<'a>,
-    id: &'a str,
-    transfer: &'a stripe_shared::TransferId,
+pub struct RetrieveTransferReversal {
+    inner: RetrieveTransferReversalBuilder,
+    id: String,
+    transfer: stripe_shared::TransferId,
 }
-impl<'a> RetrieveTransferReversal<'a> {
+impl RetrieveTransferReversal {
     /// Construct a new `RetrieveTransferReversal`.
-    pub fn new(id: &'a str, transfer: &'a stripe_shared::TransferId) -> Self {
-        Self { id, transfer, inner: RetrieveTransferReversalBuilder::new() }
+    pub fn new(id: impl Into<String>, transfer: impl Into<stripe_shared::TransferId>) -> Self {
+        Self {
+            id: id.into(),
+            transfer: transfer.into(),
+            inner: RetrieveTransferReversalBuilder::new(),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveTransferReversal<'_> {
+impl RetrieveTransferReversal {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -142,30 +146,30 @@ impl RetrieveTransferReversal<'_> {
     }
 }
 
-impl StripeRequest for RetrieveTransferReversal<'_> {
+impl StripeRequest for RetrieveTransferReversal {
     type Output = stripe_shared::TransferReversal;
 
     fn build(&self) -> RequestBuilder {
-        let id = self.id;
-        let transfer = self.transfer;
+        let id = &self.id;
+        let transfer = &self.transfer;
         RequestBuilder::new(StripeMethod::Get, format!("/transfers/{transfer}/reversals/{id}"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateIdTransferReversalBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateIdTransferReversalBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     amount: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<&'a str>,
+    description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     refund_application_fee: Option<bool>,
 }
-impl<'a> CreateIdTransferReversalBuilder<'a> {
+impl CreateIdTransferReversalBuilder {
     fn new() -> Self {
         Self {
             amount: None,
@@ -184,52 +188,55 @@ impl<'a> CreateIdTransferReversalBuilder<'a> {
 /// Once entirely reversed, a transfer can’t be reversed again.
 /// This method will return an error when called on an already-reversed transfer, or when trying to reverse more money than is left on a transfer.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateIdTransferReversal<'a> {
-    inner: CreateIdTransferReversalBuilder<'a>,
-    id: &'a stripe_shared::TransferId,
+pub struct CreateIdTransferReversal {
+    inner: CreateIdTransferReversalBuilder,
+    id: stripe_shared::TransferId,
 }
-impl<'a> CreateIdTransferReversal<'a> {
+impl CreateIdTransferReversal {
     /// Construct a new `CreateIdTransferReversal`.
-    pub fn new(id: &'a stripe_shared::TransferId) -> Self {
-        Self { id, inner: CreateIdTransferReversalBuilder::new() }
+    pub fn new(id: impl Into<stripe_shared::TransferId>) -> Self {
+        Self { id: id.into(), inner: CreateIdTransferReversalBuilder::new() }
     }
     /// A positive integer in cents (or local equivalent) representing how much of this transfer to reverse.
     /// Can only reverse up to the unreversed amount remaining of the transfer.
     /// Partial transfer reversals are only allowed for transfers to Stripe Accounts.
     /// Defaults to the entire transfer amount.
-    pub fn amount(mut self, amount: i64) -> Self {
-        self.inner.amount = Some(amount);
+    pub fn amount(mut self, amount: impl Into<i64>) -> Self {
+        self.inner.amount = Some(amount.into());
         self
     }
     /// An arbitrary string which you can attach to a reversal object.
     /// It is displayed alongside the reversal in the Dashboard.
     /// This will be unset if you POST an empty value.
-    pub fn description(mut self, description: &'a str) -> Self {
-        self.inner.description = Some(description);
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.inner.description = Some(description.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// Boolean indicating whether the application fee should be refunded when reversing this transfer.
     /// If a full transfer reversal is given, the full application fee will be refunded.
     /// Otherwise, the application fee will be refunded with an amount proportional to the amount of the transfer reversed.
-    pub fn refund_application_fee(mut self, refund_application_fee: bool) -> Self {
-        self.inner.refund_application_fee = Some(refund_application_fee);
+    pub fn refund_application_fee(mut self, refund_application_fee: impl Into<bool>) -> Self {
+        self.inner.refund_application_fee = Some(refund_application_fee.into());
         self
     }
 }
-impl CreateIdTransferReversal<'_> {
+impl CreateIdTransferReversal {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -247,23 +254,23 @@ impl CreateIdTransferReversal<'_> {
     }
 }
 
-impl StripeRequest for CreateIdTransferReversal<'_> {
+impl StripeRequest for CreateIdTransferReversal {
     type Output = stripe_shared::TransferReversal;
 
     fn build(&self) -> RequestBuilder {
-        let id = self.id;
+        let id = &self.id;
         RequestBuilder::new(StripeMethod::Post, format!("/transfers/{id}/reversals"))
             .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdateTransferReversalBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdateTransferReversalBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
 }
-impl<'a> UpdateTransferReversalBuilder<'a> {
+impl UpdateTransferReversalBuilder {
     fn new() -> Self {
         Self { expand: None, metadata: None }
     }
@@ -273,31 +280,38 @@ impl<'a> UpdateTransferReversalBuilder<'a> {
 ///
 /// This request only accepts metadata and description as arguments.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateTransferReversal<'a> {
-    inner: UpdateTransferReversalBuilder<'a>,
-    id: &'a str,
-    transfer: &'a stripe_shared::TransferId,
+pub struct UpdateTransferReversal {
+    inner: UpdateTransferReversalBuilder,
+    id: String,
+    transfer: stripe_shared::TransferId,
 }
-impl<'a> UpdateTransferReversal<'a> {
+impl UpdateTransferReversal {
     /// Construct a new `UpdateTransferReversal`.
-    pub fn new(id: &'a str, transfer: &'a stripe_shared::TransferId) -> Self {
-        Self { id, transfer, inner: UpdateTransferReversalBuilder::new() }
+    pub fn new(id: impl Into<String>, transfer: impl Into<stripe_shared::TransferId>) -> Self {
+        Self {
+            id: id.into(),
+            transfer: transfer.into(),
+            inner: UpdateTransferReversalBuilder::new(),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
 }
-impl UpdateTransferReversal<'_> {
+impl UpdateTransferReversal {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -315,12 +329,12 @@ impl UpdateTransferReversal<'_> {
     }
 }
 
-impl StripeRequest for UpdateTransferReversal<'_> {
+impl StripeRequest for UpdateTransferReversal {
     type Output = stripe_shared::TransferReversal;
 
     fn build(&self) -> RequestBuilder {
-        let id = self.id;
-        let transfer = self.transfer;
+        let id = &self.id;
+        let transfer = &self.transfer;
         RequestBuilder::new(StripeMethod::Post, format!("/transfers/{transfer}/reversals/{id}"))
             .form(&self.inner)
     }

--- a/generated/async-stripe-core/src/balance/requests.rs
+++ b/generated/async-stripe-core/src/balance/requests.rs
@@ -2,12 +2,12 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveForMyAccountBalanceBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveForMyAccountBalanceBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveForMyAccountBalanceBuilder<'a> {
+impl RetrieveForMyAccountBalanceBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
@@ -15,26 +15,26 @@ impl<'a> RetrieveForMyAccountBalanceBuilder<'a> {
 /// Retrieves the current account balance, based on the authentication that was used to make the request.
 /// For a sample request, see [Accounting for negative balances](https://stripe.com/docs/connect/account-balances#accounting-for-negative-balances).
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveForMyAccountBalance<'a> {
-    inner: RetrieveForMyAccountBalanceBuilder<'a>,
+pub struct RetrieveForMyAccountBalance {
+    inner: RetrieveForMyAccountBalanceBuilder,
 }
-impl<'a> RetrieveForMyAccountBalance<'a> {
+impl RetrieveForMyAccountBalance {
     /// Construct a new `RetrieveForMyAccountBalance`.
     pub fn new() -> Self {
         Self { inner: RetrieveForMyAccountBalanceBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl<'a> Default for RetrieveForMyAccountBalance<'a> {
+impl Default for RetrieveForMyAccountBalance {
     fn default() -> Self {
         Self::new()
     }
 }
-impl RetrieveForMyAccountBalance<'_> {
+impl RetrieveForMyAccountBalance {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -52,7 +52,7 @@ impl RetrieveForMyAccountBalance<'_> {
     }
 }
 
-impl StripeRequest for RetrieveForMyAccountBalance<'_> {
+impl StripeRequest for RetrieveForMyAccountBalance {
     type Output = stripe_core::Balance;
 
     fn build(&self) -> RequestBuilder {

--- a/generated/async-stripe-core/src/balance_transaction/requests.rs
+++ b/generated/async-stripe-core/src/balance_transaction/requests.rs
@@ -2,29 +2,29 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListBalanceTransactionBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListBalanceTransactionBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     created: Option<stripe_types::RangeQueryTs>,
     #[serde(skip_serializing_if = "Option::is_none")]
     currency: Option<stripe_types::Currency>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payout: Option<&'a str>,
+    payout: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    source: Option<&'a str>,
+    source: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
     #[serde(rename = "type")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    type_: Option<&'a str>,
+    type_: Option<String>,
 }
-impl<'a> ListBalanceTransactionBuilder<'a> {
+impl ListBalanceTransactionBuilder {
     fn new() -> Self {
         Self {
             created: None,
@@ -44,74 +44,74 @@ impl<'a> ListBalanceTransactionBuilder<'a> {
 ///
 /// Note that this endpoint was previously called “Balance history” and used the path `/v1/balance/history`.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListBalanceTransaction<'a> {
-    inner: ListBalanceTransactionBuilder<'a>,
+pub struct ListBalanceTransaction {
+    inner: ListBalanceTransactionBuilder,
 }
-impl<'a> ListBalanceTransaction<'a> {
+impl ListBalanceTransaction {
     /// Construct a new `ListBalanceTransaction`.
     pub fn new() -> Self {
         Self { inner: ListBalanceTransactionBuilder::new() }
     }
     /// Only return transactions that were created during the given date interval.
-    pub fn created(mut self, created: stripe_types::RangeQueryTs) -> Self {
-        self.inner.created = Some(created);
+    pub fn created(mut self, created: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.created = Some(created.into());
         self
     }
     /// Only return transactions in a certain currency.
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     /// Must be a [supported currency](https://stripe.com/docs/currencies).
-    pub fn currency(mut self, currency: stripe_types::Currency) -> Self {
-        self.inner.currency = Some(currency);
+    pub fn currency(mut self, currency: impl Into<stripe_types::Currency>) -> Self {
+        self.inner.currency = Some(currency.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// For automatic Stripe payouts only, only returns transactions that were paid out on the specified payout ID.
-    pub fn payout(mut self, payout: &'a str) -> Self {
-        self.inner.payout = Some(payout);
+    pub fn payout(mut self, payout: impl Into<String>) -> Self {
+        self.inner.payout = Some(payout.into());
         self
     }
     /// Only returns the original transaction.
-    pub fn source(mut self, source: &'a str) -> Self {
-        self.inner.source = Some(source);
+    pub fn source(mut self, source: impl Into<String>) -> Self {
+        self.inner.source = Some(source.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
     /// Only returns transactions of the given type.
     /// One of: `adjustment`, `advance`, `advance_funding`, `anticipation_repayment`, `application_fee`, `application_fee_refund`, `charge`, `climate_order_purchase`, `climate_order_refund`, `connect_collection_transfer`, `contribution`, `issuing_authorization_hold`, `issuing_authorization_release`, `issuing_dispute`, `issuing_transaction`, `obligation_outbound`, `obligation_reversal_inbound`, `payment`, `payment_failure_refund`, `payment_network_reserve_hold`, `payment_network_reserve_release`, `payment_refund`, `payment_reversal`, `payment_unreconciled`, `payout`, `payout_cancel`, `payout_failure`, `refund`, `refund_failure`, `reserve_transaction`, `reserved_funds`, `stripe_fee`, `stripe_fx_fee`, `tax_fee`, `topup`, `topup_reversal`, `transfer`, `transfer_cancel`, `transfer_failure`, or `transfer_refund`.
-    pub fn type_(mut self, type_: &'a str) -> Self {
-        self.inner.type_ = Some(type_);
+    pub fn type_(mut self, type_: impl Into<String>) -> Self {
+        self.inner.type_ = Some(type_.into());
         self
     }
 }
-impl<'a> Default for ListBalanceTransaction<'a> {
+impl Default for ListBalanceTransaction {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListBalanceTransaction<'_> {
+impl ListBalanceTransaction {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -132,23 +132,23 @@ impl ListBalanceTransaction<'_> {
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::BalanceTransaction>>
     {
-        stripe_client_core::ListPaginator::new_list("/balance_transactions", self.inner)
+        stripe_client_core::ListPaginator::new_list("/balance_transactions", &self.inner)
     }
 }
 
-impl StripeRequest for ListBalanceTransaction<'_> {
+impl StripeRequest for ListBalanceTransaction {
     type Output = stripe_types::List<stripe_shared::BalanceTransaction>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/balance_transactions").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveBalanceTransactionBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveBalanceTransactionBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveBalanceTransactionBuilder<'a> {
+impl RetrieveBalanceTransactionBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
@@ -157,22 +157,22 @@ impl<'a> RetrieveBalanceTransactionBuilder<'a> {
 ///
 /// Note that this endpoint previously used the path `/v1/balance/history/:id`.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveBalanceTransaction<'a> {
-    inner: RetrieveBalanceTransactionBuilder<'a>,
-    id: &'a stripe_shared::BalanceTransactionId,
+pub struct RetrieveBalanceTransaction {
+    inner: RetrieveBalanceTransactionBuilder,
+    id: stripe_shared::BalanceTransactionId,
 }
-impl<'a> RetrieveBalanceTransaction<'a> {
+impl RetrieveBalanceTransaction {
     /// Construct a new `RetrieveBalanceTransaction`.
-    pub fn new(id: &'a stripe_shared::BalanceTransactionId) -> Self {
-        Self { id, inner: RetrieveBalanceTransactionBuilder::new() }
+    pub fn new(id: impl Into<stripe_shared::BalanceTransactionId>) -> Self {
+        Self { id: id.into(), inner: RetrieveBalanceTransactionBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveBalanceTransaction<'_> {
+impl RetrieveBalanceTransaction {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -190,11 +190,11 @@ impl RetrieveBalanceTransaction<'_> {
     }
 }
 
-impl StripeRequest for RetrieveBalanceTransaction<'_> {
+impl StripeRequest for RetrieveBalanceTransaction {
     type Output = stripe_shared::BalanceTransaction;
 
     fn build(&self) -> RequestBuilder {
-        let id = self.id;
+        let id = &self.id;
         RequestBuilder::new(StripeMethod::Get, format!("/balance_transactions/{id}"))
             .query(&self.inner)
     }

--- a/generated/async-stripe-core/src/cash_balance/requests.rs
+++ b/generated/async-stripe-core/src/cash_balance/requests.rs
@@ -2,34 +2,34 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveCashBalanceBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveCashBalanceBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveCashBalanceBuilder<'a> {
+impl RetrieveCashBalanceBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves a customer’s cash balance.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveCashBalance<'a> {
-    inner: RetrieveCashBalanceBuilder<'a>,
-    customer: &'a stripe_shared::CustomerId,
+pub struct RetrieveCashBalance {
+    inner: RetrieveCashBalanceBuilder,
+    customer: stripe_shared::CustomerId,
 }
-impl<'a> RetrieveCashBalance<'a> {
+impl RetrieveCashBalance {
     /// Construct a new `RetrieveCashBalance`.
-    pub fn new(customer: &'a stripe_shared::CustomerId) -> Self {
-        Self { customer, inner: RetrieveCashBalanceBuilder::new() }
+    pub fn new(customer: impl Into<stripe_shared::CustomerId>) -> Self {
+        Self { customer: customer.into(), inner: RetrieveCashBalanceBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveCashBalance<'_> {
+impl RetrieveCashBalance {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -47,23 +47,23 @@ impl RetrieveCashBalance<'_> {
     }
 }
 
-impl StripeRequest for RetrieveCashBalance<'_> {
+impl StripeRequest for RetrieveCashBalance {
     type Output = stripe_shared::CashBalance;
 
     fn build(&self) -> RequestBuilder {
-        let customer = self.customer;
+        let customer = &self.customer;
         RequestBuilder::new(StripeMethod::Get, format!("/customers/{customer}/cash_balance"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdateCashBalanceBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdateCashBalanceBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     settings: Option<UpdateCashBalanceSettings>,
 }
-impl<'a> UpdateCashBalanceBuilder<'a> {
+impl UpdateCashBalanceBuilder {
     fn new() -> Self {
         Self { expand: None, settings: None }
     }
@@ -152,27 +152,27 @@ impl<'de> serde::Deserialize<'de> for UpdateCashBalanceSettingsReconciliationMod
 }
 /// Changes the settings on a customer’s cash balance.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateCashBalance<'a> {
-    inner: UpdateCashBalanceBuilder<'a>,
-    customer: &'a stripe_shared::CustomerId,
+pub struct UpdateCashBalance {
+    inner: UpdateCashBalanceBuilder,
+    customer: stripe_shared::CustomerId,
 }
-impl<'a> UpdateCashBalance<'a> {
+impl UpdateCashBalance {
     /// Construct a new `UpdateCashBalance`.
-    pub fn new(customer: &'a stripe_shared::CustomerId) -> Self {
-        Self { customer, inner: UpdateCashBalanceBuilder::new() }
+    pub fn new(customer: impl Into<stripe_shared::CustomerId>) -> Self {
+        Self { customer: customer.into(), inner: UpdateCashBalanceBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A hash of settings for this cash balance.
-    pub fn settings(mut self, settings: UpdateCashBalanceSettings) -> Self {
-        self.inner.settings = Some(settings);
+    pub fn settings(mut self, settings: impl Into<UpdateCashBalanceSettings>) -> Self {
+        self.inner.settings = Some(settings.into());
         self
     }
 }
-impl UpdateCashBalance<'_> {
+impl UpdateCashBalance {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -190,11 +190,11 @@ impl UpdateCashBalance<'_> {
     }
 }
 
-impl StripeRequest for UpdateCashBalance<'_> {
+impl StripeRequest for UpdateCashBalance {
     type Output = stripe_shared::CashBalance;
 
     fn build(&self) -> RequestBuilder {
-        let customer = self.customer;
+        let customer = &self.customer;
         RequestBuilder::new(StripeMethod::Post, format!("/customers/{customer}/cash_balance"))
             .form(&self.inner)
     }

--- a/generated/async-stripe-core/src/charge/requests.rs
+++ b/generated/async-stripe-core/src/charge/requests.rs
@@ -2,26 +2,26 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListChargeBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListChargeBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     created: Option<stripe_types::RangeQueryTs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    customer: Option<&'a str>,
+    customer: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_intent: Option<&'a str>,
+    payment_intent: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    transfer_group: Option<&'a str>,
+    transfer_group: Option<String>,
 }
-impl<'a> ListChargeBuilder<'a> {
+impl ListChargeBuilder {
     fn new() -> Self {
         Self {
             created: None,
@@ -38,66 +38,66 @@ impl<'a> ListChargeBuilder<'a> {
 /// Returns a list of charges you’ve previously created.
 /// The charges are returned in sorted order, with the most recent charges appearing first.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListCharge<'a> {
-    inner: ListChargeBuilder<'a>,
+pub struct ListCharge {
+    inner: ListChargeBuilder,
 }
-impl<'a> ListCharge<'a> {
+impl ListCharge {
     /// Construct a new `ListCharge`.
     pub fn new() -> Self {
         Self { inner: ListChargeBuilder::new() }
     }
     /// Only return charges that were created during the given date interval.
-    pub fn created(mut self, created: stripe_types::RangeQueryTs) -> Self {
-        self.inner.created = Some(created);
+    pub fn created(mut self, created: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.created = Some(created.into());
         self
     }
     /// Only return charges for the customer specified by this customer ID.
-    pub fn customer(mut self, customer: &'a str) -> Self {
-        self.inner.customer = Some(customer);
+    pub fn customer(mut self, customer: impl Into<String>) -> Self {
+        self.inner.customer = Some(customer.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// Only return charges that were created by the PaymentIntent specified by this PaymentIntent ID.
-    pub fn payment_intent(mut self, payment_intent: &'a str) -> Self {
-        self.inner.payment_intent = Some(payment_intent);
+    pub fn payment_intent(mut self, payment_intent: impl Into<String>) -> Self {
+        self.inner.payment_intent = Some(payment_intent.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
     /// Only return charges for this transfer group.
-    pub fn transfer_group(mut self, transfer_group: &'a str) -> Self {
-        self.inner.transfer_group = Some(transfer_group);
+    pub fn transfer_group(mut self, transfer_group: impl Into<String>) -> Self {
+        self.inner.transfer_group = Some(transfer_group.into());
         self
     }
 }
-impl<'a> Default for ListCharge<'a> {
+impl Default for ListCharge {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListCharge<'_> {
+impl ListCharge {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -117,23 +117,23 @@ impl ListCharge<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::Charge>> {
-        stripe_client_core::ListPaginator::new_list("/charges", self.inner)
+        stripe_client_core::ListPaginator::new_list("/charges", &self.inner)
     }
 }
 
-impl StripeRequest for ListCharge<'_> {
+impl StripeRequest for ListCharge {
     type Output = stripe_types::List<stripe_shared::Charge>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/charges").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveChargeBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveChargeBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveChargeBuilder<'a> {
+impl RetrieveChargeBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
@@ -142,22 +142,22 @@ impl<'a> RetrieveChargeBuilder<'a> {
 /// Supply the unique charge ID that was returned from your previous request, and Stripe will return the corresponding charge information.
 /// The same information is returned when creating or refunding the charge.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveCharge<'a> {
-    inner: RetrieveChargeBuilder<'a>,
-    charge: &'a stripe_shared::ChargeId,
+pub struct RetrieveCharge {
+    inner: RetrieveChargeBuilder,
+    charge: stripe_shared::ChargeId,
 }
-impl<'a> RetrieveCharge<'a> {
+impl RetrieveCharge {
     /// Construct a new `RetrieveCharge`.
-    pub fn new(charge: &'a stripe_shared::ChargeId) -> Self {
-        Self { charge, inner: RetrieveChargeBuilder::new() }
+    pub fn new(charge: impl Into<stripe_shared::ChargeId>) -> Self {
+        Self { charge: charge.into(), inner: RetrieveChargeBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveCharge<'_> {
+impl RetrieveCharge {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -175,27 +175,27 @@ impl RetrieveCharge<'_> {
     }
 }
 
-impl StripeRequest for RetrieveCharge<'_> {
+impl StripeRequest for RetrieveCharge {
     type Output = stripe_shared::Charge;
 
     fn build(&self) -> RequestBuilder {
-        let charge = self.charge;
+        let charge = &self.charge;
         RequestBuilder::new(StripeMethod::Get, format!("/charges/{charge}")).query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct SearchChargeBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct SearchChargeBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    page: Option<&'a str>,
-    query: &'a str,
+    page: Option<String>,
+    query: String,
 }
-impl<'a> SearchChargeBuilder<'a> {
-    fn new(query: &'a str) -> Self {
-        Self { expand: None, limit: None, page: None, query }
+impl SearchChargeBuilder {
+    fn new(query: impl Into<String>) -> Self {
+        Self { expand: None, limit: None, page: None, query: query.into() }
     }
 }
 /// Search for charges you’ve previously created using Stripe’s [Search Query Language](https://stripe.com/docs/search#search-query-language).
@@ -205,34 +205,34 @@ impl<'a> SearchChargeBuilder<'a> {
 /// Occasionally, propagation of new or updated data can be up.
 /// to an hour behind during outages. Search functionality is not available to merchants in India.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct SearchCharge<'a> {
-    inner: SearchChargeBuilder<'a>,
+pub struct SearchCharge {
+    inner: SearchChargeBuilder,
 }
-impl<'a> SearchCharge<'a> {
+impl SearchCharge {
     /// Construct a new `SearchCharge`.
-    pub fn new(query: &'a str) -> Self {
-        Self { inner: SearchChargeBuilder::new(query) }
+    pub fn new(query: impl Into<String>) -> Self {
+        Self { inner: SearchChargeBuilder::new(query.into()) }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for pagination across multiple pages of results.
     /// Don't include this parameter on the first call.
     /// Use the next_page value returned in a previous response to request subsequent results.
-    pub fn page(mut self, page: &'a str) -> Self {
-        self.inner.page = Some(page);
+    pub fn page(mut self, page: impl Into<String>) -> Self {
+        self.inner.page = Some(page.into());
         self
     }
 }
-impl SearchCharge<'_> {
+impl SearchCharge {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -252,19 +252,19 @@ impl SearchCharge<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::SearchList<stripe_shared::Charge>> {
-        stripe_client_core::ListPaginator::new_search_list("/charges/search", self.inner)
+        stripe_client_core::ListPaginator::new_search_list("/charges/search", &self.inner)
     }
 }
 
-impl StripeRequest for SearchCharge<'_> {
+impl StripeRequest for SearchCharge {
     type Output = stripe_types::SearchList<stripe_shared::Charge>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/charges/search").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateChargeBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateChargeBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     amount: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -276,35 +276,35 @@ struct CreateChargeBuilder<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     currency: Option<stripe_types::Currency>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    customer: Option<&'a str>,
+    customer: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<&'a str>,
+    description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    destination: Option<CreateChargeDestination<'a>>,
+    destination: Option<CreateChargeDestination>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    on_behalf_of: Option<&'a str>,
+    on_behalf_of: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    radar_options: Option<CreateChargeRadarOptions<'a>>,
+    radar_options: Option<CreateChargeRadarOptions>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    receipt_email: Option<&'a str>,
+    receipt_email: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    shipping: Option<OptionalFieldsShipping<'a>>,
+    shipping: Option<OptionalFieldsShipping>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    source: Option<&'a str>,
+    source: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    statement_descriptor: Option<&'a str>,
+    statement_descriptor: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    statement_descriptor_suffix: Option<&'a str>,
+    statement_descriptor_suffix: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    transfer_data: Option<CreateChargeTransferData<'a>>,
+    transfer_data: Option<CreateChargeTransferData>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    transfer_group: Option<&'a str>,
+    transfer_group: Option<String>,
 }
-impl<'a> CreateChargeBuilder<'a> {
+impl CreateChargeBuilder {
     fn new() -> Self {
         Self {
             amount: None,
@@ -329,63 +329,63 @@ impl<'a> CreateChargeBuilder<'a> {
         }
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateChargeDestination<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateChargeDestination {
     /// ID of an existing, connected Stripe account.
-    pub account: &'a str,
+    pub account: String,
     /// The amount to transfer to the destination account without creating an `Application Fee` object.
     /// Cannot be combined with the `application_fee` parameter.
     /// Must be less than or equal to the charge amount.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub amount: Option<i64>,
 }
-impl<'a> CreateChargeDestination<'a> {
-    pub fn new(account: &'a str) -> Self {
-        Self { account, amount: None }
+impl CreateChargeDestination {
+    pub fn new(account: impl Into<String>) -> Self {
+        Self { account: account.into(), amount: None }
     }
 }
 /// Options to configure Radar.
 /// See [Radar Session](https://stripe.com/docs/radar/radar-session) for more information.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateChargeRadarOptions<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateChargeRadarOptions {
     /// A [Radar Session](https://stripe.com/docs/radar/radar-session) is a snapshot of the browser metadata and device details that help Radar make more accurate predictions on your payments.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub session: Option<&'a str>,
+    pub session: Option<String>,
 }
-impl<'a> CreateChargeRadarOptions<'a> {
+impl CreateChargeRadarOptions {
     pub fn new() -> Self {
         Self { session: None }
     }
 }
-impl<'a> Default for CreateChargeRadarOptions<'a> {
+impl Default for CreateChargeRadarOptions {
     fn default() -> Self {
         Self::new()
     }
 }
 /// An optional dictionary including the account to automatically transfer to as part of a destination charge.
 /// [See the Connect documentation](https://stripe.com/docs/connect/destination-charges) for details.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateChargeTransferData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateChargeTransferData {
     /// The amount transferred to the destination account, if specified.
     /// By default, the entire charge amount is transferred to the destination account.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub amount: Option<i64>,
     /// ID of an existing, connected Stripe account.
-    pub destination: &'a str,
+    pub destination: String,
 }
-impl<'a> CreateChargeTransferData<'a> {
-    pub fn new(destination: &'a str) -> Self {
-        Self { amount: None, destination }
+impl CreateChargeTransferData {
+    pub fn new(destination: impl Into<String>) -> Self {
+        Self { amount: None, destination: destination.into() }
     }
 }
 /// This method is no longer recommended—use the [Payment Intents API](https://stripe.com/docs/api/payment_intents).
 /// to initiate a new payment instead. Confirmation of the PaymentIntent creates the `Charge`
 /// object used to request payment.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateCharge<'a> {
-    inner: CreateChargeBuilder<'a>,
+pub struct CreateCharge {
+    inner: CreateChargeBuilder,
 }
-impl<'a> CreateCharge<'a> {
+impl CreateCharge {
     /// Construct a new `CreateCharge`.
     pub fn new() -> Self {
         Self { inner: CreateChargeBuilder::new() }
@@ -394,19 +394,19 @@ impl<'a> CreateCharge<'a> {
     /// A positive integer representing how much to charge in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal) (e.g., 100 cents to charge $1.00 or 100 to charge ¥100, a zero-decimal currency).
     /// The minimum amount is $0.50 US or [equivalent in charge currency](https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts).
     /// The amount value supports up to eight digits (e.g., a value of 99999999 for a USD charge of $999,999.99).
-    pub fn amount(mut self, amount: i64) -> Self {
-        self.inner.amount = Some(amount);
+    pub fn amount(mut self, amount: impl Into<i64>) -> Self {
+        self.inner.amount = Some(amount.into());
         self
     }
-    pub fn application_fee(mut self, application_fee: i64) -> Self {
-        self.inner.application_fee = Some(application_fee);
+    pub fn application_fee(mut self, application_fee: impl Into<i64>) -> Self {
+        self.inner.application_fee = Some(application_fee.into());
         self
     }
     /// A fee in cents (or local equivalent) that will be applied to the charge and transferred to the application owner's Stripe account.
     /// The request must be made with an OAuth key or the `Stripe-Account` header in order to take an application fee.
     /// For more information, see the application fees [documentation](https://stripe.com/docs/connect/direct-charges#collect-fees).
-    pub fn application_fee_amount(mut self, application_fee_amount: i64) -> Self {
-        self.inner.application_fee_amount = Some(application_fee_amount);
+    pub fn application_fee_amount(mut self, application_fee_amount: impl Into<i64>) -> Self {
+        self.inner.application_fee_amount = Some(application_fee_amount.into());
         self
     }
     /// Whether to immediately capture the charge.
@@ -414,111 +414,117 @@ impl<'a> CreateCharge<'a> {
     /// When `false`, the charge issues an authorization (or pre-authorization), and will need to be [captured](https://stripe.com/docs/api#capture_charge) later.
     /// Uncaptured charges expire after a set number of days (7 by default).
     /// For more information, see the [authorizing charges and settling later](https://stripe.com/docs/charges/placing-a-hold) documentation.
-    pub fn capture(mut self, capture: bool) -> Self {
-        self.inner.capture = Some(capture);
+    pub fn capture(mut self, capture: impl Into<bool>) -> Self {
+        self.inner.capture = Some(capture.into());
         self
     }
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     /// Must be a [supported currency](https://stripe.com/docs/currencies).
-    pub fn currency(mut self, currency: stripe_types::Currency) -> Self {
-        self.inner.currency = Some(currency);
+    pub fn currency(mut self, currency: impl Into<stripe_types::Currency>) -> Self {
+        self.inner.currency = Some(currency.into());
         self
     }
     /// The ID of an existing customer that will be charged in this request.
-    pub fn customer(mut self, customer: &'a str) -> Self {
-        self.inner.customer = Some(customer);
+    pub fn customer(mut self, customer: impl Into<String>) -> Self {
+        self.inner.customer = Some(customer.into());
         self
     }
     /// An arbitrary string which you can attach to a `Charge` object.
     /// It is displayed when in the web interface alongside the charge.
     /// Note that if you use Stripe to send automatic email receipts to your customers, your receipt emails will include the `description` of the charge(s) that they are describing.
-    pub fn description(mut self, description: &'a str) -> Self {
-        self.inner.description = Some(description);
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.inner.description = Some(description.into());
         self
     }
-    pub fn destination(mut self, destination: CreateChargeDestination<'a>) -> Self {
-        self.inner.destination = Some(destination);
+    pub fn destination(mut self, destination: impl Into<CreateChargeDestination>) -> Self {
+        self.inner.destination = Some(destination.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// The Stripe account ID for which these funds are intended.
     /// Automatically set if you use the `destination` parameter.
     /// For details, see [Creating Separate Charges and Transfers](https://stripe.com/docs/connect/separate-charges-and-transfers#settlement-merchant).
-    pub fn on_behalf_of(mut self, on_behalf_of: &'a str) -> Self {
-        self.inner.on_behalf_of = Some(on_behalf_of);
+    pub fn on_behalf_of(mut self, on_behalf_of: impl Into<String>) -> Self {
+        self.inner.on_behalf_of = Some(on_behalf_of.into());
         self
     }
     /// Options to configure Radar.
     /// See [Radar Session](https://stripe.com/docs/radar/radar-session) for more information.
-    pub fn radar_options(mut self, radar_options: CreateChargeRadarOptions<'a>) -> Self {
-        self.inner.radar_options = Some(radar_options);
+    pub fn radar_options(mut self, radar_options: impl Into<CreateChargeRadarOptions>) -> Self {
+        self.inner.radar_options = Some(radar_options.into());
         self
     }
     /// The email address to which this charge's [receipt](https://stripe.com/docs/dashboard/receipts) will be sent.
     /// The receipt will not be sent until the charge is paid, and no receipts will be sent for test mode charges.
     /// If this charge is for a [Customer](https://stripe.com/docs/api/customers/object), the email address specified here will override the customer's email address.
     /// If `receipt_email` is specified for a charge in live mode, a receipt will be sent regardless of your [email settings](https://dashboard.stripe.com/account/emails).
-    pub fn receipt_email(mut self, receipt_email: &'a str) -> Self {
-        self.inner.receipt_email = Some(receipt_email);
+    pub fn receipt_email(mut self, receipt_email: impl Into<String>) -> Self {
+        self.inner.receipt_email = Some(receipt_email.into());
         self
     }
     /// Shipping information for the charge. Helps prevent fraud on charges for physical goods.
-    pub fn shipping(mut self, shipping: OptionalFieldsShipping<'a>) -> Self {
-        self.inner.shipping = Some(shipping);
+    pub fn shipping(mut self, shipping: impl Into<OptionalFieldsShipping>) -> Self {
+        self.inner.shipping = Some(shipping.into());
         self
     }
     /// A payment source to be charged.
     /// This can be the ID of a [card](https://stripe.com/docs/api#cards) (i.e., credit or debit card), a [bank account](https://stripe.com/docs/api#bank_accounts), a [source](https://stripe.com/docs/api#sources), a [token](https://stripe.com/docs/api#tokens), or a [connected account](https://stripe.com/docs/connect/account-debits#charging-a-connected-account).
     /// For certain sources---namely, [cards](https://stripe.com/docs/api#cards), [bank accounts](https://stripe.com/docs/api#bank_accounts), and attached [sources](https://stripe.com/docs/api#sources)---you must also pass the ID of the associated customer.
-    pub fn source(mut self, source: &'a str) -> Self {
-        self.inner.source = Some(source);
+    pub fn source(mut self, source: impl Into<String>) -> Self {
+        self.inner.source = Some(source.into());
         self
     }
     /// For card charges, use `statement_descriptor_suffix` instead.
     /// Otherwise, you can use this value as the complete description of a charge on your customers’ statements.
     /// Must contain at least one letter, maximum 22 characters.
-    pub fn statement_descriptor(mut self, statement_descriptor: &'a str) -> Self {
-        self.inner.statement_descriptor = Some(statement_descriptor);
+    pub fn statement_descriptor(mut self, statement_descriptor: impl Into<String>) -> Self {
+        self.inner.statement_descriptor = Some(statement_descriptor.into());
         self
     }
     /// Provides information about the charge that customers see on their statements.
     /// Concatenated with the prefix (shortened descriptor) or statement descriptor that’s set on the account to form the complete statement descriptor.
     /// Maximum 22 characters for the concatenated descriptor.
-    pub fn statement_descriptor_suffix(mut self, statement_descriptor_suffix: &'a str) -> Self {
-        self.inner.statement_descriptor_suffix = Some(statement_descriptor_suffix);
+    pub fn statement_descriptor_suffix(
+        mut self,
+        statement_descriptor_suffix: impl Into<String>,
+    ) -> Self {
+        self.inner.statement_descriptor_suffix = Some(statement_descriptor_suffix.into());
         self
     }
     /// An optional dictionary including the account to automatically transfer to as part of a destination charge.
     /// [See the Connect documentation](https://stripe.com/docs/connect/destination-charges) for details.
-    pub fn transfer_data(mut self, transfer_data: CreateChargeTransferData<'a>) -> Self {
-        self.inner.transfer_data = Some(transfer_data);
+    pub fn transfer_data(mut self, transfer_data: impl Into<CreateChargeTransferData>) -> Self {
+        self.inner.transfer_data = Some(transfer_data.into());
         self
     }
     /// A string that identifies this transaction as part of a group.
     /// For details, see [Grouping transactions](https://stripe.com/docs/connect/separate-charges-and-transfers#transfer-options).
-    pub fn transfer_group(mut self, transfer_group: &'a str) -> Self {
-        self.inner.transfer_group = Some(transfer_group);
+    pub fn transfer_group(mut self, transfer_group: impl Into<String>) -> Self {
+        self.inner.transfer_group = Some(transfer_group.into());
         self
     }
 }
-impl<'a> Default for CreateCharge<'a> {
+impl Default for CreateCharge {
     fn default() -> Self {
         Self::new()
     }
 }
-impl CreateCharge<'_> {
+impl CreateCharge {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -536,33 +542,33 @@ impl CreateCharge<'_> {
     }
 }
 
-impl StripeRequest for CreateCharge<'_> {
+impl StripeRequest for CreateCharge {
     type Output = stripe_shared::Charge;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Post, "/charges").form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdateChargeBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdateChargeBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    customer: Option<&'a str>,
+    customer: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<&'a str>,
+    description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     fraud_details: Option<UpdateChargeFraudDetails>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    receipt_email: Option<&'a str>,
+    receipt_email: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    shipping: Option<OptionalFieldsShipping<'a>>,
+    shipping: Option<OptionalFieldsShipping>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    transfer_group: Option<&'a str>,
+    transfer_group: Option<String>,
 }
-impl<'a> UpdateChargeBuilder<'a> {
+impl UpdateChargeBuilder {
     fn new() -> Self {
         Self {
             customer: None,
@@ -586,8 +592,8 @@ pub struct UpdateChargeFraudDetails {
     pub user_report: UpdateChargeFraudDetailsUserReport,
 }
 impl UpdateChargeFraudDetails {
-    pub fn new(user_report: UpdateChargeFraudDetailsUserReport) -> Self {
-        Self { user_report }
+    pub fn new(user_report: impl Into<UpdateChargeFraudDetailsUserReport>) -> Self {
+        Self { user_report: user_report.into() }
     }
 }
 /// Either `safe` or `fraudulent`.
@@ -649,69 +655,72 @@ impl<'de> serde::Deserialize<'de> for UpdateChargeFraudDetailsUserReport {
 /// Updates the specified charge by setting the values of the parameters passed.
 /// Any parameters not provided will be left unchanged.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateCharge<'a> {
-    inner: UpdateChargeBuilder<'a>,
-    charge: &'a stripe_shared::ChargeId,
+pub struct UpdateCharge {
+    inner: UpdateChargeBuilder,
+    charge: stripe_shared::ChargeId,
 }
-impl<'a> UpdateCharge<'a> {
+impl UpdateCharge {
     /// Construct a new `UpdateCharge`.
-    pub fn new(charge: &'a stripe_shared::ChargeId) -> Self {
-        Self { charge, inner: UpdateChargeBuilder::new() }
+    pub fn new(charge: impl Into<stripe_shared::ChargeId>) -> Self {
+        Self { charge: charge.into(), inner: UpdateChargeBuilder::new() }
     }
     /// The ID of an existing customer that will be associated with this request.
     /// This field may only be updated if there is no existing associated customer with this charge.
-    pub fn customer(mut self, customer: &'a str) -> Self {
-        self.inner.customer = Some(customer);
+    pub fn customer(mut self, customer: impl Into<String>) -> Self {
+        self.inner.customer = Some(customer.into());
         self
     }
     /// An arbitrary string which you can attach to a charge object.
     /// It is displayed when in the web interface alongside the charge.
     /// Note that if you use Stripe to send automatic email receipts to your customers, your receipt emails will include the `description` of the charge(s) that they are describing.
-    pub fn description(mut self, description: &'a str) -> Self {
-        self.inner.description = Some(description);
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.inner.description = Some(description.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A set of key-value pairs you can attach to a charge giving information about its riskiness.
     /// If you believe a charge is fraudulent, include a `user_report` key with a value of `fraudulent`.
     /// If you believe a charge is safe, include a `user_report` key with a value of `safe`.
     /// Stripe will use the information you send to improve our fraud detection algorithms.
-    pub fn fraud_details(mut self, fraud_details: UpdateChargeFraudDetails) -> Self {
-        self.inner.fraud_details = Some(fraud_details);
+    pub fn fraud_details(mut self, fraud_details: impl Into<UpdateChargeFraudDetails>) -> Self {
+        self.inner.fraud_details = Some(fraud_details.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// This is the email address that the receipt for this charge will be sent to.
     /// If this field is updated, then a new email receipt will be sent to the updated address.
-    pub fn receipt_email(mut self, receipt_email: &'a str) -> Self {
-        self.inner.receipt_email = Some(receipt_email);
+    pub fn receipt_email(mut self, receipt_email: impl Into<String>) -> Self {
+        self.inner.receipt_email = Some(receipt_email.into());
         self
     }
     /// Shipping information for the charge. Helps prevent fraud on charges for physical goods.
-    pub fn shipping(mut self, shipping: OptionalFieldsShipping<'a>) -> Self {
-        self.inner.shipping = Some(shipping);
+    pub fn shipping(mut self, shipping: impl Into<OptionalFieldsShipping>) -> Self {
+        self.inner.shipping = Some(shipping.into());
         self
     }
     /// A string that identifies this transaction as part of a group.
     /// `transfer_group` may only be provided if it has not been set.
     /// See the [Connect documentation](https://stripe.com/docs/connect/separate-charges-and-transfers#transfer-options) for details.
-    pub fn transfer_group(mut self, transfer_group: &'a str) -> Self {
-        self.inner.transfer_group = Some(transfer_group);
+    pub fn transfer_group(mut self, transfer_group: impl Into<String>) -> Self {
+        self.inner.transfer_group = Some(transfer_group.into());
         self
     }
 }
-impl UpdateCharge<'_> {
+impl UpdateCharge {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -729,16 +738,16 @@ impl UpdateCharge<'_> {
     }
 }
 
-impl StripeRequest for UpdateCharge<'_> {
+impl StripeRequest for UpdateCharge {
     type Output = stripe_shared::Charge;
 
     fn build(&self) -> RequestBuilder {
-        let charge = self.charge;
+        let charge = &self.charge;
         RequestBuilder::new(StripeMethod::Post, format!("/charges/{charge}")).form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CaptureChargeBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CaptureChargeBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     amount: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -746,19 +755,19 @@ struct CaptureChargeBuilder<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     application_fee_amount: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    receipt_email: Option<&'a str>,
+    receipt_email: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    statement_descriptor: Option<&'a str>,
+    statement_descriptor: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    statement_descriptor_suffix: Option<&'a str>,
+    statement_descriptor_suffix: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     transfer_data: Option<CaptureChargeTransferData>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    transfer_group: Option<&'a str>,
+    transfer_group: Option<String>,
 }
-impl<'a> CaptureChargeBuilder<'a> {
+impl CaptureChargeBuilder {
     fn new() -> Self {
         Self {
             amount: None,
@@ -799,72 +808,75 @@ impl Default for CaptureChargeTransferData {
 /// Don’t use this method to capture a PaymentIntent-initiated charge.
 /// Use [Capture a PaymentIntent](https://stripe.com/docs/api/payment_intents/capture).
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CaptureCharge<'a> {
-    inner: CaptureChargeBuilder<'a>,
-    charge: &'a stripe_shared::ChargeId,
+pub struct CaptureCharge {
+    inner: CaptureChargeBuilder,
+    charge: stripe_shared::ChargeId,
 }
-impl<'a> CaptureCharge<'a> {
+impl CaptureCharge {
     /// Construct a new `CaptureCharge`.
-    pub fn new(charge: &'a stripe_shared::ChargeId) -> Self {
-        Self { charge, inner: CaptureChargeBuilder::new() }
+    pub fn new(charge: impl Into<stripe_shared::ChargeId>) -> Self {
+        Self { charge: charge.into(), inner: CaptureChargeBuilder::new() }
     }
     /// The amount to capture, which must be less than or equal to the original amount.
     /// Any additional amount will be automatically refunded.
-    pub fn amount(mut self, amount: i64) -> Self {
-        self.inner.amount = Some(amount);
+    pub fn amount(mut self, amount: impl Into<i64>) -> Self {
+        self.inner.amount = Some(amount.into());
         self
     }
     /// An application fee to add on to this charge.
-    pub fn application_fee(mut self, application_fee: i64) -> Self {
-        self.inner.application_fee = Some(application_fee);
+    pub fn application_fee(mut self, application_fee: impl Into<i64>) -> Self {
+        self.inner.application_fee = Some(application_fee.into());
         self
     }
     /// An application fee amount to add on to this charge, which must be less than or equal to the original amount.
-    pub fn application_fee_amount(mut self, application_fee_amount: i64) -> Self {
-        self.inner.application_fee_amount = Some(application_fee_amount);
+    pub fn application_fee_amount(mut self, application_fee_amount: impl Into<i64>) -> Self {
+        self.inner.application_fee_amount = Some(application_fee_amount.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// The email address to send this charge's receipt to.
     /// This will override the previously-specified email address for this charge, if one was set.
     /// Receipts will not be sent in test mode.
-    pub fn receipt_email(mut self, receipt_email: &'a str) -> Self {
-        self.inner.receipt_email = Some(receipt_email);
+    pub fn receipt_email(mut self, receipt_email: impl Into<String>) -> Self {
+        self.inner.receipt_email = Some(receipt_email.into());
         self
     }
     /// For card charges, use `statement_descriptor_suffix` instead.
     /// Otherwise, you can use this value as the complete description of a charge on your customers’ statements.
     /// Must contain at least one letter, maximum 22 characters.
-    pub fn statement_descriptor(mut self, statement_descriptor: &'a str) -> Self {
-        self.inner.statement_descriptor = Some(statement_descriptor);
+    pub fn statement_descriptor(mut self, statement_descriptor: impl Into<String>) -> Self {
+        self.inner.statement_descriptor = Some(statement_descriptor.into());
         self
     }
     /// Provides information about the charge that customers see on their statements.
     /// Concatenated with the prefix (shortened descriptor) or statement descriptor that’s set on the account to form the complete statement descriptor.
     /// Maximum 22 characters for the concatenated descriptor.
-    pub fn statement_descriptor_suffix(mut self, statement_descriptor_suffix: &'a str) -> Self {
-        self.inner.statement_descriptor_suffix = Some(statement_descriptor_suffix);
+    pub fn statement_descriptor_suffix(
+        mut self,
+        statement_descriptor_suffix: impl Into<String>,
+    ) -> Self {
+        self.inner.statement_descriptor_suffix = Some(statement_descriptor_suffix.into());
         self
     }
     /// An optional dictionary including the account to automatically transfer to as part of a destination charge.
     /// [See the Connect documentation](https://stripe.com/docs/connect/destination-charges) for details.
-    pub fn transfer_data(mut self, transfer_data: CaptureChargeTransferData) -> Self {
-        self.inner.transfer_data = Some(transfer_data);
+    pub fn transfer_data(mut self, transfer_data: impl Into<CaptureChargeTransferData>) -> Self {
+        self.inner.transfer_data = Some(transfer_data.into());
         self
     }
     /// A string that identifies this transaction as part of a group.
     /// `transfer_group` may only be provided if it has not been set.
     /// See the [Connect documentation](https://stripe.com/docs/connect/separate-charges-and-transfers#transfer-options) for details.
-    pub fn transfer_group(mut self, transfer_group: &'a str) -> Self {
-        self.inner.transfer_group = Some(transfer_group);
+    pub fn transfer_group(mut self, transfer_group: impl Into<String>) -> Self {
+        self.inner.transfer_group = Some(transfer_group.into());
         self
     }
 }
-impl CaptureCharge<'_> {
+impl CaptureCharge {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -882,66 +894,72 @@ impl CaptureCharge<'_> {
     }
 }
 
-impl StripeRequest for CaptureCharge<'_> {
+impl StripeRequest for CaptureCharge {
     type Output = stripe_shared::Charge;
 
     fn build(&self) -> RequestBuilder {
-        let charge = self.charge;
+        let charge = &self.charge;
         RequestBuilder::new(StripeMethod::Post, format!("/charges/{charge}/capture"))
             .form(&self.inner)
     }
 }
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct OptionalFieldsAddress<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct OptionalFieldsAddress {
     /// City, district, suburb, town, or village.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<&'a str>,
+    pub city: Option<String>,
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub country: Option<&'a str>,
+    pub country: Option<String>,
     /// Address line 1 (e.g., street, PO Box, or company name).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line1: Option<&'a str>,
+    pub line1: Option<String>,
     /// Address line 2 (e.g., apartment, suite, unit, or building).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line2: Option<&'a str>,
+    pub line2: Option<String>,
     /// ZIP or postal code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<&'a str>,
+    pub postal_code: Option<String>,
     /// State, county, province, or region.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
 }
-impl<'a> OptionalFieldsAddress<'a> {
+impl OptionalFieldsAddress {
     pub fn new() -> Self {
         Self { city: None, country: None, line1: None, line2: None, postal_code: None, state: None }
     }
 }
-impl<'a> Default for OptionalFieldsAddress<'a> {
+impl Default for OptionalFieldsAddress {
     fn default() -> Self {
         Self::new()
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct OptionalFieldsShipping<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct OptionalFieldsShipping {
     /// Shipping address.
-    pub address: OptionalFieldsAddress<'a>,
+    pub address: OptionalFieldsAddress,
     /// The delivery service that shipped a physical product, such as Fedex, UPS, USPS, etc.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub carrier: Option<&'a str>,
+    pub carrier: Option<String>,
     /// Recipient name.
-    pub name: &'a str,
+    pub name: String,
     /// Recipient phone (including extension).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub phone: Option<&'a str>,
+    pub phone: Option<String>,
     /// The tracking number for a physical product, obtained from the delivery service.
     /// If multiple tracking numbers were generated for this purchase, please separate them with commas.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tracking_number: Option<&'a str>,
+    pub tracking_number: Option<String>,
 }
-impl<'a> OptionalFieldsShipping<'a> {
-    pub fn new(address: OptionalFieldsAddress<'a>, name: &'a str) -> Self {
-        Self { address, carrier: None, name, phone: None, tracking_number: None }
+impl OptionalFieldsShipping {
+    pub fn new(address: impl Into<OptionalFieldsAddress>, name: impl Into<String>) -> Self {
+        Self {
+            address: address.into(),
+            carrier: None,
+            name: name.into(),
+            phone: None,
+            tracking_number: None,
+        }
     }
 }

--- a/generated/async-stripe-core/src/customer/requests.rs
+++ b/generated/async-stripe-core/src/customer/requests.rs
@@ -6,16 +6,16 @@ use stripe_client_core::{
 /// It cannot be undone.
 /// Also immediately cancels any active subscriptions on the customer.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct DeleteCustomer<'a> {
-    customer: &'a stripe_shared::CustomerId,
+pub struct DeleteCustomer {
+    customer: stripe_shared::CustomerId,
 }
-impl<'a> DeleteCustomer<'a> {
+impl DeleteCustomer {
     /// Construct a new `DeleteCustomer`.
-    pub fn new(customer: &'a stripe_shared::CustomerId) -> Self {
-        Self { customer }
+    pub fn new(customer: impl Into<stripe_shared::CustomerId>) -> Self {
+        Self { customer: customer.into() }
     }
 }
-impl DeleteCustomer<'_> {
+impl DeleteCustomer {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -33,26 +33,26 @@ impl DeleteCustomer<'_> {
     }
 }
 
-impl StripeRequest for DeleteCustomer<'_> {
+impl StripeRequest for DeleteCustomer {
     type Output = stripe_shared::DeletedCustomer;
 
     fn build(&self) -> RequestBuilder {
-        let customer = self.customer;
+        let customer = &self.customer;
         RequestBuilder::new(StripeMethod::Delete, format!("/customers/{customer}"))
     }
 }
 /// Removes the currently applied discount on a customer.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct DeleteDiscountCustomer<'a> {
-    customer: &'a stripe_shared::CustomerId,
+pub struct DeleteDiscountCustomer {
+    customer: stripe_shared::CustomerId,
 }
-impl<'a> DeleteDiscountCustomer<'a> {
+impl DeleteDiscountCustomer {
     /// Construct a new `DeleteDiscountCustomer`.
-    pub fn new(customer: &'a stripe_shared::CustomerId) -> Self {
-        Self { customer }
+    pub fn new(customer: impl Into<stripe_shared::CustomerId>) -> Self {
+        Self { customer: customer.into() }
     }
 }
-impl DeleteDiscountCustomer<'_> {
+impl DeleteDiscountCustomer {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -70,32 +70,32 @@ impl DeleteDiscountCustomer<'_> {
     }
 }
 
-impl StripeRequest for DeleteDiscountCustomer<'_> {
+impl StripeRequest for DeleteDiscountCustomer {
     type Output = stripe_shared::DeletedDiscount;
 
     fn build(&self) -> RequestBuilder {
-        let customer = self.customer;
+        let customer = &self.customer;
         RequestBuilder::new(StripeMethod::Delete, format!("/customers/{customer}/discount"))
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListCustomerBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListCustomerBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     created: Option<stripe_types::RangeQueryTs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    email: Option<&'a str>,
+    email: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    test_clock: Option<&'a str>,
+    test_clock: Option<String>,
 }
-impl<'a> ListCustomerBuilder<'a> {
+impl ListCustomerBuilder {
     fn new() -> Self {
         Self {
             created: None,
@@ -111,63 +111,63 @@ impl<'a> ListCustomerBuilder<'a> {
 /// Returns a list of your customers.
 /// The customers are returned sorted by creation date, with the most recent customers appearing first.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListCustomer<'a> {
-    inner: ListCustomerBuilder<'a>,
+pub struct ListCustomer {
+    inner: ListCustomerBuilder,
 }
-impl<'a> ListCustomer<'a> {
+impl ListCustomer {
     /// Construct a new `ListCustomer`.
     pub fn new() -> Self {
         Self { inner: ListCustomerBuilder::new() }
     }
     /// Only return customers that were created during the given date interval.
-    pub fn created(mut self, created: stripe_types::RangeQueryTs) -> Self {
-        self.inner.created = Some(created);
+    pub fn created(mut self, created: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.created = Some(created.into());
         self
     }
     /// A case-sensitive filter on the list based on the customer's `email` field.
     /// The value must be a string.
-    pub fn email(mut self, email: &'a str) -> Self {
-        self.inner.email = Some(email);
+    pub fn email(mut self, email: impl Into<String>) -> Self {
+        self.inner.email = Some(email.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
     /// Provides a list of customers that are associated with the specified test clock.
     /// The response will not include customers with test clocks if this parameter is not set.
-    pub fn test_clock(mut self, test_clock: &'a str) -> Self {
-        self.inner.test_clock = Some(test_clock);
+    pub fn test_clock(mut self, test_clock: impl Into<String>) -> Self {
+        self.inner.test_clock = Some(test_clock.into());
         self
     }
 }
-impl<'a> Default for ListCustomer<'a> {
+impl Default for ListCustomer {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListCustomer<'_> {
+impl ListCustomer {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -187,45 +187,45 @@ impl ListCustomer<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::Customer>> {
-        stripe_client_core::ListPaginator::new_list("/customers", self.inner)
+        stripe_client_core::ListPaginator::new_list("/customers", &self.inner)
     }
 }
 
-impl StripeRequest for ListCustomer<'_> {
+impl StripeRequest for ListCustomer {
     type Output = stripe_types::List<stripe_shared::Customer>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/customers").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveCustomerBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveCustomerBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveCustomerBuilder<'a> {
+impl RetrieveCustomerBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves a Customer object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveCustomer<'a> {
-    inner: RetrieveCustomerBuilder<'a>,
-    customer: &'a stripe_shared::CustomerId,
+pub struct RetrieveCustomer {
+    inner: RetrieveCustomerBuilder,
+    customer: stripe_shared::CustomerId,
 }
-impl<'a> RetrieveCustomer<'a> {
+impl RetrieveCustomer {
     /// Construct a new `RetrieveCustomer`.
-    pub fn new(customer: &'a stripe_shared::CustomerId) -> Self {
-        Self { customer, inner: RetrieveCustomerBuilder::new() }
+    pub fn new(customer: impl Into<stripe_shared::CustomerId>) -> Self {
+        Self { customer: customer.into(), inner: RetrieveCustomerBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveCustomer<'_> {
+impl RetrieveCustomer {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -243,11 +243,11 @@ impl RetrieveCustomer<'_> {
     }
 }
 
-impl StripeRequest for RetrieveCustomer<'_> {
+impl StripeRequest for RetrieveCustomer {
     type Output = RetrieveCustomerReturned;
 
     fn build(&self) -> RequestBuilder {
-        let customer = self.customer;
+        let customer = &self.customer;
         RequestBuilder::new(StripeMethod::Get, format!("/customers/{customer}")).query(&self.inner)
     }
 }
@@ -331,60 +331,60 @@ const _: () = {
     }
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct BalanceTransactionsCustomerBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct BalanceTransactionsCustomerBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> BalanceTransactionsCustomerBuilder<'a> {
+impl BalanceTransactionsCustomerBuilder {
     fn new() -> Self {
         Self { ending_before: None, expand: None, limit: None, starting_after: None }
     }
 }
 /// Returns a list of transactions that updated the customer’s [balances](https://stripe.com/docs/billing/customer/balance).
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct BalanceTransactionsCustomer<'a> {
-    inner: BalanceTransactionsCustomerBuilder<'a>,
-    customer: &'a stripe_shared::CustomerId,
+pub struct BalanceTransactionsCustomer {
+    inner: BalanceTransactionsCustomerBuilder,
+    customer: stripe_shared::CustomerId,
 }
-impl<'a> BalanceTransactionsCustomer<'a> {
+impl BalanceTransactionsCustomer {
     /// Construct a new `BalanceTransactionsCustomer`.
-    pub fn new(customer: &'a stripe_shared::CustomerId) -> Self {
-        Self { customer, inner: BalanceTransactionsCustomerBuilder::new() }
+    pub fn new(customer: impl Into<stripe_shared::CustomerId>) -> Self {
+        Self { customer: customer.into(), inner: BalanceTransactionsCustomerBuilder::new() }
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl BalanceTransactionsCustomer<'_> {
+impl BalanceTransactionsCustomer {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -406,20 +406,20 @@ impl BalanceTransactionsCustomer<'_> {
     ) -> stripe_client_core::ListPaginator<
         stripe_types::List<stripe_shared::CustomerBalanceTransaction>,
     > {
-        let customer = self.customer;
+        let customer = &self.customer;
 
         stripe_client_core::ListPaginator::new_list(
             format!("/customers/{customer}/balance_transactions"),
-            self.inner,
+            &self.inner,
         )
     }
 }
 
-impl StripeRequest for BalanceTransactionsCustomer<'_> {
+impl StripeRequest for BalanceTransactionsCustomer {
     type Output = stripe_types::List<stripe_shared::CustomerBalanceTransaction>;
 
     fn build(&self) -> RequestBuilder {
-        let customer = self.customer;
+        let customer = &self.customer;
         RequestBuilder::new(
             StripeMethod::Get,
             format!("/customers/{customer}/balance_transactions"),
@@ -427,23 +427,23 @@ impl StripeRequest for BalanceTransactionsCustomer<'_> {
         .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListPaymentMethodsCustomerBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListPaymentMethodsCustomerBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     allow_redisplay: Option<ListPaymentMethodsCustomerAllowRedisplay>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
     #[serde(rename = "type")]
     #[serde(skip_serializing_if = "Option::is_none")]
     type_: Option<ListPaymentMethodsCustomerType>,
 }
-impl<'a> ListPaymentMethodsCustomerBuilder<'a> {
+impl ListPaymentMethodsCustomerBuilder {
     fn new() -> Self {
         Self {
             allow_redisplay: None,
@@ -677,59 +677,59 @@ impl<'de> serde::Deserialize<'de> for ListPaymentMethodsCustomerType {
 }
 /// Returns a list of PaymentMethods for a given Customer
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListPaymentMethodsCustomer<'a> {
-    inner: ListPaymentMethodsCustomerBuilder<'a>,
-    customer: &'a stripe_shared::CustomerId,
+pub struct ListPaymentMethodsCustomer {
+    inner: ListPaymentMethodsCustomerBuilder,
+    customer: stripe_shared::CustomerId,
 }
-impl<'a> ListPaymentMethodsCustomer<'a> {
+impl ListPaymentMethodsCustomer {
     /// Construct a new `ListPaymentMethodsCustomer`.
-    pub fn new(customer: &'a stripe_shared::CustomerId) -> Self {
-        Self { customer, inner: ListPaymentMethodsCustomerBuilder::new() }
+    pub fn new(customer: impl Into<stripe_shared::CustomerId>) -> Self {
+        Self { customer: customer.into(), inner: ListPaymentMethodsCustomerBuilder::new() }
     }
     /// This field indicates whether this payment method can be shown again to its customer in a checkout flow.
     /// Stripe products such as Checkout and Elements use this field to determine whether a payment method can be shown as a saved payment method in a checkout flow.
     /// The field defaults to `unspecified`.
     pub fn allow_redisplay(
         mut self,
-        allow_redisplay: ListPaymentMethodsCustomerAllowRedisplay,
+        allow_redisplay: impl Into<ListPaymentMethodsCustomerAllowRedisplay>,
     ) -> Self {
-        self.inner.allow_redisplay = Some(allow_redisplay);
+        self.inner.allow_redisplay = Some(allow_redisplay.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
     /// An optional filter on the list, based on the object `type` field.
     /// Without the filter, the list includes all current and future payment method types.
     /// If your integration expects only one type of payment method in the response, make sure to provide a type value in the request.
-    pub fn type_(mut self, type_: ListPaymentMethodsCustomerType) -> Self {
-        self.inner.type_ = Some(type_);
+    pub fn type_(mut self, type_: impl Into<ListPaymentMethodsCustomerType>) -> Self {
+        self.inner.type_ = Some(type_.into());
         self
     }
 }
-impl ListPaymentMethodsCustomer<'_> {
+impl ListPaymentMethodsCustomer {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -749,53 +749,60 @@ impl ListPaymentMethodsCustomer<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::PaymentMethod>> {
-        let customer = self.customer;
+        let customer = &self.customer;
 
         stripe_client_core::ListPaginator::new_list(
             format!("/customers/{customer}/payment_methods"),
-            self.inner,
+            &self.inner,
         )
     }
 }
 
-impl StripeRequest for ListPaymentMethodsCustomer<'_> {
+impl StripeRequest for ListPaymentMethodsCustomer {
     type Output = stripe_types::List<stripe_shared::PaymentMethod>;
 
     fn build(&self) -> RequestBuilder {
-        let customer = self.customer;
+        let customer = &self.customer;
         RequestBuilder::new(StripeMethod::Get, format!("/customers/{customer}/payment_methods"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrievePaymentMethodCustomerBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrievePaymentMethodCustomerBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrievePaymentMethodCustomerBuilder<'a> {
+impl RetrievePaymentMethodCustomerBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves a PaymentMethod object for a given Customer.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrievePaymentMethodCustomer<'a> {
-    inner: RetrievePaymentMethodCustomerBuilder<'a>,
-    customer: &'a stripe_shared::CustomerId,
-    payment_method: &'a str,
+pub struct RetrievePaymentMethodCustomer {
+    inner: RetrievePaymentMethodCustomerBuilder,
+    customer: stripe_shared::CustomerId,
+    payment_method: String,
 }
-impl<'a> RetrievePaymentMethodCustomer<'a> {
+impl RetrievePaymentMethodCustomer {
     /// Construct a new `RetrievePaymentMethodCustomer`.
-    pub fn new(customer: &'a stripe_shared::CustomerId, payment_method: &'a str) -> Self {
-        Self { customer, payment_method, inner: RetrievePaymentMethodCustomerBuilder::new() }
+    pub fn new(
+        customer: impl Into<stripe_shared::CustomerId>,
+        payment_method: impl Into<String>,
+    ) -> Self {
+        Self {
+            customer: customer.into(),
+            payment_method: payment_method.into(),
+            inner: RetrievePaymentMethodCustomerBuilder::new(),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrievePaymentMethodCustomer<'_> {
+impl RetrievePaymentMethodCustomer {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -813,12 +820,12 @@ impl RetrievePaymentMethodCustomer<'_> {
     }
 }
 
-impl StripeRequest for RetrievePaymentMethodCustomer<'_> {
+impl StripeRequest for RetrievePaymentMethodCustomer {
     type Output = stripe_shared::PaymentMethod;
 
     fn build(&self) -> RequestBuilder {
-        let customer = self.customer;
-        let payment_method = self.payment_method;
+        let customer = &self.customer;
+        let payment_method = &self.payment_method;
         RequestBuilder::new(
             StripeMethod::Get,
             format!("/customers/{customer}/payment_methods/{payment_method}"),
@@ -826,19 +833,19 @@ impl StripeRequest for RetrievePaymentMethodCustomer<'_> {
         .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct SearchCustomerBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct SearchCustomerBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    page: Option<&'a str>,
-    query: &'a str,
+    page: Option<String>,
+    query: String,
 }
-impl<'a> SearchCustomerBuilder<'a> {
-    fn new(query: &'a str) -> Self {
-        Self { expand: None, limit: None, page: None, query }
+impl SearchCustomerBuilder {
+    fn new(query: impl Into<String>) -> Self {
+        Self { expand: None, limit: None, page: None, query: query.into() }
     }
 }
 /// Search for customers you’ve previously created using Stripe’s [Search Query Language](https://stripe.com/docs/search#search-query-language).
@@ -848,34 +855,34 @@ impl<'a> SearchCustomerBuilder<'a> {
 /// Occasionally, propagation of new or updated data can be up.
 /// to an hour behind during outages. Search functionality is not available to merchants in India.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct SearchCustomer<'a> {
-    inner: SearchCustomerBuilder<'a>,
+pub struct SearchCustomer {
+    inner: SearchCustomerBuilder,
 }
-impl<'a> SearchCustomer<'a> {
+impl SearchCustomer {
     /// Construct a new `SearchCustomer`.
-    pub fn new(query: &'a str) -> Self {
-        Self { inner: SearchCustomerBuilder::new(query) }
+    pub fn new(query: impl Into<String>) -> Self {
+        Self { inner: SearchCustomerBuilder::new(query.into()) }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for pagination across multiple pages of results.
     /// Don't include this parameter on the first call.
     /// Use the next_page value returned in a previous response to request subsequent results.
-    pub fn page(mut self, page: &'a str) -> Self {
-        self.inner.page = Some(page);
+    pub fn page(mut self, page: impl Into<String>) -> Self {
+        self.inner.page = Some(page.into());
         self
     }
 }
-impl SearchCustomer<'_> {
+impl SearchCustomer {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -895,67 +902,67 @@ impl SearchCustomer<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::SearchList<stripe_shared::Customer>> {
-        stripe_client_core::ListPaginator::new_search_list("/customers/search", self.inner)
+        stripe_client_core::ListPaginator::new_search_list("/customers/search", &self.inner)
     }
 }
 
-impl StripeRequest for SearchCustomer<'_> {
+impl StripeRequest for SearchCustomer {
     type Output = stripe_types::SearchList<stripe_shared::Customer>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/customers/search").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateCustomerBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateCustomerBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    address: Option<OptionalFieldsAddress<'a>>,
+    address: Option<OptionalFieldsAddress>,
     #[serde(skip_serializing_if = "Option::is_none")]
     balance: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     cash_balance: Option<CreateCustomerCashBalance>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    coupon: Option<&'a str>,
+    coupon: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<&'a str>,
+    description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    email: Option<&'a str>,
+    email: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    invoice_prefix: Option<&'a str>,
+    invoice_prefix: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    invoice_settings: Option<CreateCustomerInvoiceSettings<'a>>,
+    invoice_settings: Option<CreateCustomerInvoiceSettings>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    name: Option<&'a str>,
+    name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     next_invoice_sequence: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_method: Option<&'a str>,
+    payment_method: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    phone: Option<&'a str>,
+    phone: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    preferred_locales: Option<&'a [&'a str]>,
+    preferred_locales: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    promotion_code: Option<&'a str>,
+    promotion_code: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    shipping: Option<CustomerShipping<'a>>,
+    shipping: Option<CustomerShipping>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    source: Option<&'a str>,
+    source: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    tax: Option<CreateCustomerTax<'a>>,
+    tax: Option<CreateCustomerTax>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tax_exempt: Option<stripe_shared::CustomerTaxExempt>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    tax_id_data: Option<&'a [CreateCustomerTaxIdData<'a>]>,
+    tax_id_data: Option<Vec<CreateCustomerTaxIdData>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    test_clock: Option<&'a str>,
+    test_clock: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     validate: Option<bool>,
 }
-impl<'a> CreateCustomerBuilder<'a> {
+impl CreateCustomerBuilder {
     fn new() -> Self {
         Self {
             address: None,
@@ -1086,23 +1093,23 @@ impl<'de> serde::Deserialize<'de> for CreateCustomerCashBalanceSettingsReconcili
     }
 }
 /// Default invoice settings for this customer.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateCustomerInvoiceSettings<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateCustomerInvoiceSettings {
     /// The list of up to 4 default custom fields to be displayed on invoices for this customer.
     /// When updating, pass an empty string to remove previously-defined fields.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub custom_fields: Option<&'a [CustomFieldParams<'a>]>,
+    pub custom_fields: Option<Vec<CustomFieldParams>>,
     /// ID of a payment method that's attached to the customer, to be used as the customer's default payment method for subscriptions and invoices.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub default_payment_method: Option<&'a str>,
+    pub default_payment_method: Option<String>,
     /// Default footer to be displayed on invoices for this customer.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub footer: Option<&'a str>,
+    pub footer: Option<String>,
     /// Default options for invoice PDF rendering for this customer.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rendering_options: Option<CreateCustomerInvoiceSettingsRenderingOptions>,
 }
-impl<'a> CreateCustomerInvoiceSettings<'a> {
+impl CreateCustomerInvoiceSettings {
     pub fn new() -> Self {
         Self {
             custom_fields: None,
@@ -1112,7 +1119,7 @@ impl<'a> CreateCustomerInvoiceSettings<'a> {
         }
     }
 }
-impl<'a> Default for CreateCustomerInvoiceSettings<'a> {
+impl Default for CreateCustomerInvoiceSettings {
     fn default() -> Self {
         Self::new()
     }
@@ -1201,24 +1208,24 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// Tax details about the customer.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateCustomerTax<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateCustomerTax {
     /// A recent IP address of the customer used for tax reporting and tax location inference.
     /// Stripe recommends updating the IP address when a new PaymentMethod is attached or the address field on the customer is updated.
     /// We recommend against updating this field more frequently since it could result in unexpected tax location/reporting outcomes.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ip_address: Option<&'a str>,
+    pub ip_address: Option<String>,
     /// A flag that indicates when Stripe should validate the customer tax location.
     /// Defaults to `deferred`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub validate_location: Option<CreateCustomerTaxValidateLocation>,
 }
-impl<'a> CreateCustomerTax<'a> {
+impl CreateCustomerTax {
     pub fn new() -> Self {
         Self { ip_address: None, validate_location: None }
     }
 }
-impl<'a> Default for CreateCustomerTax<'a> {
+impl Default for CreateCustomerTax {
     fn default() -> Self {
         Self::new()
     }
@@ -1281,17 +1288,17 @@ impl<'de> serde::Deserialize<'de> for CreateCustomerTaxValidateLocation {
     }
 }
 /// The customer's tax IDs.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateCustomerTaxIdData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateCustomerTaxIdData {
     /// Type of the tax ID, one of `ad_nrt`, `ae_trn`, `ar_cuit`, `au_abn`, `au_arn`, `bg_uic`, `bh_vat`, `bo_tin`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `cn_tin`, `co_nit`, `cr_tin`, `do_rcn`, `ec_ruc`, `eg_tin`, `es_cif`, `eu_oss_vat`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `hu_tin`, `id_npwp`, `il_vat`, `in_gst`, `is_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `ke_pin`, `kr_brn`, `kz_bin`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `ng_tin`, `no_vat`, `no_voec`, `nz_gst`, `om_vat`, `pe_ruc`, `ph_tin`, `ro_tin`, `rs_pib`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `si_tin`, `sv_nit`, `th_vat`, `tr_tin`, `tw_vat`, `ua_vat`, `us_ein`, `uy_ruc`, `ve_rif`, `vn_tin`, or `za_vat`.
     #[serde(rename = "type")]
     pub type_: CreateCustomerTaxIdDataType,
     /// Value of the tax ID.
-    pub value: &'a str,
+    pub value: String,
 }
-impl<'a> CreateCustomerTaxIdData<'a> {
-    pub fn new(type_: CreateCustomerTaxIdDataType, value: &'a str) -> Self {
-        Self { type_, value }
+impl CreateCustomerTaxIdData {
+    pub fn new(type_: impl Into<CreateCustomerTaxIdDataType>, value: impl Into<String>) -> Self {
+        Self { type_: type_.into(), value: value.into() }
     }
 }
 /// Type of the tax ID, one of `ad_nrt`, `ae_trn`, `ar_cuit`, `au_abn`, `au_arn`, `bg_uic`, `bh_vat`, `bo_tin`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `cn_tin`, `co_nit`, `cr_tin`, `do_rcn`, `ec_ruc`, `eg_tin`, `es_cif`, `eu_oss_vat`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `hu_tin`, `id_npwp`, `il_vat`, `in_gst`, `is_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `ke_pin`, `kr_brn`, `kz_bin`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `ng_tin`, `no_vat`, `no_voec`, `nz_gst`, `om_vat`, `pe_ruc`, `ph_tin`, `ro_tin`, `rs_pib`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `si_tin`, `sv_nit`, `th_vat`, `tr_tin`, `tw_vat`, `ua_vat`, `us_ein`, `uy_ruc`, `ve_rif`, `vn_tin`, or `za_vat`.
@@ -1561,142 +1568,148 @@ impl<'de> serde::Deserialize<'de> for CreateCustomerTaxIdDataType {
 }
 /// Creates a new customer object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateCustomer<'a> {
-    inner: CreateCustomerBuilder<'a>,
+pub struct CreateCustomer {
+    inner: CreateCustomerBuilder,
 }
-impl<'a> CreateCustomer<'a> {
+impl CreateCustomer {
     /// Construct a new `CreateCustomer`.
     pub fn new() -> Self {
         Self { inner: CreateCustomerBuilder::new() }
     }
     /// The customer's address.
-    pub fn address(mut self, address: OptionalFieldsAddress<'a>) -> Self {
-        self.inner.address = Some(address);
+    pub fn address(mut self, address: impl Into<OptionalFieldsAddress>) -> Self {
+        self.inner.address = Some(address.into());
         self
     }
     /// An integer amount in cents (or local equivalent) that represents the customer's current balance, which affect the customer's future invoices.
     /// A negative amount represents a credit that decreases the amount due on an invoice; a positive amount increases the amount due on an invoice.
-    pub fn balance(mut self, balance: i64) -> Self {
-        self.inner.balance = Some(balance);
+    pub fn balance(mut self, balance: impl Into<i64>) -> Self {
+        self.inner.balance = Some(balance.into());
         self
     }
     /// Balance information and default balance settings for this customer.
-    pub fn cash_balance(mut self, cash_balance: CreateCustomerCashBalance) -> Self {
-        self.inner.cash_balance = Some(cash_balance);
+    pub fn cash_balance(mut self, cash_balance: impl Into<CreateCustomerCashBalance>) -> Self {
+        self.inner.cash_balance = Some(cash_balance.into());
         self
     }
-    pub fn coupon(mut self, coupon: &'a str) -> Self {
-        self.inner.coupon = Some(coupon);
+    pub fn coupon(mut self, coupon: impl Into<String>) -> Self {
+        self.inner.coupon = Some(coupon.into());
         self
     }
     /// An arbitrary string that you can attach to a customer object.
     /// It is displayed alongside the customer in the dashboard.
-    pub fn description(mut self, description: &'a str) -> Self {
-        self.inner.description = Some(description);
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.inner.description = Some(description.into());
         self
     }
     /// Customer's email address.
     /// It's displayed alongside the customer in your dashboard and can be useful for searching and tracking.
     /// This may be up to *512 characters*.
-    pub fn email(mut self, email: &'a str) -> Self {
-        self.inner.email = Some(email);
+    pub fn email(mut self, email: impl Into<String>) -> Self {
+        self.inner.email = Some(email.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// The prefix for the customer used to generate unique invoice numbers.
     /// Must be 3–12 uppercase letters or numbers.
-    pub fn invoice_prefix(mut self, invoice_prefix: &'a str) -> Self {
-        self.inner.invoice_prefix = Some(invoice_prefix);
+    pub fn invoice_prefix(mut self, invoice_prefix: impl Into<String>) -> Self {
+        self.inner.invoice_prefix = Some(invoice_prefix.into());
         self
     }
     /// Default invoice settings for this customer.
-    pub fn invoice_settings(mut self, invoice_settings: CreateCustomerInvoiceSettings<'a>) -> Self {
-        self.inner.invoice_settings = Some(invoice_settings);
+    pub fn invoice_settings(
+        mut self,
+        invoice_settings: impl Into<CreateCustomerInvoiceSettings>,
+    ) -> Self {
+        self.inner.invoice_settings = Some(invoice_settings.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// The customer's full name or business name.
-    pub fn name(mut self, name: &'a str) -> Self {
-        self.inner.name = Some(name);
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.inner.name = Some(name.into());
         self
     }
     /// The sequence to be used on the customer's next invoice. Defaults to 1.
-    pub fn next_invoice_sequence(mut self, next_invoice_sequence: i64) -> Self {
-        self.inner.next_invoice_sequence = Some(next_invoice_sequence);
+    pub fn next_invoice_sequence(mut self, next_invoice_sequence: impl Into<i64>) -> Self {
+        self.inner.next_invoice_sequence = Some(next_invoice_sequence.into());
         self
     }
-    pub fn payment_method(mut self, payment_method: &'a str) -> Self {
-        self.inner.payment_method = Some(payment_method);
+    pub fn payment_method(mut self, payment_method: impl Into<String>) -> Self {
+        self.inner.payment_method = Some(payment_method.into());
         self
     }
     /// The customer's phone number.
-    pub fn phone(mut self, phone: &'a str) -> Self {
-        self.inner.phone = Some(phone);
+    pub fn phone(mut self, phone: impl Into<String>) -> Self {
+        self.inner.phone = Some(phone.into());
         self
     }
     /// Customer's preferred languages, ordered by preference.
-    pub fn preferred_locales(mut self, preferred_locales: &'a [&'a str]) -> Self {
-        self.inner.preferred_locales = Some(preferred_locales);
+    pub fn preferred_locales(mut self, preferred_locales: impl Into<Vec<String>>) -> Self {
+        self.inner.preferred_locales = Some(preferred_locales.into());
         self
     }
     /// The ID of a promotion code to apply to the customer.
     /// The customer will have a discount applied on all recurring payments.
     /// Charges you create through the API will not have the discount.
-    pub fn promotion_code(mut self, promotion_code: &'a str) -> Self {
-        self.inner.promotion_code = Some(promotion_code);
+    pub fn promotion_code(mut self, promotion_code: impl Into<String>) -> Self {
+        self.inner.promotion_code = Some(promotion_code.into());
         self
     }
     /// The customer's shipping information. Appears on invoices emailed to this customer.
-    pub fn shipping(mut self, shipping: CustomerShipping<'a>) -> Self {
-        self.inner.shipping = Some(shipping);
+    pub fn shipping(mut self, shipping: impl Into<CustomerShipping>) -> Self {
+        self.inner.shipping = Some(shipping.into());
         self
     }
-    pub fn source(mut self, source: &'a str) -> Self {
-        self.inner.source = Some(source);
+    pub fn source(mut self, source: impl Into<String>) -> Self {
+        self.inner.source = Some(source.into());
         self
     }
     /// Tax details about the customer.
-    pub fn tax(mut self, tax: CreateCustomerTax<'a>) -> Self {
-        self.inner.tax = Some(tax);
+    pub fn tax(mut self, tax: impl Into<CreateCustomerTax>) -> Self {
+        self.inner.tax = Some(tax.into());
         self
     }
     /// The customer's tax exemption. One of `none`, `exempt`, or `reverse`.
-    pub fn tax_exempt(mut self, tax_exempt: stripe_shared::CustomerTaxExempt) -> Self {
-        self.inner.tax_exempt = Some(tax_exempt);
+    pub fn tax_exempt(mut self, tax_exempt: impl Into<stripe_shared::CustomerTaxExempt>) -> Self {
+        self.inner.tax_exempt = Some(tax_exempt.into());
         self
     }
     /// The customer's tax IDs.
-    pub fn tax_id_data(mut self, tax_id_data: &'a [CreateCustomerTaxIdData<'a>]) -> Self {
-        self.inner.tax_id_data = Some(tax_id_data);
+    pub fn tax_id_data(mut self, tax_id_data: impl Into<Vec<CreateCustomerTaxIdData>>) -> Self {
+        self.inner.tax_id_data = Some(tax_id_data.into());
         self
     }
     /// ID of the test clock to attach to the customer.
-    pub fn test_clock(mut self, test_clock: &'a str) -> Self {
-        self.inner.test_clock = Some(test_clock);
+    pub fn test_clock(mut self, test_clock: impl Into<String>) -> Self {
+        self.inner.test_clock = Some(test_clock.into());
         self
     }
-    pub fn validate(mut self, validate: bool) -> Self {
-        self.inner.validate = Some(validate);
+    pub fn validate(mut self, validate: impl Into<bool>) -> Self {
+        self.inner.validate = Some(validate.into());
         self
     }
 }
-impl<'a> Default for CreateCustomer<'a> {
+impl Default for CreateCustomer {
     fn default() -> Self {
         Self::new()
     }
 }
-impl CreateCustomer<'_> {
+impl CreateCustomer {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -1714,59 +1727,59 @@ impl CreateCustomer<'_> {
     }
 }
 
-impl StripeRequest for CreateCustomer<'_> {
+impl StripeRequest for CreateCustomer {
     type Output = stripe_shared::Customer;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Post, "/customers").form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdateCustomerBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdateCustomerBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    address: Option<OptionalFieldsAddress<'a>>,
+    address: Option<OptionalFieldsAddress>,
     #[serde(skip_serializing_if = "Option::is_none")]
     balance: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     cash_balance: Option<UpdateCustomerCashBalance>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    coupon: Option<&'a str>,
+    coupon: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    default_source: Option<&'a str>,
+    default_source: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<&'a str>,
+    description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    email: Option<&'a str>,
+    email: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    invoice_prefix: Option<&'a str>,
+    invoice_prefix: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    invoice_settings: Option<UpdateCustomerInvoiceSettings<'a>>,
+    invoice_settings: Option<UpdateCustomerInvoiceSettings>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    name: Option<&'a str>,
+    name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     next_invoice_sequence: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    phone: Option<&'a str>,
+    phone: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    preferred_locales: Option<&'a [&'a str]>,
+    preferred_locales: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    promotion_code: Option<&'a str>,
+    promotion_code: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    shipping: Option<CustomerShipping<'a>>,
+    shipping: Option<CustomerShipping>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    source: Option<&'a str>,
+    source: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    tax: Option<UpdateCustomerTax<'a>>,
+    tax: Option<UpdateCustomerTax>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tax_exempt: Option<stripe_shared::CustomerTaxExempt>,
     #[serde(skip_serializing_if = "Option::is_none")]
     validate: Option<bool>,
 }
-impl<'a> UpdateCustomerBuilder<'a> {
+impl UpdateCustomerBuilder {
     fn new() -> Self {
         Self {
             address: None,
@@ -1895,23 +1908,23 @@ impl<'de> serde::Deserialize<'de> for UpdateCustomerCashBalanceSettingsReconcili
     }
 }
 /// Default invoice settings for this customer.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateCustomerInvoiceSettings<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateCustomerInvoiceSettings {
     /// The list of up to 4 default custom fields to be displayed on invoices for this customer.
     /// When updating, pass an empty string to remove previously-defined fields.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub custom_fields: Option<&'a [CustomFieldParams<'a>]>,
+    pub custom_fields: Option<Vec<CustomFieldParams>>,
     /// ID of a payment method that's attached to the customer, to be used as the customer's default payment method for subscriptions and invoices.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub default_payment_method: Option<&'a str>,
+    pub default_payment_method: Option<String>,
     /// Default footer to be displayed on invoices for this customer.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub footer: Option<&'a str>,
+    pub footer: Option<String>,
     /// Default options for invoice PDF rendering for this customer.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rendering_options: Option<UpdateCustomerInvoiceSettingsRenderingOptions>,
 }
-impl<'a> UpdateCustomerInvoiceSettings<'a> {
+impl UpdateCustomerInvoiceSettings {
     pub fn new() -> Self {
         Self {
             custom_fields: None,
@@ -1921,7 +1934,7 @@ impl<'a> UpdateCustomerInvoiceSettings<'a> {
         }
     }
 }
-impl<'a> Default for UpdateCustomerInvoiceSettings<'a> {
+impl Default for UpdateCustomerInvoiceSettings {
     fn default() -> Self {
         Self::new()
     }
@@ -2010,24 +2023,24 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// Tax details about the customer.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateCustomerTax<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateCustomerTax {
     /// A recent IP address of the customer used for tax reporting and tax location inference.
     /// Stripe recommends updating the IP address when a new PaymentMethod is attached or the address field on the customer is updated.
     /// We recommend against updating this field more frequently since it could result in unexpected tax location/reporting outcomes.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ip_address: Option<&'a str>,
+    pub ip_address: Option<String>,
     /// A flag that indicates when Stripe should validate the customer tax location.
     /// Defaults to `deferred`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub validate_location: Option<UpdateCustomerTaxValidateLocation>,
 }
-impl<'a> UpdateCustomerTax<'a> {
+impl UpdateCustomerTax {
     pub fn new() -> Self {
         Self { ip_address: None, validate_location: None }
     }
 }
-impl<'a> Default for UpdateCustomerTax<'a> {
+impl Default for UpdateCustomerTax {
     fn default() -> Self {
         Self::new()
     }
@@ -2098,33 +2111,33 @@ impl<'de> serde::Deserialize<'de> for UpdateCustomerTaxValidateLocation {
 ///
 /// This request accepts mostly the same arguments as the customer creation call.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateCustomer<'a> {
-    inner: UpdateCustomerBuilder<'a>,
-    customer: &'a stripe_shared::CustomerId,
+pub struct UpdateCustomer {
+    inner: UpdateCustomerBuilder,
+    customer: stripe_shared::CustomerId,
 }
-impl<'a> UpdateCustomer<'a> {
+impl UpdateCustomer {
     /// Construct a new `UpdateCustomer`.
-    pub fn new(customer: &'a stripe_shared::CustomerId) -> Self {
-        Self { customer, inner: UpdateCustomerBuilder::new() }
+    pub fn new(customer: impl Into<stripe_shared::CustomerId>) -> Self {
+        Self { customer: customer.into(), inner: UpdateCustomerBuilder::new() }
     }
     /// The customer's address.
-    pub fn address(mut self, address: OptionalFieldsAddress<'a>) -> Self {
-        self.inner.address = Some(address);
+    pub fn address(mut self, address: impl Into<OptionalFieldsAddress>) -> Self {
+        self.inner.address = Some(address.into());
         self
     }
     /// An integer amount in cents (or local equivalent) that represents the customer's current balance, which affect the customer's future invoices.
     /// A negative amount represents a credit that decreases the amount due on an invoice; a positive amount increases the amount due on an invoice.
-    pub fn balance(mut self, balance: i64) -> Self {
-        self.inner.balance = Some(balance);
+    pub fn balance(mut self, balance: impl Into<i64>) -> Self {
+        self.inner.balance = Some(balance.into());
         self
     }
     /// Balance information and default balance settings for this customer.
-    pub fn cash_balance(mut self, cash_balance: UpdateCustomerCashBalance) -> Self {
-        self.inner.cash_balance = Some(cash_balance);
+    pub fn cash_balance(mut self, cash_balance: impl Into<UpdateCustomerCashBalance>) -> Self {
+        self.inner.cash_balance = Some(cash_balance.into());
         self
     }
-    pub fn coupon(mut self, coupon: &'a str) -> Self {
-        self.inner.coupon = Some(coupon);
+    pub fn coupon(mut self, coupon: impl Into<String>) -> Self {
+        self.inner.coupon = Some(coupon.into());
         self
     }
     /// If you are using payment methods created via the PaymentMethods API, see the [invoice_settings.default_payment_method](https://stripe.com/docs/api/customers/update#update_customer-invoice_settings-default_payment_method) parameter.
@@ -2132,99 +2145,105 @@ impl<'a> UpdateCustomer<'a> {
     /// Provide the ID of a payment source already attached to this customer to make it this customer's default payment source.
     ///
     /// If you want to add a new payment source and make it the default, see the [source](https://stripe.com/docs/api/customers/update#update_customer-source) property.
-    pub fn default_source(mut self, default_source: &'a str) -> Self {
-        self.inner.default_source = Some(default_source);
+    pub fn default_source(mut self, default_source: impl Into<String>) -> Self {
+        self.inner.default_source = Some(default_source.into());
         self
     }
     /// An arbitrary string that you can attach to a customer object.
     /// It is displayed alongside the customer in the dashboard.
-    pub fn description(mut self, description: &'a str) -> Self {
-        self.inner.description = Some(description);
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.inner.description = Some(description.into());
         self
     }
     /// Customer's email address.
     /// It's displayed alongside the customer in your dashboard and can be useful for searching and tracking.
     /// This may be up to *512 characters*.
-    pub fn email(mut self, email: &'a str) -> Self {
-        self.inner.email = Some(email);
+    pub fn email(mut self, email: impl Into<String>) -> Self {
+        self.inner.email = Some(email.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// The prefix for the customer used to generate unique invoice numbers.
     /// Must be 3–12 uppercase letters or numbers.
-    pub fn invoice_prefix(mut self, invoice_prefix: &'a str) -> Self {
-        self.inner.invoice_prefix = Some(invoice_prefix);
+    pub fn invoice_prefix(mut self, invoice_prefix: impl Into<String>) -> Self {
+        self.inner.invoice_prefix = Some(invoice_prefix.into());
         self
     }
     /// Default invoice settings for this customer.
-    pub fn invoice_settings(mut self, invoice_settings: UpdateCustomerInvoiceSettings<'a>) -> Self {
-        self.inner.invoice_settings = Some(invoice_settings);
+    pub fn invoice_settings(
+        mut self,
+        invoice_settings: impl Into<UpdateCustomerInvoiceSettings>,
+    ) -> Self {
+        self.inner.invoice_settings = Some(invoice_settings.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// The customer's full name or business name.
-    pub fn name(mut self, name: &'a str) -> Self {
-        self.inner.name = Some(name);
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.inner.name = Some(name.into());
         self
     }
     /// The sequence to be used on the customer's next invoice. Defaults to 1.
-    pub fn next_invoice_sequence(mut self, next_invoice_sequence: i64) -> Self {
-        self.inner.next_invoice_sequence = Some(next_invoice_sequence);
+    pub fn next_invoice_sequence(mut self, next_invoice_sequence: impl Into<i64>) -> Self {
+        self.inner.next_invoice_sequence = Some(next_invoice_sequence.into());
         self
     }
     /// The customer's phone number.
-    pub fn phone(mut self, phone: &'a str) -> Self {
-        self.inner.phone = Some(phone);
+    pub fn phone(mut self, phone: impl Into<String>) -> Self {
+        self.inner.phone = Some(phone.into());
         self
     }
     /// Customer's preferred languages, ordered by preference.
-    pub fn preferred_locales(mut self, preferred_locales: &'a [&'a str]) -> Self {
-        self.inner.preferred_locales = Some(preferred_locales);
+    pub fn preferred_locales(mut self, preferred_locales: impl Into<Vec<String>>) -> Self {
+        self.inner.preferred_locales = Some(preferred_locales.into());
         self
     }
     /// The ID of a promotion code to apply to the customer.
     /// The customer will have a discount applied on all recurring payments.
     /// Charges you create through the API will not have the discount.
-    pub fn promotion_code(mut self, promotion_code: &'a str) -> Self {
-        self.inner.promotion_code = Some(promotion_code);
+    pub fn promotion_code(mut self, promotion_code: impl Into<String>) -> Self {
+        self.inner.promotion_code = Some(promotion_code.into());
         self
     }
     /// The customer's shipping information. Appears on invoices emailed to this customer.
-    pub fn shipping(mut self, shipping: CustomerShipping<'a>) -> Self {
-        self.inner.shipping = Some(shipping);
+    pub fn shipping(mut self, shipping: impl Into<CustomerShipping>) -> Self {
+        self.inner.shipping = Some(shipping.into());
         self
     }
-    pub fn source(mut self, source: &'a str) -> Self {
-        self.inner.source = Some(source);
+    pub fn source(mut self, source: impl Into<String>) -> Self {
+        self.inner.source = Some(source.into());
         self
     }
     /// Tax details about the customer.
-    pub fn tax(mut self, tax: UpdateCustomerTax<'a>) -> Self {
-        self.inner.tax = Some(tax);
+    pub fn tax(mut self, tax: impl Into<UpdateCustomerTax>) -> Self {
+        self.inner.tax = Some(tax.into());
         self
     }
     /// The customer's tax exemption. One of `none`, `exempt`, or `reverse`.
-    pub fn tax_exempt(mut self, tax_exempt: stripe_shared::CustomerTaxExempt) -> Self {
-        self.inner.tax_exempt = Some(tax_exempt);
+    pub fn tax_exempt(mut self, tax_exempt: impl Into<stripe_shared::CustomerTaxExempt>) -> Self {
+        self.inner.tax_exempt = Some(tax_exempt.into());
         self
     }
-    pub fn validate(mut self, validate: bool) -> Self {
-        self.inner.validate = Some(validate);
+    pub fn validate(mut self, validate: impl Into<bool>) -> Self {
+        self.inner.validate = Some(validate.into());
         self
     }
 }
-impl UpdateCustomer<'_> {
+impl UpdateCustomer {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -2242,63 +2261,68 @@ impl UpdateCustomer<'_> {
     }
 }
 
-impl StripeRequest for UpdateCustomer<'_> {
+impl StripeRequest for UpdateCustomer {
     type Output = stripe_shared::Customer;
 
     fn build(&self) -> RequestBuilder {
-        let customer = self.customer;
+        let customer = &self.customer;
         RequestBuilder::new(StripeMethod::Post, format!("/customers/{customer}")).form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateFundingInstructionsCustomerBuilder<'a> {
-    bank_transfer: CreateFundingInstructionsCustomerBankTransfer<'a>,
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateFundingInstructionsCustomerBuilder {
+    bank_transfer: CreateFundingInstructionsCustomerBankTransfer,
     currency: stripe_types::Currency,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     funding_type: CreateFundingInstructionsCustomerFundingType,
 }
-impl<'a> CreateFundingInstructionsCustomerBuilder<'a> {
+impl CreateFundingInstructionsCustomerBuilder {
     fn new(
-        bank_transfer: CreateFundingInstructionsCustomerBankTransfer<'a>,
-        currency: stripe_types::Currency,
-        funding_type: CreateFundingInstructionsCustomerFundingType,
+        bank_transfer: impl Into<CreateFundingInstructionsCustomerBankTransfer>,
+        currency: impl Into<stripe_types::Currency>,
+        funding_type: impl Into<CreateFundingInstructionsCustomerFundingType>,
     ) -> Self {
-        Self { bank_transfer, currency, expand: None, funding_type }
+        Self {
+            bank_transfer: bank_transfer.into(),
+            currency: currency.into(),
+            expand: None,
+            funding_type: funding_type.into(),
+        }
     }
 }
 /// Additional parameters for `bank_transfer` funding types
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateFundingInstructionsCustomerBankTransfer<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateFundingInstructionsCustomerBankTransfer {
     /// Configuration for eu_bank_transfer funding type.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub eu_bank_transfer: Option<CreateFundingInstructionsCustomerBankTransferEuBankTransfer<'a>>,
+    pub eu_bank_transfer: Option<CreateFundingInstructionsCustomerBankTransferEuBankTransfer>,
     /// List of address types that should be returned in the financial_addresses response.
     /// If not specified, all valid types will be returned.
     ///
     /// Permitted values include: `sort_code`, `zengin`, `iban`, or `spei`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub requested_address_types:
-        Option<&'a [CreateFundingInstructionsCustomerBankTransferRequestedAddressTypes]>,
+        Option<Vec<CreateFundingInstructionsCustomerBankTransferRequestedAddressTypes>>,
     /// The type of the `bank_transfer`
     #[serde(rename = "type")]
     pub type_: CreateFundingInstructionsCustomerBankTransferType,
 }
-impl<'a> CreateFundingInstructionsCustomerBankTransfer<'a> {
-    pub fn new(type_: CreateFundingInstructionsCustomerBankTransferType) -> Self {
-        Self { eu_bank_transfer: None, requested_address_types: None, type_ }
+impl CreateFundingInstructionsCustomerBankTransfer {
+    pub fn new(type_: impl Into<CreateFundingInstructionsCustomerBankTransferType>) -> Self {
+        Self { eu_bank_transfer: None, requested_address_types: None, type_: type_.into() }
     }
 }
 /// Configuration for eu_bank_transfer funding type.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateFundingInstructionsCustomerBankTransferEuBankTransfer<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateFundingInstructionsCustomerBankTransferEuBankTransfer {
     /// The desired country code of the bank account information.
     /// Permitted values include: `BE`, `DE`, `ES`, `FR`, `IE`, or `NL`.
-    pub country: &'a str,
+    pub country: String,
 }
-impl<'a> CreateFundingInstructionsCustomerBankTransferEuBankTransfer<'a> {
-    pub fn new(country: &'a str) -> Self {
-        Self { country }
+impl CreateFundingInstructionsCustomerBankTransferEuBankTransfer {
+    pub fn new(country: impl Into<String>) -> Self {
+        Self { country: country.into() }
     }
 }
 /// List of address types that should be returned in the financial_addresses response.
@@ -2495,34 +2519,34 @@ impl<'de> serde::Deserialize<'de> for CreateFundingInstructionsCustomerFundingTy
 /// funding instructions will be retrieved.
 /// In other words, we will return the same funding instructions each time.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateFundingInstructionsCustomer<'a> {
-    inner: CreateFundingInstructionsCustomerBuilder<'a>,
-    customer: &'a stripe_shared::CustomerId,
+pub struct CreateFundingInstructionsCustomer {
+    inner: CreateFundingInstructionsCustomerBuilder,
+    customer: stripe_shared::CustomerId,
 }
-impl<'a> CreateFundingInstructionsCustomer<'a> {
+impl CreateFundingInstructionsCustomer {
     /// Construct a new `CreateFundingInstructionsCustomer`.
     pub fn new(
-        customer: &'a stripe_shared::CustomerId,
-        bank_transfer: CreateFundingInstructionsCustomerBankTransfer<'a>,
-        currency: stripe_types::Currency,
-        funding_type: CreateFundingInstructionsCustomerFundingType,
+        customer: impl Into<stripe_shared::CustomerId>,
+        bank_transfer: impl Into<CreateFundingInstructionsCustomerBankTransfer>,
+        currency: impl Into<stripe_types::Currency>,
+        funding_type: impl Into<CreateFundingInstructionsCustomerFundingType>,
     ) -> Self {
         Self {
-            customer,
+            customer: customer.into(),
             inner: CreateFundingInstructionsCustomerBuilder::new(
-                bank_transfer,
-                currency,
-                funding_type,
+                bank_transfer.into(),
+                currency.into(),
+                funding_type.into(),
             ),
         }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl CreateFundingInstructionsCustomer<'_> {
+impl CreateFundingInstructionsCustomer {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -2540,11 +2564,11 @@ impl CreateFundingInstructionsCustomer<'_> {
     }
 }
 
-impl StripeRequest for CreateFundingInstructionsCustomer<'_> {
+impl StripeRequest for CreateFundingInstructionsCustomer {
     type Output = stripe_shared::FundingInstructions;
 
     fn build(&self) -> RequestBuilder {
-        let customer = self.customer;
+        let customer = &self.customer;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/customers/{customer}/funding_instructions"),
@@ -2552,45 +2576,52 @@ impl StripeRequest for CreateFundingInstructionsCustomer<'_> {
         .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct FundCashBalanceCustomerBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct FundCashBalanceCustomerBuilder {
     amount: i64,
     currency: stripe_types::Currency,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    reference: Option<&'a str>,
+    reference: Option<String>,
 }
-impl<'a> FundCashBalanceCustomerBuilder<'a> {
-    fn new(amount: i64, currency: stripe_types::Currency) -> Self {
-        Self { amount, currency, expand: None, reference: None }
+impl FundCashBalanceCustomerBuilder {
+    fn new(amount: impl Into<i64>, currency: impl Into<stripe_types::Currency>) -> Self {
+        Self { amount: amount.into(), currency: currency.into(), expand: None, reference: None }
     }
 }
 /// Create an incoming testmode bank transfer
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct FundCashBalanceCustomer<'a> {
-    inner: FundCashBalanceCustomerBuilder<'a>,
-    customer: &'a str,
+pub struct FundCashBalanceCustomer {
+    inner: FundCashBalanceCustomerBuilder,
+    customer: String,
 }
-impl<'a> FundCashBalanceCustomer<'a> {
+impl FundCashBalanceCustomer {
     /// Construct a new `FundCashBalanceCustomer`.
-    pub fn new(customer: &'a str, amount: i64, currency: stripe_types::Currency) -> Self {
-        Self { customer, inner: FundCashBalanceCustomerBuilder::new(amount, currency) }
+    pub fn new(
+        customer: impl Into<String>,
+        amount: impl Into<i64>,
+        currency: impl Into<stripe_types::Currency>,
+    ) -> Self {
+        Self {
+            customer: customer.into(),
+            inner: FundCashBalanceCustomerBuilder::new(amount.into(), currency.into()),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A description of the test funding.
     /// This simulates free-text references supplied by customers when making bank transfers to their cash balance.
     /// You can use this to test how Stripe's [reconciliation algorithm](https://stripe.com/docs/payments/customer-balance/reconciliation) applies to different user inputs.
-    pub fn reference(mut self, reference: &'a str) -> Self {
-        self.inner.reference = Some(reference);
+    pub fn reference(mut self, reference: impl Into<String>) -> Self {
+        self.inner.reference = Some(reference.into());
         self
     }
 }
-impl FundCashBalanceCustomer<'_> {
+impl FundCashBalanceCustomer {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -2608,11 +2639,11 @@ impl FundCashBalanceCustomer<'_> {
     }
 }
 
-impl StripeRequest for FundCashBalanceCustomer<'_> {
+impl StripeRequest for FundCashBalanceCustomer {
     type Output = stripe_shared::CustomerCashBalanceTransaction;
 
     fn build(&self) -> RequestBuilder {
-        let customer = self.customer;
+        let customer = &self.customer;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/test_helpers/customers/{customer}/fund_cash_balance"),
@@ -2621,61 +2652,61 @@ impl StripeRequest for FundCashBalanceCustomer<'_> {
     }
 }
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct OptionalFieldsAddress<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct OptionalFieldsAddress {
     /// City, district, suburb, town, or village.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<&'a str>,
+    pub city: Option<String>,
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub country: Option<&'a str>,
+    pub country: Option<String>,
     /// Address line 1 (e.g., street, PO Box, or company name).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line1: Option<&'a str>,
+    pub line1: Option<String>,
     /// Address line 2 (e.g., apartment, suite, unit, or building).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line2: Option<&'a str>,
+    pub line2: Option<String>,
     /// ZIP or postal code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<&'a str>,
+    pub postal_code: Option<String>,
     /// State, county, province, or region.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
 }
-impl<'a> OptionalFieldsAddress<'a> {
+impl OptionalFieldsAddress {
     pub fn new() -> Self {
         Self { city: None, country: None, line1: None, line2: None, postal_code: None, state: None }
     }
 }
-impl<'a> Default for OptionalFieldsAddress<'a> {
+impl Default for OptionalFieldsAddress {
     fn default() -> Self {
         Self::new()
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CustomFieldParams<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CustomFieldParams {
     /// The name of the custom field. This may be up to 40 characters.
-    pub name: &'a str,
+    pub name: String,
     /// The value of the custom field. This may be up to 140 characters.
-    pub value: &'a str,
+    pub value: String,
 }
-impl<'a> CustomFieldParams<'a> {
-    pub fn new(name: &'a str, value: &'a str) -> Self {
-        Self { name, value }
+impl CustomFieldParams {
+    pub fn new(name: impl Into<String>, value: impl Into<String>) -> Self {
+        Self { name: name.into(), value: value.into() }
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CustomerShipping<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CustomerShipping {
     /// Customer shipping address.
-    pub address: OptionalFieldsAddress<'a>,
+    pub address: OptionalFieldsAddress,
     /// Customer name.
-    pub name: &'a str,
+    pub name: String,
     /// Customer phone (including extension).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub phone: Option<&'a str>,
+    pub phone: Option<String>,
 }
-impl<'a> CustomerShipping<'a> {
-    pub fn new(address: OptionalFieldsAddress<'a>, name: &'a str) -> Self {
-        Self { address, name, phone: None }
+impl CustomerShipping {
+    pub fn new(address: impl Into<OptionalFieldsAddress>, name: impl Into<String>) -> Self {
+        Self { address: address.into(), name: name.into(), phone: None }
     }
 }

--- a/generated/async-stripe-core/src/customer_balance_transaction/requests.rs
+++ b/generated/async-stripe-core/src/customer_balance_transaction/requests.rs
@@ -2,60 +2,63 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListCustomerCustomerBalanceTransactionBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListCustomerCustomerBalanceTransactionBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListCustomerCustomerBalanceTransactionBuilder<'a> {
+impl ListCustomerCustomerBalanceTransactionBuilder {
     fn new() -> Self {
         Self { ending_before: None, expand: None, limit: None, starting_after: None }
     }
 }
 /// Returns a list of transactions that updated the customer’s [balances](https://stripe.com/docs/billing/customer/balance).
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListCustomerCustomerBalanceTransaction<'a> {
-    inner: ListCustomerCustomerBalanceTransactionBuilder<'a>,
-    customer: &'a stripe_shared::CustomerId,
+pub struct ListCustomerCustomerBalanceTransaction {
+    inner: ListCustomerCustomerBalanceTransactionBuilder,
+    customer: stripe_shared::CustomerId,
 }
-impl<'a> ListCustomerCustomerBalanceTransaction<'a> {
+impl ListCustomerCustomerBalanceTransaction {
     /// Construct a new `ListCustomerCustomerBalanceTransaction`.
-    pub fn new(customer: &'a stripe_shared::CustomerId) -> Self {
-        Self { customer, inner: ListCustomerCustomerBalanceTransactionBuilder::new() }
+    pub fn new(customer: impl Into<stripe_shared::CustomerId>) -> Self {
+        Self {
+            customer: customer.into(),
+            inner: ListCustomerCustomerBalanceTransactionBuilder::new(),
+        }
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl ListCustomerCustomerBalanceTransaction<'_> {
+impl ListCustomerCustomerBalanceTransaction {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -77,20 +80,20 @@ impl ListCustomerCustomerBalanceTransaction<'_> {
     ) -> stripe_client_core::ListPaginator<
         stripe_types::List<stripe_shared::CustomerBalanceTransaction>,
     > {
-        let customer = self.customer;
+        let customer = &self.customer;
 
         stripe_client_core::ListPaginator::new_list(
             format!("/customers/{customer}/balance_transactions"),
-            self.inner,
+            &self.inner,
         )
     }
 }
 
-impl StripeRequest for ListCustomerCustomerBalanceTransaction<'_> {
+impl StripeRequest for ListCustomerCustomerBalanceTransaction {
     type Output = stripe_types::List<stripe_shared::CustomerBalanceTransaction>;
 
     fn build(&self) -> RequestBuilder {
-        let customer = self.customer;
+        let customer = &self.customer;
         RequestBuilder::new(
             StripeMethod::Get,
             format!("/customers/{customer}/balance_transactions"),
@@ -98,35 +101,42 @@ impl StripeRequest for ListCustomerCustomerBalanceTransaction<'_> {
         .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveCustomerBalanceTransactionBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveCustomerBalanceTransactionBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveCustomerBalanceTransactionBuilder<'a> {
+impl RetrieveCustomerBalanceTransactionBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves a specific customer balance transaction that updated the customer’s [balances](https://stripe.com/docs/billing/customer/balance).
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveCustomerBalanceTransaction<'a> {
-    inner: RetrieveCustomerBalanceTransactionBuilder<'a>,
-    customer: &'a stripe_shared::CustomerId,
-    transaction: &'a str,
+pub struct RetrieveCustomerBalanceTransaction {
+    inner: RetrieveCustomerBalanceTransactionBuilder,
+    customer: stripe_shared::CustomerId,
+    transaction: String,
 }
-impl<'a> RetrieveCustomerBalanceTransaction<'a> {
+impl RetrieveCustomerBalanceTransaction {
     /// Construct a new `RetrieveCustomerBalanceTransaction`.
-    pub fn new(customer: &'a stripe_shared::CustomerId, transaction: &'a str) -> Self {
-        Self { customer, transaction, inner: RetrieveCustomerBalanceTransactionBuilder::new() }
+    pub fn new(
+        customer: impl Into<stripe_shared::CustomerId>,
+        transaction: impl Into<String>,
+    ) -> Self {
+        Self {
+            customer: customer.into(),
+            transaction: transaction.into(),
+            inner: RetrieveCustomerBalanceTransactionBuilder::new(),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveCustomerBalanceTransaction<'_> {
+impl RetrieveCustomerBalanceTransaction {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -144,12 +154,12 @@ impl RetrieveCustomerBalanceTransaction<'_> {
     }
 }
 
-impl StripeRequest for RetrieveCustomerBalanceTransaction<'_> {
+impl StripeRequest for RetrieveCustomerBalanceTransaction {
     type Output = stripe_shared::CustomerBalanceTransaction;
 
     fn build(&self) -> RequestBuilder {
-        let customer = self.customer;
-        let transaction = self.transaction;
+        let customer = &self.customer;
+        let transaction = &self.transaction;
         RequestBuilder::new(
             StripeMethod::Get,
             format!("/customers/{customer}/balance_transactions/{transaction}"),
@@ -157,60 +167,72 @@ impl StripeRequest for RetrieveCustomerBalanceTransaction<'_> {
         .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateCustomerCustomerBalanceTransactionBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateCustomerCustomerBalanceTransactionBuilder {
     amount: i64,
     currency: stripe_types::Currency,
     #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<&'a str>,
+    description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
 }
-impl<'a> CreateCustomerCustomerBalanceTransactionBuilder<'a> {
-    fn new(amount: i64, currency: stripe_types::Currency) -> Self {
-        Self { amount, currency, description: None, expand: None, metadata: None }
+impl CreateCustomerCustomerBalanceTransactionBuilder {
+    fn new(amount: impl Into<i64>, currency: impl Into<stripe_types::Currency>) -> Self {
+        Self {
+            amount: amount.into(),
+            currency: currency.into(),
+            description: None,
+            expand: None,
+            metadata: None,
+        }
     }
 }
 /// Creates an immutable transaction that updates the customer’s credit [balance](https://stripe.com/docs/billing/customer/balance).
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateCustomerCustomerBalanceTransaction<'a> {
-    inner: CreateCustomerCustomerBalanceTransactionBuilder<'a>,
-    customer: &'a stripe_shared::CustomerId,
+pub struct CreateCustomerCustomerBalanceTransaction {
+    inner: CreateCustomerCustomerBalanceTransactionBuilder,
+    customer: stripe_shared::CustomerId,
 }
-impl<'a> CreateCustomerCustomerBalanceTransaction<'a> {
+impl CreateCustomerCustomerBalanceTransaction {
     /// Construct a new `CreateCustomerCustomerBalanceTransaction`.
     pub fn new(
-        customer: &'a stripe_shared::CustomerId,
-        amount: i64,
-        currency: stripe_types::Currency,
+        customer: impl Into<stripe_shared::CustomerId>,
+        amount: impl Into<i64>,
+        currency: impl Into<stripe_types::Currency>,
     ) -> Self {
         Self {
-            customer,
-            inner: CreateCustomerCustomerBalanceTransactionBuilder::new(amount, currency),
+            customer: customer.into(),
+            inner: CreateCustomerCustomerBalanceTransactionBuilder::new(
+                amount.into(),
+                currency.into(),
+            ),
         }
     }
     /// An arbitrary string attached to the object. Often useful for displaying to users.
-    pub fn description(mut self, description: &'a str) -> Self {
-        self.inner.description = Some(description);
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.inner.description = Some(description.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
 }
-impl CreateCustomerCustomerBalanceTransaction<'_> {
+impl CreateCustomerCustomerBalanceTransaction {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -228,11 +250,11 @@ impl CreateCustomerCustomerBalanceTransaction<'_> {
     }
 }
 
-impl StripeRequest for CreateCustomerCustomerBalanceTransaction<'_> {
+impl StripeRequest for CreateCustomerCustomerBalanceTransaction {
     type Output = stripe_shared::CustomerBalanceTransaction;
 
     fn build(&self) -> RequestBuilder {
-        let customer = self.customer;
+        let customer = &self.customer;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/customers/{customer}/balance_transactions"),
@@ -240,52 +262,62 @@ impl StripeRequest for CreateCustomerCustomerBalanceTransaction<'_> {
         .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdateCustomerBalanceTransactionBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdateCustomerBalanceTransactionBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<&'a str>,
+    description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
 }
-impl<'a> UpdateCustomerBalanceTransactionBuilder<'a> {
+impl UpdateCustomerBalanceTransactionBuilder {
     fn new() -> Self {
         Self { description: None, expand: None, metadata: None }
     }
 }
 /// Most credit balance transaction fields are immutable, but you may update its `description` and `metadata`.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateCustomerBalanceTransaction<'a> {
-    inner: UpdateCustomerBalanceTransactionBuilder<'a>,
-    customer: &'a stripe_shared::CustomerId,
-    transaction: &'a str,
+pub struct UpdateCustomerBalanceTransaction {
+    inner: UpdateCustomerBalanceTransactionBuilder,
+    customer: stripe_shared::CustomerId,
+    transaction: String,
 }
-impl<'a> UpdateCustomerBalanceTransaction<'a> {
+impl UpdateCustomerBalanceTransaction {
     /// Construct a new `UpdateCustomerBalanceTransaction`.
-    pub fn new(customer: &'a stripe_shared::CustomerId, transaction: &'a str) -> Self {
-        Self { customer, transaction, inner: UpdateCustomerBalanceTransactionBuilder::new() }
+    pub fn new(
+        customer: impl Into<stripe_shared::CustomerId>,
+        transaction: impl Into<String>,
+    ) -> Self {
+        Self {
+            customer: customer.into(),
+            transaction: transaction.into(),
+            inner: UpdateCustomerBalanceTransactionBuilder::new(),
+        }
     }
     /// An arbitrary string attached to the object. Often useful for displaying to users.
-    pub fn description(mut self, description: &'a str) -> Self {
-        self.inner.description = Some(description);
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.inner.description = Some(description.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
 }
-impl UpdateCustomerBalanceTransaction<'_> {
+impl UpdateCustomerBalanceTransaction {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -303,12 +335,12 @@ impl UpdateCustomerBalanceTransaction<'_> {
     }
 }
 
-impl StripeRequest for UpdateCustomerBalanceTransaction<'_> {
+impl StripeRequest for UpdateCustomerBalanceTransaction {
     type Output = stripe_shared::CustomerBalanceTransaction;
 
     fn build(&self) -> RequestBuilder {
-        let customer = self.customer;
-        let transaction = self.transaction;
+        let customer = &self.customer;
+        let transaction = &self.transaction;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/customers/{customer}/balance_transactions/{transaction}"),

--- a/generated/async-stripe-core/src/customer_cash_balance_transaction/requests.rs
+++ b/generated/async-stripe-core/src/customer_cash_balance_transaction/requests.rs
@@ -2,60 +2,63 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListCustomerCustomerCashBalanceTransactionBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListCustomerCustomerCashBalanceTransactionBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListCustomerCustomerCashBalanceTransactionBuilder<'a> {
+impl ListCustomerCustomerCashBalanceTransactionBuilder {
     fn new() -> Self {
         Self { ending_before: None, expand: None, limit: None, starting_after: None }
     }
 }
 /// Returns a list of transactions that modified the customer’s [cash balance](https://stripe.com/docs/payments/customer-balance).
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListCustomerCustomerCashBalanceTransaction<'a> {
-    inner: ListCustomerCustomerCashBalanceTransactionBuilder<'a>,
-    customer: &'a stripe_shared::CustomerId,
+pub struct ListCustomerCustomerCashBalanceTransaction {
+    inner: ListCustomerCustomerCashBalanceTransactionBuilder,
+    customer: stripe_shared::CustomerId,
 }
-impl<'a> ListCustomerCustomerCashBalanceTransaction<'a> {
+impl ListCustomerCustomerCashBalanceTransaction {
     /// Construct a new `ListCustomerCustomerCashBalanceTransaction`.
-    pub fn new(customer: &'a stripe_shared::CustomerId) -> Self {
-        Self { customer, inner: ListCustomerCustomerCashBalanceTransactionBuilder::new() }
+    pub fn new(customer: impl Into<stripe_shared::CustomerId>) -> Self {
+        Self {
+            customer: customer.into(),
+            inner: ListCustomerCustomerCashBalanceTransactionBuilder::new(),
+        }
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl ListCustomerCustomerCashBalanceTransaction<'_> {
+impl ListCustomerCustomerCashBalanceTransaction {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -77,20 +80,20 @@ impl ListCustomerCustomerCashBalanceTransaction<'_> {
     ) -> stripe_client_core::ListPaginator<
         stripe_types::List<stripe_shared::CustomerCashBalanceTransaction>,
     > {
-        let customer = self.customer;
+        let customer = &self.customer;
 
         stripe_client_core::ListPaginator::new_list(
             format!("/customers/{customer}/cash_balance_transactions"),
-            self.inner,
+            &self.inner,
         )
     }
 }
 
-impl StripeRequest for ListCustomerCustomerCashBalanceTransaction<'_> {
+impl StripeRequest for ListCustomerCustomerCashBalanceTransaction {
     type Output = stripe_types::List<stripe_shared::CustomerCashBalanceTransaction>;
 
     fn build(&self) -> RequestBuilder {
-        let customer = self.customer;
+        let customer = &self.customer;
         RequestBuilder::new(
             StripeMethod::Get,
             format!("/customers/{customer}/cash_balance_transactions"),
@@ -98,35 +101,42 @@ impl StripeRequest for ListCustomerCustomerCashBalanceTransaction<'_> {
         .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveCustomerCashBalanceTransactionBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveCustomerCashBalanceTransactionBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveCustomerCashBalanceTransactionBuilder<'a> {
+impl RetrieveCustomerCashBalanceTransactionBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves a specific cash balance transaction, which updated the customer’s [cash balance](https://stripe.com/docs/payments/customer-balance).
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveCustomerCashBalanceTransaction<'a> {
-    inner: RetrieveCustomerCashBalanceTransactionBuilder<'a>,
-    customer: &'a stripe_shared::CustomerId,
-    transaction: &'a str,
+pub struct RetrieveCustomerCashBalanceTransaction {
+    inner: RetrieveCustomerCashBalanceTransactionBuilder,
+    customer: stripe_shared::CustomerId,
+    transaction: String,
 }
-impl<'a> RetrieveCustomerCashBalanceTransaction<'a> {
+impl RetrieveCustomerCashBalanceTransaction {
     /// Construct a new `RetrieveCustomerCashBalanceTransaction`.
-    pub fn new(customer: &'a stripe_shared::CustomerId, transaction: &'a str) -> Self {
-        Self { customer, transaction, inner: RetrieveCustomerCashBalanceTransactionBuilder::new() }
+    pub fn new(
+        customer: impl Into<stripe_shared::CustomerId>,
+        transaction: impl Into<String>,
+    ) -> Self {
+        Self {
+            customer: customer.into(),
+            transaction: transaction.into(),
+            inner: RetrieveCustomerCashBalanceTransactionBuilder::new(),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveCustomerCashBalanceTransaction<'_> {
+impl RetrieveCustomerCashBalanceTransaction {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -144,12 +154,12 @@ impl RetrieveCustomerCashBalanceTransaction<'_> {
     }
 }
 
-impl StripeRequest for RetrieveCustomerCashBalanceTransaction<'_> {
+impl StripeRequest for RetrieveCustomerCashBalanceTransaction {
     type Output = stripe_shared::CustomerCashBalanceTransaction;
 
     fn build(&self) -> RequestBuilder {
-        let customer = self.customer;
-        let transaction = self.transaction;
+        let customer = &self.customer;
+        let transaction = &self.transaction;
         RequestBuilder::new(
             StripeMethod::Get,
             format!("/customers/{customer}/cash_balance_transactions/{transaction}"),

--- a/generated/async-stripe-core/src/customer_session/requests.rs
+++ b/generated/async-stripe-core/src/customer_session/requests.rs
@@ -2,16 +2,19 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateCustomerSessionBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateCustomerSessionBuilder {
     components: CreateCustomerSessionComponents,
-    customer: &'a str,
+    customer: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> CreateCustomerSessionBuilder<'a> {
-    fn new(components: CreateCustomerSessionComponents, customer: &'a str) -> Self {
-        Self { components, customer, expand: None }
+impl CreateCustomerSessionBuilder {
+    fn new(
+        components: impl Into<CreateCustomerSessionComponents>,
+        customer: impl Into<String>,
+    ) -> Self {
+        Self { components: components.into(), customer: customer.into(), expand: None }
     }
 }
 /// Configuration for each component. Exactly 1 component must be enabled.
@@ -41,8 +44,8 @@ pub struct CreateCustomerSessionComponentsBuyButton {
     pub enabled: bool,
 }
 impl CreateCustomerSessionComponentsBuyButton {
-    pub fn new(enabled: bool) -> Self {
-        Self { enabled }
+    pub fn new(enabled: impl Into<bool>) -> Self {
+        Self { enabled: enabled.into() }
     }
 }
 /// Configuration for the pricing table.
@@ -52,27 +55,30 @@ pub struct CreateCustomerSessionComponentsPricingTable {
     pub enabled: bool,
 }
 impl CreateCustomerSessionComponentsPricingTable {
-    pub fn new(enabled: bool) -> Self {
-        Self { enabled }
+    pub fn new(enabled: impl Into<bool>) -> Self {
+        Self { enabled: enabled.into() }
     }
 }
 /// Creates a customer session object that includes a single-use client secret that you can use on your front-end to grant client-side API access for certain customer resources.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateCustomerSession<'a> {
-    inner: CreateCustomerSessionBuilder<'a>,
+pub struct CreateCustomerSession {
+    inner: CreateCustomerSessionBuilder,
 }
-impl<'a> CreateCustomerSession<'a> {
+impl CreateCustomerSession {
     /// Construct a new `CreateCustomerSession`.
-    pub fn new(components: CreateCustomerSessionComponents, customer: &'a str) -> Self {
-        Self { inner: CreateCustomerSessionBuilder::new(components, customer) }
+    pub fn new(
+        components: impl Into<CreateCustomerSessionComponents>,
+        customer: impl Into<String>,
+    ) -> Self {
+        Self { inner: CreateCustomerSessionBuilder::new(components.into(), customer.into()) }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl CreateCustomerSession<'_> {
+impl CreateCustomerSession {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -90,7 +96,7 @@ impl CreateCustomerSession<'_> {
     }
 }
 
-impl StripeRequest for CreateCustomerSession<'_> {
+impl StripeRequest for CreateCustomerSession {
     type Output = stripe_core::CustomerSession;
 
     fn build(&self) -> RequestBuilder {

--- a/generated/async-stripe-core/src/dispute/requests.rs
+++ b/generated/async-stripe-core/src/dispute/requests.rs
@@ -2,24 +2,24 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListDisputeBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListDisputeBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    charge: Option<&'a str>,
+    charge: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     created: Option<stripe_types::RangeQueryTs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_intent: Option<&'a str>,
+    payment_intent: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListDisputeBuilder<'a> {
+impl ListDisputeBuilder {
     fn new() -> Self {
         Self {
             charge: None,
@@ -34,60 +34,60 @@ impl<'a> ListDisputeBuilder<'a> {
 }
 /// Returns a list of your disputes.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListDispute<'a> {
-    inner: ListDisputeBuilder<'a>,
+pub struct ListDispute {
+    inner: ListDisputeBuilder,
 }
-impl<'a> ListDispute<'a> {
+impl ListDispute {
     /// Construct a new `ListDispute`.
     pub fn new() -> Self {
         Self { inner: ListDisputeBuilder::new() }
     }
     /// Only return disputes associated to the charge specified by this charge ID.
-    pub fn charge(mut self, charge: &'a str) -> Self {
-        self.inner.charge = Some(charge);
+    pub fn charge(mut self, charge: impl Into<String>) -> Self {
+        self.inner.charge = Some(charge.into());
         self
     }
-    pub fn created(mut self, created: stripe_types::RangeQueryTs) -> Self {
-        self.inner.created = Some(created);
+    pub fn created(mut self, created: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.created = Some(created.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// Only return disputes associated to the PaymentIntent specified by this PaymentIntent ID.
-    pub fn payment_intent(mut self, payment_intent: &'a str) -> Self {
-        self.inner.payment_intent = Some(payment_intent);
+    pub fn payment_intent(mut self, payment_intent: impl Into<String>) -> Self {
+        self.inner.payment_intent = Some(payment_intent.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl<'a> Default for ListDispute<'a> {
+impl Default for ListDispute {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListDispute<'_> {
+impl ListDispute {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -107,45 +107,45 @@ impl ListDispute<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::Dispute>> {
-        stripe_client_core::ListPaginator::new_list("/disputes", self.inner)
+        stripe_client_core::ListPaginator::new_list("/disputes", &self.inner)
     }
 }
 
-impl StripeRequest for ListDispute<'_> {
+impl StripeRequest for ListDispute {
     type Output = stripe_types::List<stripe_shared::Dispute>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/disputes").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveDisputeBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveDisputeBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveDisputeBuilder<'a> {
+impl RetrieveDisputeBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves the dispute with the given ID.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveDispute<'a> {
-    inner: RetrieveDisputeBuilder<'a>,
-    dispute: &'a stripe_shared::DisputeId,
+pub struct RetrieveDispute {
+    inner: RetrieveDisputeBuilder,
+    dispute: stripe_shared::DisputeId,
 }
-impl<'a> RetrieveDispute<'a> {
+impl RetrieveDispute {
     /// Construct a new `RetrieveDispute`.
-    pub fn new(dispute: &'a stripe_shared::DisputeId) -> Self {
-        Self { dispute, inner: RetrieveDisputeBuilder::new() }
+    pub fn new(dispute: impl Into<stripe_shared::DisputeId>) -> Self {
+        Self { dispute: dispute.into(), inner: RetrieveDisputeBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveDispute<'_> {
+impl RetrieveDispute {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -163,26 +163,26 @@ impl RetrieveDispute<'_> {
     }
 }
 
-impl StripeRequest for RetrieveDispute<'_> {
+impl StripeRequest for RetrieveDispute {
     type Output = stripe_shared::Dispute;
 
     fn build(&self) -> RequestBuilder {
-        let dispute = self.dispute;
+        let dispute = &self.dispute;
         RequestBuilder::new(StripeMethod::Get, format!("/disputes/{dispute}")).query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdateDisputeBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdateDisputeBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    evidence: Option<UpdateDisputeEvidence<'a>>,
+    evidence: Option<UpdateDisputeEvidence>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     submit: Option<bool>,
 }
-impl<'a> UpdateDisputeBuilder<'a> {
+impl UpdateDisputeBuilder {
     fn new() -> Self {
         Self { evidence: None, expand: None, metadata: None, submit: None }
     }
@@ -190,106 +190,106 @@ impl<'a> UpdateDisputeBuilder<'a> {
 /// Evidence to upload, to respond to a dispute.
 /// Updating any field in the hash will submit all fields in the hash for review.
 /// The combined character count of all fields is limited to 150,000.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateDisputeEvidence<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateDisputeEvidence {
     /// Any server or activity logs showing proof that the customer accessed or downloaded the purchased digital product.
     /// This information should include IP addresses, corresponding timestamps, and any detailed recorded activity.
     /// Has a maximum character count of 20,000.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub access_activity_log: Option<&'a str>,
+    pub access_activity_log: Option<String>,
     /// The billing address provided by the customer.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub billing_address: Option<&'a str>,
+    pub billing_address: Option<String>,
     /// (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Your subscription cancellation policy, as shown to the customer.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub cancellation_policy: Option<&'a str>,
+    pub cancellation_policy: Option<String>,
     /// An explanation of how and when the customer was shown your refund policy prior to purchase.
     /// Has a maximum character count of 20,000.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub cancellation_policy_disclosure: Option<&'a str>,
+    pub cancellation_policy_disclosure: Option<String>,
     /// A justification for why the customer's subscription was not canceled.
     /// Has a maximum character count of 20,000.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub cancellation_rebuttal: Option<&'a str>,
+    pub cancellation_rebuttal: Option<String>,
     /// (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Any communication with the customer that you feel is relevant to your case.
     /// Examples include emails proving that the customer received the product or service, or demonstrating their use of or satisfaction with the product or service.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub customer_communication: Option<&'a str>,
+    pub customer_communication: Option<String>,
     /// The email address of the customer.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub customer_email_address: Option<&'a str>,
+    pub customer_email_address: Option<String>,
     /// The name of the customer.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub customer_name: Option<&'a str>,
+    pub customer_name: Option<String>,
     /// The IP address that the customer used when making the purchase.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub customer_purchase_ip: Option<&'a str>,
+    pub customer_purchase_ip: Option<String>,
     /// (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) A relevant document or contract showing the customer's signature.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub customer_signature: Option<&'a str>,
+    pub customer_signature: Option<String>,
     /// (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Documentation for the prior charge that can uniquely identify the charge, such as a receipt, shipping label, work order, etc.
     /// This document should be paired with a similar document from the disputed payment that proves the two payments are separate.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub duplicate_charge_documentation: Option<&'a str>,
+    pub duplicate_charge_documentation: Option<String>,
     /// An explanation of the difference between the disputed charge versus the prior charge that appears to be a duplicate.
     /// Has a maximum character count of 20,000.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub duplicate_charge_explanation: Option<&'a str>,
+    pub duplicate_charge_explanation: Option<String>,
     /// The Stripe ID for the prior charge which appears to be a duplicate of the disputed charge.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub duplicate_charge_id: Option<&'a str>,
+    pub duplicate_charge_id: Option<String>,
     /// A description of the product or service that was sold. Has a maximum character count of 20,000.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub product_description: Option<&'a str>,
+    pub product_description: Option<String>,
     /// (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Any receipt or message sent to the customer notifying them of the charge.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub receipt: Option<&'a str>,
+    pub receipt: Option<String>,
     /// (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Your refund policy, as shown to the customer.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub refund_policy: Option<&'a str>,
+    pub refund_policy: Option<String>,
     /// Documentation demonstrating that the customer was shown your refund policy prior to purchase.
     /// Has a maximum character count of 20,000.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub refund_policy_disclosure: Option<&'a str>,
+    pub refund_policy_disclosure: Option<String>,
     /// A justification for why the customer is not entitled to a refund.
     /// Has a maximum character count of 20,000.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub refund_refusal_explanation: Option<&'a str>,
+    pub refund_refusal_explanation: Option<String>,
     /// The date on which the customer received or began receiving the purchased service, in a clear human-readable format.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub service_date: Option<&'a str>,
+    pub service_date: Option<String>,
     /// (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Documentation showing proof that a service was provided to the customer.
     /// This could include a copy of a signed contract, work order, or other form of written agreement.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub service_documentation: Option<&'a str>,
+    pub service_documentation: Option<String>,
     /// The address to which a physical product was shipped.
     /// You should try to include as complete address information as possible.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub shipping_address: Option<&'a str>,
+    pub shipping_address: Option<String>,
     /// The delivery service that shipped a physical product, such as Fedex, UPS, USPS, etc.
     /// If multiple carriers were used for this purchase, please separate them with commas.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub shipping_carrier: Option<&'a str>,
+    pub shipping_carrier: Option<String>,
     /// The date on which a physical product began its route to the shipping address, in a clear human-readable format.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub shipping_date: Option<&'a str>,
+    pub shipping_date: Option<String>,
     /// (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Documentation showing proof that a product was shipped to the customer at the same address the customer provided to you.
     /// This could include a copy of the shipment receipt, shipping label, etc.
     /// It should show the customer's full shipping address, if possible.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub shipping_documentation: Option<&'a str>,
+    pub shipping_documentation: Option<String>,
     /// The tracking number for a physical product, obtained from the delivery service.
     /// If multiple tracking numbers were generated for this purchase, please separate them with commas.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub shipping_tracking_number: Option<&'a str>,
+    pub shipping_tracking_number: Option<String>,
     /// (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Any additional evidence or statements.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub uncategorized_file: Option<&'a str>,
+    pub uncategorized_file: Option<String>,
     /// Any additional evidence or statements. Has a maximum character count of 20,000.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub uncategorized_text: Option<&'a str>,
+    pub uncategorized_text: Option<String>,
 }
-impl<'a> UpdateDisputeEvidence<'a> {
+impl UpdateDisputeEvidence {
     pub fn new() -> Self {
         Self {
             access_activity_log: None,
@@ -322,7 +322,7 @@ impl<'a> UpdateDisputeEvidence<'a> {
         }
     }
 }
-impl<'a> Default for UpdateDisputeEvidence<'a> {
+impl Default for UpdateDisputeEvidence {
     fn default() -> Self {
         Self::new()
     }
@@ -334,44 +334,47 @@ impl<'a> Default for UpdateDisputeEvidence<'a> {
 /// Depending on your dispute type, different evidence fields will give you a better chance of winning your dispute.
 /// To figure out which evidence fields to provide, see our [guide to dispute types](https://stripe.com/docs/disputes/categories).
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateDispute<'a> {
-    inner: UpdateDisputeBuilder<'a>,
-    dispute: &'a stripe_shared::DisputeId,
+pub struct UpdateDispute {
+    inner: UpdateDisputeBuilder,
+    dispute: stripe_shared::DisputeId,
 }
-impl<'a> UpdateDispute<'a> {
+impl UpdateDispute {
     /// Construct a new `UpdateDispute`.
-    pub fn new(dispute: &'a stripe_shared::DisputeId) -> Self {
-        Self { dispute, inner: UpdateDisputeBuilder::new() }
+    pub fn new(dispute: impl Into<stripe_shared::DisputeId>) -> Self {
+        Self { dispute: dispute.into(), inner: UpdateDisputeBuilder::new() }
     }
     /// Evidence to upload, to respond to a dispute.
     /// Updating any field in the hash will submit all fields in the hash for review.
     /// The combined character count of all fields is limited to 150,000.
-    pub fn evidence(mut self, evidence: UpdateDisputeEvidence<'a>) -> Self {
-        self.inner.evidence = Some(evidence);
+    pub fn evidence(mut self, evidence: impl Into<UpdateDisputeEvidence>) -> Self {
+        self.inner.evidence = Some(evidence.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// Whether to immediately submit evidence to the bank.
     /// If `false`, evidence is staged on the dispute.
     /// Staged evidence is visible in the API and Dashboard, and can be submitted to the bank by making another request with this attribute set to `true` (the default).
-    pub fn submit(mut self, submit: bool) -> Self {
-        self.inner.submit = Some(submit);
+    pub fn submit(mut self, submit: impl Into<bool>) -> Self {
+        self.inner.submit = Some(submit.into());
         self
     }
 }
-impl UpdateDispute<'_> {
+impl UpdateDispute {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -389,20 +392,20 @@ impl UpdateDispute<'_> {
     }
 }
 
-impl StripeRequest for UpdateDispute<'_> {
+impl StripeRequest for UpdateDispute {
     type Output = stripe_shared::Dispute;
 
     fn build(&self) -> RequestBuilder {
-        let dispute = self.dispute;
+        let dispute = &self.dispute;
         RequestBuilder::new(StripeMethod::Post, format!("/disputes/{dispute}")).form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CloseDisputeBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CloseDisputeBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> CloseDisputeBuilder<'a> {
+impl CloseDisputeBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
@@ -412,22 +415,22 @@ impl<'a> CloseDisputeBuilder<'a> {
 /// The status of the dispute will change from `needs_response` to `lost`.
 /// _Closing a dispute is irreversible_.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CloseDispute<'a> {
-    inner: CloseDisputeBuilder<'a>,
-    dispute: &'a stripe_shared::DisputeId,
+pub struct CloseDispute {
+    inner: CloseDisputeBuilder,
+    dispute: stripe_shared::DisputeId,
 }
-impl<'a> CloseDispute<'a> {
+impl CloseDispute {
     /// Construct a new `CloseDispute`.
-    pub fn new(dispute: &'a stripe_shared::DisputeId) -> Self {
-        Self { dispute, inner: CloseDisputeBuilder::new() }
+    pub fn new(dispute: impl Into<stripe_shared::DisputeId>) -> Self {
+        Self { dispute: dispute.into(), inner: CloseDisputeBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl CloseDispute<'_> {
+impl CloseDispute {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -445,11 +448,11 @@ impl CloseDispute<'_> {
     }
 }
 
-impl StripeRequest for CloseDispute<'_> {
+impl StripeRequest for CloseDispute {
     type Output = stripe_shared::Dispute;
 
     fn build(&self) -> RequestBuilder {
-        let dispute = self.dispute;
+        let dispute = &self.dispute;
         RequestBuilder::new(StripeMethod::Post, format!("/disputes/{dispute}/close"))
             .form(&self.inner)
     }

--- a/generated/async-stripe-core/src/event/requests.rs
+++ b/generated/async-stripe-core/src/event/requests.rs
@@ -2,27 +2,27 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListEventBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListEventBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     created: Option<stripe_types::RangeQueryTs>,
     #[serde(skip_serializing_if = "Option::is_none")]
     delivery_success: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
     #[serde(rename = "type")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    type_: Option<&'a str>,
+    type_: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    types: Option<&'a [&'a str]>,
+    types: Option<Vec<String>>,
 }
-impl<'a> ListEventBuilder<'a> {
+impl ListEventBuilder {
     fn new() -> Self {
         Self {
             created: None,
@@ -39,70 +39,70 @@ impl<'a> ListEventBuilder<'a> {
 /// List events, going back up to 30 days.
 /// Each event data is rendered according to Stripe API version at its creation time, specified in [event object](https://docs.stripe.com/api/events/object) `api_version` attribute (not according to your current Stripe API version or `Stripe-Version` header).
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListEvent<'a> {
-    inner: ListEventBuilder<'a>,
+pub struct ListEvent {
+    inner: ListEventBuilder,
 }
-impl<'a> ListEvent<'a> {
+impl ListEvent {
     /// Construct a new `ListEvent`.
     pub fn new() -> Self {
         Self { inner: ListEventBuilder::new() }
     }
     /// Only return events that were created during the given date interval.
-    pub fn created(mut self, created: stripe_types::RangeQueryTs) -> Self {
-        self.inner.created = Some(created);
+    pub fn created(mut self, created: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.created = Some(created.into());
         self
     }
     /// Filter events by whether all webhooks were successfully delivered.
     /// If false, events which are still pending or have failed all delivery attempts to a webhook endpoint will be returned.
-    pub fn delivery_success(mut self, delivery_success: bool) -> Self {
-        self.inner.delivery_success = Some(delivery_success);
+    pub fn delivery_success(mut self, delivery_success: impl Into<bool>) -> Self {
+        self.inner.delivery_success = Some(delivery_success.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
     /// A string containing a specific event name, or group of events using * as a wildcard.
     /// The list will be filtered to include only events with a matching event property.
-    pub fn type_(mut self, type_: &'a str) -> Self {
-        self.inner.type_ = Some(type_);
+    pub fn type_(mut self, type_: impl Into<String>) -> Self {
+        self.inner.type_ = Some(type_.into());
         self
     }
     /// An array of up to 20 strings containing specific event names.
     /// The list will be filtered to include only events with a matching event property.
     /// You may pass either `type` or `types`, but not both.
-    pub fn types(mut self, types: &'a [&'a str]) -> Self {
-        self.inner.types = Some(types);
+    pub fn types(mut self, types: impl Into<Vec<String>>) -> Self {
+        self.inner.types = Some(types.into());
         self
     }
 }
-impl<'a> Default for ListEvent<'a> {
+impl Default for ListEvent {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListEvent<'_> {
+impl ListEvent {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -122,23 +122,23 @@ impl ListEvent<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::Event>> {
-        stripe_client_core::ListPaginator::new_list("/events", self.inner)
+        stripe_client_core::ListPaginator::new_list("/events", &self.inner)
     }
 }
 
-impl StripeRequest for ListEvent<'_> {
+impl StripeRequest for ListEvent {
     type Output = stripe_types::List<stripe_shared::Event>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/events").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveEventBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveEventBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveEventBuilder<'a> {
+impl RetrieveEventBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
@@ -146,22 +146,22 @@ impl<'a> RetrieveEventBuilder<'a> {
 /// Retrieves the details of an event.
 /// Supply the unique identifier of the event, which you might have received in a webhook.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveEvent<'a> {
-    inner: RetrieveEventBuilder<'a>,
-    id: &'a stripe_shared::EventId,
+pub struct RetrieveEvent {
+    inner: RetrieveEventBuilder,
+    id: stripe_shared::EventId,
 }
-impl<'a> RetrieveEvent<'a> {
+impl RetrieveEvent {
     /// Construct a new `RetrieveEvent`.
-    pub fn new(id: &'a stripe_shared::EventId) -> Self {
-        Self { id, inner: RetrieveEventBuilder::new() }
+    pub fn new(id: impl Into<stripe_shared::EventId>) -> Self {
+        Self { id: id.into(), inner: RetrieveEventBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveEvent<'_> {
+impl RetrieveEvent {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -179,11 +179,11 @@ impl RetrieveEvent<'_> {
     }
 }
 
-impl StripeRequest for RetrieveEvent<'_> {
+impl StripeRequest for RetrieveEvent {
     type Output = stripe_shared::Event;
 
     fn build(&self) -> RequestBuilder {
-        let id = self.id;
+        let id = &self.id;
         RequestBuilder::new(StripeMethod::Get, format!("/events/{id}")).query(&self.inner)
     }
 }

--- a/generated/async-stripe-core/src/file/requests.rs
+++ b/generated/async-stripe-core/src/file/requests.rs
@@ -2,22 +2,22 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListFileBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListFileBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     created: Option<stripe_types::RangeQueryTs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     purpose: Option<stripe_shared::FilePurpose>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListFileBuilder<'a> {
+impl ListFileBuilder {
     fn new() -> Self {
         Self {
             created: None,
@@ -32,57 +32,57 @@ impl<'a> ListFileBuilder<'a> {
 /// Returns a list of the files that your account has access to.
 /// Stripe sorts and returns the files by their creation dates, placing the most recently created files at the top.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListFile<'a> {
-    inner: ListFileBuilder<'a>,
+pub struct ListFile {
+    inner: ListFileBuilder,
 }
-impl<'a> ListFile<'a> {
+impl ListFile {
     /// Construct a new `ListFile`.
     pub fn new() -> Self {
         Self { inner: ListFileBuilder::new() }
     }
     /// Only return files that were created during the given date interval.
-    pub fn created(mut self, created: stripe_types::RangeQueryTs) -> Self {
-        self.inner.created = Some(created);
+    pub fn created(mut self, created: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.created = Some(created.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// Filter queries by the file purpose.
     /// If you don't provide a purpose, the queries return unfiltered files.
-    pub fn purpose(mut self, purpose: stripe_shared::FilePurpose) -> Self {
-        self.inner.purpose = Some(purpose);
+    pub fn purpose(mut self, purpose: impl Into<stripe_shared::FilePurpose>) -> Self {
+        self.inner.purpose = Some(purpose.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl<'a> Default for ListFile<'a> {
+impl Default for ListFile {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListFile<'_> {
+impl ListFile {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -102,23 +102,23 @@ impl ListFile<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::File>> {
-        stripe_client_core::ListPaginator::new_list("/files", self.inner)
+        stripe_client_core::ListPaginator::new_list("/files", &self.inner)
     }
 }
 
-impl StripeRequest for ListFile<'_> {
+impl StripeRequest for ListFile {
     type Output = stripe_types::List<stripe_shared::File>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/files").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveFileBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveFileBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveFileBuilder<'a> {
+impl RetrieveFileBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
@@ -127,22 +127,22 @@ impl<'a> RetrieveFileBuilder<'a> {
 /// After you supply a unique file ID, Stripe returns the corresponding file object.
 /// Learn how to [access file contents](https://stripe.com/docs/file-upload#download-file-contents).
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveFile<'a> {
-    inner: RetrieveFileBuilder<'a>,
-    file: &'a stripe_shared::FileId,
+pub struct RetrieveFile {
+    inner: RetrieveFileBuilder,
+    file: stripe_shared::FileId,
 }
-impl<'a> RetrieveFile<'a> {
+impl RetrieveFile {
     /// Construct a new `RetrieveFile`.
-    pub fn new(file: &'a stripe_shared::FileId) -> Self {
-        Self { file, inner: RetrieveFileBuilder::new() }
+    pub fn new(file: impl Into<stripe_shared::FileId>) -> Self {
+        Self { file: file.into(), inner: RetrieveFileBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveFile<'_> {
+impl RetrieveFile {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -160,11 +160,11 @@ impl RetrieveFile<'_> {
     }
 }
 
-impl StripeRequest for RetrieveFile<'_> {
+impl StripeRequest for RetrieveFile {
     type Output = stripe_shared::File;
 
     fn build(&self) -> RequestBuilder {
-        let file = self.file;
+        let file = &self.file;
         RequestBuilder::new(StripeMethod::Get, format!("/files/{file}")).query(&self.inner)
     }
 }

--- a/generated/async-stripe-core/src/file_link/requests.rs
+++ b/generated/async-stripe-core/src/file_link/requests.rs
@@ -2,24 +2,24 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListFileLinkBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListFileLinkBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     created: Option<stripe_types::RangeQueryTs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     expired: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    file: Option<&'a str>,
+    file: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListFileLinkBuilder<'a> {
+impl ListFileLinkBuilder {
     fn new() -> Self {
         Self {
             created: None,
@@ -34,61 +34,61 @@ impl<'a> ListFileLinkBuilder<'a> {
 }
 /// Returns a list of file links.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListFileLink<'a> {
-    inner: ListFileLinkBuilder<'a>,
+pub struct ListFileLink {
+    inner: ListFileLinkBuilder,
 }
-impl<'a> ListFileLink<'a> {
+impl ListFileLink {
     /// Construct a new `ListFileLink`.
     pub fn new() -> Self {
         Self { inner: ListFileLinkBuilder::new() }
     }
     /// Only return links that were created during the given date interval.
-    pub fn created(mut self, created: stripe_types::RangeQueryTs) -> Self {
-        self.inner.created = Some(created);
+    pub fn created(mut self, created: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.created = Some(created.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Filter links by their expiration status. By default, Stripe returns all links.
-    pub fn expired(mut self, expired: bool) -> Self {
-        self.inner.expired = Some(expired);
+    pub fn expired(mut self, expired: impl Into<bool>) -> Self {
+        self.inner.expired = Some(expired.into());
         self
     }
     /// Only return links for the given file.
-    pub fn file(mut self, file: &'a str) -> Self {
-        self.inner.file = Some(file);
+    pub fn file(mut self, file: impl Into<String>) -> Self {
+        self.inner.file = Some(file.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl<'a> Default for ListFileLink<'a> {
+impl Default for ListFileLink {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListFileLink<'_> {
+impl ListFileLink {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -108,45 +108,45 @@ impl ListFileLink<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::FileLink>> {
-        stripe_client_core::ListPaginator::new_list("/file_links", self.inner)
+        stripe_client_core::ListPaginator::new_list("/file_links", &self.inner)
     }
 }
 
-impl StripeRequest for ListFileLink<'_> {
+impl StripeRequest for ListFileLink {
     type Output = stripe_types::List<stripe_shared::FileLink>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/file_links").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveFileLinkBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveFileLinkBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveFileLinkBuilder<'a> {
+impl RetrieveFileLinkBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves the file link with the given ID.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveFileLink<'a> {
-    inner: RetrieveFileLinkBuilder<'a>,
-    link: &'a stripe_shared::FileLinkId,
+pub struct RetrieveFileLink {
+    inner: RetrieveFileLinkBuilder,
+    link: stripe_shared::FileLinkId,
 }
-impl<'a> RetrieveFileLink<'a> {
+impl RetrieveFileLink {
     /// Construct a new `RetrieveFileLink`.
-    pub fn new(link: &'a stripe_shared::FileLinkId) -> Self {
-        Self { link, inner: RetrieveFileLinkBuilder::new() }
+    pub fn new(link: impl Into<stripe_shared::FileLinkId>) -> Self {
+        Self { link: link.into(), inner: RetrieveFileLinkBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveFileLink<'_> {
+impl RetrieveFileLink {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -164,59 +164,62 @@ impl RetrieveFileLink<'_> {
     }
 }
 
-impl StripeRequest for RetrieveFileLink<'_> {
+impl StripeRequest for RetrieveFileLink {
     type Output = stripe_shared::FileLink;
 
     fn build(&self) -> RequestBuilder {
-        let link = self.link;
+        let link = &self.link;
         RequestBuilder::new(StripeMethod::Get, format!("/file_links/{link}")).query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateFileLinkBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateFileLinkBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     expires_at: Option<stripe_types::Timestamp>,
-    file: &'a str,
+    file: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
 }
-impl<'a> CreateFileLinkBuilder<'a> {
-    fn new(file: &'a str) -> Self {
-        Self { expand: None, expires_at: None, file, metadata: None }
+impl CreateFileLinkBuilder {
+    fn new(file: impl Into<String>) -> Self {
+        Self { expand: None, expires_at: None, file: file.into(), metadata: None }
     }
 }
 /// Creates a new file link object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateFileLink<'a> {
-    inner: CreateFileLinkBuilder<'a>,
+pub struct CreateFileLink {
+    inner: CreateFileLinkBuilder,
 }
-impl<'a> CreateFileLink<'a> {
+impl CreateFileLink {
     /// Construct a new `CreateFileLink`.
-    pub fn new(file: &'a str) -> Self {
-        Self { inner: CreateFileLinkBuilder::new(file) }
+    pub fn new(file: impl Into<String>) -> Self {
+        Self { inner: CreateFileLinkBuilder::new(file.into()) }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// The link isn't usable after this future timestamp.
-    pub fn expires_at(mut self, expires_at: stripe_types::Timestamp) -> Self {
-        self.inner.expires_at = Some(expires_at);
+    pub fn expires_at(mut self, expires_at: impl Into<stripe_types::Timestamp>) -> Self {
+        self.inner.expires_at = Some(expires_at.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
 }
-impl CreateFileLink<'_> {
+impl CreateFileLink {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -234,23 +237,23 @@ impl CreateFileLink<'_> {
     }
 }
 
-impl StripeRequest for CreateFileLink<'_> {
+impl StripeRequest for CreateFileLink {
     type Output = stripe_shared::FileLink;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Post, "/file_links").form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdateFileLinkBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdateFileLinkBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     expires_at: Option<UpdateFileLinkExpiresAt>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
 }
-impl<'a> UpdateFileLinkBuilder<'a> {
+impl UpdateFileLinkBuilder {
     fn new() -> Self {
         Self { expand: None, expires_at: None, metadata: None }
     }
@@ -265,35 +268,38 @@ pub enum UpdateFileLinkExpiresAt {
 }
 /// Updates an existing file link object. Expired links can no longer be updated.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateFileLink<'a> {
-    inner: UpdateFileLinkBuilder<'a>,
-    link: &'a stripe_shared::FileLinkId,
+pub struct UpdateFileLink {
+    inner: UpdateFileLinkBuilder,
+    link: stripe_shared::FileLinkId,
 }
-impl<'a> UpdateFileLink<'a> {
+impl UpdateFileLink {
     /// Construct a new `UpdateFileLink`.
-    pub fn new(link: &'a stripe_shared::FileLinkId) -> Self {
-        Self { link, inner: UpdateFileLinkBuilder::new() }
+    pub fn new(link: impl Into<stripe_shared::FileLinkId>) -> Self {
+        Self { link: link.into(), inner: UpdateFileLinkBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A future timestamp after which the link will no longer be usable, or `now` to expire the link immediately.
-    pub fn expires_at(mut self, expires_at: UpdateFileLinkExpiresAt) -> Self {
-        self.inner.expires_at = Some(expires_at);
+    pub fn expires_at(mut self, expires_at: impl Into<UpdateFileLinkExpiresAt>) -> Self {
+        self.inner.expires_at = Some(expires_at.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
 }
-impl UpdateFileLink<'_> {
+impl UpdateFileLink {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -311,11 +317,11 @@ impl UpdateFileLink<'_> {
     }
 }
 
-impl StripeRequest for UpdateFileLink<'_> {
+impl StripeRequest for UpdateFileLink {
     type Output = stripe_shared::FileLink;
 
     fn build(&self) -> RequestBuilder {
-        let link = self.link;
+        let link = &self.link;
         RequestBuilder::new(StripeMethod::Post, format!("/file_links/{link}")).form(&self.inner)
     }
 }

--- a/generated/async-stripe-core/src/mandate/requests.rs
+++ b/generated/async-stripe-core/src/mandate/requests.rs
@@ -2,34 +2,34 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveMandateBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveMandateBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveMandateBuilder<'a> {
+impl RetrieveMandateBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves a Mandate object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveMandate<'a> {
-    inner: RetrieveMandateBuilder<'a>,
-    mandate: &'a stripe_shared::MandateId,
+pub struct RetrieveMandate {
+    inner: RetrieveMandateBuilder,
+    mandate: stripe_shared::MandateId,
 }
-impl<'a> RetrieveMandate<'a> {
+impl RetrieveMandate {
     /// Construct a new `RetrieveMandate`.
-    pub fn new(mandate: &'a stripe_shared::MandateId) -> Self {
-        Self { mandate, inner: RetrieveMandateBuilder::new() }
+    pub fn new(mandate: impl Into<stripe_shared::MandateId>) -> Self {
+        Self { mandate: mandate.into(), inner: RetrieveMandateBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveMandate<'_> {
+impl RetrieveMandate {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -47,11 +47,11 @@ impl RetrieveMandate<'_> {
     }
 }
 
-impl StripeRequest for RetrieveMandate<'_> {
+impl StripeRequest for RetrieveMandate {
     type Output = stripe_shared::Mandate;
 
     fn build(&self) -> RequestBuilder {
-        let mandate = self.mandate;
+        let mandate = &self.mandate;
         RequestBuilder::new(StripeMethod::Get, format!("/mandates/{mandate}")).query(&self.inner)
     }
 }

--- a/generated/async-stripe-core/src/payment_intent/requests.rs
+++ b/generated/async-stripe-core/src/payment_intent/requests.rs
@@ -2,22 +2,22 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListPaymentIntentBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListPaymentIntentBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     created: Option<stripe_types::RangeQueryTs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    customer: Option<&'a str>,
+    customer: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListPaymentIntentBuilder<'a> {
+impl ListPaymentIntentBuilder {
     fn new() -> Self {
         Self {
             created: None,
@@ -31,57 +31,57 @@ impl<'a> ListPaymentIntentBuilder<'a> {
 }
 /// Returns a list of PaymentIntents.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListPaymentIntent<'a> {
-    inner: ListPaymentIntentBuilder<'a>,
+pub struct ListPaymentIntent {
+    inner: ListPaymentIntentBuilder,
 }
-impl<'a> ListPaymentIntent<'a> {
+impl ListPaymentIntent {
     /// Construct a new `ListPaymentIntent`.
     pub fn new() -> Self {
         Self { inner: ListPaymentIntentBuilder::new() }
     }
     /// A filter on the list, based on the object `created` field.
     /// The value can be a string with an integer Unix timestamp or a dictionary with a number of different query options.
-    pub fn created(mut self, created: stripe_types::RangeQueryTs) -> Self {
-        self.inner.created = Some(created);
+    pub fn created(mut self, created: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.created = Some(created.into());
         self
     }
     /// Only return PaymentIntents for the customer that this customer ID specifies.
-    pub fn customer(mut self, customer: &'a str) -> Self {
-        self.inner.customer = Some(customer);
+    pub fn customer(mut self, customer: impl Into<String>) -> Self {
+        self.inner.customer = Some(customer.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl<'a> Default for ListPaymentIntent<'a> {
+impl Default for ListPaymentIntent {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListPaymentIntent<'_> {
+impl ListPaymentIntent {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -101,25 +101,25 @@ impl ListPaymentIntent<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::PaymentIntent>> {
-        stripe_client_core::ListPaginator::new_list("/payment_intents", self.inner)
+        stripe_client_core::ListPaginator::new_list("/payment_intents", &self.inner)
     }
 }
 
-impl StripeRequest for ListPaymentIntent<'_> {
+impl StripeRequest for ListPaymentIntent {
     type Output = stripe_types::List<stripe_shared::PaymentIntent>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/payment_intents").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrievePaymentIntentBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrievePaymentIntentBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    client_secret: Option<&'a str>,
+    client_secret: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrievePaymentIntentBuilder<'a> {
+impl RetrievePaymentIntentBuilder {
     fn new() -> Self {
         Self { client_secret: None, expand: None }
     }
@@ -132,28 +132,28 @@ impl<'a> RetrievePaymentIntentBuilder<'a> {
 /// If you retrieve a PaymentIntent with a publishable key, it only returns a subset of properties.
 /// Refer to the [payment intent](https://stripe.com/docs/api#payment_intent_object) object reference for more details.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrievePaymentIntent<'a> {
-    inner: RetrievePaymentIntentBuilder<'a>,
-    intent: &'a stripe_shared::PaymentIntentId,
+pub struct RetrievePaymentIntent {
+    inner: RetrievePaymentIntentBuilder,
+    intent: stripe_shared::PaymentIntentId,
 }
-impl<'a> RetrievePaymentIntent<'a> {
+impl RetrievePaymentIntent {
     /// Construct a new `RetrievePaymentIntent`.
-    pub fn new(intent: &'a stripe_shared::PaymentIntentId) -> Self {
-        Self { intent, inner: RetrievePaymentIntentBuilder::new() }
+    pub fn new(intent: impl Into<stripe_shared::PaymentIntentId>) -> Self {
+        Self { intent: intent.into(), inner: RetrievePaymentIntentBuilder::new() }
     }
     /// The client secret of the PaymentIntent.
     /// We require it if you use a publishable key to retrieve the source.
-    pub fn client_secret(mut self, client_secret: &'a str) -> Self {
-        self.inner.client_secret = Some(client_secret);
+    pub fn client_secret(mut self, client_secret: impl Into<String>) -> Self {
+        self.inner.client_secret = Some(client_secret.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrievePaymentIntent<'_> {
+impl RetrievePaymentIntent {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -171,28 +171,28 @@ impl RetrievePaymentIntent<'_> {
     }
 }
 
-impl StripeRequest for RetrievePaymentIntent<'_> {
+impl StripeRequest for RetrievePaymentIntent {
     type Output = stripe_shared::PaymentIntent;
 
     fn build(&self) -> RequestBuilder {
-        let intent = self.intent;
+        let intent = &self.intent;
         RequestBuilder::new(StripeMethod::Get, format!("/payment_intents/{intent}"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct SearchPaymentIntentBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct SearchPaymentIntentBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    page: Option<&'a str>,
-    query: &'a str,
+    page: Option<String>,
+    query: String,
 }
-impl<'a> SearchPaymentIntentBuilder<'a> {
-    fn new(query: &'a str) -> Self {
-        Self { expand: None, limit: None, page: None, query }
+impl SearchPaymentIntentBuilder {
+    fn new(query: impl Into<String>) -> Self {
+        Self { expand: None, limit: None, page: None, query: query.into() }
     }
 }
 /// Search for PaymentIntents you’ve previously created using Stripe’s [Search Query Language](https://stripe.com/docs/search#search-query-language).
@@ -202,34 +202,34 @@ impl<'a> SearchPaymentIntentBuilder<'a> {
 /// Occasionally, propagation of new or updated data can be up.
 /// to an hour behind during outages. Search functionality is not available to merchants in India.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct SearchPaymentIntent<'a> {
-    inner: SearchPaymentIntentBuilder<'a>,
+pub struct SearchPaymentIntent {
+    inner: SearchPaymentIntentBuilder,
 }
-impl<'a> SearchPaymentIntent<'a> {
+impl SearchPaymentIntent {
     /// Construct a new `SearchPaymentIntent`.
-    pub fn new(query: &'a str) -> Self {
-        Self { inner: SearchPaymentIntentBuilder::new(query) }
+    pub fn new(query: impl Into<String>) -> Self {
+        Self { inner: SearchPaymentIntentBuilder::new(query.into()) }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for pagination across multiple pages of results.
     /// Don't include this parameter on the first call.
     /// Use the next_page value returned in a previous response to request subsequent results.
-    pub fn page(mut self, page: &'a str) -> Self {
-        self.inner.page = Some(page);
+    pub fn page(mut self, page: impl Into<String>) -> Self {
+        self.inner.page = Some(page.into());
         self
     }
 }
-impl SearchPaymentIntent<'_> {
+impl SearchPaymentIntent {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -250,11 +250,11 @@ impl SearchPaymentIntent<'_> {
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::SearchList<stripe_shared::PaymentIntent>>
     {
-        stripe_client_core::ListPaginator::new_search_list("/payment_intents/search", self.inner)
+        stripe_client_core::ListPaginator::new_search_list("/payment_intents/search", &self.inner)
     }
 }
 
-impl StripeRequest for SearchPaymentIntent<'_> {
+impl StripeRequest for SearchPaymentIntent {
     type Output = stripe_types::SearchList<stripe_shared::PaymentIntent>;
 
     fn build(&self) -> RequestBuilder {
@@ -262,7 +262,7 @@ impl StripeRequest for SearchPaymentIntent<'_> {
     }
 }
 #[derive(Clone, Debug, serde::Serialize)]
-struct CreatePaymentIntentBuilder<'a> {
+struct CreatePaymentIntentBuilder {
     amount: i64,
     #[serde(skip_serializing_if = "Option::is_none")]
     application_fee_amount: Option<i64>,
@@ -275,68 +275,68 @@ struct CreatePaymentIntentBuilder<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     confirmation_method: Option<stripe_shared::PaymentIntentConfirmationMethod>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    confirmation_token: Option<&'a str>,
+    confirmation_token: Option<String>,
     currency: stripe_types::Currency,
     #[serde(skip_serializing_if = "Option::is_none")]
-    customer: Option<&'a str>,
+    customer: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<&'a str>,
+    description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     error_on_requires_action: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    mandate: Option<&'a str>,
+    mandate: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    mandate_data: Option<CreatePaymentIntentMandateData<'a>>,
+    mandate_data: Option<CreatePaymentIntentMandateData>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     off_session: Option<CreatePaymentIntentOffSession>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    on_behalf_of: Option<&'a str>,
+    on_behalf_of: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_method: Option<&'a str>,
+    payment_method: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_method_configuration: Option<&'a str>,
+    payment_method_configuration: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_method_data: Option<CreatePaymentIntentPaymentMethodData<'a>>,
+    payment_method_data: Option<CreatePaymentIntentPaymentMethodData>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_method_options: Option<CreatePaymentIntentPaymentMethodOptions<'a>>,
+    payment_method_options: Option<CreatePaymentIntentPaymentMethodOptions>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_method_types: Option<&'a [&'a str]>,
+    payment_method_types: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    radar_options: Option<RadarOptionsWithHiddenOptions<'a>>,
+    radar_options: Option<RadarOptionsWithHiddenOptions>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    receipt_email: Option<&'a str>,
+    receipt_email: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    return_url: Option<&'a str>,
+    return_url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     setup_future_usage: Option<stripe_shared::PaymentIntentSetupFutureUsage>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    shipping: Option<CreatePaymentIntentShipping<'a>>,
+    shipping: Option<CreatePaymentIntentShipping>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    statement_descriptor: Option<&'a str>,
+    statement_descriptor: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    statement_descriptor_suffix: Option<&'a str>,
+    statement_descriptor_suffix: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    transfer_data: Option<CreatePaymentIntentTransferData<'a>>,
+    transfer_data: Option<CreatePaymentIntentTransferData>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    transfer_group: Option<&'a str>,
+    transfer_group: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     use_stripe_sdk: Option<bool>,
 }
-impl<'a> CreatePaymentIntentBuilder<'a> {
-    fn new(amount: i64, currency: stripe_types::Currency) -> Self {
+impl CreatePaymentIntentBuilder {
+    fn new(amount: impl Into<i64>, currency: impl Into<stripe_types::Currency>) -> Self {
         Self {
-            amount,
+            amount: amount.into(),
             application_fee_amount: None,
             automatic_payment_methods: None,
             capture_method: None,
             confirm: None,
             confirmation_method: None,
             confirmation_token: None,
-            currency,
+            currency: currency.into(),
             customer: None,
             description: None,
             error_on_requires_action: None,
@@ -377,8 +377,8 @@ pub struct CreatePaymentIntentAutomaticPaymentMethods {
     pub enabled: bool,
 }
 impl CreatePaymentIntentAutomaticPaymentMethods {
-    pub fn new(enabled: bool) -> Self {
-        Self { allow_redirects: None, enabled }
+    pub fn new(enabled: impl Into<bool>) -> Self {
+        Self { allow_redirects: None, enabled: enabled.into() }
     }
 }
 /// Controls whether this PaymentIntent will accept redirect-based payment methods.
@@ -445,18 +445,20 @@ impl<'de> serde::Deserialize<'de> for CreatePaymentIntentAutomaticPaymentMethods
 /// This hash contains details about the Mandate to create.
 /// This parameter can only be used with [`confirm=true`](https://stripe.com/docs/api/payment_intents/create#create_payment_intent-confirm).
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentIntentMandateData<'a> {
+pub struct CreatePaymentIntentMandateData {
     /// This hash contains details about the customer acceptance of the Mandate.
-    pub customer_acceptance: CreatePaymentIntentMandateDataCustomerAcceptance<'a>,
+    pub customer_acceptance: CreatePaymentIntentMandateDataCustomerAcceptance,
 }
-impl<'a> CreatePaymentIntentMandateData<'a> {
-    pub fn new(customer_acceptance: CreatePaymentIntentMandateDataCustomerAcceptance<'a>) -> Self {
-        Self { customer_acceptance }
+impl CreatePaymentIntentMandateData {
+    pub fn new(
+        customer_acceptance: impl Into<CreatePaymentIntentMandateDataCustomerAcceptance>,
+    ) -> Self {
+        Self { customer_acceptance: customer_acceptance.into() }
     }
 }
 /// This hash contains details about the customer acceptance of the Mandate.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentIntentMandateDataCustomerAcceptance<'a> {
+pub struct CreatePaymentIntentMandateDataCustomerAcceptance {
     /// The time at which the customer accepted the Mandate.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub accepted_at: Option<stripe_types::Timestamp>,
@@ -466,15 +468,15 @@ pub struct CreatePaymentIntentMandateDataCustomerAcceptance<'a> {
     pub offline: Option<miniserde::json::Value>,
     /// If this is a Mandate accepted online, this hash contains details about the online acceptance.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub online: Option<OnlineParam<'a>>,
+    pub online: Option<OnlineParam>,
     /// The type of customer acceptance information included with the Mandate.
     /// One of `online` or `offline`.
     #[serde(rename = "type")]
     pub type_: CreatePaymentIntentMandateDataCustomerAcceptanceType,
 }
-impl<'a> CreatePaymentIntentMandateDataCustomerAcceptance<'a> {
-    pub fn new(type_: CreatePaymentIntentMandateDataCustomerAcceptanceType) -> Self {
-        Self { accepted_at: None, offline: None, online: None, type_ }
+impl CreatePaymentIntentMandateDataCustomerAcceptance {
+    pub fn new(type_: impl Into<CreatePaymentIntentMandateDataCustomerAcceptanceType>) -> Self {
+        Self { accepted_at: None, offline: None, online: None, type_: type_.into() }
     }
 }
 /// The type of customer acceptance information included with the Mandate.
@@ -551,10 +553,10 @@ pub enum CreatePaymentIntentOffSession {
 /// in the [payment_method](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-payment_method).
 /// property on the PaymentIntent.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentIntentPaymentMethodData<'a> {
+pub struct CreatePaymentIntentPaymentMethodData {
     /// If this is an `acss_debit` PaymentMethod, this hash contains details about the ACSS Debit payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub acss_debit: Option<PaymentMethodParam<'a>>,
+    pub acss_debit: Option<PaymentMethodParam>,
     /// If this is an `affirm` PaymentMethod, this hash contains details about the Affirm payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
@@ -578,24 +580,24 @@ pub struct CreatePaymentIntentPaymentMethodData<'a> {
     pub amazon_pay: Option<miniserde::json::Value>,
     /// If this is an `au_becs_debit` PaymentMethod, this hash contains details about the bank account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub au_becs_debit: Option<CreatePaymentIntentPaymentMethodDataAuBecsDebit<'a>>,
+    pub au_becs_debit: Option<CreatePaymentIntentPaymentMethodDataAuBecsDebit>,
     /// If this is a `bacs_debit` PaymentMethod, this hash contains details about the Bacs Direct Debit bank account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub bacs_debit: Option<CreatePaymentIntentPaymentMethodDataBacsDebit<'a>>,
+    pub bacs_debit: Option<CreatePaymentIntentPaymentMethodDataBacsDebit>,
     /// If this is a `bancontact` PaymentMethod, this hash contains details about the Bancontact payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
     pub bancontact: Option<miniserde::json::Value>,
     /// Billing information associated with the PaymentMethod that may be used or required by particular types of payment methods.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub billing_details: Option<CreatePaymentIntentPaymentMethodDataBillingDetails<'a>>,
+    pub billing_details: Option<CreatePaymentIntentPaymentMethodDataBillingDetails>,
     /// If this is a `blik` PaymentMethod, this hash contains details about the BLIK payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
     pub blik: Option<miniserde::json::Value>,
     /// If this is a `boleto` PaymentMethod, this hash contains details about the Boleto payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub boleto: Option<CreatePaymentIntentPaymentMethodDataBoleto<'a>>,
+    pub boleto: Option<CreatePaymentIntentPaymentMethodDataBoleto>,
     /// If this is a `cashapp` PaymentMethod, this hash contains details about the Cash App Pay payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
@@ -641,7 +643,7 @@ pub struct CreatePaymentIntentPaymentMethodData<'a> {
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// If this is a `mobilepay` PaymentMethod, this hash contains details about the MobilePay payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
@@ -672,14 +674,14 @@ pub struct CreatePaymentIntentPaymentMethodData<'a> {
     /// Options to configure Radar.
     /// See [Radar Session](https://stripe.com/docs/radar/radar-session) for more information.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub radar_options: Option<RadarOptionsWithHiddenOptions<'a>>,
+    pub radar_options: Option<RadarOptionsWithHiddenOptions>,
     /// If this is a `Revolut Pay` PaymentMethod, this hash contains details about the Revolut Pay payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
     pub revolut_pay: Option<miniserde::json::Value>,
     /// If this is a `sepa_debit` PaymentMethod, this hash contains details about the SEPA debit bank account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub sepa_debit: Option<CreatePaymentIntentPaymentMethodDataSepaDebit<'a>>,
+    pub sepa_debit: Option<CreatePaymentIntentPaymentMethodDataSepaDebit>,
     /// If this is a `sofort` PaymentMethod, this hash contains details about the SOFORT payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sofort: Option<CreatePaymentIntentPaymentMethodDataSofort>,
@@ -694,7 +696,7 @@ pub struct CreatePaymentIntentPaymentMethodData<'a> {
     pub type_: CreatePaymentIntentPaymentMethodDataType,
     /// If this is an `us_bank_account` PaymentMethod, this hash contains details about the US bank account payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub us_bank_account: Option<CreatePaymentIntentPaymentMethodDataUsBankAccount<'a>>,
+    pub us_bank_account: Option<CreatePaymentIntentPaymentMethodDataUsBankAccount>,
     /// If this is an `wechat_pay` PaymentMethod, this hash contains details about the wechat_pay payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
@@ -704,8 +706,8 @@ pub struct CreatePaymentIntentPaymentMethodData<'a> {
     #[serde(with = "stripe_types::with_serde_json_opt")]
     pub zip: Option<miniserde::json::Value>,
 }
-impl<'a> CreatePaymentIntentPaymentMethodData<'a> {
-    pub fn new(type_: CreatePaymentIntentPaymentMethodDataType) -> Self {
+impl CreatePaymentIntentPaymentMethodData {
+    pub fn new(type_: impl Into<CreatePaymentIntentPaymentMethodDataType>) -> Self {
         Self {
             acss_debit: None,
             affirm: None,
@@ -743,7 +745,7 @@ impl<'a> CreatePaymentIntentPaymentMethodData<'a> {
             sepa_debit: None,
             sofort: None,
             swish: None,
-            type_,
+            type_: type_.into(),
             us_bank_account: None,
             wechat_pay: None,
             zip: None,
@@ -814,105 +816,105 @@ impl<'de> serde::Deserialize<'de> for CreatePaymentIntentPaymentMethodDataAllowR
     }
 }
 /// If this is an `au_becs_debit` PaymentMethod, this hash contains details about the bank account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentIntentPaymentMethodDataAuBecsDebit<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentIntentPaymentMethodDataAuBecsDebit {
     /// The account number for the bank account.
-    pub account_number: &'a str,
+    pub account_number: String,
     /// Bank-State-Branch number of the bank account.
-    pub bsb_number: &'a str,
+    pub bsb_number: String,
 }
-impl<'a> CreatePaymentIntentPaymentMethodDataAuBecsDebit<'a> {
-    pub fn new(account_number: &'a str, bsb_number: &'a str) -> Self {
-        Self { account_number, bsb_number }
+impl CreatePaymentIntentPaymentMethodDataAuBecsDebit {
+    pub fn new(account_number: impl Into<String>, bsb_number: impl Into<String>) -> Self {
+        Self { account_number: account_number.into(), bsb_number: bsb_number.into() }
     }
 }
 /// If this is a `bacs_debit` PaymentMethod, this hash contains details about the Bacs Direct Debit bank account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentIntentPaymentMethodDataBacsDebit<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentIntentPaymentMethodDataBacsDebit {
     /// Account number of the bank account that the funds will be debited from.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account_number: Option<&'a str>,
+    pub account_number: Option<String>,
     /// Sort code of the bank account. (e.g., `10-20-30`)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub sort_code: Option<&'a str>,
+    pub sort_code: Option<String>,
 }
-impl<'a> CreatePaymentIntentPaymentMethodDataBacsDebit<'a> {
+impl CreatePaymentIntentPaymentMethodDataBacsDebit {
     pub fn new() -> Self {
         Self { account_number: None, sort_code: None }
     }
 }
-impl<'a> Default for CreatePaymentIntentPaymentMethodDataBacsDebit<'a> {
+impl Default for CreatePaymentIntentPaymentMethodDataBacsDebit {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Billing information associated with the PaymentMethod that may be used or required by particular types of payment methods.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentIntentPaymentMethodDataBillingDetails<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentIntentPaymentMethodDataBillingDetails {
     /// Billing address.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub address: Option<CreatePaymentIntentPaymentMethodDataBillingDetailsAddress<'a>>,
+    pub address: Option<CreatePaymentIntentPaymentMethodDataBillingDetailsAddress>,
     /// Email address.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub email: Option<&'a str>,
+    pub email: Option<String>,
     /// Full name.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<&'a str>,
+    pub name: Option<String>,
     /// Billing phone number (including extension).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub phone: Option<&'a str>,
+    pub phone: Option<String>,
 }
-impl<'a> CreatePaymentIntentPaymentMethodDataBillingDetails<'a> {
+impl CreatePaymentIntentPaymentMethodDataBillingDetails {
     pub fn new() -> Self {
         Self { address: None, email: None, name: None, phone: None }
     }
 }
-impl<'a> Default for CreatePaymentIntentPaymentMethodDataBillingDetails<'a> {
+impl Default for CreatePaymentIntentPaymentMethodDataBillingDetails {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Billing address.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentIntentPaymentMethodDataBillingDetailsAddress<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentIntentPaymentMethodDataBillingDetailsAddress {
     /// City, district, suburb, town, or village.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<&'a str>,
+    pub city: Option<String>,
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub country: Option<&'a str>,
+    pub country: Option<String>,
     /// Address line 1 (e.g., street, PO Box, or company name).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line1: Option<&'a str>,
+    pub line1: Option<String>,
     /// Address line 2 (e.g., apartment, suite, unit, or building).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line2: Option<&'a str>,
+    pub line2: Option<String>,
     /// ZIP or postal code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<&'a str>,
+    pub postal_code: Option<String>,
     /// State, county, province, or region.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
 }
-impl<'a> CreatePaymentIntentPaymentMethodDataBillingDetailsAddress<'a> {
+impl CreatePaymentIntentPaymentMethodDataBillingDetailsAddress {
     pub fn new() -> Self {
         Self { city: None, country: None, line1: None, line2: None, postal_code: None, state: None }
     }
 }
-impl<'a> Default for CreatePaymentIntentPaymentMethodDataBillingDetailsAddress<'a> {
+impl Default for CreatePaymentIntentPaymentMethodDataBillingDetailsAddress {
     fn default() -> Self {
         Self::new()
     }
 }
 /// If this is a `boleto` PaymentMethod, this hash contains details about the Boleto payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentIntentPaymentMethodDataBoleto<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentIntentPaymentMethodDataBoleto {
     /// The tax ID of the customer (CPF for individual consumers or CNPJ for businesses consumers)
-    pub tax_id: &'a str,
+    pub tax_id: String,
 }
-impl<'a> CreatePaymentIntentPaymentMethodDataBoleto<'a> {
-    pub fn new(tax_id: &'a str) -> Self {
-        Self { tax_id }
+impl CreatePaymentIntentPaymentMethodDataBoleto {
+    pub fn new(tax_id: impl Into<String>) -> Self {
+        Self { tax_id: tax_id.into() }
     }
 }
 /// If this is an `eps` PaymentMethod, this hash contains details about the EPS payment method.
@@ -1078,8 +1080,8 @@ pub struct CreatePaymentIntentPaymentMethodDataFpx {
     pub bank: CreatePaymentIntentPaymentMethodDataFpxBank,
 }
 impl CreatePaymentIntentPaymentMethodDataFpx {
-    pub fn new(bank: CreatePaymentIntentPaymentMethodDataFpxBank) -> Self {
-        Self { account_holder_type: None, bank }
+    pub fn new(bank: impl Into<CreatePaymentIntentPaymentMethodDataFpxBank>) -> Self {
+        Self { account_holder_type: None, bank: bank.into() }
     }
 }
 /// Account holder type for FPX transaction
@@ -1540,14 +1542,14 @@ impl<'de> serde::Deserialize<'de> for CreatePaymentIntentPaymentMethodDataP24Ban
     }
 }
 /// If this is a `sepa_debit` PaymentMethod, this hash contains details about the SEPA debit bank account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentIntentPaymentMethodDataSepaDebit<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentIntentPaymentMethodDataSepaDebit {
     /// IBAN of the bank account.
-    pub iban: &'a str,
+    pub iban: String,
 }
-impl<'a> CreatePaymentIntentPaymentMethodDataSepaDebit<'a> {
-    pub fn new(iban: &'a str) -> Self {
-        Self { iban }
+impl CreatePaymentIntentPaymentMethodDataSepaDebit {
+    pub fn new(iban: impl Into<String>) -> Self {
+        Self { iban: iban.into() }
     }
 }
 /// If this is a `sofort` PaymentMethod, this hash contains details about the SOFORT payment method.
@@ -1557,8 +1559,8 @@ pub struct CreatePaymentIntentPaymentMethodDataSofort {
     pub country: CreatePaymentIntentPaymentMethodDataSofortCountry,
 }
 impl CreatePaymentIntentPaymentMethodDataSofort {
-    pub fn new(country: CreatePaymentIntentPaymentMethodDataSofortCountry) -> Self {
-        Self { country }
+    pub fn new(country: impl Into<CreatePaymentIntentPaymentMethodDataSofortCountry>) -> Self {
+        Self { country: country.into() }
     }
 }
 /// Two-letter ISO code representing the country the bank account is located in.
@@ -1788,26 +1790,26 @@ impl<'de> serde::Deserialize<'de> for CreatePaymentIntentPaymentMethodDataType {
     }
 }
 /// If this is an `us_bank_account` PaymentMethod, this hash contains details about the US bank account payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentIntentPaymentMethodDataUsBankAccount<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentIntentPaymentMethodDataUsBankAccount {
     /// Account holder type: individual or company.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub account_holder_type:
         Option<CreatePaymentIntentPaymentMethodDataUsBankAccountAccountHolderType>,
     /// Account number of the bank account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account_number: Option<&'a str>,
+    pub account_number: Option<String>,
     /// Account type: checkings or savings. Defaults to checking if omitted.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub account_type: Option<CreatePaymentIntentPaymentMethodDataUsBankAccountAccountType>,
     /// The ID of a Financial Connections Account to use as a payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub financial_connections_account: Option<&'a str>,
+    pub financial_connections_account: Option<String>,
     /// Routing number of the bank account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub routing_number: Option<&'a str>,
+    pub routing_number: Option<String>,
 }
-impl<'a> CreatePaymentIntentPaymentMethodDataUsBankAccount<'a> {
+impl CreatePaymentIntentPaymentMethodDataUsBankAccount {
     pub fn new() -> Self {
         Self {
             account_holder_type: None,
@@ -1818,7 +1820,7 @@ impl<'a> CreatePaymentIntentPaymentMethodDataUsBankAccount<'a> {
         }
     }
 }
-impl<'a> Default for CreatePaymentIntentPaymentMethodDataUsBankAccount<'a> {
+impl Default for CreatePaymentIntentPaymentMethodDataUsBankAccount {
     fn default() -> Self {
         Self::new()
     }
@@ -1939,16 +1941,16 @@ impl<'de> serde::Deserialize<'de> for CreatePaymentIntentPaymentMethodDataUsBank
 }
 /// Payment method-specific configuration for this PaymentIntent.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentIntentPaymentMethodOptions<'a> {
+pub struct CreatePaymentIntentPaymentMethodOptions {
     /// If this is a `acss_debit` PaymentMethod, this sub-hash contains details about the ACSS Debit payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub acss_debit: Option<CreatePaymentIntentPaymentMethodOptionsAcssDebit<'a>>,
+    pub acss_debit: Option<CreatePaymentIntentPaymentMethodOptionsAcssDebit>,
     /// If this is an `affirm` PaymentMethod, this sub-hash contains details about the Affirm payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub affirm: Option<CreatePaymentIntentPaymentMethodOptionsAffirm<'a>>,
+    pub affirm: Option<CreatePaymentIntentPaymentMethodOptionsAffirm>,
     /// If this is a `afterpay_clearpay` PaymentMethod, this sub-hash contains details about the Afterpay Clearpay payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub afterpay_clearpay: Option<CreatePaymentIntentPaymentMethodOptionsAfterpayClearpay<'a>>,
+    pub afterpay_clearpay: Option<CreatePaymentIntentPaymentMethodOptionsAfterpayClearpay>,
     /// If this is a `alipay` PaymentMethod, this sub-hash contains details about the Alipay payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub alipay: Option<CreatePaymentIntentPaymentMethodOptionsAlipay>,
@@ -1966,13 +1968,13 @@ pub struct CreatePaymentIntentPaymentMethodOptions<'a> {
     pub bancontact: Option<CreatePaymentIntentPaymentMethodOptionsBancontact>,
     /// If this is a `blik` PaymentMethod, this sub-hash contains details about the BLIK payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub blik: Option<CreatePaymentIntentPaymentMethodOptionsBlik<'a>>,
+    pub blik: Option<CreatePaymentIntentPaymentMethodOptionsBlik>,
     /// If this is a `boleto` PaymentMethod, this sub-hash contains details about the Boleto payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub boleto: Option<CreatePaymentIntentPaymentMethodOptionsBoleto>,
     /// Configuration for any card payments attempted on this PaymentIntent.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub card: Option<CreatePaymentIntentPaymentMethodOptionsCard<'a>>,
+    pub card: Option<CreatePaymentIntentPaymentMethodOptionsCard>,
     /// If this is a `card_present` PaymentMethod, this sub-hash contains details about the Card Present payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub card_present: Option<PaymentMethodOptionsParam>,
@@ -1981,7 +1983,7 @@ pub struct CreatePaymentIntentPaymentMethodOptions<'a> {
     pub cashapp: Option<CreatePaymentIntentPaymentMethodOptionsCashapp>,
     /// If this is a `customer balance` PaymentMethod, this sub-hash contains details about the customer balance payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub customer_balance: Option<CreatePaymentIntentPaymentMethodOptionsCustomerBalance<'a>>,
+    pub customer_balance: Option<CreatePaymentIntentPaymentMethodOptionsCustomerBalance>,
     /// If this is a `eps` PaymentMethod, this sub-hash contains details about the EPS payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub eps: Option<CreatePaymentIntentPaymentMethodOptionsEps>,
@@ -2006,10 +2008,10 @@ pub struct CreatePaymentIntentPaymentMethodOptions<'a> {
     pub klarna: Option<CreatePaymentIntentPaymentMethodOptionsKlarna>,
     /// If this is a `konbini` PaymentMethod, this sub-hash contains details about the Konbini payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub konbini: Option<CreatePaymentIntentPaymentMethodOptionsKonbini<'a>>,
+    pub konbini: Option<CreatePaymentIntentPaymentMethodOptionsKonbini>,
     /// If this is a `link` PaymentMethod, this sub-hash contains details about the Link payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub link: Option<CreatePaymentIntentPaymentMethodOptionsLink<'a>>,
+    pub link: Option<CreatePaymentIntentPaymentMethodOptionsLink>,
     /// If this is a `MobilePay` PaymentMethod, this sub-hash contains details about the MobilePay payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mobilepay: Option<CreatePaymentIntentPaymentMethodOptionsMobilepay>,
@@ -2024,7 +2026,7 @@ pub struct CreatePaymentIntentPaymentMethodOptions<'a> {
     pub paynow: Option<CreatePaymentIntentPaymentMethodOptionsPaynow>,
     /// If this is a `paypal` PaymentMethod, this sub-hash contains details about the PayPal payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub paypal: Option<CreatePaymentIntentPaymentMethodOptionsPaypal<'a>>,
+    pub paypal: Option<CreatePaymentIntentPaymentMethodOptionsPaypal>,
     /// If this is a `pix` PaymentMethod, this sub-hash contains details about the Pix payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pix: Option<CreatePaymentIntentPaymentMethodOptionsPix>,
@@ -2042,18 +2044,18 @@ pub struct CreatePaymentIntentPaymentMethodOptions<'a> {
     pub sofort: Option<CreatePaymentIntentPaymentMethodOptionsSofort>,
     /// If this is a `Swish` PaymentMethod, this sub-hash contains details about the Swish payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub swish: Option<CreatePaymentIntentPaymentMethodOptionsSwish<'a>>,
+    pub swish: Option<CreatePaymentIntentPaymentMethodOptionsSwish>,
     /// If this is a `us_bank_account` PaymentMethod, this sub-hash contains details about the US bank account payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub us_bank_account: Option<CreatePaymentIntentPaymentMethodOptionsUsBankAccount<'a>>,
+    pub us_bank_account: Option<CreatePaymentIntentPaymentMethodOptionsUsBankAccount>,
     /// If this is a `wechat_pay` PaymentMethod, this sub-hash contains details about the WeChat Pay payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub wechat_pay: Option<CreatePaymentIntentPaymentMethodOptionsWechatPay<'a>>,
+    pub wechat_pay: Option<CreatePaymentIntentPaymentMethodOptionsWechatPay>,
     /// If this is a `zip` PaymentMethod, this sub-hash contains details about the Zip payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub zip: Option<CreatePaymentIntentPaymentMethodOptionsZip>,
 }
-impl<'a> CreatePaymentIntentPaymentMethodOptions<'a> {
+impl CreatePaymentIntentPaymentMethodOptions {
     pub fn new() -> Self {
         Self {
             acss_debit: None,
@@ -2096,17 +2098,17 @@ impl<'a> CreatePaymentIntentPaymentMethodOptions<'a> {
         }
     }
 }
-impl<'a> Default for CreatePaymentIntentPaymentMethodOptions<'a> {
+impl Default for CreatePaymentIntentPaymentMethodOptions {
     fn default() -> Self {
         Self::new()
     }
 }
 /// If this is a `acss_debit` PaymentMethod, this sub-hash contains details about the ACSS Debit payment method options.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentIntentPaymentMethodOptionsAcssDebit<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentIntentPaymentMethodOptionsAcssDebit {
     /// Additional fields for Mandate creation
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub mandate_options: Option<CreatePaymentIntentPaymentMethodOptionsAcssDebitMandateOptions<'a>>,
+    pub mandate_options: Option<CreatePaymentIntentPaymentMethodOptionsAcssDebitMandateOptions>,
     /// Indicates that you intend to make future payments with this PaymentIntent's payment method.
     ///
     /// Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete.
@@ -2123,28 +2125,28 @@ pub struct CreatePaymentIntentPaymentMethodOptionsAcssDebit<'a> {
     pub verification_method:
         Option<CreatePaymentIntentPaymentMethodOptionsAcssDebitVerificationMethod>,
 }
-impl<'a> CreatePaymentIntentPaymentMethodOptionsAcssDebit<'a> {
+impl CreatePaymentIntentPaymentMethodOptionsAcssDebit {
     pub fn new() -> Self {
         Self { mandate_options: None, setup_future_usage: None, verification_method: None }
     }
 }
-impl<'a> Default for CreatePaymentIntentPaymentMethodOptionsAcssDebit<'a> {
+impl Default for CreatePaymentIntentPaymentMethodOptionsAcssDebit {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Additional fields for Mandate creation
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentIntentPaymentMethodOptionsAcssDebitMandateOptions<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentIntentPaymentMethodOptionsAcssDebitMandateOptions {
     /// A URL for custom mandate text to render during confirmation step.
     /// The URL will be rendered with additional GET parameters `payment_intent` and `payment_intent_client_secret` when confirming a Payment Intent,.
     /// or `setup_intent` and `setup_intent_client_secret` when confirming a Setup Intent.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub custom_mandate_url: Option<&'a str>,
+    pub custom_mandate_url: Option<String>,
     /// Description of the mandate interval.
     /// Only required if 'payment_schedule' parameter is 'interval' or 'combined'.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub interval_description: Option<&'a str>,
+    pub interval_description: Option<String>,
     /// Payment schedule for the mandate.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub payment_schedule:
@@ -2154,7 +2156,7 @@ pub struct CreatePaymentIntentPaymentMethodOptionsAcssDebitMandateOptions<'a> {
     pub transaction_type:
         Option<CreatePaymentIntentPaymentMethodOptionsAcssDebitMandateOptionsTransactionType>,
 }
-impl<'a> CreatePaymentIntentPaymentMethodOptionsAcssDebitMandateOptions<'a> {
+impl CreatePaymentIntentPaymentMethodOptionsAcssDebitMandateOptions {
     pub fn new() -> Self {
         Self {
             custom_mandate_url: None,
@@ -2164,7 +2166,7 @@ impl<'a> CreatePaymentIntentPaymentMethodOptionsAcssDebitMandateOptions<'a> {
         }
     }
 }
-impl<'a> Default for CreatePaymentIntentPaymentMethodOptionsAcssDebitMandateOptions<'a> {
+impl Default for CreatePaymentIntentPaymentMethodOptionsAcssDebitMandateOptions {
     fn default() -> Self {
         Self::new()
     }
@@ -2426,8 +2428,8 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// If this is an `affirm` PaymentMethod, this sub-hash contains details about the Affirm payment method options.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentIntentPaymentMethodOptionsAffirm<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentIntentPaymentMethodOptionsAffirm {
     /// Controls when the funds will be captured from the customer's account.
     ///
     /// If provided, this parameter will override the top level behavior of `capture_method` when finalizing the payment with this payment method type.
@@ -2437,7 +2439,7 @@ pub struct CreatePaymentIntentPaymentMethodOptionsAffirm<'a> {
     pub capture_method: Option<CreatePaymentIntentPaymentMethodOptionsAffirmCaptureMethod>,
     /// Preferred language of the Affirm authorization page that the customer is redirected to.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub preferred_locale: Option<&'a str>,
+    pub preferred_locale: Option<String>,
     /// Indicates that you intend to make future payments with this PaymentIntent's payment method.
     ///
     /// Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete.
@@ -2449,12 +2451,12 @@ pub struct CreatePaymentIntentPaymentMethodOptionsAffirm<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub setup_future_usage: Option<CreatePaymentIntentPaymentMethodOptionsAffirmSetupFutureUsage>,
 }
-impl<'a> CreatePaymentIntentPaymentMethodOptionsAffirm<'a> {
+impl CreatePaymentIntentPaymentMethodOptionsAffirm {
     pub fn new() -> Self {
         Self { capture_method: None, preferred_locale: None, setup_future_usage: None }
     }
 }
-impl<'a> Default for CreatePaymentIntentPaymentMethodOptionsAffirm<'a> {
+impl Default for CreatePaymentIntentPaymentMethodOptionsAffirm {
     fn default() -> Self {
         Self::new()
     }
@@ -2583,8 +2585,8 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// If this is a `afterpay_clearpay` PaymentMethod, this sub-hash contains details about the Afterpay Clearpay payment method options.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentIntentPaymentMethodOptionsAfterpayClearpay<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentIntentPaymentMethodOptionsAfterpayClearpay {
     /// Controls when the funds will be captured from the customer's account.
     ///
     /// If provided, this parameter will override the top level behavior of `capture_method` when finalizing the payment with this payment method type.
@@ -2597,7 +2599,7 @@ pub struct CreatePaymentIntentPaymentMethodOptionsAfterpayClearpay<'a> {
     /// You must limit the identifier to 128 characters, and it can only contain letters, numbers, underscores, backslashes, and dashes.
     /// This field differs from the statement descriptor and item name.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reference: Option<&'a str>,
+    pub reference: Option<String>,
     /// Indicates that you intend to make future payments with this PaymentIntent's payment method.
     ///
     /// Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete.
@@ -2610,12 +2612,12 @@ pub struct CreatePaymentIntentPaymentMethodOptionsAfterpayClearpay<'a> {
     pub setup_future_usage:
         Option<CreatePaymentIntentPaymentMethodOptionsAfterpayClearpaySetupFutureUsage>,
 }
-impl<'a> CreatePaymentIntentPaymentMethodOptionsAfterpayClearpay<'a> {
+impl CreatePaymentIntentPaymentMethodOptionsAfterpayClearpay {
     pub fn new() -> Self {
         Self { capture_method: None, reference: None, setup_future_usage: None }
     }
 }
-impl<'a> Default for CreatePaymentIntentPaymentMethodOptionsAfterpayClearpay<'a> {
+impl Default for CreatePaymentIntentPaymentMethodOptionsAfterpayClearpay {
     fn default() -> Self {
         Self::new()
     }
@@ -3317,12 +3319,12 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// If this is a `blik` PaymentMethod, this sub-hash contains details about the BLIK payment method options.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentIntentPaymentMethodOptionsBlik<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentIntentPaymentMethodOptionsBlik {
     /// The 6-digit BLIK code that a customer has generated using their banking application.
     /// Can only be set on confirmation.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub code: Option<&'a str>,
+    pub code: Option<String>,
     /// Indicates that you intend to make future payments with this PaymentIntent's payment method.
     ///
     /// Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete.
@@ -3334,12 +3336,12 @@ pub struct CreatePaymentIntentPaymentMethodOptionsBlik<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub setup_future_usage: Option<CreatePaymentIntentPaymentMethodOptionsBlikSetupFutureUsage>,
 }
-impl<'a> CreatePaymentIntentPaymentMethodOptionsBlik<'a> {
+impl CreatePaymentIntentPaymentMethodOptionsBlik {
     pub fn new() -> Self {
         Self { code: None, setup_future_usage: None }
     }
 }
-impl<'a> Default for CreatePaymentIntentPaymentMethodOptionsBlik<'a> {
+impl Default for CreatePaymentIntentPaymentMethodOptionsBlik {
     fn default() -> Self {
         Self::new()
     }
@@ -3505,8 +3507,8 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// Configuration for any card payments attempted on this PaymentIntent.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentIntentPaymentMethodOptionsCard<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentIntentPaymentMethodOptionsCard {
     /// Controls when the funds will be captured from the customer's account.
     ///
     /// If provided, this parameter will override the top level behavior of `capture_method` when finalizing the payment with this payment method type.
@@ -3518,7 +3520,7 @@ pub struct CreatePaymentIntentPaymentMethodOptionsCard<'a> {
     /// When provided, the CVC value will be verified during the card payment attempt.
     /// This parameter can only be provided during confirmation.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub cvc_token: Option<&'a str>,
+    pub cvc_token: Option<String>,
     /// Installment configuration for payments attempted on this PaymentIntent (Mexico Only).
     ///
     /// For more information, see the [installments integration guide](https://stripe.com/docs/payments/installments).
@@ -3526,7 +3528,7 @@ pub struct CreatePaymentIntentPaymentMethodOptionsCard<'a> {
     pub installments: Option<CreatePaymentIntentPaymentMethodOptionsCardInstallments>,
     /// Configuration options for setting up an eMandate for cards issued in India.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub mandate_options: Option<CreatePaymentIntentPaymentMethodOptionsCardMandateOptions<'a>>,
+    pub mandate_options: Option<CreatePaymentIntentPaymentMethodOptionsCardMandateOptions>,
     /// When specified, this parameter indicates that a transaction will be marked
     /// as MOTO (Mail Order Telephone Order) and thus out of scope for SCA. This
     /// parameter can only be provided during confirmation.
@@ -3578,19 +3580,19 @@ pub struct CreatePaymentIntentPaymentMethodOptionsCard<'a> {
     /// Maximum 22 characters.
     /// On card statements, the *concatenation* of both prefix and suffix (including separators) will appear truncated to 22 characters.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub statement_descriptor_suffix_kana: Option<&'a str>,
+    pub statement_descriptor_suffix_kana: Option<String>,
     /// Provides information about a card payment that customers see on their statements.
     /// Concatenated with the Kanji prefix (shortened Kanji descriptor) or Kanji statement descriptor that’s set on the account to form the complete statement descriptor.
     /// Maximum 17 characters.
     /// On card statements, the *concatenation* of both prefix and suffix (including separators) will appear truncated to 17 characters.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub statement_descriptor_suffix_kanji: Option<&'a str>,
+    pub statement_descriptor_suffix_kanji: Option<String>,
     /// If 3D Secure authentication was performed with a third-party provider,
     /// the authentication details to use for this payment.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub three_d_secure: Option<CreatePaymentIntentPaymentMethodOptionsCardThreeDSecure<'a>>,
+    pub three_d_secure: Option<CreatePaymentIntentPaymentMethodOptionsCardThreeDSecure>,
 }
-impl<'a> CreatePaymentIntentPaymentMethodOptionsCard<'a> {
+impl CreatePaymentIntentPaymentMethodOptionsCard {
     pub fn new() -> Self {
         Self {
             capture_method: None,
@@ -3612,7 +3614,7 @@ impl<'a> CreatePaymentIntentPaymentMethodOptionsCard<'a> {
         }
     }
 }
-impl<'a> Default for CreatePaymentIntentPaymentMethodOptionsCard<'a> {
+impl Default for CreatePaymentIntentPaymentMethodOptionsCard {
     fn default() -> Self {
         Self::new()
     }
@@ -3716,11 +3718,11 @@ pub struct CreatePaymentIntentPaymentMethodOptionsCardInstallmentsPlan {
 }
 impl CreatePaymentIntentPaymentMethodOptionsCardInstallmentsPlan {
     pub fn new(
-        count: u64,
-        interval: CreatePaymentIntentPaymentMethodOptionsCardInstallmentsPlanInterval,
-        type_: CreatePaymentIntentPaymentMethodOptionsCardInstallmentsPlanType,
+        count: impl Into<u64>,
+        interval: impl Into<CreatePaymentIntentPaymentMethodOptionsCardInstallmentsPlanInterval>,
+        type_: impl Into<CreatePaymentIntentPaymentMethodOptionsCardInstallmentsPlanType>,
     ) -> Self {
-        Self { count, interval, type_ }
+        Self { count: count.into(), interval: interval.into(), type_: type_.into() }
     }
 }
 /// For `fixed_count` installment plans, this is the interval between installment payments your customer will make to their credit card.
@@ -3835,8 +3837,8 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// Configuration options for setting up an eMandate for cards issued in India.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentIntentPaymentMethodOptionsCardMandateOptions<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentIntentPaymentMethodOptionsCardMandateOptions {
     /// Amount to be charged for future payments.
     pub amount: i64,
     /// One of `fixed` or `maximum`.
@@ -3845,7 +3847,7 @@ pub struct CreatePaymentIntentPaymentMethodOptionsCardMandateOptions<'a> {
     pub amount_type: CreatePaymentIntentPaymentMethodOptionsCardMandateOptionsAmountType,
     /// A description of the mandate or subscription that is meant to be displayed to the customer.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<&'a str>,
+    pub description: Option<String>,
     /// End date of the mandate or subscription.
     /// If not provided, the mandate will be active until canceled.
     /// If provided, end date should be after start date.
@@ -3860,31 +3862,31 @@ pub struct CreatePaymentIntentPaymentMethodOptionsCardMandateOptions<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub interval_count: Option<u64>,
     /// Unique identifier for the mandate or subscription.
-    pub reference: &'a str,
+    pub reference: String,
     /// Start date of the mandate or subscription. Start date should not be lesser than yesterday.
     pub start_date: stripe_types::Timestamp,
     /// Specifies the type of mandates supported. Possible values are `india`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub supported_types:
-        Option<&'a [CreatePaymentIntentPaymentMethodOptionsCardMandateOptionsSupportedTypes]>,
+        Option<Vec<CreatePaymentIntentPaymentMethodOptionsCardMandateOptionsSupportedTypes>>,
 }
-impl<'a> CreatePaymentIntentPaymentMethodOptionsCardMandateOptions<'a> {
+impl CreatePaymentIntentPaymentMethodOptionsCardMandateOptions {
     pub fn new(
-        amount: i64,
-        amount_type: CreatePaymentIntentPaymentMethodOptionsCardMandateOptionsAmountType,
-        interval: CreatePaymentIntentPaymentMethodOptionsCardMandateOptionsInterval,
-        reference: &'a str,
-        start_date: stripe_types::Timestamp,
+        amount: impl Into<i64>,
+        amount_type: impl Into<CreatePaymentIntentPaymentMethodOptionsCardMandateOptionsAmountType>,
+        interval: impl Into<CreatePaymentIntentPaymentMethodOptionsCardMandateOptionsInterval>,
+        reference: impl Into<String>,
+        start_date: impl Into<stripe_types::Timestamp>,
     ) -> Self {
         Self {
-            amount,
-            amount_type,
+            amount: amount.into(),
+            amount_type: amount_type.into(),
             description: None,
             end_date: None,
-            interval,
+            interval: interval.into(),
             interval_count: None,
-            reference,
-            start_date,
+            reference: reference.into(),
+            start_date: start_date.into(),
             supported_types: None,
         }
     }
@@ -4528,8 +4530,8 @@ impl<'de> serde::Deserialize<'de> for CreatePaymentIntentPaymentMethodOptionsCar
 }
 /// If 3D Secure authentication was performed with a third-party provider,
 /// the authentication details to use for this payment.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentIntentPaymentMethodOptionsCardThreeDSecure<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentIntentPaymentMethodOptionsCardThreeDSecure {
     /// The `transStatus` returned from the card Issuer’s ACS in the ARes.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ares_trans_status:
@@ -4538,7 +4540,7 @@ pub struct CreatePaymentIntentPaymentMethodOptionsCardThreeDSecure<'a> {
     /// AEVV). This value is 20 bytes, base64-encoded into a 28-character string.
     /// (Most 3D Secure providers will return the base64-encoded version, which
     /// is what you should specify here.)
-    pub cryptogram: &'a str,
+    pub cryptogram: String,
     /// The Electronic Commerce Indicator (ECI) is returned by your 3D Secure
     /// provider and indicates what degree of authentication was performed.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -4553,32 +4555,32 @@ pub struct CreatePaymentIntentPaymentMethodOptionsCardThreeDSecure<'a> {
     /// must be populated accordingly
     #[serde(skip_serializing_if = "Option::is_none")]
     pub network_options:
-        Option<CreatePaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptions<'a>>,
+        Option<CreatePaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptions>,
     /// The challenge indicator (`threeDSRequestorChallengeInd`) which was requested in the
     /// AReq sent to the card Issuer's ACS. A string containing 2 digits from 01-99.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub requestor_challenge_indicator: Option<&'a str>,
+    pub requestor_challenge_indicator: Option<String>,
     /// For 3D Secure 1, the XID. For 3D Secure 2, the Directory Server
     /// Transaction ID (dsTransID).
-    pub transaction_id: &'a str,
+    pub transaction_id: String,
     /// The version of 3D Secure that was performed.
     pub version: CreatePaymentIntentPaymentMethodOptionsCardThreeDSecureVersion,
 }
-impl<'a> CreatePaymentIntentPaymentMethodOptionsCardThreeDSecure<'a> {
+impl CreatePaymentIntentPaymentMethodOptionsCardThreeDSecure {
     pub fn new(
-        cryptogram: &'a str,
-        transaction_id: &'a str,
-        version: CreatePaymentIntentPaymentMethodOptionsCardThreeDSecureVersion,
+        cryptogram: impl Into<String>,
+        transaction_id: impl Into<String>,
+        version: impl Into<CreatePaymentIntentPaymentMethodOptionsCardThreeDSecureVersion>,
     ) -> Self {
         Self {
             ares_trans_status: None,
-            cryptogram,
+            cryptogram: cryptogram.into(),
             electronic_commerce_indicator: None,
             exemption_indicator: None,
             network_options: None,
             requestor_challenge_indicator: None,
-            transaction_id,
-            version,
+            transaction_id: transaction_id.into(),
+            version: version.into(),
         }
     }
 }
@@ -4792,27 +4794,27 @@ impl<'de> serde::Deserialize<'de>
 /// Network specific 3DS fields. Network specific arguments require an
 /// explicit card brand choice. The parameter `payment_method_options.card.network``
 /// must be populated accordingly
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptions<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptions {
     /// Cartes Bancaires-specific 3DS fields.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cartes_bancaires: Option<
-        CreatePaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancaires<'a>,
+        CreatePaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancaires,
     >,
 }
-impl<'a> CreatePaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptions<'a> {
+impl CreatePaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptions {
     pub fn new() -> Self {
         Self { cartes_bancaires: None }
     }
 }
-impl<'a> Default for CreatePaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptions<'a> {
+impl Default for CreatePaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptions {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Cartes Bancaires-specific 3DS fields.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancaires<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancaires {
     /// The cryptogram calculation algorithm used by the card Issuer's ACS
     /// to calculate the Authentication cryptogram. Also known as `cavvAlgorithm`.
     /// messageExtension: CB-AVALGO
@@ -4822,18 +4824,18 @@ pub cb_avalgo: CreatePaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOpt
     /// This is a 3 byte bitmap (low significant byte first and most significant
     /// bit first) that has been Base64 encoded
 #[serde(skip_serializing_if = "Option::is_none")]
-pub cb_exemption: Option<&'a str>,
+pub cb_exemption: Option<String>,
     /// The risk score returned from Cartes Bancaires in the ARes.
     /// message extension: CB-SCORE; numeric value 0-99
 #[serde(skip_serializing_if = "Option::is_none")]
 pub cb_score: Option<i64>,
 
 }
-impl<'a> CreatePaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancaires<'a> {
+impl CreatePaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancaires {
     pub fn new(
-        cb_avalgo: CreatePaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancairesCbAvalgo,
+        cb_avalgo: impl Into<CreatePaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancairesCbAvalgo>,
     ) -> Self {
-        Self { cb_avalgo, cb_exemption: None, cb_score: None }
+        Self { cb_avalgo: cb_avalgo.into(), cb_exemption: None, cb_score: None }
     }
 }
 /// The cryptogram calculation algorithm used by the card Issuer's ACS
@@ -5139,12 +5141,11 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// If this is a `customer balance` PaymentMethod, this sub-hash contains details about the customer balance payment method options.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentIntentPaymentMethodOptionsCustomerBalance<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentIntentPaymentMethodOptionsCustomerBalance {
     /// Configuration for the bank transfer funding type, if the `funding_type` is set to `bank_transfer`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub bank_transfer:
-        Option<CreatePaymentIntentPaymentMethodOptionsCustomerBalanceBankTransfer<'a>>,
+    pub bank_transfer: Option<CreatePaymentIntentPaymentMethodOptionsCustomerBalanceBankTransfer>,
     /// The funding method type to be used when there are not enough funds in the customer balance.
     /// Permitted values include: `bank_transfer`.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -5161,38 +5162,41 @@ pub struct CreatePaymentIntentPaymentMethodOptionsCustomerBalance<'a> {
     pub setup_future_usage:
         Option<CreatePaymentIntentPaymentMethodOptionsCustomerBalanceSetupFutureUsage>,
 }
-impl<'a> CreatePaymentIntentPaymentMethodOptionsCustomerBalance<'a> {
+impl CreatePaymentIntentPaymentMethodOptionsCustomerBalance {
     pub fn new() -> Self {
         Self { bank_transfer: None, funding_type: None, setup_future_usage: None }
     }
 }
-impl<'a> Default for CreatePaymentIntentPaymentMethodOptionsCustomerBalance<'a> {
+impl Default for CreatePaymentIntentPaymentMethodOptionsCustomerBalance {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Configuration for the bank transfer funding type, if the `funding_type` is set to `bank_transfer`.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentIntentPaymentMethodOptionsCustomerBalanceBankTransfer<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentIntentPaymentMethodOptionsCustomerBalanceBankTransfer {
     /// Configuration for the eu_bank_transfer funding type.
-#[serde(skip_serializing_if = "Option::is_none")]
-pub eu_bank_transfer: Option<EuBankTransferParams<'a>>,
-        /// List of address types that should be returned in the financial_addresses response.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub eu_bank_transfer: Option<EuBankTransferParams>,
+    /// List of address types that should be returned in the financial_addresses response.
     /// If not specified, all valid types will be returned.
     ///
     /// Permitted values include: `sort_code`, `zengin`, `iban`, or `spei`.
-#[serde(skip_serializing_if = "Option::is_none")]
-pub requested_address_types: Option<&'a [CreatePaymentIntentPaymentMethodOptionsCustomerBalanceBankTransferRequestedAddressTypes]>,
-        /// The list of bank transfer types that this PaymentIntent is allowed to use for funding Permitted values include: `eu_bank_transfer`, `gb_bank_transfer`, `jp_bank_transfer`, `mx_bank_transfer`, or `us_bank_transfer`.
-#[serde(rename = "type")]
-pub type_: CreatePaymentIntentPaymentMethodOptionsCustomerBalanceBankTransferType,
-
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub requested_address_types: Option<
+        Vec<
+            CreatePaymentIntentPaymentMethodOptionsCustomerBalanceBankTransferRequestedAddressTypes,
+        >,
+    >,
+    /// The list of bank transfer types that this PaymentIntent is allowed to use for funding Permitted values include: `eu_bank_transfer`, `gb_bank_transfer`, `jp_bank_transfer`, `mx_bank_transfer`, or `us_bank_transfer`.
+    #[serde(rename = "type")]
+    pub type_: CreatePaymentIntentPaymentMethodOptionsCustomerBalanceBankTransferType,
 }
-impl<'a> CreatePaymentIntentPaymentMethodOptionsCustomerBalanceBankTransfer<'a> {
+impl CreatePaymentIntentPaymentMethodOptionsCustomerBalanceBankTransfer {
     pub fn new(
-        type_: CreatePaymentIntentPaymentMethodOptionsCustomerBalanceBankTransferType,
+        type_: impl Into<CreatePaymentIntentPaymentMethodOptionsCustomerBalanceBankTransferType>,
     ) -> Self {
-        Self { eu_bank_transfer: None, requested_address_types: None, type_ }
+        Self { eu_bank_transfer: None, requested_address_types: None, type_: type_.into() }
     }
 }
 /// List of address types that should be returned in the financial_addresses response.
@@ -6235,13 +6239,13 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// If this is a `konbini` PaymentMethod, this sub-hash contains details about the Konbini payment method options.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentIntentPaymentMethodOptionsKonbini<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentIntentPaymentMethodOptionsKonbini {
     /// An optional 10 to 11 digit numeric-only string determining the confirmation code at applicable convenience stores.
     /// Must not consist of only zeroes and could be rejected in case of insufficient uniqueness.
     /// We recommend to use the customer's phone number.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub confirmation_number: Option<&'a str>,
+    pub confirmation_number: Option<String>,
     /// The number of calendar days (between 1 and 60) after which Konbini payment instructions will expire.
     /// For example, if a PaymentIntent is confirmed with Konbini and `expires_after_days` set to 2 on Monday JST, the instructions will expire on Wednesday 23:59:59 JST.
     /// Defaults to 3 days.
@@ -6253,7 +6257,7 @@ pub struct CreatePaymentIntentPaymentMethodOptionsKonbini<'a> {
     pub expires_at: Option<stripe_types::Timestamp>,
     /// A product descriptor of up to 22 characters, which will appear to customers at the convenience store.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub product_description: Option<&'a str>,
+    pub product_description: Option<String>,
     /// Indicates that you intend to make future payments with this PaymentIntent's payment method.
     ///
     /// Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete.
@@ -6265,7 +6269,7 @@ pub struct CreatePaymentIntentPaymentMethodOptionsKonbini<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub setup_future_usage: Option<CreatePaymentIntentPaymentMethodOptionsKonbiniSetupFutureUsage>,
 }
-impl<'a> CreatePaymentIntentPaymentMethodOptionsKonbini<'a> {
+impl CreatePaymentIntentPaymentMethodOptionsKonbini {
     pub fn new() -> Self {
         Self {
             confirmation_number: None,
@@ -6276,7 +6280,7 @@ impl<'a> CreatePaymentIntentPaymentMethodOptionsKonbini<'a> {
         }
     }
 }
-impl<'a> Default for CreatePaymentIntentPaymentMethodOptionsKonbini<'a> {
+impl Default for CreatePaymentIntentPaymentMethodOptionsKonbini {
     fn default() -> Self {
         Self::new()
     }
@@ -6346,8 +6350,8 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// If this is a `link` PaymentMethod, this sub-hash contains details about the Link payment method options.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentIntentPaymentMethodOptionsLink<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentIntentPaymentMethodOptionsLink {
     /// Controls when the funds will be captured from the customer's account.
     ///
     /// If provided, this parameter will override the top level behavior of `capture_method` when finalizing the payment with this payment method type.
@@ -6357,7 +6361,7 @@ pub struct CreatePaymentIntentPaymentMethodOptionsLink<'a> {
     pub capture_method: Option<CreatePaymentIntentPaymentMethodOptionsLinkCaptureMethod>,
     /// \[Deprecated\] This is a legacy parameter that no longer has any function.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub persistent_token: Option<&'a str>,
+    pub persistent_token: Option<String>,
     /// Indicates that you intend to make future payments with this PaymentIntent's payment method.
     ///
     /// Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete.
@@ -6369,12 +6373,12 @@ pub struct CreatePaymentIntentPaymentMethodOptionsLink<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub setup_future_usage: Option<CreatePaymentIntentPaymentMethodOptionsLinkSetupFutureUsage>,
 }
-impl<'a> CreatePaymentIntentPaymentMethodOptionsLink<'a> {
+impl CreatePaymentIntentPaymentMethodOptionsLink {
     pub fn new() -> Self {
         Self { capture_method: None, persistent_token: None, setup_future_usage: None }
     }
 }
-impl<'a> Default for CreatePaymentIntentPaymentMethodOptionsLink<'a> {
+impl Default for CreatePaymentIntentPaymentMethodOptionsLink {
     fn default() -> Self {
         Self::new()
     }
@@ -6924,8 +6928,8 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// If this is a `paypal` PaymentMethod, this sub-hash contains details about the PayPal payment method options.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentIntentPaymentMethodOptionsPaypal<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentIntentPaymentMethodOptionsPaypal {
     /// Controls when the funds will be captured from the customer's account.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub capture_method: Option<CreatePaymentIntentPaymentMethodOptionsPaypalCaptureMethod>,
@@ -6935,10 +6939,10 @@ pub struct CreatePaymentIntentPaymentMethodOptionsPaypal<'a> {
     /// A reference of the PayPal transaction visible to customer which is mapped to PayPal's invoice ID.
     /// This must be a globally unique ID if you have configured in your PayPal settings to block multiple payments per invoice ID.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reference: Option<&'a str>,
+    pub reference: Option<String>,
     /// The risk correlation ID for an on-session payment using a saved PayPal payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub risk_correlation_id: Option<&'a str>,
+    pub risk_correlation_id: Option<String>,
     /// Indicates that you intend to make future payments with this PaymentIntent's payment method.
     ///
     /// Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete.
@@ -6950,7 +6954,7 @@ pub struct CreatePaymentIntentPaymentMethodOptionsPaypal<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub setup_future_usage: Option<CreatePaymentIntentPaymentMethodOptionsPaypalSetupFutureUsage>,
 }
-impl<'a> CreatePaymentIntentPaymentMethodOptionsPaypal<'a> {
+impl CreatePaymentIntentPaymentMethodOptionsPaypal {
     pub fn new() -> Self {
         Self {
             capture_method: None,
@@ -6961,7 +6965,7 @@ impl<'a> CreatePaymentIntentPaymentMethodOptionsPaypal<'a> {
         }
     }
 }
-impl<'a> Default for CreatePaymentIntentPaymentMethodOptionsPaypal<'a> {
+impl Default for CreatePaymentIntentPaymentMethodOptionsPaypal {
     fn default() -> Self {
         Self::new()
     }
@@ -7799,11 +7803,11 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// If this is a `Swish` PaymentMethod, this sub-hash contains details about the Swish payment method options.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentIntentPaymentMethodOptionsSwish<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentIntentPaymentMethodOptionsSwish {
     /// The order ID displayed in the Swish app after the payment is authorized.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reference: Option<&'a str>,
+    pub reference: Option<String>,
     /// Indicates that you intend to make future payments with this PaymentIntent's payment method.
     ///
     /// Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete.
@@ -7815,12 +7819,12 @@ pub struct CreatePaymentIntentPaymentMethodOptionsSwish<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub setup_future_usage: Option<CreatePaymentIntentPaymentMethodOptionsSwishSetupFutureUsage>,
 }
-impl<'a> CreatePaymentIntentPaymentMethodOptionsSwish<'a> {
+impl CreatePaymentIntentPaymentMethodOptionsSwish {
     pub fn new() -> Self {
         Self { reference: None, setup_future_usage: None }
     }
 }
-impl<'a> Default for CreatePaymentIntentPaymentMethodOptionsSwish<'a> {
+impl Default for CreatePaymentIntentPaymentMethodOptionsSwish {
     fn default() -> Self {
         Self::new()
     }
@@ -7888,18 +7892,18 @@ impl<'de> serde::Deserialize<'de> for CreatePaymentIntentPaymentMethodOptionsSwi
     }
 }
 /// If this is a `us_bank_account` PaymentMethod, this sub-hash contains details about the US bank account payment method options.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentIntentPaymentMethodOptionsUsBankAccount<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentIntentPaymentMethodOptionsUsBankAccount {
     /// Additional fields for Financial Connections Session creation
     #[serde(skip_serializing_if = "Option::is_none")]
     pub financial_connections:
-        Option<CreatePaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnections<'a>>,
+        Option<CreatePaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnections>,
     /// Additional fields for Mandate creation
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mandate_options: Option<CreatePaymentIntentPaymentMethodOptionsUsBankAccountMandateOptions>,
     /// Additional fields for network related functions
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub networks: Option<CreatePaymentIntentPaymentMethodOptionsUsBankAccountNetworks<'a>>,
+    pub networks: Option<CreatePaymentIntentPaymentMethodOptionsUsBankAccountNetworks>,
     /// Preferred transaction settlement speed
     #[serde(skip_serializing_if = "Option::is_none")]
     pub preferred_settlement_speed:
@@ -7920,7 +7924,7 @@ pub struct CreatePaymentIntentPaymentMethodOptionsUsBankAccount<'a> {
     pub verification_method:
         Option<CreatePaymentIntentPaymentMethodOptionsUsBankAccountVerificationMethod>,
 }
-impl<'a> CreatePaymentIntentPaymentMethodOptionsUsBankAccount<'a> {
+impl CreatePaymentIntentPaymentMethodOptionsUsBankAccount {
     pub fn new() -> Self {
         Self {
             financial_connections: None,
@@ -7932,37 +7936,37 @@ impl<'a> CreatePaymentIntentPaymentMethodOptionsUsBankAccount<'a> {
         }
     }
 }
-impl<'a> Default for CreatePaymentIntentPaymentMethodOptionsUsBankAccount<'a> {
+impl Default for CreatePaymentIntentPaymentMethodOptionsUsBankAccount {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Additional fields for Financial Connections Session creation
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnections<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnections {
     /// The list of permissions to request.
     /// If this parameter is passed, the `payment_method` permission must be included.
     /// Valid permissions include: `balances`, `ownership`, `payment_method`, and `transactions`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub permissions: Option<
-        &'a [CreatePaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPermissions],
+        Vec<CreatePaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPermissions>,
     >,
     /// List of data features that you would like to retrieve upon account creation.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub prefetch: Option<
-        &'a [CreatePaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPrefetch],
+        Vec<CreatePaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPrefetch>,
     >,
     /// For webview integrations only.
     /// Upon completing OAuth login in the native browser, the user will be redirected to this URL to return to your app.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub return_url: Option<&'a str>,
+    pub return_url: Option<String>,
 }
-impl<'a> CreatePaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnections<'a> {
+impl CreatePaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnections {
     pub fn new() -> Self {
         Self { permissions: None, prefetch: None, return_url: None }
     }
 }
-impl<'a> Default for CreatePaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnections<'a> {
+impl Default for CreatePaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnections {
     fn default() -> Self {
         Self::new()
     }
@@ -8186,19 +8190,19 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// Additional fields for network related functions
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentIntentPaymentMethodOptionsUsBankAccountNetworks<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentIntentPaymentMethodOptionsUsBankAccountNetworks {
     /// Triggers validations to run across the selected networks
     #[serde(skip_serializing_if = "Option::is_none")]
     pub requested:
-        Option<&'a [CreatePaymentIntentPaymentMethodOptionsUsBankAccountNetworksRequested]>,
+        Option<Vec<CreatePaymentIntentPaymentMethodOptionsUsBankAccountNetworksRequested>>,
 }
-impl<'a> CreatePaymentIntentPaymentMethodOptionsUsBankAccountNetworks<'a> {
+impl CreatePaymentIntentPaymentMethodOptionsUsBankAccountNetworks {
     pub fn new() -> Self {
         Self { requested: None }
     }
 }
-impl<'a> Default for CreatePaymentIntentPaymentMethodOptionsUsBankAccountNetworks<'a> {
+impl Default for CreatePaymentIntentPaymentMethodOptionsUsBankAccountNetworks {
     fn default() -> Self {
         Self::new()
     }
@@ -8449,11 +8453,11 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// If this is a `wechat_pay` PaymentMethod, this sub-hash contains details about the WeChat Pay payment method options.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentIntentPaymentMethodOptionsWechatPay<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentIntentPaymentMethodOptionsWechatPay {
     /// The app ID registered with WeChat Pay. Only required when client is ios or android.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub app_id: Option<&'a str>,
+    pub app_id: Option<String>,
     /// The client type that the end customer will pay from
     pub client: CreatePaymentIntentPaymentMethodOptionsWechatPayClient,
     /// Indicates that you intend to make future payments with this PaymentIntent's payment method.
@@ -8468,9 +8472,9 @@ pub struct CreatePaymentIntentPaymentMethodOptionsWechatPay<'a> {
     pub setup_future_usage:
         Option<CreatePaymentIntentPaymentMethodOptionsWechatPaySetupFutureUsage>,
 }
-impl<'a> CreatePaymentIntentPaymentMethodOptionsWechatPay<'a> {
-    pub fn new(client: CreatePaymentIntentPaymentMethodOptionsWechatPayClient) -> Self {
-        Self { app_id: None, client, setup_future_usage: None }
+impl CreatePaymentIntentPaymentMethodOptionsWechatPay {
+    pub fn new(client: impl Into<CreatePaymentIntentPaymentMethodOptionsWechatPayClient>) -> Self {
+        Self { app_id: None, client: client.into(), setup_future_usage: None }
     }
 }
 /// The client type that the end customer will pay from
@@ -8681,64 +8685,73 @@ impl<'de> serde::Deserialize<'de> for CreatePaymentIntentPaymentMethodOptionsZip
     }
 }
 /// Shipping information for this PaymentIntent.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentIntentShipping<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentIntentShipping {
     /// Shipping address.
-    pub address: CreatePaymentIntentShippingAddress<'a>,
+    pub address: CreatePaymentIntentShippingAddress,
     /// The delivery service that shipped a physical product, such as Fedex, UPS, USPS, etc.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub carrier: Option<&'a str>,
+    pub carrier: Option<String>,
     /// Recipient name.
-    pub name: &'a str,
+    pub name: String,
     /// Recipient phone (including extension).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub phone: Option<&'a str>,
+    pub phone: Option<String>,
     /// The tracking number for a physical product, obtained from the delivery service.
     /// If multiple tracking numbers were generated for this purchase, please separate them with commas.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tracking_number: Option<&'a str>,
+    pub tracking_number: Option<String>,
 }
-impl<'a> CreatePaymentIntentShipping<'a> {
-    pub fn new(address: CreatePaymentIntentShippingAddress<'a>, name: &'a str) -> Self {
-        Self { address, carrier: None, name, phone: None, tracking_number: None }
+impl CreatePaymentIntentShipping {
+    pub fn new(
+        address: impl Into<CreatePaymentIntentShippingAddress>,
+        name: impl Into<String>,
+    ) -> Self {
+        Self {
+            address: address.into(),
+            carrier: None,
+            name: name.into(),
+            phone: None,
+            tracking_number: None,
+        }
     }
 }
 /// Shipping address.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentIntentShippingAddress<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentIntentShippingAddress {
     /// City, district, suburb, town, or village.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<&'a str>,
+    pub city: Option<String>,
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub country: Option<&'a str>,
+    pub country: Option<String>,
     /// Address line 1 (e.g., street, PO Box, or company name).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line1: Option<&'a str>,
+    pub line1: Option<String>,
     /// Address line 2 (e.g., apartment, suite, unit, or building).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line2: Option<&'a str>,
+    pub line2: Option<String>,
     /// ZIP or postal code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<&'a str>,
+    pub postal_code: Option<String>,
     /// State, county, province, or region.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
 }
-impl<'a> CreatePaymentIntentShippingAddress<'a> {
+impl CreatePaymentIntentShippingAddress {
     pub fn new() -> Self {
         Self { city: None, country: None, line1: None, line2: None, postal_code: None, state: None }
     }
 }
-impl<'a> Default for CreatePaymentIntentShippingAddress<'a> {
+impl Default for CreatePaymentIntentShippingAddress {
     fn default() -> Self {
         Self::new()
     }
 }
 /// The parameters that you can use to automatically create a Transfer.
 /// Learn more about the [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts).
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentIntentTransferData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentIntentTransferData {
     /// The amount that will be transferred automatically when a charge succeeds.
     /// The amount is capped at the total transaction amount and if no amount is set,
     /// the full amount is transferred.
@@ -8752,11 +8765,11 @@ pub struct CreatePaymentIntentTransferData<'a> {
     /// account for tax reporting, and the funds from charges will be transferred
     /// to the destination account. The ID of the resulting transfer will be
     /// returned on the successful charge's `transfer` field.
-    pub destination: &'a str,
+    pub destination: String,
 }
-impl<'a> CreatePaymentIntentTransferData<'a> {
-    pub fn new(destination: &'a str) -> Self {
-        Self { amount: None, destination }
+impl CreatePaymentIntentTransferData {
+    pub fn new(destination: impl Into<String>) -> Self {
+        Self { amount: None, destination: destination.into() }
     }
 }
 /// Creates a PaymentIntent object.
@@ -8770,57 +8783,57 @@ impl<'a> CreatePaymentIntentTransferData<'a> {
 /// available in the [confirm API](https://stripe.com/docs/api/payment_intents/confirm) when you supply
 /// `confirm=true`.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentIntent<'a> {
-    inner: CreatePaymentIntentBuilder<'a>,
+pub struct CreatePaymentIntent {
+    inner: CreatePaymentIntentBuilder,
 }
-impl<'a> CreatePaymentIntent<'a> {
+impl CreatePaymentIntent {
     /// Construct a new `CreatePaymentIntent`.
-    pub fn new(amount: i64, currency: stripe_types::Currency) -> Self {
-        Self { inner: CreatePaymentIntentBuilder::new(amount, currency) }
+    pub fn new(amount: impl Into<i64>, currency: impl Into<stripe_types::Currency>) -> Self {
+        Self { inner: CreatePaymentIntentBuilder::new(amount.into(), currency.into()) }
     }
     /// The amount of the application fee (if any) that will be requested to be applied to the payment and transferred to the application owner's Stripe account.
     /// The amount of the application fee collected will be capped at the total payment amount.
     /// For more information, see the PaymentIntents [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts).
-    pub fn application_fee_amount(mut self, application_fee_amount: i64) -> Self {
-        self.inner.application_fee_amount = Some(application_fee_amount);
+    pub fn application_fee_amount(mut self, application_fee_amount: impl Into<i64>) -> Self {
+        self.inner.application_fee_amount = Some(application_fee_amount.into());
         self
     }
     /// When you enable this parameter, this PaymentIntent accepts payment methods that you enable in the Dashboard and that are compatible with this PaymentIntent's other parameters.
     pub fn automatic_payment_methods(
         mut self,
-        automatic_payment_methods: CreatePaymentIntentAutomaticPaymentMethods,
+        automatic_payment_methods: impl Into<CreatePaymentIntentAutomaticPaymentMethods>,
     ) -> Self {
-        self.inner.automatic_payment_methods = Some(automatic_payment_methods);
+        self.inner.automatic_payment_methods = Some(automatic_payment_methods.into());
         self
     }
     /// Controls when the funds will be captured from the customer's account.
     pub fn capture_method(
         mut self,
-        capture_method: stripe_shared::PaymentIntentCaptureMethod,
+        capture_method: impl Into<stripe_shared::PaymentIntentCaptureMethod>,
     ) -> Self {
-        self.inner.capture_method = Some(capture_method);
+        self.inner.capture_method = Some(capture_method.into());
         self
     }
     /// Set to `true` to attempt to [confirm this PaymentIntent](https://stripe.com/docs/api/payment_intents/confirm) immediately.
     /// This parameter defaults to `false`.
     /// When creating and confirming a PaymentIntent at the same time, you can also provide the parameters available in the [Confirm API](https://stripe.com/docs/api/payment_intents/confirm).
-    pub fn confirm(mut self, confirm: bool) -> Self {
-        self.inner.confirm = Some(confirm);
+    pub fn confirm(mut self, confirm: impl Into<bool>) -> Self {
+        self.inner.confirm = Some(confirm.into());
         self
     }
     /// Describes whether we can confirm this PaymentIntent automatically, or if it requires customer action to confirm the payment.
     pub fn confirmation_method(
         mut self,
-        confirmation_method: stripe_shared::PaymentIntentConfirmationMethod,
+        confirmation_method: impl Into<stripe_shared::PaymentIntentConfirmationMethod>,
     ) -> Self {
-        self.inner.confirmation_method = Some(confirmation_method);
+        self.inner.confirmation_method = Some(confirmation_method.into());
         self
     }
     /// ID of the ConfirmationToken used to confirm this PaymentIntent.
     ///
     /// If the provided ConfirmationToken contains properties that are also being provided in this request, such as `payment_method`, then the values in this request will take precedence.
-    pub fn confirmation_token(mut self, confirmation_token: &'a str) -> Self {
-        self.inner.confirmation_token = Some(confirmation_token);
+    pub fn confirmation_token(mut self, confirmation_token: impl Into<String>) -> Self {
+        self.inner.confirmation_token = Some(confirmation_token.into());
         self
     }
     /// ID of the Customer this PaymentIntent belongs to, if one exists.
@@ -8828,71 +8841,77 @@ impl<'a> CreatePaymentIntent<'a> {
     /// Payment methods attached to other Customers cannot be used with this PaymentIntent.
     ///
     /// If present in combination with [setup_future_usage](https://stripe.com/docs/api#payment_intent_object-setup_future_usage), this PaymentIntent's payment method will be attached to the Customer after the PaymentIntent has been confirmed and any required actions from the user are complete.
-    pub fn customer(mut self, customer: &'a str) -> Self {
-        self.inner.customer = Some(customer);
+    pub fn customer(mut self, customer: impl Into<String>) -> Self {
+        self.inner.customer = Some(customer.into());
         self
     }
     /// An arbitrary string attached to the object. Often useful for displaying to users.
-    pub fn description(mut self, description: &'a str) -> Self {
-        self.inner.description = Some(description);
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.inner.description = Some(description.into());
         self
     }
     /// Set to `true` to fail the payment attempt if the PaymentIntent transitions into `requires_action`.
     /// Use this parameter for simpler integrations that don't handle customer actions, such as [saving cards without authentication](https://stripe.com/docs/payments/save-card-without-authentication).
     /// This parameter can only be used with [`confirm=true`](https://stripe.com/docs/api/payment_intents/create#create_payment_intent-confirm).
-    pub fn error_on_requires_action(mut self, error_on_requires_action: bool) -> Self {
-        self.inner.error_on_requires_action = Some(error_on_requires_action);
+    pub fn error_on_requires_action(mut self, error_on_requires_action: impl Into<bool>) -> Self {
+        self.inner.error_on_requires_action = Some(error_on_requires_action.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// ID of the mandate that's used for this payment.
     /// This parameter can only be used with [`confirm=true`](https://stripe.com/docs/api/payment_intents/create#create_payment_intent-confirm).
-    pub fn mandate(mut self, mandate: &'a str) -> Self {
-        self.inner.mandate = Some(mandate);
+    pub fn mandate(mut self, mandate: impl Into<String>) -> Self {
+        self.inner.mandate = Some(mandate.into());
         self
     }
     /// This hash contains details about the Mandate to create.
     /// This parameter can only be used with [`confirm=true`](https://stripe.com/docs/api/payment_intents/create#create_payment_intent-confirm).
-    pub fn mandate_data(mut self, mandate_data: CreatePaymentIntentMandateData<'a>) -> Self {
-        self.inner.mandate_data = Some(mandate_data);
+    pub fn mandate_data(mut self, mandate_data: impl Into<CreatePaymentIntentMandateData>) -> Self {
+        self.inner.mandate_data = Some(mandate_data.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// Set to `true` to indicate that the customer isn't in your checkout flow during this payment attempt and can't authenticate.
     /// Use this parameter in scenarios where you collect card details and [charge them later](https://stripe.com/docs/payments/cards/charging-saved-cards).
     /// This parameter can only be used with [`confirm=true`](https://stripe.com/docs/api/payment_intents/create#create_payment_intent-confirm).
-    pub fn off_session(mut self, off_session: CreatePaymentIntentOffSession) -> Self {
-        self.inner.off_session = Some(off_session);
+    pub fn off_session(mut self, off_session: impl Into<CreatePaymentIntentOffSession>) -> Self {
+        self.inner.off_session = Some(off_session.into());
         self
     }
     /// The Stripe account ID that these funds are intended for.
     /// Learn more about the [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts).
-    pub fn on_behalf_of(mut self, on_behalf_of: &'a str) -> Self {
-        self.inner.on_behalf_of = Some(on_behalf_of);
+    pub fn on_behalf_of(mut self, on_behalf_of: impl Into<String>) -> Self {
+        self.inner.on_behalf_of = Some(on_behalf_of.into());
         self
     }
     /// ID of the payment method (a PaymentMethod, Card, or [compatible Source](https://stripe.com/docs/payments/payment-methods#compatibility) object) to attach to this PaymentIntent.
     ///
     /// If you don't provide the `payment_method` parameter or the `source` parameter with `confirm=true`, `source` automatically populates with `customer.default_source` to improve migration for users of the Charges API.
     /// We recommend that you explicitly provide the `payment_method` moving forward.
-    pub fn payment_method(mut self, payment_method: &'a str) -> Self {
-        self.inner.payment_method = Some(payment_method);
+    pub fn payment_method(mut self, payment_method: impl Into<String>) -> Self {
+        self.inner.payment_method = Some(payment_method.into());
         self
     }
     /// The ID of the payment method configuration to use with this PaymentIntent.
-    pub fn payment_method_configuration(mut self, payment_method_configuration: &'a str) -> Self {
-        self.inner.payment_method_configuration = Some(payment_method_configuration);
+    pub fn payment_method_configuration(
+        mut self,
+        payment_method_configuration: impl Into<String>,
+    ) -> Self {
+        self.inner.payment_method_configuration = Some(payment_method_configuration.into());
         self
     }
     /// If provided, this hash will be used to create a PaymentMethod. The new PaymentMethod will appear
@@ -8900,43 +8919,46 @@ impl<'a> CreatePaymentIntent<'a> {
     /// property on the PaymentIntent.
     pub fn payment_method_data(
         mut self,
-        payment_method_data: CreatePaymentIntentPaymentMethodData<'a>,
+        payment_method_data: impl Into<CreatePaymentIntentPaymentMethodData>,
     ) -> Self {
-        self.inner.payment_method_data = Some(payment_method_data);
+        self.inner.payment_method_data = Some(payment_method_data.into());
         self
     }
     /// Payment method-specific configuration for this PaymentIntent.
     pub fn payment_method_options(
         mut self,
-        payment_method_options: CreatePaymentIntentPaymentMethodOptions<'a>,
+        payment_method_options: impl Into<CreatePaymentIntentPaymentMethodOptions>,
     ) -> Self {
-        self.inner.payment_method_options = Some(payment_method_options);
+        self.inner.payment_method_options = Some(payment_method_options.into());
         self
     }
     /// The list of payment method types (for example, a card) that this PaymentIntent can use.
     /// If you don't provide this, it defaults to ["card"].
     /// Use `automatic_payment_methods` to manage payment methods from the [Stripe Dashboard](https://dashboard.stripe.com/settings/payment_methods).
-    pub fn payment_method_types(mut self, payment_method_types: &'a [&'a str]) -> Self {
-        self.inner.payment_method_types = Some(payment_method_types);
+    pub fn payment_method_types(mut self, payment_method_types: impl Into<Vec<String>>) -> Self {
+        self.inner.payment_method_types = Some(payment_method_types.into());
         self
     }
     /// Options to configure Radar.
     /// Learn more about [Radar Sessions](https://stripe.com/docs/radar/radar-session).
-    pub fn radar_options(mut self, radar_options: RadarOptionsWithHiddenOptions<'a>) -> Self {
-        self.inner.radar_options = Some(radar_options);
+    pub fn radar_options(
+        mut self,
+        radar_options: impl Into<RadarOptionsWithHiddenOptions>,
+    ) -> Self {
+        self.inner.radar_options = Some(radar_options.into());
         self
     }
     /// Email address to send the receipt to.
     /// If you specify `receipt_email` for a payment in live mode, you send a receipt regardless of your [email settings](https://dashboard.stripe.com/account/emails).
-    pub fn receipt_email(mut self, receipt_email: &'a str) -> Self {
-        self.inner.receipt_email = Some(receipt_email);
+    pub fn receipt_email(mut self, receipt_email: impl Into<String>) -> Self {
+        self.inner.receipt_email = Some(receipt_email.into());
         self
     }
     /// The URL to redirect your customer back to after they authenticate or cancel their payment on the payment method's app or site.
     /// If you'd prefer to redirect to a mobile application, you can alternatively supply an application URI scheme.
     /// This parameter can only be used with [`confirm=true`](https://stripe.com/docs/api/payment_intents/create#create_payment_intent-confirm).
-    pub fn return_url(mut self, return_url: &'a str) -> Self {
-        self.inner.return_url = Some(return_url);
+    pub fn return_url(mut self, return_url: impl Into<String>) -> Self {
+        self.inner.return_url = Some(return_url.into());
         self
     }
     /// Indicates that you intend to make future payments with this PaymentIntent's payment method.
@@ -8947,49 +8969,55 @@ impl<'a> CreatePaymentIntent<'a> {
     /// When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
     pub fn setup_future_usage(
         mut self,
-        setup_future_usage: stripe_shared::PaymentIntentSetupFutureUsage,
+        setup_future_usage: impl Into<stripe_shared::PaymentIntentSetupFutureUsage>,
     ) -> Self {
-        self.inner.setup_future_usage = Some(setup_future_usage);
+        self.inner.setup_future_usage = Some(setup_future_usage.into());
         self
     }
     /// Shipping information for this PaymentIntent.
-    pub fn shipping(mut self, shipping: CreatePaymentIntentShipping<'a>) -> Self {
-        self.inner.shipping = Some(shipping);
+    pub fn shipping(mut self, shipping: impl Into<CreatePaymentIntentShipping>) -> Self {
+        self.inner.shipping = Some(shipping.into());
         self
     }
     /// For card charges, use [statement_descriptor_suffix](https://stripe.com/docs/payments/account/statement-descriptors#dynamic).
     /// Otherwise, you can use this value as the complete description of a charge on your customers' statements.
     /// It must contain at least one letter and be 1–22 characters long.
-    pub fn statement_descriptor(mut self, statement_descriptor: &'a str) -> Self {
-        self.inner.statement_descriptor = Some(statement_descriptor);
+    pub fn statement_descriptor(mut self, statement_descriptor: impl Into<String>) -> Self {
+        self.inner.statement_descriptor = Some(statement_descriptor.into());
         self
     }
     /// Provides information about a card payment that customers see on their statements.
     /// Concatenated with the prefix (shortened descriptor) or statement descriptor that’s set on the account to form the complete statement descriptor.
     /// The concatenated descriptor must contain 1-22 characters.
-    pub fn statement_descriptor_suffix(mut self, statement_descriptor_suffix: &'a str) -> Self {
-        self.inner.statement_descriptor_suffix = Some(statement_descriptor_suffix);
+    pub fn statement_descriptor_suffix(
+        mut self,
+        statement_descriptor_suffix: impl Into<String>,
+    ) -> Self {
+        self.inner.statement_descriptor_suffix = Some(statement_descriptor_suffix.into());
         self
     }
     /// The parameters that you can use to automatically create a Transfer.
     /// Learn more about the [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts).
-    pub fn transfer_data(mut self, transfer_data: CreatePaymentIntentTransferData<'a>) -> Self {
-        self.inner.transfer_data = Some(transfer_data);
+    pub fn transfer_data(
+        mut self,
+        transfer_data: impl Into<CreatePaymentIntentTransferData>,
+    ) -> Self {
+        self.inner.transfer_data = Some(transfer_data.into());
         self
     }
     /// A string that identifies the resulting payment as part of a group.
     /// Learn more about the [use case for connected accounts](https://stripe.com/docs/connect/separate-charges-and-transfers).
-    pub fn transfer_group(mut self, transfer_group: &'a str) -> Self {
-        self.inner.transfer_group = Some(transfer_group);
+    pub fn transfer_group(mut self, transfer_group: impl Into<String>) -> Self {
+        self.inner.transfer_group = Some(transfer_group.into());
         self
     }
     /// Set to `true` when confirming server-side and using Stripe.js, iOS, or Android client-side SDKs to handle the next actions.
-    pub fn use_stripe_sdk(mut self, use_stripe_sdk: bool) -> Self {
-        self.inner.use_stripe_sdk = Some(use_stripe_sdk);
+    pub fn use_stripe_sdk(mut self, use_stripe_sdk: impl Into<bool>) -> Self {
+        self.inner.use_stripe_sdk = Some(use_stripe_sdk.into());
         self
     }
 }
-impl CreatePaymentIntent<'_> {
+impl CreatePaymentIntent {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -9007,7 +9035,7 @@ impl CreatePaymentIntent<'_> {
     }
 }
 
-impl StripeRequest for CreatePaymentIntent<'_> {
+impl StripeRequest for CreatePaymentIntent {
     type Output = stripe_shared::PaymentIntent;
 
     fn build(&self) -> RequestBuilder {
@@ -9015,7 +9043,7 @@ impl StripeRequest for CreatePaymentIntent<'_> {
     }
 }
 #[derive(Clone, Debug, serde::Serialize)]
-struct UpdatePaymentIntentBuilder<'a> {
+struct UpdatePaymentIntentBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     amount: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -9025,39 +9053,39 @@ struct UpdatePaymentIntentBuilder<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     currency: Option<stripe_types::Currency>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    customer: Option<&'a str>,
+    customer: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<&'a str>,
+    description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_method: Option<&'a str>,
+    payment_method: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_method_configuration: Option<&'a str>,
+    payment_method_configuration: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_method_data: Option<UpdatePaymentIntentPaymentMethodData<'a>>,
+    payment_method_data: Option<UpdatePaymentIntentPaymentMethodData>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_method_options: Option<UpdatePaymentIntentPaymentMethodOptions<'a>>,
+    payment_method_options: Option<UpdatePaymentIntentPaymentMethodOptions>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_method_types: Option<&'a [&'a str]>,
+    payment_method_types: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    receipt_email: Option<&'a str>,
+    receipt_email: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     setup_future_usage: Option<stripe_shared::PaymentIntentSetupFutureUsage>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    shipping: Option<UpdatePaymentIntentShipping<'a>>,
+    shipping: Option<UpdatePaymentIntentShipping>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    statement_descriptor: Option<&'a str>,
+    statement_descriptor: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    statement_descriptor_suffix: Option<&'a str>,
+    statement_descriptor_suffix: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     transfer_data: Option<TransferDataUpdateParams>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    transfer_group: Option<&'a str>,
+    transfer_group: Option<String>,
 }
-impl<'a> UpdatePaymentIntentBuilder<'a> {
+impl UpdatePaymentIntentBuilder {
     fn new() -> Self {
         Self {
             amount: None,
@@ -9087,10 +9115,10 @@ impl<'a> UpdatePaymentIntentBuilder<'a> {
 /// in the [payment_method](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-payment_method).
 /// property on the PaymentIntent.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentIntentPaymentMethodData<'a> {
+pub struct UpdatePaymentIntentPaymentMethodData {
     /// If this is an `acss_debit` PaymentMethod, this hash contains details about the ACSS Debit payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub acss_debit: Option<PaymentMethodParam<'a>>,
+    pub acss_debit: Option<PaymentMethodParam>,
     /// If this is an `affirm` PaymentMethod, this hash contains details about the Affirm payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
@@ -9114,24 +9142,24 @@ pub struct UpdatePaymentIntentPaymentMethodData<'a> {
     pub amazon_pay: Option<miniserde::json::Value>,
     /// If this is an `au_becs_debit` PaymentMethod, this hash contains details about the bank account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub au_becs_debit: Option<UpdatePaymentIntentPaymentMethodDataAuBecsDebit<'a>>,
+    pub au_becs_debit: Option<UpdatePaymentIntentPaymentMethodDataAuBecsDebit>,
     /// If this is a `bacs_debit` PaymentMethod, this hash contains details about the Bacs Direct Debit bank account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub bacs_debit: Option<UpdatePaymentIntentPaymentMethodDataBacsDebit<'a>>,
+    pub bacs_debit: Option<UpdatePaymentIntentPaymentMethodDataBacsDebit>,
     /// If this is a `bancontact` PaymentMethod, this hash contains details about the Bancontact payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
     pub bancontact: Option<miniserde::json::Value>,
     /// Billing information associated with the PaymentMethod that may be used or required by particular types of payment methods.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub billing_details: Option<UpdatePaymentIntentPaymentMethodDataBillingDetails<'a>>,
+    pub billing_details: Option<UpdatePaymentIntentPaymentMethodDataBillingDetails>,
     /// If this is a `blik` PaymentMethod, this hash contains details about the BLIK payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
     pub blik: Option<miniserde::json::Value>,
     /// If this is a `boleto` PaymentMethod, this hash contains details about the Boleto payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub boleto: Option<UpdatePaymentIntentPaymentMethodDataBoleto<'a>>,
+    pub boleto: Option<UpdatePaymentIntentPaymentMethodDataBoleto>,
     /// If this is a `cashapp` PaymentMethod, this hash contains details about the Cash App Pay payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
@@ -9177,7 +9205,7 @@ pub struct UpdatePaymentIntentPaymentMethodData<'a> {
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// If this is a `mobilepay` PaymentMethod, this hash contains details about the MobilePay payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
@@ -9208,14 +9236,14 @@ pub struct UpdatePaymentIntentPaymentMethodData<'a> {
     /// Options to configure Radar.
     /// See [Radar Session](https://stripe.com/docs/radar/radar-session) for more information.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub radar_options: Option<RadarOptionsWithHiddenOptions<'a>>,
+    pub radar_options: Option<RadarOptionsWithHiddenOptions>,
     /// If this is a `Revolut Pay` PaymentMethod, this hash contains details about the Revolut Pay payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
     pub revolut_pay: Option<miniserde::json::Value>,
     /// If this is a `sepa_debit` PaymentMethod, this hash contains details about the SEPA debit bank account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub sepa_debit: Option<UpdatePaymentIntentPaymentMethodDataSepaDebit<'a>>,
+    pub sepa_debit: Option<UpdatePaymentIntentPaymentMethodDataSepaDebit>,
     /// If this is a `sofort` PaymentMethod, this hash contains details about the SOFORT payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sofort: Option<UpdatePaymentIntentPaymentMethodDataSofort>,
@@ -9230,7 +9258,7 @@ pub struct UpdatePaymentIntentPaymentMethodData<'a> {
     pub type_: UpdatePaymentIntentPaymentMethodDataType,
     /// If this is an `us_bank_account` PaymentMethod, this hash contains details about the US bank account payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub us_bank_account: Option<UpdatePaymentIntentPaymentMethodDataUsBankAccount<'a>>,
+    pub us_bank_account: Option<UpdatePaymentIntentPaymentMethodDataUsBankAccount>,
     /// If this is an `wechat_pay` PaymentMethod, this hash contains details about the wechat_pay payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
@@ -9240,8 +9268,8 @@ pub struct UpdatePaymentIntentPaymentMethodData<'a> {
     #[serde(with = "stripe_types::with_serde_json_opt")]
     pub zip: Option<miniserde::json::Value>,
 }
-impl<'a> UpdatePaymentIntentPaymentMethodData<'a> {
-    pub fn new(type_: UpdatePaymentIntentPaymentMethodDataType) -> Self {
+impl UpdatePaymentIntentPaymentMethodData {
+    pub fn new(type_: impl Into<UpdatePaymentIntentPaymentMethodDataType>) -> Self {
         Self {
             acss_debit: None,
             affirm: None,
@@ -9279,7 +9307,7 @@ impl<'a> UpdatePaymentIntentPaymentMethodData<'a> {
             sepa_debit: None,
             sofort: None,
             swish: None,
-            type_,
+            type_: type_.into(),
             us_bank_account: None,
             wechat_pay: None,
             zip: None,
@@ -9350,105 +9378,105 @@ impl<'de> serde::Deserialize<'de> for UpdatePaymentIntentPaymentMethodDataAllowR
     }
 }
 /// If this is an `au_becs_debit` PaymentMethod, this hash contains details about the bank account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentIntentPaymentMethodDataAuBecsDebit<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdatePaymentIntentPaymentMethodDataAuBecsDebit {
     /// The account number for the bank account.
-    pub account_number: &'a str,
+    pub account_number: String,
     /// Bank-State-Branch number of the bank account.
-    pub bsb_number: &'a str,
+    pub bsb_number: String,
 }
-impl<'a> UpdatePaymentIntentPaymentMethodDataAuBecsDebit<'a> {
-    pub fn new(account_number: &'a str, bsb_number: &'a str) -> Self {
-        Self { account_number, bsb_number }
+impl UpdatePaymentIntentPaymentMethodDataAuBecsDebit {
+    pub fn new(account_number: impl Into<String>, bsb_number: impl Into<String>) -> Self {
+        Self { account_number: account_number.into(), bsb_number: bsb_number.into() }
     }
 }
 /// If this is a `bacs_debit` PaymentMethod, this hash contains details about the Bacs Direct Debit bank account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentIntentPaymentMethodDataBacsDebit<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdatePaymentIntentPaymentMethodDataBacsDebit {
     /// Account number of the bank account that the funds will be debited from.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account_number: Option<&'a str>,
+    pub account_number: Option<String>,
     /// Sort code of the bank account. (e.g., `10-20-30`)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub sort_code: Option<&'a str>,
+    pub sort_code: Option<String>,
 }
-impl<'a> UpdatePaymentIntentPaymentMethodDataBacsDebit<'a> {
+impl UpdatePaymentIntentPaymentMethodDataBacsDebit {
     pub fn new() -> Self {
         Self { account_number: None, sort_code: None }
     }
 }
-impl<'a> Default for UpdatePaymentIntentPaymentMethodDataBacsDebit<'a> {
+impl Default for UpdatePaymentIntentPaymentMethodDataBacsDebit {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Billing information associated with the PaymentMethod that may be used or required by particular types of payment methods.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentIntentPaymentMethodDataBillingDetails<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdatePaymentIntentPaymentMethodDataBillingDetails {
     /// Billing address.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub address: Option<UpdatePaymentIntentPaymentMethodDataBillingDetailsAddress<'a>>,
+    pub address: Option<UpdatePaymentIntentPaymentMethodDataBillingDetailsAddress>,
     /// Email address.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub email: Option<&'a str>,
+    pub email: Option<String>,
     /// Full name.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<&'a str>,
+    pub name: Option<String>,
     /// Billing phone number (including extension).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub phone: Option<&'a str>,
+    pub phone: Option<String>,
 }
-impl<'a> UpdatePaymentIntentPaymentMethodDataBillingDetails<'a> {
+impl UpdatePaymentIntentPaymentMethodDataBillingDetails {
     pub fn new() -> Self {
         Self { address: None, email: None, name: None, phone: None }
     }
 }
-impl<'a> Default for UpdatePaymentIntentPaymentMethodDataBillingDetails<'a> {
+impl Default for UpdatePaymentIntentPaymentMethodDataBillingDetails {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Billing address.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentIntentPaymentMethodDataBillingDetailsAddress<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdatePaymentIntentPaymentMethodDataBillingDetailsAddress {
     /// City, district, suburb, town, or village.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<&'a str>,
+    pub city: Option<String>,
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub country: Option<&'a str>,
+    pub country: Option<String>,
     /// Address line 1 (e.g., street, PO Box, or company name).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line1: Option<&'a str>,
+    pub line1: Option<String>,
     /// Address line 2 (e.g., apartment, suite, unit, or building).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line2: Option<&'a str>,
+    pub line2: Option<String>,
     /// ZIP or postal code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<&'a str>,
+    pub postal_code: Option<String>,
     /// State, county, province, or region.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
 }
-impl<'a> UpdatePaymentIntentPaymentMethodDataBillingDetailsAddress<'a> {
+impl UpdatePaymentIntentPaymentMethodDataBillingDetailsAddress {
     pub fn new() -> Self {
         Self { city: None, country: None, line1: None, line2: None, postal_code: None, state: None }
     }
 }
-impl<'a> Default for UpdatePaymentIntentPaymentMethodDataBillingDetailsAddress<'a> {
+impl Default for UpdatePaymentIntentPaymentMethodDataBillingDetailsAddress {
     fn default() -> Self {
         Self::new()
     }
 }
 /// If this is a `boleto` PaymentMethod, this hash contains details about the Boleto payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentIntentPaymentMethodDataBoleto<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdatePaymentIntentPaymentMethodDataBoleto {
     /// The tax ID of the customer (CPF for individual consumers or CNPJ for businesses consumers)
-    pub tax_id: &'a str,
+    pub tax_id: String,
 }
-impl<'a> UpdatePaymentIntentPaymentMethodDataBoleto<'a> {
-    pub fn new(tax_id: &'a str) -> Self {
-        Self { tax_id }
+impl UpdatePaymentIntentPaymentMethodDataBoleto {
+    pub fn new(tax_id: impl Into<String>) -> Self {
+        Self { tax_id: tax_id.into() }
     }
 }
 /// If this is an `eps` PaymentMethod, this hash contains details about the EPS payment method.
@@ -9614,8 +9642,8 @@ pub struct UpdatePaymentIntentPaymentMethodDataFpx {
     pub bank: UpdatePaymentIntentPaymentMethodDataFpxBank,
 }
 impl UpdatePaymentIntentPaymentMethodDataFpx {
-    pub fn new(bank: UpdatePaymentIntentPaymentMethodDataFpxBank) -> Self {
-        Self { account_holder_type: None, bank }
+    pub fn new(bank: impl Into<UpdatePaymentIntentPaymentMethodDataFpxBank>) -> Self {
+        Self { account_holder_type: None, bank: bank.into() }
     }
 }
 /// Account holder type for FPX transaction
@@ -10076,14 +10104,14 @@ impl<'de> serde::Deserialize<'de> for UpdatePaymentIntentPaymentMethodDataP24Ban
     }
 }
 /// If this is a `sepa_debit` PaymentMethod, this hash contains details about the SEPA debit bank account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentIntentPaymentMethodDataSepaDebit<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdatePaymentIntentPaymentMethodDataSepaDebit {
     /// IBAN of the bank account.
-    pub iban: &'a str,
+    pub iban: String,
 }
-impl<'a> UpdatePaymentIntentPaymentMethodDataSepaDebit<'a> {
-    pub fn new(iban: &'a str) -> Self {
-        Self { iban }
+impl UpdatePaymentIntentPaymentMethodDataSepaDebit {
+    pub fn new(iban: impl Into<String>) -> Self {
+        Self { iban: iban.into() }
     }
 }
 /// If this is a `sofort` PaymentMethod, this hash contains details about the SOFORT payment method.
@@ -10093,8 +10121,8 @@ pub struct UpdatePaymentIntentPaymentMethodDataSofort {
     pub country: UpdatePaymentIntentPaymentMethodDataSofortCountry,
 }
 impl UpdatePaymentIntentPaymentMethodDataSofort {
-    pub fn new(country: UpdatePaymentIntentPaymentMethodDataSofortCountry) -> Self {
-        Self { country }
+    pub fn new(country: impl Into<UpdatePaymentIntentPaymentMethodDataSofortCountry>) -> Self {
+        Self { country: country.into() }
     }
 }
 /// Two-letter ISO code representing the country the bank account is located in.
@@ -10324,26 +10352,26 @@ impl<'de> serde::Deserialize<'de> for UpdatePaymentIntentPaymentMethodDataType {
     }
 }
 /// If this is an `us_bank_account` PaymentMethod, this hash contains details about the US bank account payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentIntentPaymentMethodDataUsBankAccount<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdatePaymentIntentPaymentMethodDataUsBankAccount {
     /// Account holder type: individual or company.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub account_holder_type:
         Option<UpdatePaymentIntentPaymentMethodDataUsBankAccountAccountHolderType>,
     /// Account number of the bank account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account_number: Option<&'a str>,
+    pub account_number: Option<String>,
     /// Account type: checkings or savings. Defaults to checking if omitted.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub account_type: Option<UpdatePaymentIntentPaymentMethodDataUsBankAccountAccountType>,
     /// The ID of a Financial Connections Account to use as a payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub financial_connections_account: Option<&'a str>,
+    pub financial_connections_account: Option<String>,
     /// Routing number of the bank account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub routing_number: Option<&'a str>,
+    pub routing_number: Option<String>,
 }
-impl<'a> UpdatePaymentIntentPaymentMethodDataUsBankAccount<'a> {
+impl UpdatePaymentIntentPaymentMethodDataUsBankAccount {
     pub fn new() -> Self {
         Self {
             account_holder_type: None,
@@ -10354,7 +10382,7 @@ impl<'a> UpdatePaymentIntentPaymentMethodDataUsBankAccount<'a> {
         }
     }
 }
-impl<'a> Default for UpdatePaymentIntentPaymentMethodDataUsBankAccount<'a> {
+impl Default for UpdatePaymentIntentPaymentMethodDataUsBankAccount {
     fn default() -> Self {
         Self::new()
     }
@@ -10475,16 +10503,16 @@ impl<'de> serde::Deserialize<'de> for UpdatePaymentIntentPaymentMethodDataUsBank
 }
 /// Payment-method-specific configuration for this PaymentIntent.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentIntentPaymentMethodOptions<'a> {
+pub struct UpdatePaymentIntentPaymentMethodOptions {
     /// If this is a `acss_debit` PaymentMethod, this sub-hash contains details about the ACSS Debit payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub acss_debit: Option<UpdatePaymentIntentPaymentMethodOptionsAcssDebit<'a>>,
+    pub acss_debit: Option<UpdatePaymentIntentPaymentMethodOptionsAcssDebit>,
     /// If this is an `affirm` PaymentMethod, this sub-hash contains details about the Affirm payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub affirm: Option<UpdatePaymentIntentPaymentMethodOptionsAffirm<'a>>,
+    pub affirm: Option<UpdatePaymentIntentPaymentMethodOptionsAffirm>,
     /// If this is a `afterpay_clearpay` PaymentMethod, this sub-hash contains details about the Afterpay Clearpay payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub afterpay_clearpay: Option<UpdatePaymentIntentPaymentMethodOptionsAfterpayClearpay<'a>>,
+    pub afterpay_clearpay: Option<UpdatePaymentIntentPaymentMethodOptionsAfterpayClearpay>,
     /// If this is a `alipay` PaymentMethod, this sub-hash contains details about the Alipay payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub alipay: Option<UpdatePaymentIntentPaymentMethodOptionsAlipay>,
@@ -10502,13 +10530,13 @@ pub struct UpdatePaymentIntentPaymentMethodOptions<'a> {
     pub bancontact: Option<UpdatePaymentIntentPaymentMethodOptionsBancontact>,
     /// If this is a `blik` PaymentMethod, this sub-hash contains details about the BLIK payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub blik: Option<UpdatePaymentIntentPaymentMethodOptionsBlik<'a>>,
+    pub blik: Option<UpdatePaymentIntentPaymentMethodOptionsBlik>,
     /// If this is a `boleto` PaymentMethod, this sub-hash contains details about the Boleto payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub boleto: Option<UpdatePaymentIntentPaymentMethodOptionsBoleto>,
     /// Configuration for any card payments attempted on this PaymentIntent.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub card: Option<UpdatePaymentIntentPaymentMethodOptionsCard<'a>>,
+    pub card: Option<UpdatePaymentIntentPaymentMethodOptionsCard>,
     /// If this is a `card_present` PaymentMethod, this sub-hash contains details about the Card Present payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub card_present: Option<PaymentMethodOptionsParam>,
@@ -10517,7 +10545,7 @@ pub struct UpdatePaymentIntentPaymentMethodOptions<'a> {
     pub cashapp: Option<UpdatePaymentIntentPaymentMethodOptionsCashapp>,
     /// If this is a `customer balance` PaymentMethod, this sub-hash contains details about the customer balance payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub customer_balance: Option<UpdatePaymentIntentPaymentMethodOptionsCustomerBalance<'a>>,
+    pub customer_balance: Option<UpdatePaymentIntentPaymentMethodOptionsCustomerBalance>,
     /// If this is a `eps` PaymentMethod, this sub-hash contains details about the EPS payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub eps: Option<UpdatePaymentIntentPaymentMethodOptionsEps>,
@@ -10542,10 +10570,10 @@ pub struct UpdatePaymentIntentPaymentMethodOptions<'a> {
     pub klarna: Option<UpdatePaymentIntentPaymentMethodOptionsKlarna>,
     /// If this is a `konbini` PaymentMethod, this sub-hash contains details about the Konbini payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub konbini: Option<UpdatePaymentIntentPaymentMethodOptionsKonbini<'a>>,
+    pub konbini: Option<UpdatePaymentIntentPaymentMethodOptionsKonbini>,
     /// If this is a `link` PaymentMethod, this sub-hash contains details about the Link payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub link: Option<UpdatePaymentIntentPaymentMethodOptionsLink<'a>>,
+    pub link: Option<UpdatePaymentIntentPaymentMethodOptionsLink>,
     /// If this is a `MobilePay` PaymentMethod, this sub-hash contains details about the MobilePay payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mobilepay: Option<UpdatePaymentIntentPaymentMethodOptionsMobilepay>,
@@ -10560,7 +10588,7 @@ pub struct UpdatePaymentIntentPaymentMethodOptions<'a> {
     pub paynow: Option<UpdatePaymentIntentPaymentMethodOptionsPaynow>,
     /// If this is a `paypal` PaymentMethod, this sub-hash contains details about the PayPal payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub paypal: Option<UpdatePaymentIntentPaymentMethodOptionsPaypal<'a>>,
+    pub paypal: Option<UpdatePaymentIntentPaymentMethodOptionsPaypal>,
     /// If this is a `pix` PaymentMethod, this sub-hash contains details about the Pix payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pix: Option<UpdatePaymentIntentPaymentMethodOptionsPix>,
@@ -10578,18 +10606,18 @@ pub struct UpdatePaymentIntentPaymentMethodOptions<'a> {
     pub sofort: Option<UpdatePaymentIntentPaymentMethodOptionsSofort>,
     /// If this is a `Swish` PaymentMethod, this sub-hash contains details about the Swish payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub swish: Option<UpdatePaymentIntentPaymentMethodOptionsSwish<'a>>,
+    pub swish: Option<UpdatePaymentIntentPaymentMethodOptionsSwish>,
     /// If this is a `us_bank_account` PaymentMethod, this sub-hash contains details about the US bank account payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub us_bank_account: Option<UpdatePaymentIntentPaymentMethodOptionsUsBankAccount<'a>>,
+    pub us_bank_account: Option<UpdatePaymentIntentPaymentMethodOptionsUsBankAccount>,
     /// If this is a `wechat_pay` PaymentMethod, this sub-hash contains details about the WeChat Pay payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub wechat_pay: Option<UpdatePaymentIntentPaymentMethodOptionsWechatPay<'a>>,
+    pub wechat_pay: Option<UpdatePaymentIntentPaymentMethodOptionsWechatPay>,
     /// If this is a `zip` PaymentMethod, this sub-hash contains details about the Zip payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub zip: Option<UpdatePaymentIntentPaymentMethodOptionsZip>,
 }
-impl<'a> UpdatePaymentIntentPaymentMethodOptions<'a> {
+impl UpdatePaymentIntentPaymentMethodOptions {
     pub fn new() -> Self {
         Self {
             acss_debit: None,
@@ -10632,17 +10660,17 @@ impl<'a> UpdatePaymentIntentPaymentMethodOptions<'a> {
         }
     }
 }
-impl<'a> Default for UpdatePaymentIntentPaymentMethodOptions<'a> {
+impl Default for UpdatePaymentIntentPaymentMethodOptions {
     fn default() -> Self {
         Self::new()
     }
 }
 /// If this is a `acss_debit` PaymentMethod, this sub-hash contains details about the ACSS Debit payment method options.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentIntentPaymentMethodOptionsAcssDebit<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdatePaymentIntentPaymentMethodOptionsAcssDebit {
     /// Additional fields for Mandate creation
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub mandate_options: Option<UpdatePaymentIntentPaymentMethodOptionsAcssDebitMandateOptions<'a>>,
+    pub mandate_options: Option<UpdatePaymentIntentPaymentMethodOptionsAcssDebitMandateOptions>,
     /// Indicates that you intend to make future payments with this PaymentIntent's payment method.
     ///
     /// Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete.
@@ -10659,28 +10687,28 @@ pub struct UpdatePaymentIntentPaymentMethodOptionsAcssDebit<'a> {
     pub verification_method:
         Option<UpdatePaymentIntentPaymentMethodOptionsAcssDebitVerificationMethod>,
 }
-impl<'a> UpdatePaymentIntentPaymentMethodOptionsAcssDebit<'a> {
+impl UpdatePaymentIntentPaymentMethodOptionsAcssDebit {
     pub fn new() -> Self {
         Self { mandate_options: None, setup_future_usage: None, verification_method: None }
     }
 }
-impl<'a> Default for UpdatePaymentIntentPaymentMethodOptionsAcssDebit<'a> {
+impl Default for UpdatePaymentIntentPaymentMethodOptionsAcssDebit {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Additional fields for Mandate creation
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentIntentPaymentMethodOptionsAcssDebitMandateOptions<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdatePaymentIntentPaymentMethodOptionsAcssDebitMandateOptions {
     /// A URL for custom mandate text to render during confirmation step.
     /// The URL will be rendered with additional GET parameters `payment_intent` and `payment_intent_client_secret` when confirming a Payment Intent,.
     /// or `setup_intent` and `setup_intent_client_secret` when confirming a Setup Intent.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub custom_mandate_url: Option<&'a str>,
+    pub custom_mandate_url: Option<String>,
     /// Description of the mandate interval.
     /// Only required if 'payment_schedule' parameter is 'interval' or 'combined'.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub interval_description: Option<&'a str>,
+    pub interval_description: Option<String>,
     /// Payment schedule for the mandate.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub payment_schedule:
@@ -10690,7 +10718,7 @@ pub struct UpdatePaymentIntentPaymentMethodOptionsAcssDebitMandateOptions<'a> {
     pub transaction_type:
         Option<UpdatePaymentIntentPaymentMethodOptionsAcssDebitMandateOptionsTransactionType>,
 }
-impl<'a> UpdatePaymentIntentPaymentMethodOptionsAcssDebitMandateOptions<'a> {
+impl UpdatePaymentIntentPaymentMethodOptionsAcssDebitMandateOptions {
     pub fn new() -> Self {
         Self {
             custom_mandate_url: None,
@@ -10700,7 +10728,7 @@ impl<'a> UpdatePaymentIntentPaymentMethodOptionsAcssDebitMandateOptions<'a> {
         }
     }
 }
-impl<'a> Default for UpdatePaymentIntentPaymentMethodOptionsAcssDebitMandateOptions<'a> {
+impl Default for UpdatePaymentIntentPaymentMethodOptionsAcssDebitMandateOptions {
     fn default() -> Self {
         Self::new()
     }
@@ -10962,8 +10990,8 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// If this is an `affirm` PaymentMethod, this sub-hash contains details about the Affirm payment method options.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentIntentPaymentMethodOptionsAffirm<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdatePaymentIntentPaymentMethodOptionsAffirm {
     /// Controls when the funds will be captured from the customer's account.
     ///
     /// If provided, this parameter will override the top level behavior of `capture_method` when finalizing the payment with this payment method type.
@@ -10973,7 +11001,7 @@ pub struct UpdatePaymentIntentPaymentMethodOptionsAffirm<'a> {
     pub capture_method: Option<UpdatePaymentIntentPaymentMethodOptionsAffirmCaptureMethod>,
     /// Preferred language of the Affirm authorization page that the customer is redirected to.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub preferred_locale: Option<&'a str>,
+    pub preferred_locale: Option<String>,
     /// Indicates that you intend to make future payments with this PaymentIntent's payment method.
     ///
     /// Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete.
@@ -10985,12 +11013,12 @@ pub struct UpdatePaymentIntentPaymentMethodOptionsAffirm<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub setup_future_usage: Option<UpdatePaymentIntentPaymentMethodOptionsAffirmSetupFutureUsage>,
 }
-impl<'a> UpdatePaymentIntentPaymentMethodOptionsAffirm<'a> {
+impl UpdatePaymentIntentPaymentMethodOptionsAffirm {
     pub fn new() -> Self {
         Self { capture_method: None, preferred_locale: None, setup_future_usage: None }
     }
 }
-impl<'a> Default for UpdatePaymentIntentPaymentMethodOptionsAffirm<'a> {
+impl Default for UpdatePaymentIntentPaymentMethodOptionsAffirm {
     fn default() -> Self {
         Self::new()
     }
@@ -11119,8 +11147,8 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// If this is a `afterpay_clearpay` PaymentMethod, this sub-hash contains details about the Afterpay Clearpay payment method options.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentIntentPaymentMethodOptionsAfterpayClearpay<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdatePaymentIntentPaymentMethodOptionsAfterpayClearpay {
     /// Controls when the funds will be captured from the customer's account.
     ///
     /// If provided, this parameter will override the top level behavior of `capture_method` when finalizing the payment with this payment method type.
@@ -11133,7 +11161,7 @@ pub struct UpdatePaymentIntentPaymentMethodOptionsAfterpayClearpay<'a> {
     /// You must limit the identifier to 128 characters, and it can only contain letters, numbers, underscores, backslashes, and dashes.
     /// This field differs from the statement descriptor and item name.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reference: Option<&'a str>,
+    pub reference: Option<String>,
     /// Indicates that you intend to make future payments with this PaymentIntent's payment method.
     ///
     /// Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete.
@@ -11146,12 +11174,12 @@ pub struct UpdatePaymentIntentPaymentMethodOptionsAfterpayClearpay<'a> {
     pub setup_future_usage:
         Option<UpdatePaymentIntentPaymentMethodOptionsAfterpayClearpaySetupFutureUsage>,
 }
-impl<'a> UpdatePaymentIntentPaymentMethodOptionsAfterpayClearpay<'a> {
+impl UpdatePaymentIntentPaymentMethodOptionsAfterpayClearpay {
     pub fn new() -> Self {
         Self { capture_method: None, reference: None, setup_future_usage: None }
     }
 }
-impl<'a> Default for UpdatePaymentIntentPaymentMethodOptionsAfterpayClearpay<'a> {
+impl Default for UpdatePaymentIntentPaymentMethodOptionsAfterpayClearpay {
     fn default() -> Self {
         Self::new()
     }
@@ -11853,12 +11881,12 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// If this is a `blik` PaymentMethod, this sub-hash contains details about the BLIK payment method options.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentIntentPaymentMethodOptionsBlik<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdatePaymentIntentPaymentMethodOptionsBlik {
     /// The 6-digit BLIK code that a customer has generated using their banking application.
     /// Can only be set on confirmation.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub code: Option<&'a str>,
+    pub code: Option<String>,
     /// Indicates that you intend to make future payments with this PaymentIntent's payment method.
     ///
     /// Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete.
@@ -11870,12 +11898,12 @@ pub struct UpdatePaymentIntentPaymentMethodOptionsBlik<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub setup_future_usage: Option<UpdatePaymentIntentPaymentMethodOptionsBlikSetupFutureUsage>,
 }
-impl<'a> UpdatePaymentIntentPaymentMethodOptionsBlik<'a> {
+impl UpdatePaymentIntentPaymentMethodOptionsBlik {
     pub fn new() -> Self {
         Self { code: None, setup_future_usage: None }
     }
 }
-impl<'a> Default for UpdatePaymentIntentPaymentMethodOptionsBlik<'a> {
+impl Default for UpdatePaymentIntentPaymentMethodOptionsBlik {
     fn default() -> Self {
         Self::new()
     }
@@ -12041,8 +12069,8 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// Configuration for any card payments attempted on this PaymentIntent.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentIntentPaymentMethodOptionsCard<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdatePaymentIntentPaymentMethodOptionsCard {
     /// Controls when the funds will be captured from the customer's account.
     ///
     /// If provided, this parameter will override the top level behavior of `capture_method` when finalizing the payment with this payment method type.
@@ -12054,7 +12082,7 @@ pub struct UpdatePaymentIntentPaymentMethodOptionsCard<'a> {
     /// When provided, the CVC value will be verified during the card payment attempt.
     /// This parameter can only be provided during confirmation.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub cvc_token: Option<&'a str>,
+    pub cvc_token: Option<String>,
     /// Installment configuration for payments attempted on this PaymentIntent (Mexico Only).
     ///
     /// For more information, see the [installments integration guide](https://stripe.com/docs/payments/installments).
@@ -12062,7 +12090,7 @@ pub struct UpdatePaymentIntentPaymentMethodOptionsCard<'a> {
     pub installments: Option<UpdatePaymentIntentPaymentMethodOptionsCardInstallments>,
     /// Configuration options for setting up an eMandate for cards issued in India.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub mandate_options: Option<UpdatePaymentIntentPaymentMethodOptionsCardMandateOptions<'a>>,
+    pub mandate_options: Option<UpdatePaymentIntentPaymentMethodOptionsCardMandateOptions>,
     /// When specified, this parameter indicates that a transaction will be marked
     /// as MOTO (Mail Order Telephone Order) and thus out of scope for SCA. This
     /// parameter can only be provided during confirmation.
@@ -12114,19 +12142,19 @@ pub struct UpdatePaymentIntentPaymentMethodOptionsCard<'a> {
     /// Maximum 22 characters.
     /// On card statements, the *concatenation* of both prefix and suffix (including separators) will appear truncated to 22 characters.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub statement_descriptor_suffix_kana: Option<&'a str>,
+    pub statement_descriptor_suffix_kana: Option<String>,
     /// Provides information about a card payment that customers see on their statements.
     /// Concatenated with the Kanji prefix (shortened Kanji descriptor) or Kanji statement descriptor that’s set on the account to form the complete statement descriptor.
     /// Maximum 17 characters.
     /// On card statements, the *concatenation* of both prefix and suffix (including separators) will appear truncated to 17 characters.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub statement_descriptor_suffix_kanji: Option<&'a str>,
+    pub statement_descriptor_suffix_kanji: Option<String>,
     /// If 3D Secure authentication was performed with a third-party provider,
     /// the authentication details to use for this payment.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub three_d_secure: Option<UpdatePaymentIntentPaymentMethodOptionsCardThreeDSecure<'a>>,
+    pub three_d_secure: Option<UpdatePaymentIntentPaymentMethodOptionsCardThreeDSecure>,
 }
-impl<'a> UpdatePaymentIntentPaymentMethodOptionsCard<'a> {
+impl UpdatePaymentIntentPaymentMethodOptionsCard {
     pub fn new() -> Self {
         Self {
             capture_method: None,
@@ -12148,7 +12176,7 @@ impl<'a> UpdatePaymentIntentPaymentMethodOptionsCard<'a> {
         }
     }
 }
-impl<'a> Default for UpdatePaymentIntentPaymentMethodOptionsCard<'a> {
+impl Default for UpdatePaymentIntentPaymentMethodOptionsCard {
     fn default() -> Self {
         Self::new()
     }
@@ -12252,11 +12280,11 @@ pub struct UpdatePaymentIntentPaymentMethodOptionsCardInstallmentsPlan {
 }
 impl UpdatePaymentIntentPaymentMethodOptionsCardInstallmentsPlan {
     pub fn new(
-        count: u64,
-        interval: UpdatePaymentIntentPaymentMethodOptionsCardInstallmentsPlanInterval,
-        type_: UpdatePaymentIntentPaymentMethodOptionsCardInstallmentsPlanType,
+        count: impl Into<u64>,
+        interval: impl Into<UpdatePaymentIntentPaymentMethodOptionsCardInstallmentsPlanInterval>,
+        type_: impl Into<UpdatePaymentIntentPaymentMethodOptionsCardInstallmentsPlanType>,
     ) -> Self {
-        Self { count, interval, type_ }
+        Self { count: count.into(), interval: interval.into(), type_: type_.into() }
     }
 }
 /// For `fixed_count` installment plans, this is the interval between installment payments your customer will make to their credit card.
@@ -12371,8 +12399,8 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// Configuration options for setting up an eMandate for cards issued in India.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentIntentPaymentMethodOptionsCardMandateOptions<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdatePaymentIntentPaymentMethodOptionsCardMandateOptions {
     /// Amount to be charged for future payments.
     pub amount: i64,
     /// One of `fixed` or `maximum`.
@@ -12381,7 +12409,7 @@ pub struct UpdatePaymentIntentPaymentMethodOptionsCardMandateOptions<'a> {
     pub amount_type: UpdatePaymentIntentPaymentMethodOptionsCardMandateOptionsAmountType,
     /// A description of the mandate or subscription that is meant to be displayed to the customer.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<&'a str>,
+    pub description: Option<String>,
     /// End date of the mandate or subscription.
     /// If not provided, the mandate will be active until canceled.
     /// If provided, end date should be after start date.
@@ -12396,31 +12424,31 @@ pub struct UpdatePaymentIntentPaymentMethodOptionsCardMandateOptions<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub interval_count: Option<u64>,
     /// Unique identifier for the mandate or subscription.
-    pub reference: &'a str,
+    pub reference: String,
     /// Start date of the mandate or subscription. Start date should not be lesser than yesterday.
     pub start_date: stripe_types::Timestamp,
     /// Specifies the type of mandates supported. Possible values are `india`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub supported_types:
-        Option<&'a [UpdatePaymentIntentPaymentMethodOptionsCardMandateOptionsSupportedTypes]>,
+        Option<Vec<UpdatePaymentIntentPaymentMethodOptionsCardMandateOptionsSupportedTypes>>,
 }
-impl<'a> UpdatePaymentIntentPaymentMethodOptionsCardMandateOptions<'a> {
+impl UpdatePaymentIntentPaymentMethodOptionsCardMandateOptions {
     pub fn new(
-        amount: i64,
-        amount_type: UpdatePaymentIntentPaymentMethodOptionsCardMandateOptionsAmountType,
-        interval: UpdatePaymentIntentPaymentMethodOptionsCardMandateOptionsInterval,
-        reference: &'a str,
-        start_date: stripe_types::Timestamp,
+        amount: impl Into<i64>,
+        amount_type: impl Into<UpdatePaymentIntentPaymentMethodOptionsCardMandateOptionsAmountType>,
+        interval: impl Into<UpdatePaymentIntentPaymentMethodOptionsCardMandateOptionsInterval>,
+        reference: impl Into<String>,
+        start_date: impl Into<stripe_types::Timestamp>,
     ) -> Self {
         Self {
-            amount,
-            amount_type,
+            amount: amount.into(),
+            amount_type: amount_type.into(),
             description: None,
             end_date: None,
-            interval,
+            interval: interval.into(),
             interval_count: None,
-            reference,
-            start_date,
+            reference: reference.into(),
+            start_date: start_date.into(),
             supported_types: None,
         }
     }
@@ -13064,8 +13092,8 @@ impl<'de> serde::Deserialize<'de> for UpdatePaymentIntentPaymentMethodOptionsCar
 }
 /// If 3D Secure authentication was performed with a third-party provider,
 /// the authentication details to use for this payment.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentIntentPaymentMethodOptionsCardThreeDSecure<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdatePaymentIntentPaymentMethodOptionsCardThreeDSecure {
     /// The `transStatus` returned from the card Issuer’s ACS in the ARes.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ares_trans_status:
@@ -13074,7 +13102,7 @@ pub struct UpdatePaymentIntentPaymentMethodOptionsCardThreeDSecure<'a> {
     /// AEVV). This value is 20 bytes, base64-encoded into a 28-character string.
     /// (Most 3D Secure providers will return the base64-encoded version, which
     /// is what you should specify here.)
-    pub cryptogram: &'a str,
+    pub cryptogram: String,
     /// The Electronic Commerce Indicator (ECI) is returned by your 3D Secure
     /// provider and indicates what degree of authentication was performed.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -13089,32 +13117,32 @@ pub struct UpdatePaymentIntentPaymentMethodOptionsCardThreeDSecure<'a> {
     /// must be populated accordingly
     #[serde(skip_serializing_if = "Option::is_none")]
     pub network_options:
-        Option<UpdatePaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptions<'a>>,
+        Option<UpdatePaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptions>,
     /// The challenge indicator (`threeDSRequestorChallengeInd`) which was requested in the
     /// AReq sent to the card Issuer's ACS. A string containing 2 digits from 01-99.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub requestor_challenge_indicator: Option<&'a str>,
+    pub requestor_challenge_indicator: Option<String>,
     /// For 3D Secure 1, the XID. For 3D Secure 2, the Directory Server
     /// Transaction ID (dsTransID).
-    pub transaction_id: &'a str,
+    pub transaction_id: String,
     /// The version of 3D Secure that was performed.
     pub version: UpdatePaymentIntentPaymentMethodOptionsCardThreeDSecureVersion,
 }
-impl<'a> UpdatePaymentIntentPaymentMethodOptionsCardThreeDSecure<'a> {
+impl UpdatePaymentIntentPaymentMethodOptionsCardThreeDSecure {
     pub fn new(
-        cryptogram: &'a str,
-        transaction_id: &'a str,
-        version: UpdatePaymentIntentPaymentMethodOptionsCardThreeDSecureVersion,
+        cryptogram: impl Into<String>,
+        transaction_id: impl Into<String>,
+        version: impl Into<UpdatePaymentIntentPaymentMethodOptionsCardThreeDSecureVersion>,
     ) -> Self {
         Self {
             ares_trans_status: None,
-            cryptogram,
+            cryptogram: cryptogram.into(),
             electronic_commerce_indicator: None,
             exemption_indicator: None,
             network_options: None,
             requestor_challenge_indicator: None,
-            transaction_id,
-            version,
+            transaction_id: transaction_id.into(),
+            version: version.into(),
         }
     }
 }
@@ -13328,27 +13356,27 @@ impl<'de> serde::Deserialize<'de>
 /// Network specific 3DS fields. Network specific arguments require an
 /// explicit card brand choice. The parameter `payment_method_options.card.network``
 /// must be populated accordingly
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptions<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdatePaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptions {
     /// Cartes Bancaires-specific 3DS fields.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cartes_bancaires: Option<
-        UpdatePaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancaires<'a>,
+        UpdatePaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancaires,
     >,
 }
-impl<'a> UpdatePaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptions<'a> {
+impl UpdatePaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptions {
     pub fn new() -> Self {
         Self { cartes_bancaires: None }
     }
 }
-impl<'a> Default for UpdatePaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptions<'a> {
+impl Default for UpdatePaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptions {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Cartes Bancaires-specific 3DS fields.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancaires<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdatePaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancaires {
     /// The cryptogram calculation algorithm used by the card Issuer's ACS
     /// to calculate the Authentication cryptogram. Also known as `cavvAlgorithm`.
     /// messageExtension: CB-AVALGO
@@ -13358,18 +13386,18 @@ pub cb_avalgo: UpdatePaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOpt
     /// This is a 3 byte bitmap (low significant byte first and most significant
     /// bit first) that has been Base64 encoded
 #[serde(skip_serializing_if = "Option::is_none")]
-pub cb_exemption: Option<&'a str>,
+pub cb_exemption: Option<String>,
     /// The risk score returned from Cartes Bancaires in the ARes.
     /// message extension: CB-SCORE; numeric value 0-99
 #[serde(skip_serializing_if = "Option::is_none")]
 pub cb_score: Option<i64>,
 
 }
-impl<'a> UpdatePaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancaires<'a> {
+impl UpdatePaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancaires {
     pub fn new(
-        cb_avalgo: UpdatePaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancairesCbAvalgo,
+        cb_avalgo: impl Into<UpdatePaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancairesCbAvalgo>,
     ) -> Self {
-        Self { cb_avalgo, cb_exemption: None, cb_score: None }
+        Self { cb_avalgo: cb_avalgo.into(), cb_exemption: None, cb_score: None }
     }
 }
 /// The cryptogram calculation algorithm used by the card Issuer's ACS
@@ -13675,12 +13703,11 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// If this is a `customer balance` PaymentMethod, this sub-hash contains details about the customer balance payment method options.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentIntentPaymentMethodOptionsCustomerBalance<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdatePaymentIntentPaymentMethodOptionsCustomerBalance {
     /// Configuration for the bank transfer funding type, if the `funding_type` is set to `bank_transfer`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub bank_transfer:
-        Option<UpdatePaymentIntentPaymentMethodOptionsCustomerBalanceBankTransfer<'a>>,
+    pub bank_transfer: Option<UpdatePaymentIntentPaymentMethodOptionsCustomerBalanceBankTransfer>,
     /// The funding method type to be used when there are not enough funds in the customer balance.
     /// Permitted values include: `bank_transfer`.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -13697,38 +13724,41 @@ pub struct UpdatePaymentIntentPaymentMethodOptionsCustomerBalance<'a> {
     pub setup_future_usage:
         Option<UpdatePaymentIntentPaymentMethodOptionsCustomerBalanceSetupFutureUsage>,
 }
-impl<'a> UpdatePaymentIntentPaymentMethodOptionsCustomerBalance<'a> {
+impl UpdatePaymentIntentPaymentMethodOptionsCustomerBalance {
     pub fn new() -> Self {
         Self { bank_transfer: None, funding_type: None, setup_future_usage: None }
     }
 }
-impl<'a> Default for UpdatePaymentIntentPaymentMethodOptionsCustomerBalance<'a> {
+impl Default for UpdatePaymentIntentPaymentMethodOptionsCustomerBalance {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Configuration for the bank transfer funding type, if the `funding_type` is set to `bank_transfer`.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentIntentPaymentMethodOptionsCustomerBalanceBankTransfer<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdatePaymentIntentPaymentMethodOptionsCustomerBalanceBankTransfer {
     /// Configuration for the eu_bank_transfer funding type.
-#[serde(skip_serializing_if = "Option::is_none")]
-pub eu_bank_transfer: Option<EuBankTransferParams<'a>>,
-        /// List of address types that should be returned in the financial_addresses response.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub eu_bank_transfer: Option<EuBankTransferParams>,
+    /// List of address types that should be returned in the financial_addresses response.
     /// If not specified, all valid types will be returned.
     ///
     /// Permitted values include: `sort_code`, `zengin`, `iban`, or `spei`.
-#[serde(skip_serializing_if = "Option::is_none")]
-pub requested_address_types: Option<&'a [UpdatePaymentIntentPaymentMethodOptionsCustomerBalanceBankTransferRequestedAddressTypes]>,
-        /// The list of bank transfer types that this PaymentIntent is allowed to use for funding Permitted values include: `eu_bank_transfer`, `gb_bank_transfer`, `jp_bank_transfer`, `mx_bank_transfer`, or `us_bank_transfer`.
-#[serde(rename = "type")]
-pub type_: UpdatePaymentIntentPaymentMethodOptionsCustomerBalanceBankTransferType,
-
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub requested_address_types: Option<
+        Vec<
+            UpdatePaymentIntentPaymentMethodOptionsCustomerBalanceBankTransferRequestedAddressTypes,
+        >,
+    >,
+    /// The list of bank transfer types that this PaymentIntent is allowed to use for funding Permitted values include: `eu_bank_transfer`, `gb_bank_transfer`, `jp_bank_transfer`, `mx_bank_transfer`, or `us_bank_transfer`.
+    #[serde(rename = "type")]
+    pub type_: UpdatePaymentIntentPaymentMethodOptionsCustomerBalanceBankTransferType,
 }
-impl<'a> UpdatePaymentIntentPaymentMethodOptionsCustomerBalanceBankTransfer<'a> {
+impl UpdatePaymentIntentPaymentMethodOptionsCustomerBalanceBankTransfer {
     pub fn new(
-        type_: UpdatePaymentIntentPaymentMethodOptionsCustomerBalanceBankTransferType,
+        type_: impl Into<UpdatePaymentIntentPaymentMethodOptionsCustomerBalanceBankTransferType>,
     ) -> Self {
-        Self { eu_bank_transfer: None, requested_address_types: None, type_ }
+        Self { eu_bank_transfer: None, requested_address_types: None, type_: type_.into() }
     }
 }
 /// List of address types that should be returned in the financial_addresses response.
@@ -14771,13 +14801,13 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// If this is a `konbini` PaymentMethod, this sub-hash contains details about the Konbini payment method options.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentIntentPaymentMethodOptionsKonbini<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdatePaymentIntentPaymentMethodOptionsKonbini {
     /// An optional 10 to 11 digit numeric-only string determining the confirmation code at applicable convenience stores.
     /// Must not consist of only zeroes and could be rejected in case of insufficient uniqueness.
     /// We recommend to use the customer's phone number.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub confirmation_number: Option<&'a str>,
+    pub confirmation_number: Option<String>,
     /// The number of calendar days (between 1 and 60) after which Konbini payment instructions will expire.
     /// For example, if a PaymentIntent is confirmed with Konbini and `expires_after_days` set to 2 on Monday JST, the instructions will expire on Wednesday 23:59:59 JST.
     /// Defaults to 3 days.
@@ -14789,7 +14819,7 @@ pub struct UpdatePaymentIntentPaymentMethodOptionsKonbini<'a> {
     pub expires_at: Option<stripe_types::Timestamp>,
     /// A product descriptor of up to 22 characters, which will appear to customers at the convenience store.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub product_description: Option<&'a str>,
+    pub product_description: Option<String>,
     /// Indicates that you intend to make future payments with this PaymentIntent's payment method.
     ///
     /// Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete.
@@ -14801,7 +14831,7 @@ pub struct UpdatePaymentIntentPaymentMethodOptionsKonbini<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub setup_future_usage: Option<UpdatePaymentIntentPaymentMethodOptionsKonbiniSetupFutureUsage>,
 }
-impl<'a> UpdatePaymentIntentPaymentMethodOptionsKonbini<'a> {
+impl UpdatePaymentIntentPaymentMethodOptionsKonbini {
     pub fn new() -> Self {
         Self {
             confirmation_number: None,
@@ -14812,7 +14842,7 @@ impl<'a> UpdatePaymentIntentPaymentMethodOptionsKonbini<'a> {
         }
     }
 }
-impl<'a> Default for UpdatePaymentIntentPaymentMethodOptionsKonbini<'a> {
+impl Default for UpdatePaymentIntentPaymentMethodOptionsKonbini {
     fn default() -> Self {
         Self::new()
     }
@@ -14882,8 +14912,8 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// If this is a `link` PaymentMethod, this sub-hash contains details about the Link payment method options.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentIntentPaymentMethodOptionsLink<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdatePaymentIntentPaymentMethodOptionsLink {
     /// Controls when the funds will be captured from the customer's account.
     ///
     /// If provided, this parameter will override the top level behavior of `capture_method` when finalizing the payment with this payment method type.
@@ -14893,7 +14923,7 @@ pub struct UpdatePaymentIntentPaymentMethodOptionsLink<'a> {
     pub capture_method: Option<UpdatePaymentIntentPaymentMethodOptionsLinkCaptureMethod>,
     /// \[Deprecated\] This is a legacy parameter that no longer has any function.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub persistent_token: Option<&'a str>,
+    pub persistent_token: Option<String>,
     /// Indicates that you intend to make future payments with this PaymentIntent's payment method.
     ///
     /// Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete.
@@ -14905,12 +14935,12 @@ pub struct UpdatePaymentIntentPaymentMethodOptionsLink<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub setup_future_usage: Option<UpdatePaymentIntentPaymentMethodOptionsLinkSetupFutureUsage>,
 }
-impl<'a> UpdatePaymentIntentPaymentMethodOptionsLink<'a> {
+impl UpdatePaymentIntentPaymentMethodOptionsLink {
     pub fn new() -> Self {
         Self { capture_method: None, persistent_token: None, setup_future_usage: None }
     }
 }
-impl<'a> Default for UpdatePaymentIntentPaymentMethodOptionsLink<'a> {
+impl Default for UpdatePaymentIntentPaymentMethodOptionsLink {
     fn default() -> Self {
         Self::new()
     }
@@ -15460,8 +15490,8 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// If this is a `paypal` PaymentMethod, this sub-hash contains details about the PayPal payment method options.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentIntentPaymentMethodOptionsPaypal<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdatePaymentIntentPaymentMethodOptionsPaypal {
     /// Controls when the funds will be captured from the customer's account.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub capture_method: Option<UpdatePaymentIntentPaymentMethodOptionsPaypalCaptureMethod>,
@@ -15471,10 +15501,10 @@ pub struct UpdatePaymentIntentPaymentMethodOptionsPaypal<'a> {
     /// A reference of the PayPal transaction visible to customer which is mapped to PayPal's invoice ID.
     /// This must be a globally unique ID if you have configured in your PayPal settings to block multiple payments per invoice ID.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reference: Option<&'a str>,
+    pub reference: Option<String>,
     /// The risk correlation ID for an on-session payment using a saved PayPal payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub risk_correlation_id: Option<&'a str>,
+    pub risk_correlation_id: Option<String>,
     /// Indicates that you intend to make future payments with this PaymentIntent's payment method.
     ///
     /// Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete.
@@ -15486,7 +15516,7 @@ pub struct UpdatePaymentIntentPaymentMethodOptionsPaypal<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub setup_future_usage: Option<UpdatePaymentIntentPaymentMethodOptionsPaypalSetupFutureUsage>,
 }
-impl<'a> UpdatePaymentIntentPaymentMethodOptionsPaypal<'a> {
+impl UpdatePaymentIntentPaymentMethodOptionsPaypal {
     pub fn new() -> Self {
         Self {
             capture_method: None,
@@ -15497,7 +15527,7 @@ impl<'a> UpdatePaymentIntentPaymentMethodOptionsPaypal<'a> {
         }
     }
 }
-impl<'a> Default for UpdatePaymentIntentPaymentMethodOptionsPaypal<'a> {
+impl Default for UpdatePaymentIntentPaymentMethodOptionsPaypal {
     fn default() -> Self {
         Self::new()
     }
@@ -16335,11 +16365,11 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// If this is a `Swish` PaymentMethod, this sub-hash contains details about the Swish payment method options.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentIntentPaymentMethodOptionsSwish<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdatePaymentIntentPaymentMethodOptionsSwish {
     /// The order ID displayed in the Swish app after the payment is authorized.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reference: Option<&'a str>,
+    pub reference: Option<String>,
     /// Indicates that you intend to make future payments with this PaymentIntent's payment method.
     ///
     /// Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete.
@@ -16351,12 +16381,12 @@ pub struct UpdatePaymentIntentPaymentMethodOptionsSwish<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub setup_future_usage: Option<UpdatePaymentIntentPaymentMethodOptionsSwishSetupFutureUsage>,
 }
-impl<'a> UpdatePaymentIntentPaymentMethodOptionsSwish<'a> {
+impl UpdatePaymentIntentPaymentMethodOptionsSwish {
     pub fn new() -> Self {
         Self { reference: None, setup_future_usage: None }
     }
 }
-impl<'a> Default for UpdatePaymentIntentPaymentMethodOptionsSwish<'a> {
+impl Default for UpdatePaymentIntentPaymentMethodOptionsSwish {
     fn default() -> Self {
         Self::new()
     }
@@ -16424,18 +16454,18 @@ impl<'de> serde::Deserialize<'de> for UpdatePaymentIntentPaymentMethodOptionsSwi
     }
 }
 /// If this is a `us_bank_account` PaymentMethod, this sub-hash contains details about the US bank account payment method options.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentIntentPaymentMethodOptionsUsBankAccount<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdatePaymentIntentPaymentMethodOptionsUsBankAccount {
     /// Additional fields for Financial Connections Session creation
     #[serde(skip_serializing_if = "Option::is_none")]
     pub financial_connections:
-        Option<UpdatePaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnections<'a>>,
+        Option<UpdatePaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnections>,
     /// Additional fields for Mandate creation
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mandate_options: Option<UpdatePaymentIntentPaymentMethodOptionsUsBankAccountMandateOptions>,
     /// Additional fields for network related functions
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub networks: Option<UpdatePaymentIntentPaymentMethodOptionsUsBankAccountNetworks<'a>>,
+    pub networks: Option<UpdatePaymentIntentPaymentMethodOptionsUsBankAccountNetworks>,
     /// Preferred transaction settlement speed
     #[serde(skip_serializing_if = "Option::is_none")]
     pub preferred_settlement_speed:
@@ -16456,7 +16486,7 @@ pub struct UpdatePaymentIntentPaymentMethodOptionsUsBankAccount<'a> {
     pub verification_method:
         Option<UpdatePaymentIntentPaymentMethodOptionsUsBankAccountVerificationMethod>,
 }
-impl<'a> UpdatePaymentIntentPaymentMethodOptionsUsBankAccount<'a> {
+impl UpdatePaymentIntentPaymentMethodOptionsUsBankAccount {
     pub fn new() -> Self {
         Self {
             financial_connections: None,
@@ -16468,37 +16498,37 @@ impl<'a> UpdatePaymentIntentPaymentMethodOptionsUsBankAccount<'a> {
         }
     }
 }
-impl<'a> Default for UpdatePaymentIntentPaymentMethodOptionsUsBankAccount<'a> {
+impl Default for UpdatePaymentIntentPaymentMethodOptionsUsBankAccount {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Additional fields for Financial Connections Session creation
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnections<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdatePaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnections {
     /// The list of permissions to request.
     /// If this parameter is passed, the `payment_method` permission must be included.
     /// Valid permissions include: `balances`, `ownership`, `payment_method`, and `transactions`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub permissions: Option<
-        &'a [UpdatePaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPermissions],
+        Vec<UpdatePaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPermissions>,
     >,
     /// List of data features that you would like to retrieve upon account creation.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub prefetch: Option<
-        &'a [UpdatePaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPrefetch],
+        Vec<UpdatePaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPrefetch>,
     >,
     /// For webview integrations only.
     /// Upon completing OAuth login in the native browser, the user will be redirected to this URL to return to your app.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub return_url: Option<&'a str>,
+    pub return_url: Option<String>,
 }
-impl<'a> UpdatePaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnections<'a> {
+impl UpdatePaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnections {
     pub fn new() -> Self {
         Self { permissions: None, prefetch: None, return_url: None }
     }
 }
-impl<'a> Default for UpdatePaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnections<'a> {
+impl Default for UpdatePaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnections {
     fn default() -> Self {
         Self::new()
     }
@@ -16722,19 +16752,19 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// Additional fields for network related functions
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentIntentPaymentMethodOptionsUsBankAccountNetworks<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdatePaymentIntentPaymentMethodOptionsUsBankAccountNetworks {
     /// Triggers validations to run across the selected networks
     #[serde(skip_serializing_if = "Option::is_none")]
     pub requested:
-        Option<&'a [UpdatePaymentIntentPaymentMethodOptionsUsBankAccountNetworksRequested]>,
+        Option<Vec<UpdatePaymentIntentPaymentMethodOptionsUsBankAccountNetworksRequested>>,
 }
-impl<'a> UpdatePaymentIntentPaymentMethodOptionsUsBankAccountNetworks<'a> {
+impl UpdatePaymentIntentPaymentMethodOptionsUsBankAccountNetworks {
     pub fn new() -> Self {
         Self { requested: None }
     }
 }
-impl<'a> Default for UpdatePaymentIntentPaymentMethodOptionsUsBankAccountNetworks<'a> {
+impl Default for UpdatePaymentIntentPaymentMethodOptionsUsBankAccountNetworks {
     fn default() -> Self {
         Self::new()
     }
@@ -16985,11 +17015,11 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// If this is a `wechat_pay` PaymentMethod, this sub-hash contains details about the WeChat Pay payment method options.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentIntentPaymentMethodOptionsWechatPay<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdatePaymentIntentPaymentMethodOptionsWechatPay {
     /// The app ID registered with WeChat Pay. Only required when client is ios or android.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub app_id: Option<&'a str>,
+    pub app_id: Option<String>,
     /// The client type that the end customer will pay from
     pub client: UpdatePaymentIntentPaymentMethodOptionsWechatPayClient,
     /// Indicates that you intend to make future payments with this PaymentIntent's payment method.
@@ -17004,9 +17034,9 @@ pub struct UpdatePaymentIntentPaymentMethodOptionsWechatPay<'a> {
     pub setup_future_usage:
         Option<UpdatePaymentIntentPaymentMethodOptionsWechatPaySetupFutureUsage>,
 }
-impl<'a> UpdatePaymentIntentPaymentMethodOptionsWechatPay<'a> {
-    pub fn new(client: UpdatePaymentIntentPaymentMethodOptionsWechatPayClient) -> Self {
-        Self { app_id: None, client, setup_future_usage: None }
+impl UpdatePaymentIntentPaymentMethodOptionsWechatPay {
+    pub fn new(client: impl Into<UpdatePaymentIntentPaymentMethodOptionsWechatPayClient>) -> Self {
+        Self { app_id: None, client: client.into(), setup_future_usage: None }
     }
 }
 /// The client type that the end customer will pay from
@@ -17217,56 +17247,65 @@ impl<'de> serde::Deserialize<'de> for UpdatePaymentIntentPaymentMethodOptionsZip
     }
 }
 /// Shipping information for this PaymentIntent.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentIntentShipping<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdatePaymentIntentShipping {
     /// Shipping address.
-    pub address: UpdatePaymentIntentShippingAddress<'a>,
+    pub address: UpdatePaymentIntentShippingAddress,
     /// The delivery service that shipped a physical product, such as Fedex, UPS, USPS, etc.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub carrier: Option<&'a str>,
+    pub carrier: Option<String>,
     /// Recipient name.
-    pub name: &'a str,
+    pub name: String,
     /// Recipient phone (including extension).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub phone: Option<&'a str>,
+    pub phone: Option<String>,
     /// The tracking number for a physical product, obtained from the delivery service.
     /// If multiple tracking numbers were generated for this purchase, please separate them with commas.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tracking_number: Option<&'a str>,
+    pub tracking_number: Option<String>,
 }
-impl<'a> UpdatePaymentIntentShipping<'a> {
-    pub fn new(address: UpdatePaymentIntentShippingAddress<'a>, name: &'a str) -> Self {
-        Self { address, carrier: None, name, phone: None, tracking_number: None }
+impl UpdatePaymentIntentShipping {
+    pub fn new(
+        address: impl Into<UpdatePaymentIntentShippingAddress>,
+        name: impl Into<String>,
+    ) -> Self {
+        Self {
+            address: address.into(),
+            carrier: None,
+            name: name.into(),
+            phone: None,
+            tracking_number: None,
+        }
     }
 }
 /// Shipping address.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentIntentShippingAddress<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdatePaymentIntentShippingAddress {
     /// City, district, suburb, town, or village.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<&'a str>,
+    pub city: Option<String>,
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub country: Option<&'a str>,
+    pub country: Option<String>,
     /// Address line 1 (e.g., street, PO Box, or company name).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line1: Option<&'a str>,
+    pub line1: Option<String>,
     /// Address line 2 (e.g., apartment, suite, unit, or building).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line2: Option<&'a str>,
+    pub line2: Option<String>,
     /// ZIP or postal code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<&'a str>,
+    pub postal_code: Option<String>,
     /// State, county, province, or region.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
 }
-impl<'a> UpdatePaymentIntentShippingAddress<'a> {
+impl UpdatePaymentIntentShippingAddress {
     pub fn new() -> Self {
         Self { city: None, country: None, line1: None, line2: None, postal_code: None, state: None }
     }
 }
-impl<'a> Default for UpdatePaymentIntentShippingAddress<'a> {
+impl Default for UpdatePaymentIntentShippingAddress {
     fn default() -> Self {
         Self::new()
     }
@@ -17279,42 +17318,42 @@ impl<'a> Default for UpdatePaymentIntentShippingAddress<'a> {
 /// update and confirm at the same time, we recommend updating properties through
 /// the [confirm API](https://stripe.com/docs/api/payment_intents/confirm) instead.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentIntent<'a> {
-    inner: UpdatePaymentIntentBuilder<'a>,
-    intent: &'a stripe_shared::PaymentIntentId,
+pub struct UpdatePaymentIntent {
+    inner: UpdatePaymentIntentBuilder,
+    intent: stripe_shared::PaymentIntentId,
 }
-impl<'a> UpdatePaymentIntent<'a> {
+impl UpdatePaymentIntent {
     /// Construct a new `UpdatePaymentIntent`.
-    pub fn new(intent: &'a stripe_shared::PaymentIntentId) -> Self {
-        Self { intent, inner: UpdatePaymentIntentBuilder::new() }
+    pub fn new(intent: impl Into<stripe_shared::PaymentIntentId>) -> Self {
+        Self { intent: intent.into(), inner: UpdatePaymentIntentBuilder::new() }
     }
     /// Amount intended to be collected by this PaymentIntent.
     /// A positive integer representing how much to charge in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal) (e.g., 100 cents to charge $1.00 or 100 to charge ¥100, a zero-decimal currency).
     /// The minimum amount is $0.50 US or [equivalent in charge currency](https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts).
     /// The amount value supports up to eight digits (e.g., a value of 99999999 for a USD charge of $999,999.99).
-    pub fn amount(mut self, amount: i64) -> Self {
-        self.inner.amount = Some(amount);
+    pub fn amount(mut self, amount: impl Into<i64>) -> Self {
+        self.inner.amount = Some(amount.into());
         self
     }
     /// The amount of the application fee (if any) that will be requested to be applied to the payment and transferred to the application owner's Stripe account.
     /// The amount of the application fee collected will be capped at the total payment amount.
     /// For more information, see the PaymentIntents [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts).
-    pub fn application_fee_amount(mut self, application_fee_amount: i64) -> Self {
-        self.inner.application_fee_amount = Some(application_fee_amount);
+    pub fn application_fee_amount(mut self, application_fee_amount: impl Into<i64>) -> Self {
+        self.inner.application_fee_amount = Some(application_fee_amount.into());
         self
     }
     /// Controls when the funds will be captured from the customer's account.
     pub fn capture_method(
         mut self,
-        capture_method: stripe_shared::PaymentIntentCaptureMethod,
+        capture_method: impl Into<stripe_shared::PaymentIntentCaptureMethod>,
     ) -> Self {
-        self.inner.capture_method = Some(capture_method);
+        self.inner.capture_method = Some(capture_method.into());
         self
     }
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     /// Must be a [supported currency](https://stripe.com/docs/currencies).
-    pub fn currency(mut self, currency: stripe_types::Currency) -> Self {
-        self.inner.currency = Some(currency);
+    pub fn currency(mut self, currency: impl Into<stripe_types::Currency>) -> Self {
+        self.inner.currency = Some(currency.into());
         self
     }
     /// ID of the Customer this PaymentIntent belongs to, if one exists.
@@ -17322,36 +17361,42 @@ impl<'a> UpdatePaymentIntent<'a> {
     /// Payment methods attached to other Customers cannot be used with this PaymentIntent.
     ///
     /// If present in combination with [setup_future_usage](https://stripe.com/docs/api#payment_intent_object-setup_future_usage), this PaymentIntent's payment method will be attached to the Customer after the PaymentIntent has been confirmed and any required actions from the user are complete.
-    pub fn customer(mut self, customer: &'a str) -> Self {
-        self.inner.customer = Some(customer);
+    pub fn customer(mut self, customer: impl Into<String>) -> Self {
+        self.inner.customer = Some(customer.into());
         self
     }
     /// An arbitrary string attached to the object. Often useful for displaying to users.
-    pub fn description(mut self, description: &'a str) -> Self {
-        self.inner.description = Some(description);
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.inner.description = Some(description.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// ID of the payment method (a PaymentMethod, Card, or [compatible Source](https://stripe.com/docs/payments/payment-methods/transitioning#compatibility) object) to attach to this PaymentIntent.
-    pub fn payment_method(mut self, payment_method: &'a str) -> Self {
-        self.inner.payment_method = Some(payment_method);
+    pub fn payment_method(mut self, payment_method: impl Into<String>) -> Self {
+        self.inner.payment_method = Some(payment_method.into());
         self
     }
     /// The ID of the payment method configuration to use with this PaymentIntent.
-    pub fn payment_method_configuration(mut self, payment_method_configuration: &'a str) -> Self {
-        self.inner.payment_method_configuration = Some(payment_method_configuration);
+    pub fn payment_method_configuration(
+        mut self,
+        payment_method_configuration: impl Into<String>,
+    ) -> Self {
+        self.inner.payment_method_configuration = Some(payment_method_configuration.into());
         self
     }
     /// If provided, this hash will be used to create a PaymentMethod. The new PaymentMethod will appear
@@ -17359,29 +17404,29 @@ impl<'a> UpdatePaymentIntent<'a> {
     /// property on the PaymentIntent.
     pub fn payment_method_data(
         mut self,
-        payment_method_data: UpdatePaymentIntentPaymentMethodData<'a>,
+        payment_method_data: impl Into<UpdatePaymentIntentPaymentMethodData>,
     ) -> Self {
-        self.inner.payment_method_data = Some(payment_method_data);
+        self.inner.payment_method_data = Some(payment_method_data.into());
         self
     }
     /// Payment-method-specific configuration for this PaymentIntent.
     pub fn payment_method_options(
         mut self,
-        payment_method_options: UpdatePaymentIntentPaymentMethodOptions<'a>,
+        payment_method_options: impl Into<UpdatePaymentIntentPaymentMethodOptions>,
     ) -> Self {
-        self.inner.payment_method_options = Some(payment_method_options);
+        self.inner.payment_method_options = Some(payment_method_options.into());
         self
     }
     /// The list of payment method types (for example, card) that this PaymentIntent can use.
     /// Use `automatic_payment_methods` to manage payment methods from the [Stripe Dashboard](https://dashboard.stripe.com/settings/payment_methods).
-    pub fn payment_method_types(mut self, payment_method_types: &'a [&'a str]) -> Self {
-        self.inner.payment_method_types = Some(payment_method_types);
+    pub fn payment_method_types(mut self, payment_method_types: impl Into<Vec<String>>) -> Self {
+        self.inner.payment_method_types = Some(payment_method_types.into());
         self
     }
     /// Email address that the receipt for the resulting payment will be sent to.
     /// If `receipt_email` is specified for a payment in live mode, a receipt will be sent regardless of your [email settings](https://dashboard.stripe.com/account/emails).
-    pub fn receipt_email(mut self, receipt_email: &'a str) -> Self {
-        self.inner.receipt_email = Some(receipt_email);
+    pub fn receipt_email(mut self, receipt_email: impl Into<String>) -> Self {
+        self.inner.receipt_email = Some(receipt_email.into());
         self
     }
     /// Indicates that you intend to make future payments with this PaymentIntent's payment method.
@@ -17394,45 +17439,48 @@ impl<'a> UpdatePaymentIntent<'a> {
     /// If `setup_future_usage` is already set and you are performing a request using a publishable key, you may only update the value from `on_session` to `off_session`.
     pub fn setup_future_usage(
         mut self,
-        setup_future_usage: stripe_shared::PaymentIntentSetupFutureUsage,
+        setup_future_usage: impl Into<stripe_shared::PaymentIntentSetupFutureUsage>,
     ) -> Self {
-        self.inner.setup_future_usage = Some(setup_future_usage);
+        self.inner.setup_future_usage = Some(setup_future_usage.into());
         self
     }
     /// Shipping information for this PaymentIntent.
-    pub fn shipping(mut self, shipping: UpdatePaymentIntentShipping<'a>) -> Self {
-        self.inner.shipping = Some(shipping);
+    pub fn shipping(mut self, shipping: impl Into<UpdatePaymentIntentShipping>) -> Self {
+        self.inner.shipping = Some(shipping.into());
         self
     }
     /// For card charges, use [statement_descriptor_suffix](https://stripe.com/docs/payments/account/statement-descriptors#dynamic).
     /// Otherwise, you can use this value as the complete description of a charge on your customers' statements.
     /// It must contain at least one letter and be 1–22 characters long.
-    pub fn statement_descriptor(mut self, statement_descriptor: &'a str) -> Self {
-        self.inner.statement_descriptor = Some(statement_descriptor);
+    pub fn statement_descriptor(mut self, statement_descriptor: impl Into<String>) -> Self {
+        self.inner.statement_descriptor = Some(statement_descriptor.into());
         self
     }
     /// Provides information about a card payment that customers see on their statements.
     /// Concatenated with the prefix (shortened descriptor) or statement descriptor that’s set on the account to form the complete statement descriptor.
     /// Maximum 22 characters for the concatenated descriptor.
-    pub fn statement_descriptor_suffix(mut self, statement_descriptor_suffix: &'a str) -> Self {
-        self.inner.statement_descriptor_suffix = Some(statement_descriptor_suffix);
+    pub fn statement_descriptor_suffix(
+        mut self,
+        statement_descriptor_suffix: impl Into<String>,
+    ) -> Self {
+        self.inner.statement_descriptor_suffix = Some(statement_descriptor_suffix.into());
         self
     }
     /// Use this parameter to automatically create a Transfer when the payment succeeds.
     /// Learn more about the [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts).
-    pub fn transfer_data(mut self, transfer_data: TransferDataUpdateParams) -> Self {
-        self.inner.transfer_data = Some(transfer_data);
+    pub fn transfer_data(mut self, transfer_data: impl Into<TransferDataUpdateParams>) -> Self {
+        self.inner.transfer_data = Some(transfer_data.into());
         self
     }
     /// A string that identifies the resulting payment as part of a group.
     /// You can only provide `transfer_group` if it hasn't been set.
     /// Learn more about the [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts).
-    pub fn transfer_group(mut self, transfer_group: &'a str) -> Self {
-        self.inner.transfer_group = Some(transfer_group);
+    pub fn transfer_group(mut self, transfer_group: impl Into<String>) -> Self {
+        self.inner.transfer_group = Some(transfer_group.into());
         self
     }
 }
-impl UpdatePaymentIntent<'_> {
+impl UpdatePaymentIntent {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -17450,39 +17498,39 @@ impl UpdatePaymentIntent<'_> {
     }
 }
 
-impl StripeRequest for UpdatePaymentIntent<'_> {
+impl StripeRequest for UpdatePaymentIntent {
     type Output = stripe_shared::PaymentIntent;
 
     fn build(&self) -> RequestBuilder {
-        let intent = self.intent;
+        let intent = &self.intent;
         RequestBuilder::new(StripeMethod::Post, format!("/payment_intents/{intent}"))
             .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ApplyCustomerBalancePaymentIntentBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ApplyCustomerBalancePaymentIntentBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     amount: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     currency: Option<stripe_types::Currency>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> ApplyCustomerBalancePaymentIntentBuilder<'a> {
+impl ApplyCustomerBalancePaymentIntentBuilder {
     fn new() -> Self {
         Self { amount: None, currency: None, expand: None }
     }
 }
 /// Manually reconcile the remaining amount for a `customer_balance` PaymentIntent.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ApplyCustomerBalancePaymentIntent<'a> {
-    inner: ApplyCustomerBalancePaymentIntentBuilder<'a>,
-    intent: &'a stripe_shared::PaymentIntentId,
+pub struct ApplyCustomerBalancePaymentIntent {
+    inner: ApplyCustomerBalancePaymentIntentBuilder,
+    intent: stripe_shared::PaymentIntentId,
 }
-impl<'a> ApplyCustomerBalancePaymentIntent<'a> {
+impl ApplyCustomerBalancePaymentIntent {
     /// Construct a new `ApplyCustomerBalancePaymentIntent`.
-    pub fn new(intent: &'a stripe_shared::PaymentIntentId) -> Self {
-        Self { intent, inner: ApplyCustomerBalancePaymentIntentBuilder::new() }
+    pub fn new(intent: impl Into<stripe_shared::PaymentIntentId>) -> Self {
+        Self { intent: intent.into(), inner: ApplyCustomerBalancePaymentIntentBuilder::new() }
     }
     /// Amount that you intend to apply to this PaymentIntent from the customer’s cash balance.
     ///
@@ -17491,23 +17539,23 @@ impl<'a> ApplyCustomerBalancePaymentIntent<'a> {
     /// The maximum amount is the amount of the PaymentIntent.
     ///
     /// When you omit the amount, it defaults to the remaining amount requested on the PaymentIntent.
-    pub fn amount(mut self, amount: i64) -> Self {
-        self.inner.amount = Some(amount);
+    pub fn amount(mut self, amount: impl Into<i64>) -> Self {
+        self.inner.amount = Some(amount.into());
         self
     }
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     /// Must be a [supported currency](https://stripe.com/docs/currencies).
-    pub fn currency(mut self, currency: stripe_types::Currency) -> Self {
-        self.inner.currency = Some(currency);
+    pub fn currency(mut self, currency: impl Into<stripe_types::Currency>) -> Self {
+        self.inner.currency = Some(currency.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl ApplyCustomerBalancePaymentIntent<'_> {
+impl ApplyCustomerBalancePaymentIntent {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -17525,11 +17573,11 @@ impl ApplyCustomerBalancePaymentIntent<'_> {
     }
 }
 
-impl StripeRequest for ApplyCustomerBalancePaymentIntent<'_> {
+impl StripeRequest for ApplyCustomerBalancePaymentIntent {
     type Output = stripe_shared::PaymentIntent;
 
     fn build(&self) -> RequestBuilder {
-        let intent = self.intent;
+        let intent = &self.intent;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/payment_intents/{intent}/apply_customer_balance"),
@@ -17537,14 +17585,14 @@ impl StripeRequest for ApplyCustomerBalancePaymentIntent<'_> {
         .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CancelPaymentIntentBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CancelPaymentIntentBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     cancellation_reason: Option<CancelPaymentIntentCancellationReason>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> CancelPaymentIntentBuilder<'a> {
+impl CancelPaymentIntentBuilder {
     fn new() -> Self {
         Self { cancellation_reason: None, expand: None }
     }
@@ -17622,31 +17670,31 @@ impl<'de> serde::Deserialize<'de> for CancelPaymentIntentCancellationReason {
 /// You can’t cancel the PaymentIntent for a Checkout Session.
 /// [Expire the Checkout Session](https://stripe.com/docs/api/checkout/sessions/expire) instead.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CancelPaymentIntent<'a> {
-    inner: CancelPaymentIntentBuilder<'a>,
-    intent: &'a stripe_shared::PaymentIntentId,
+pub struct CancelPaymentIntent {
+    inner: CancelPaymentIntentBuilder,
+    intent: stripe_shared::PaymentIntentId,
 }
-impl<'a> CancelPaymentIntent<'a> {
+impl CancelPaymentIntent {
     /// Construct a new `CancelPaymentIntent`.
-    pub fn new(intent: &'a stripe_shared::PaymentIntentId) -> Self {
-        Self { intent, inner: CancelPaymentIntentBuilder::new() }
+    pub fn new(intent: impl Into<stripe_shared::PaymentIntentId>) -> Self {
+        Self { intent: intent.into(), inner: CancelPaymentIntentBuilder::new() }
     }
     /// Reason for canceling this PaymentIntent.
     /// Possible values are: `duplicate`, `fraudulent`, `requested_by_customer`, or `abandoned`.
     pub fn cancellation_reason(
         mut self,
-        cancellation_reason: CancelPaymentIntentCancellationReason,
+        cancellation_reason: impl Into<CancelPaymentIntentCancellationReason>,
     ) -> Self {
-        self.inner.cancellation_reason = Some(cancellation_reason);
+        self.inner.cancellation_reason = Some(cancellation_reason.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl CancelPaymentIntent<'_> {
+impl CancelPaymentIntent {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -17664,35 +17712,35 @@ impl CancelPaymentIntent<'_> {
     }
 }
 
-impl StripeRequest for CancelPaymentIntent<'_> {
+impl StripeRequest for CancelPaymentIntent {
     type Output = stripe_shared::PaymentIntent;
 
     fn build(&self) -> RequestBuilder {
-        let intent = self.intent;
+        let intent = &self.intent;
         RequestBuilder::new(StripeMethod::Post, format!("/payment_intents/{intent}/cancel"))
             .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CapturePaymentIntentBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CapturePaymentIntentBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     amount_to_capture: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     application_fee_amount: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     final_capture: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    statement_descriptor: Option<&'a str>,
+    statement_descriptor: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    statement_descriptor_suffix: Option<&'a str>,
+    statement_descriptor_suffix: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     transfer_data: Option<TransferDataUpdateParams>,
 }
-impl<'a> CapturePaymentIntentBuilder<'a> {
+impl CapturePaymentIntentBuilder {
     fn new() -> Self {
         Self {
             amount_to_capture: None,
@@ -17712,72 +17760,78 @@ impl<'a> CapturePaymentIntentBuilder<'a> {
 ///
 /// Learn more about [separate authorization and capture](https://stripe.com/docs/payments/capture-later).
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CapturePaymentIntent<'a> {
-    inner: CapturePaymentIntentBuilder<'a>,
-    intent: &'a stripe_shared::PaymentIntentId,
+pub struct CapturePaymentIntent {
+    inner: CapturePaymentIntentBuilder,
+    intent: stripe_shared::PaymentIntentId,
 }
-impl<'a> CapturePaymentIntent<'a> {
+impl CapturePaymentIntent {
     /// Construct a new `CapturePaymentIntent`.
-    pub fn new(intent: &'a stripe_shared::PaymentIntentId) -> Self {
-        Self { intent, inner: CapturePaymentIntentBuilder::new() }
+    pub fn new(intent: impl Into<stripe_shared::PaymentIntentId>) -> Self {
+        Self { intent: intent.into(), inner: CapturePaymentIntentBuilder::new() }
     }
     /// The amount to capture from the PaymentIntent, which must be less than or equal to the original amount.
     /// Any additional amount is automatically refunded.
     /// Defaults to the full `amount_capturable` if it's not provided.
-    pub fn amount_to_capture(mut self, amount_to_capture: i64) -> Self {
-        self.inner.amount_to_capture = Some(amount_to_capture);
+    pub fn amount_to_capture(mut self, amount_to_capture: impl Into<i64>) -> Self {
+        self.inner.amount_to_capture = Some(amount_to_capture.into());
         self
     }
     /// The amount of the application fee (if any) that will be requested to be applied to the payment and transferred to the application owner's Stripe account.
     /// The amount of the application fee collected will be capped at the total payment amount.
     /// For more information, see the PaymentIntents [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts).
-    pub fn application_fee_amount(mut self, application_fee_amount: i64) -> Self {
-        self.inner.application_fee_amount = Some(application_fee_amount);
+    pub fn application_fee_amount(mut self, application_fee_amount: impl Into<i64>) -> Self {
+        self.inner.application_fee_amount = Some(application_fee_amount.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Defaults to `true`.
     /// When capturing a PaymentIntent, setting `final_capture` to `false` notifies Stripe to not release the remaining uncaptured funds to make sure that they're captured in future requests.
     /// You can only use this setting when [multicapture](https://stripe.com/docs/payments/multicapture) is available for PaymentIntents.
-    pub fn final_capture(mut self, final_capture: bool) -> Self {
-        self.inner.final_capture = Some(final_capture);
+    pub fn final_capture(mut self, final_capture: impl Into<bool>) -> Self {
+        self.inner.final_capture = Some(final_capture.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// For card charges, use [statement_descriptor_suffix](https://stripe.com/docs/payments/account/statement-descriptors#dynamic).
     /// Otherwise, you can use this value as the complete description of a charge on your customers' statements.
     /// It must contain at least one letter and be 1–22 characters long.
-    pub fn statement_descriptor(mut self, statement_descriptor: &'a str) -> Self {
-        self.inner.statement_descriptor = Some(statement_descriptor);
+    pub fn statement_descriptor(mut self, statement_descriptor: impl Into<String>) -> Self {
+        self.inner.statement_descriptor = Some(statement_descriptor.into());
         self
     }
     /// Provides information about a card payment that customers see on their statements.
     /// Concatenated with the prefix (shortened descriptor) or statement descriptor that’s set on the account to form the complete statement descriptor.
     /// The concatenated descriptor must be 1-22 characters long.
-    pub fn statement_descriptor_suffix(mut self, statement_descriptor_suffix: &'a str) -> Self {
-        self.inner.statement_descriptor_suffix = Some(statement_descriptor_suffix);
+    pub fn statement_descriptor_suffix(
+        mut self,
+        statement_descriptor_suffix: impl Into<String>,
+    ) -> Self {
+        self.inner.statement_descriptor_suffix = Some(statement_descriptor_suffix.into());
         self
     }
     /// The parameters that you can use to automatically create a transfer after the payment
     /// is captured.
     /// Learn more about the [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts).
-    pub fn transfer_data(mut self, transfer_data: TransferDataUpdateParams) -> Self {
-        self.inner.transfer_data = Some(transfer_data);
+    pub fn transfer_data(mut self, transfer_data: impl Into<TransferDataUpdateParams>) -> Self {
+        self.inner.transfer_data = Some(transfer_data.into());
         self
     }
 }
-impl CapturePaymentIntent<'_> {
+impl CapturePaymentIntent {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -17795,53 +17849,53 @@ impl CapturePaymentIntent<'_> {
     }
 }
 
-impl StripeRequest for CapturePaymentIntent<'_> {
+impl StripeRequest for CapturePaymentIntent {
     type Output = stripe_shared::PaymentIntent;
 
     fn build(&self) -> RequestBuilder {
-        let intent = self.intent;
+        let intent = &self.intent;
         RequestBuilder::new(StripeMethod::Post, format!("/payment_intents/{intent}/capture"))
             .form(&self.inner)
     }
 }
 #[derive(Clone, Debug, serde::Serialize)]
-struct ConfirmPaymentIntentBuilder<'a> {
+struct ConfirmPaymentIntentBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     capture_method: Option<stripe_shared::PaymentIntentCaptureMethod>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    confirmation_token: Option<&'a str>,
+    confirmation_token: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     error_on_requires_action: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    mandate: Option<&'a str>,
+    mandate: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    mandate_data: Option<ConfirmPaymentIntentMandateData<'a>>,
+    mandate_data: Option<ConfirmPaymentIntentMandateData>,
     #[serde(skip_serializing_if = "Option::is_none")]
     off_session: Option<ConfirmPaymentIntentOffSession>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_method: Option<&'a str>,
+    payment_method: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_method_data: Option<ConfirmPaymentIntentPaymentMethodData<'a>>,
+    payment_method_data: Option<ConfirmPaymentIntentPaymentMethodData>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_method_options: Option<ConfirmPaymentIntentPaymentMethodOptions<'a>>,
+    payment_method_options: Option<ConfirmPaymentIntentPaymentMethodOptions>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_method_types: Option<&'a [&'a str]>,
+    payment_method_types: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    radar_options: Option<RadarOptionsWithHiddenOptions<'a>>,
+    radar_options: Option<RadarOptionsWithHiddenOptions>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    receipt_email: Option<&'a str>,
+    receipt_email: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    return_url: Option<&'a str>,
+    return_url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     setup_future_usage: Option<stripe_shared::PaymentIntentSetupFutureUsage>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    shipping: Option<ConfirmPaymentIntentShipping<'a>>,
+    shipping: Option<ConfirmPaymentIntentShipping>,
     #[serde(skip_serializing_if = "Option::is_none")]
     use_stripe_sdk: Option<bool>,
 }
-impl<'a> ConfirmPaymentIntentBuilder<'a> {
+impl ConfirmPaymentIntentBuilder {
     fn new() -> Self {
         Self {
             capture_method: None,
@@ -17866,27 +17920,27 @@ impl<'a> ConfirmPaymentIntentBuilder<'a> {
 }
 #[derive(Clone, Debug, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
-pub enum ConfirmPaymentIntentMandateData<'a> {
+pub enum ConfirmPaymentIntentMandateData {
     #[serde(untagged)]
-    SecretKeyParam(ConfirmPaymentIntentSecretKeyParam<'a>),
+    SecretKeyParam(ConfirmPaymentIntentSecretKeyParam),
     #[serde(untagged)]
-    ClientKeyParam(ConfirmPaymentIntentClientKeyParam<'a>),
+    ClientKeyParam(ConfirmPaymentIntentClientKeyParam),
 }
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ConfirmPaymentIntentSecretKeyParam<'a> {
+pub struct ConfirmPaymentIntentSecretKeyParam {
     /// This hash contains details about the customer acceptance of the Mandate.
-    pub customer_acceptance: ConfirmPaymentIntentSecretKeyParamCustomerAcceptance<'a>,
+    pub customer_acceptance: ConfirmPaymentIntentSecretKeyParamCustomerAcceptance,
 }
-impl<'a> ConfirmPaymentIntentSecretKeyParam<'a> {
+impl ConfirmPaymentIntentSecretKeyParam {
     pub fn new(
-        customer_acceptance: ConfirmPaymentIntentSecretKeyParamCustomerAcceptance<'a>,
+        customer_acceptance: impl Into<ConfirmPaymentIntentSecretKeyParamCustomerAcceptance>,
     ) -> Self {
-        Self { customer_acceptance }
+        Self { customer_acceptance: customer_acceptance.into() }
     }
 }
 /// This hash contains details about the customer acceptance of the Mandate.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ConfirmPaymentIntentSecretKeyParamCustomerAcceptance<'a> {
+pub struct ConfirmPaymentIntentSecretKeyParamCustomerAcceptance {
     /// The time at which the customer accepted the Mandate.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub accepted_at: Option<stripe_types::Timestamp>,
@@ -17896,15 +17950,15 @@ pub struct ConfirmPaymentIntentSecretKeyParamCustomerAcceptance<'a> {
     pub offline: Option<miniserde::json::Value>,
     /// If this is a Mandate accepted online, this hash contains details about the online acceptance.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub online: Option<OnlineParam<'a>>,
+    pub online: Option<OnlineParam>,
     /// The type of customer acceptance information included with the Mandate.
     /// One of `online` or `offline`.
     #[serde(rename = "type")]
     pub type_: ConfirmPaymentIntentSecretKeyParamCustomerAcceptanceType,
 }
-impl<'a> ConfirmPaymentIntentSecretKeyParamCustomerAcceptance<'a> {
-    pub fn new(type_: ConfirmPaymentIntentSecretKeyParamCustomerAcceptanceType) -> Self {
-        Self { accepted_at: None, offline: None, online: None, type_ }
+impl ConfirmPaymentIntentSecretKeyParamCustomerAcceptance {
+    pub fn new(type_: impl Into<ConfirmPaymentIntentSecretKeyParamCustomerAcceptanceType>) -> Self {
+        Self { accepted_at: None, offline: None, online: None, type_: type_.into() }
     }
 }
 /// The type of customer acceptance information included with the Mandate.
@@ -17966,51 +18020,51 @@ impl<'de> serde::Deserialize<'de> for ConfirmPaymentIntentSecretKeyParamCustomer
         })
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmPaymentIntentClientKeyParam<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmPaymentIntentClientKeyParam {
     /// This hash contains details about the customer acceptance of the Mandate.
-    pub customer_acceptance: ConfirmPaymentIntentClientKeyParamCustomerAcceptance<'a>,
+    pub customer_acceptance: ConfirmPaymentIntentClientKeyParamCustomerAcceptance,
 }
-impl<'a> ConfirmPaymentIntentClientKeyParam<'a> {
+impl ConfirmPaymentIntentClientKeyParam {
     pub fn new(
-        customer_acceptance: ConfirmPaymentIntentClientKeyParamCustomerAcceptance<'a>,
+        customer_acceptance: impl Into<ConfirmPaymentIntentClientKeyParamCustomerAcceptance>,
     ) -> Self {
-        Self { customer_acceptance }
+        Self { customer_acceptance: customer_acceptance.into() }
     }
 }
 /// This hash contains details about the customer acceptance of the Mandate.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmPaymentIntentClientKeyParamCustomerAcceptance<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmPaymentIntentClientKeyParamCustomerAcceptance {
     /// If this is a Mandate accepted online, this hash contains details about the online acceptance.
-    pub online: ConfirmPaymentIntentClientKeyParamCustomerAcceptanceOnline<'a>,
+    pub online: ConfirmPaymentIntentClientKeyParamCustomerAcceptanceOnline,
     /// The type of customer acceptance information included with the Mandate.
     #[serde(rename = "type")]
     pub type_: ConfirmPaymentIntentClientKeyParamCustomerAcceptanceType,
 }
-impl<'a> ConfirmPaymentIntentClientKeyParamCustomerAcceptance<'a> {
+impl ConfirmPaymentIntentClientKeyParamCustomerAcceptance {
     pub fn new(
-        online: ConfirmPaymentIntentClientKeyParamCustomerAcceptanceOnline<'a>,
-        type_: ConfirmPaymentIntentClientKeyParamCustomerAcceptanceType,
+        online: impl Into<ConfirmPaymentIntentClientKeyParamCustomerAcceptanceOnline>,
+        type_: impl Into<ConfirmPaymentIntentClientKeyParamCustomerAcceptanceType>,
     ) -> Self {
-        Self { online, type_ }
+        Self { online: online.into(), type_: type_.into() }
     }
 }
 /// If this is a Mandate accepted online, this hash contains details about the online acceptance.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmPaymentIntentClientKeyParamCustomerAcceptanceOnline<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmPaymentIntentClientKeyParamCustomerAcceptanceOnline {
     /// The IP address from which the Mandate was accepted by the customer.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ip_address: Option<&'a str>,
+    pub ip_address: Option<String>,
     /// The user agent of the browser from which the Mandate was accepted by the customer.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user_agent: Option<&'a str>,
+    pub user_agent: Option<String>,
 }
-impl<'a> ConfirmPaymentIntentClientKeyParamCustomerAcceptanceOnline<'a> {
+impl ConfirmPaymentIntentClientKeyParamCustomerAcceptanceOnline {
     pub fn new() -> Self {
         Self { ip_address: None, user_agent: None }
     }
 }
-impl<'a> Default for ConfirmPaymentIntentClientKeyParamCustomerAcceptanceOnline<'a> {
+impl Default for ConfirmPaymentIntentClientKeyParamCustomerAcceptanceOnline {
     fn default() -> Self {
         Self::new()
     }
@@ -18084,10 +18138,10 @@ pub enum ConfirmPaymentIntentOffSession {
 /// in the [payment_method](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-payment_method).
 /// property on the PaymentIntent.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ConfirmPaymentIntentPaymentMethodData<'a> {
+pub struct ConfirmPaymentIntentPaymentMethodData {
     /// If this is an `acss_debit` PaymentMethod, this hash contains details about the ACSS Debit payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub acss_debit: Option<PaymentMethodParam<'a>>,
+    pub acss_debit: Option<PaymentMethodParam>,
     /// If this is an `affirm` PaymentMethod, this hash contains details about the Affirm payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
@@ -18111,24 +18165,24 @@ pub struct ConfirmPaymentIntentPaymentMethodData<'a> {
     pub amazon_pay: Option<miniserde::json::Value>,
     /// If this is an `au_becs_debit` PaymentMethod, this hash contains details about the bank account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub au_becs_debit: Option<ConfirmPaymentIntentPaymentMethodDataAuBecsDebit<'a>>,
+    pub au_becs_debit: Option<ConfirmPaymentIntentPaymentMethodDataAuBecsDebit>,
     /// If this is a `bacs_debit` PaymentMethod, this hash contains details about the Bacs Direct Debit bank account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub bacs_debit: Option<ConfirmPaymentIntentPaymentMethodDataBacsDebit<'a>>,
+    pub bacs_debit: Option<ConfirmPaymentIntentPaymentMethodDataBacsDebit>,
     /// If this is a `bancontact` PaymentMethod, this hash contains details about the Bancontact payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
     pub bancontact: Option<miniserde::json::Value>,
     /// Billing information associated with the PaymentMethod that may be used or required by particular types of payment methods.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub billing_details: Option<ConfirmPaymentIntentPaymentMethodDataBillingDetails<'a>>,
+    pub billing_details: Option<ConfirmPaymentIntentPaymentMethodDataBillingDetails>,
     /// If this is a `blik` PaymentMethod, this hash contains details about the BLIK payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
     pub blik: Option<miniserde::json::Value>,
     /// If this is a `boleto` PaymentMethod, this hash contains details about the Boleto payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub boleto: Option<ConfirmPaymentIntentPaymentMethodDataBoleto<'a>>,
+    pub boleto: Option<ConfirmPaymentIntentPaymentMethodDataBoleto>,
     /// If this is a `cashapp` PaymentMethod, this hash contains details about the Cash App Pay payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
@@ -18174,7 +18228,7 @@ pub struct ConfirmPaymentIntentPaymentMethodData<'a> {
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// If this is a `mobilepay` PaymentMethod, this hash contains details about the MobilePay payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
@@ -18205,14 +18259,14 @@ pub struct ConfirmPaymentIntentPaymentMethodData<'a> {
     /// Options to configure Radar.
     /// See [Radar Session](https://stripe.com/docs/radar/radar-session) for more information.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub radar_options: Option<RadarOptionsWithHiddenOptions<'a>>,
+    pub radar_options: Option<RadarOptionsWithHiddenOptions>,
     /// If this is a `Revolut Pay` PaymentMethod, this hash contains details about the Revolut Pay payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
     pub revolut_pay: Option<miniserde::json::Value>,
     /// If this is a `sepa_debit` PaymentMethod, this hash contains details about the SEPA debit bank account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub sepa_debit: Option<ConfirmPaymentIntentPaymentMethodDataSepaDebit<'a>>,
+    pub sepa_debit: Option<ConfirmPaymentIntentPaymentMethodDataSepaDebit>,
     /// If this is a `sofort` PaymentMethod, this hash contains details about the SOFORT payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sofort: Option<ConfirmPaymentIntentPaymentMethodDataSofort>,
@@ -18227,7 +18281,7 @@ pub struct ConfirmPaymentIntentPaymentMethodData<'a> {
     pub type_: ConfirmPaymentIntentPaymentMethodDataType,
     /// If this is an `us_bank_account` PaymentMethod, this hash contains details about the US bank account payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub us_bank_account: Option<ConfirmPaymentIntentPaymentMethodDataUsBankAccount<'a>>,
+    pub us_bank_account: Option<ConfirmPaymentIntentPaymentMethodDataUsBankAccount>,
     /// If this is an `wechat_pay` PaymentMethod, this hash contains details about the wechat_pay payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
@@ -18237,8 +18291,8 @@ pub struct ConfirmPaymentIntentPaymentMethodData<'a> {
     #[serde(with = "stripe_types::with_serde_json_opt")]
     pub zip: Option<miniserde::json::Value>,
 }
-impl<'a> ConfirmPaymentIntentPaymentMethodData<'a> {
-    pub fn new(type_: ConfirmPaymentIntentPaymentMethodDataType) -> Self {
+impl ConfirmPaymentIntentPaymentMethodData {
+    pub fn new(type_: impl Into<ConfirmPaymentIntentPaymentMethodDataType>) -> Self {
         Self {
             acss_debit: None,
             affirm: None,
@@ -18276,7 +18330,7 @@ impl<'a> ConfirmPaymentIntentPaymentMethodData<'a> {
             sepa_debit: None,
             sofort: None,
             swish: None,
-            type_,
+            type_: type_.into(),
             us_bank_account: None,
             wechat_pay: None,
             zip: None,
@@ -18347,105 +18401,105 @@ impl<'de> serde::Deserialize<'de> for ConfirmPaymentIntentPaymentMethodDataAllow
     }
 }
 /// If this is an `au_becs_debit` PaymentMethod, this hash contains details about the bank account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmPaymentIntentPaymentMethodDataAuBecsDebit<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmPaymentIntentPaymentMethodDataAuBecsDebit {
     /// The account number for the bank account.
-    pub account_number: &'a str,
+    pub account_number: String,
     /// Bank-State-Branch number of the bank account.
-    pub bsb_number: &'a str,
+    pub bsb_number: String,
 }
-impl<'a> ConfirmPaymentIntentPaymentMethodDataAuBecsDebit<'a> {
-    pub fn new(account_number: &'a str, bsb_number: &'a str) -> Self {
-        Self { account_number, bsb_number }
+impl ConfirmPaymentIntentPaymentMethodDataAuBecsDebit {
+    pub fn new(account_number: impl Into<String>, bsb_number: impl Into<String>) -> Self {
+        Self { account_number: account_number.into(), bsb_number: bsb_number.into() }
     }
 }
 /// If this is a `bacs_debit` PaymentMethod, this hash contains details about the Bacs Direct Debit bank account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmPaymentIntentPaymentMethodDataBacsDebit<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmPaymentIntentPaymentMethodDataBacsDebit {
     /// Account number of the bank account that the funds will be debited from.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account_number: Option<&'a str>,
+    pub account_number: Option<String>,
     /// Sort code of the bank account. (e.g., `10-20-30`)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub sort_code: Option<&'a str>,
+    pub sort_code: Option<String>,
 }
-impl<'a> ConfirmPaymentIntentPaymentMethodDataBacsDebit<'a> {
+impl ConfirmPaymentIntentPaymentMethodDataBacsDebit {
     pub fn new() -> Self {
         Self { account_number: None, sort_code: None }
     }
 }
-impl<'a> Default for ConfirmPaymentIntentPaymentMethodDataBacsDebit<'a> {
+impl Default for ConfirmPaymentIntentPaymentMethodDataBacsDebit {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Billing information associated with the PaymentMethod that may be used or required by particular types of payment methods.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmPaymentIntentPaymentMethodDataBillingDetails<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmPaymentIntentPaymentMethodDataBillingDetails {
     /// Billing address.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub address: Option<ConfirmPaymentIntentPaymentMethodDataBillingDetailsAddress<'a>>,
+    pub address: Option<ConfirmPaymentIntentPaymentMethodDataBillingDetailsAddress>,
     /// Email address.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub email: Option<&'a str>,
+    pub email: Option<String>,
     /// Full name.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<&'a str>,
+    pub name: Option<String>,
     /// Billing phone number (including extension).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub phone: Option<&'a str>,
+    pub phone: Option<String>,
 }
-impl<'a> ConfirmPaymentIntentPaymentMethodDataBillingDetails<'a> {
+impl ConfirmPaymentIntentPaymentMethodDataBillingDetails {
     pub fn new() -> Self {
         Self { address: None, email: None, name: None, phone: None }
     }
 }
-impl<'a> Default for ConfirmPaymentIntentPaymentMethodDataBillingDetails<'a> {
+impl Default for ConfirmPaymentIntentPaymentMethodDataBillingDetails {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Billing address.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmPaymentIntentPaymentMethodDataBillingDetailsAddress<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmPaymentIntentPaymentMethodDataBillingDetailsAddress {
     /// City, district, suburb, town, or village.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<&'a str>,
+    pub city: Option<String>,
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub country: Option<&'a str>,
+    pub country: Option<String>,
     /// Address line 1 (e.g., street, PO Box, or company name).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line1: Option<&'a str>,
+    pub line1: Option<String>,
     /// Address line 2 (e.g., apartment, suite, unit, or building).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line2: Option<&'a str>,
+    pub line2: Option<String>,
     /// ZIP or postal code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<&'a str>,
+    pub postal_code: Option<String>,
     /// State, county, province, or region.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
 }
-impl<'a> ConfirmPaymentIntentPaymentMethodDataBillingDetailsAddress<'a> {
+impl ConfirmPaymentIntentPaymentMethodDataBillingDetailsAddress {
     pub fn new() -> Self {
         Self { city: None, country: None, line1: None, line2: None, postal_code: None, state: None }
     }
 }
-impl<'a> Default for ConfirmPaymentIntentPaymentMethodDataBillingDetailsAddress<'a> {
+impl Default for ConfirmPaymentIntentPaymentMethodDataBillingDetailsAddress {
     fn default() -> Self {
         Self::new()
     }
 }
 /// If this is a `boleto` PaymentMethod, this hash contains details about the Boleto payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmPaymentIntentPaymentMethodDataBoleto<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmPaymentIntentPaymentMethodDataBoleto {
     /// The tax ID of the customer (CPF for individual consumers or CNPJ for businesses consumers)
-    pub tax_id: &'a str,
+    pub tax_id: String,
 }
-impl<'a> ConfirmPaymentIntentPaymentMethodDataBoleto<'a> {
-    pub fn new(tax_id: &'a str) -> Self {
-        Self { tax_id }
+impl ConfirmPaymentIntentPaymentMethodDataBoleto {
+    pub fn new(tax_id: impl Into<String>) -> Self {
+        Self { tax_id: tax_id.into() }
     }
 }
 /// If this is an `eps` PaymentMethod, this hash contains details about the EPS payment method.
@@ -18611,8 +18665,8 @@ pub struct ConfirmPaymentIntentPaymentMethodDataFpx {
     pub bank: ConfirmPaymentIntentPaymentMethodDataFpxBank,
 }
 impl ConfirmPaymentIntentPaymentMethodDataFpx {
-    pub fn new(bank: ConfirmPaymentIntentPaymentMethodDataFpxBank) -> Self {
-        Self { account_holder_type: None, bank }
+    pub fn new(bank: impl Into<ConfirmPaymentIntentPaymentMethodDataFpxBank>) -> Self {
+        Self { account_holder_type: None, bank: bank.into() }
     }
 }
 /// Account holder type for FPX transaction
@@ -19073,14 +19127,14 @@ impl<'de> serde::Deserialize<'de> for ConfirmPaymentIntentPaymentMethodDataP24Ba
     }
 }
 /// If this is a `sepa_debit` PaymentMethod, this hash contains details about the SEPA debit bank account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmPaymentIntentPaymentMethodDataSepaDebit<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmPaymentIntentPaymentMethodDataSepaDebit {
     /// IBAN of the bank account.
-    pub iban: &'a str,
+    pub iban: String,
 }
-impl<'a> ConfirmPaymentIntentPaymentMethodDataSepaDebit<'a> {
-    pub fn new(iban: &'a str) -> Self {
-        Self { iban }
+impl ConfirmPaymentIntentPaymentMethodDataSepaDebit {
+    pub fn new(iban: impl Into<String>) -> Self {
+        Self { iban: iban.into() }
     }
 }
 /// If this is a `sofort` PaymentMethod, this hash contains details about the SOFORT payment method.
@@ -19090,8 +19144,8 @@ pub struct ConfirmPaymentIntentPaymentMethodDataSofort {
     pub country: ConfirmPaymentIntentPaymentMethodDataSofortCountry,
 }
 impl ConfirmPaymentIntentPaymentMethodDataSofort {
-    pub fn new(country: ConfirmPaymentIntentPaymentMethodDataSofortCountry) -> Self {
-        Self { country }
+    pub fn new(country: impl Into<ConfirmPaymentIntentPaymentMethodDataSofortCountry>) -> Self {
+        Self { country: country.into() }
     }
 }
 /// Two-letter ISO code representing the country the bank account is located in.
@@ -19321,26 +19375,26 @@ impl<'de> serde::Deserialize<'de> for ConfirmPaymentIntentPaymentMethodDataType 
     }
 }
 /// If this is an `us_bank_account` PaymentMethod, this hash contains details about the US bank account payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmPaymentIntentPaymentMethodDataUsBankAccount<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmPaymentIntentPaymentMethodDataUsBankAccount {
     /// Account holder type: individual or company.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub account_holder_type:
         Option<ConfirmPaymentIntentPaymentMethodDataUsBankAccountAccountHolderType>,
     /// Account number of the bank account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account_number: Option<&'a str>,
+    pub account_number: Option<String>,
     /// Account type: checkings or savings. Defaults to checking if omitted.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub account_type: Option<ConfirmPaymentIntentPaymentMethodDataUsBankAccountAccountType>,
     /// The ID of a Financial Connections Account to use as a payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub financial_connections_account: Option<&'a str>,
+    pub financial_connections_account: Option<String>,
     /// Routing number of the bank account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub routing_number: Option<&'a str>,
+    pub routing_number: Option<String>,
 }
-impl<'a> ConfirmPaymentIntentPaymentMethodDataUsBankAccount<'a> {
+impl ConfirmPaymentIntentPaymentMethodDataUsBankAccount {
     pub fn new() -> Self {
         Self {
             account_holder_type: None,
@@ -19351,7 +19405,7 @@ impl<'a> ConfirmPaymentIntentPaymentMethodDataUsBankAccount<'a> {
         }
     }
 }
-impl<'a> Default for ConfirmPaymentIntentPaymentMethodDataUsBankAccount<'a> {
+impl Default for ConfirmPaymentIntentPaymentMethodDataUsBankAccount {
     fn default() -> Self {
         Self::new()
     }
@@ -19474,16 +19528,16 @@ impl<'de> serde::Deserialize<'de>
 }
 /// Payment method-specific configuration for this PaymentIntent.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ConfirmPaymentIntentPaymentMethodOptions<'a> {
+pub struct ConfirmPaymentIntentPaymentMethodOptions {
     /// If this is a `acss_debit` PaymentMethod, this sub-hash contains details about the ACSS Debit payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub acss_debit: Option<ConfirmPaymentIntentPaymentMethodOptionsAcssDebit<'a>>,
+    pub acss_debit: Option<ConfirmPaymentIntentPaymentMethodOptionsAcssDebit>,
     /// If this is an `affirm` PaymentMethod, this sub-hash contains details about the Affirm payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub affirm: Option<ConfirmPaymentIntentPaymentMethodOptionsAffirm<'a>>,
+    pub affirm: Option<ConfirmPaymentIntentPaymentMethodOptionsAffirm>,
     /// If this is a `afterpay_clearpay` PaymentMethod, this sub-hash contains details about the Afterpay Clearpay payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub afterpay_clearpay: Option<ConfirmPaymentIntentPaymentMethodOptionsAfterpayClearpay<'a>>,
+    pub afterpay_clearpay: Option<ConfirmPaymentIntentPaymentMethodOptionsAfterpayClearpay>,
     /// If this is a `alipay` PaymentMethod, this sub-hash contains details about the Alipay payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub alipay: Option<ConfirmPaymentIntentPaymentMethodOptionsAlipay>,
@@ -19501,13 +19555,13 @@ pub struct ConfirmPaymentIntentPaymentMethodOptions<'a> {
     pub bancontact: Option<ConfirmPaymentIntentPaymentMethodOptionsBancontact>,
     /// If this is a `blik` PaymentMethod, this sub-hash contains details about the BLIK payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub blik: Option<ConfirmPaymentIntentPaymentMethodOptionsBlik<'a>>,
+    pub blik: Option<ConfirmPaymentIntentPaymentMethodOptionsBlik>,
     /// If this is a `boleto` PaymentMethod, this sub-hash contains details about the Boleto payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub boleto: Option<ConfirmPaymentIntentPaymentMethodOptionsBoleto>,
     /// Configuration for any card payments attempted on this PaymentIntent.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub card: Option<ConfirmPaymentIntentPaymentMethodOptionsCard<'a>>,
+    pub card: Option<ConfirmPaymentIntentPaymentMethodOptionsCard>,
     /// If this is a `card_present` PaymentMethod, this sub-hash contains details about the Card Present payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub card_present: Option<PaymentMethodOptionsParam>,
@@ -19516,7 +19570,7 @@ pub struct ConfirmPaymentIntentPaymentMethodOptions<'a> {
     pub cashapp: Option<ConfirmPaymentIntentPaymentMethodOptionsCashapp>,
     /// If this is a `customer balance` PaymentMethod, this sub-hash contains details about the customer balance payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub customer_balance: Option<ConfirmPaymentIntentPaymentMethodOptionsCustomerBalance<'a>>,
+    pub customer_balance: Option<ConfirmPaymentIntentPaymentMethodOptionsCustomerBalance>,
     /// If this is a `eps` PaymentMethod, this sub-hash contains details about the EPS payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub eps: Option<ConfirmPaymentIntentPaymentMethodOptionsEps>,
@@ -19541,10 +19595,10 @@ pub struct ConfirmPaymentIntentPaymentMethodOptions<'a> {
     pub klarna: Option<ConfirmPaymentIntentPaymentMethodOptionsKlarna>,
     /// If this is a `konbini` PaymentMethod, this sub-hash contains details about the Konbini payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub konbini: Option<ConfirmPaymentIntentPaymentMethodOptionsKonbini<'a>>,
+    pub konbini: Option<ConfirmPaymentIntentPaymentMethodOptionsKonbini>,
     /// If this is a `link` PaymentMethod, this sub-hash contains details about the Link payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub link: Option<ConfirmPaymentIntentPaymentMethodOptionsLink<'a>>,
+    pub link: Option<ConfirmPaymentIntentPaymentMethodOptionsLink>,
     /// If this is a `MobilePay` PaymentMethod, this sub-hash contains details about the MobilePay payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mobilepay: Option<ConfirmPaymentIntentPaymentMethodOptionsMobilepay>,
@@ -19559,7 +19613,7 @@ pub struct ConfirmPaymentIntentPaymentMethodOptions<'a> {
     pub paynow: Option<ConfirmPaymentIntentPaymentMethodOptionsPaynow>,
     /// If this is a `paypal` PaymentMethod, this sub-hash contains details about the PayPal payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub paypal: Option<ConfirmPaymentIntentPaymentMethodOptionsPaypal<'a>>,
+    pub paypal: Option<ConfirmPaymentIntentPaymentMethodOptionsPaypal>,
     /// If this is a `pix` PaymentMethod, this sub-hash contains details about the Pix payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pix: Option<ConfirmPaymentIntentPaymentMethodOptionsPix>,
@@ -19577,18 +19631,18 @@ pub struct ConfirmPaymentIntentPaymentMethodOptions<'a> {
     pub sofort: Option<ConfirmPaymentIntentPaymentMethodOptionsSofort>,
     /// If this is a `Swish` PaymentMethod, this sub-hash contains details about the Swish payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub swish: Option<ConfirmPaymentIntentPaymentMethodOptionsSwish<'a>>,
+    pub swish: Option<ConfirmPaymentIntentPaymentMethodOptionsSwish>,
     /// If this is a `us_bank_account` PaymentMethod, this sub-hash contains details about the US bank account payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub us_bank_account: Option<ConfirmPaymentIntentPaymentMethodOptionsUsBankAccount<'a>>,
+    pub us_bank_account: Option<ConfirmPaymentIntentPaymentMethodOptionsUsBankAccount>,
     /// If this is a `wechat_pay` PaymentMethod, this sub-hash contains details about the WeChat Pay payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub wechat_pay: Option<ConfirmPaymentIntentPaymentMethodOptionsWechatPay<'a>>,
+    pub wechat_pay: Option<ConfirmPaymentIntentPaymentMethodOptionsWechatPay>,
     /// If this is a `zip` PaymentMethod, this sub-hash contains details about the Zip payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub zip: Option<ConfirmPaymentIntentPaymentMethodOptionsZip>,
 }
-impl<'a> ConfirmPaymentIntentPaymentMethodOptions<'a> {
+impl ConfirmPaymentIntentPaymentMethodOptions {
     pub fn new() -> Self {
         Self {
             acss_debit: None,
@@ -19631,18 +19685,17 @@ impl<'a> ConfirmPaymentIntentPaymentMethodOptions<'a> {
         }
     }
 }
-impl<'a> Default for ConfirmPaymentIntentPaymentMethodOptions<'a> {
+impl Default for ConfirmPaymentIntentPaymentMethodOptions {
     fn default() -> Self {
         Self::new()
     }
 }
 /// If this is a `acss_debit` PaymentMethod, this sub-hash contains details about the ACSS Debit payment method options.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmPaymentIntentPaymentMethodOptionsAcssDebit<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmPaymentIntentPaymentMethodOptionsAcssDebit {
     /// Additional fields for Mandate creation
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub mandate_options:
-        Option<ConfirmPaymentIntentPaymentMethodOptionsAcssDebitMandateOptions<'a>>,
+    pub mandate_options: Option<ConfirmPaymentIntentPaymentMethodOptionsAcssDebitMandateOptions>,
     /// Indicates that you intend to make future payments with this PaymentIntent's payment method.
     ///
     /// Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete.
@@ -19659,28 +19712,28 @@ pub struct ConfirmPaymentIntentPaymentMethodOptionsAcssDebit<'a> {
     pub verification_method:
         Option<ConfirmPaymentIntentPaymentMethodOptionsAcssDebitVerificationMethod>,
 }
-impl<'a> ConfirmPaymentIntentPaymentMethodOptionsAcssDebit<'a> {
+impl ConfirmPaymentIntentPaymentMethodOptionsAcssDebit {
     pub fn new() -> Self {
         Self { mandate_options: None, setup_future_usage: None, verification_method: None }
     }
 }
-impl<'a> Default for ConfirmPaymentIntentPaymentMethodOptionsAcssDebit<'a> {
+impl Default for ConfirmPaymentIntentPaymentMethodOptionsAcssDebit {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Additional fields for Mandate creation
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmPaymentIntentPaymentMethodOptionsAcssDebitMandateOptions<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmPaymentIntentPaymentMethodOptionsAcssDebitMandateOptions {
     /// A URL for custom mandate text to render during confirmation step.
     /// The URL will be rendered with additional GET parameters `payment_intent` and `payment_intent_client_secret` when confirming a Payment Intent,.
     /// or `setup_intent` and `setup_intent_client_secret` when confirming a Setup Intent.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub custom_mandate_url: Option<&'a str>,
+    pub custom_mandate_url: Option<String>,
     /// Description of the mandate interval.
     /// Only required if 'payment_schedule' parameter is 'interval' or 'combined'.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub interval_description: Option<&'a str>,
+    pub interval_description: Option<String>,
     /// Payment schedule for the mandate.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub payment_schedule:
@@ -19690,7 +19743,7 @@ pub struct ConfirmPaymentIntentPaymentMethodOptionsAcssDebitMandateOptions<'a> {
     pub transaction_type:
         Option<ConfirmPaymentIntentPaymentMethodOptionsAcssDebitMandateOptionsTransactionType>,
 }
-impl<'a> ConfirmPaymentIntentPaymentMethodOptionsAcssDebitMandateOptions<'a> {
+impl ConfirmPaymentIntentPaymentMethodOptionsAcssDebitMandateOptions {
     pub fn new() -> Self {
         Self {
             custom_mandate_url: None,
@@ -19700,7 +19753,7 @@ impl<'a> ConfirmPaymentIntentPaymentMethodOptionsAcssDebitMandateOptions<'a> {
         }
     }
 }
-impl<'a> Default for ConfirmPaymentIntentPaymentMethodOptionsAcssDebitMandateOptions<'a> {
+impl Default for ConfirmPaymentIntentPaymentMethodOptionsAcssDebitMandateOptions {
     fn default() -> Self {
         Self::new()
     }
@@ -19962,8 +20015,8 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// If this is an `affirm` PaymentMethod, this sub-hash contains details about the Affirm payment method options.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmPaymentIntentPaymentMethodOptionsAffirm<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmPaymentIntentPaymentMethodOptionsAffirm {
     /// Controls when the funds will be captured from the customer's account.
     ///
     /// If provided, this parameter will override the top level behavior of `capture_method` when finalizing the payment with this payment method type.
@@ -19973,7 +20026,7 @@ pub struct ConfirmPaymentIntentPaymentMethodOptionsAffirm<'a> {
     pub capture_method: Option<ConfirmPaymentIntentPaymentMethodOptionsAffirmCaptureMethod>,
     /// Preferred language of the Affirm authorization page that the customer is redirected to.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub preferred_locale: Option<&'a str>,
+    pub preferred_locale: Option<String>,
     /// Indicates that you intend to make future payments with this PaymentIntent's payment method.
     ///
     /// Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete.
@@ -19985,12 +20038,12 @@ pub struct ConfirmPaymentIntentPaymentMethodOptionsAffirm<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub setup_future_usage: Option<ConfirmPaymentIntentPaymentMethodOptionsAffirmSetupFutureUsage>,
 }
-impl<'a> ConfirmPaymentIntentPaymentMethodOptionsAffirm<'a> {
+impl ConfirmPaymentIntentPaymentMethodOptionsAffirm {
     pub fn new() -> Self {
         Self { capture_method: None, preferred_locale: None, setup_future_usage: None }
     }
 }
-impl<'a> Default for ConfirmPaymentIntentPaymentMethodOptionsAffirm<'a> {
+impl Default for ConfirmPaymentIntentPaymentMethodOptionsAffirm {
     fn default() -> Self {
         Self::new()
     }
@@ -20119,8 +20172,8 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// If this is a `afterpay_clearpay` PaymentMethod, this sub-hash contains details about the Afterpay Clearpay payment method options.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmPaymentIntentPaymentMethodOptionsAfterpayClearpay<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmPaymentIntentPaymentMethodOptionsAfterpayClearpay {
     /// Controls when the funds will be captured from the customer's account.
     ///
     /// If provided, this parameter will override the top level behavior of `capture_method` when finalizing the payment with this payment method type.
@@ -20133,7 +20186,7 @@ pub struct ConfirmPaymentIntentPaymentMethodOptionsAfterpayClearpay<'a> {
     /// You must limit the identifier to 128 characters, and it can only contain letters, numbers, underscores, backslashes, and dashes.
     /// This field differs from the statement descriptor and item name.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reference: Option<&'a str>,
+    pub reference: Option<String>,
     /// Indicates that you intend to make future payments with this PaymentIntent's payment method.
     ///
     /// Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete.
@@ -20146,12 +20199,12 @@ pub struct ConfirmPaymentIntentPaymentMethodOptionsAfterpayClearpay<'a> {
     pub setup_future_usage:
         Option<ConfirmPaymentIntentPaymentMethodOptionsAfterpayClearpaySetupFutureUsage>,
 }
-impl<'a> ConfirmPaymentIntentPaymentMethodOptionsAfterpayClearpay<'a> {
+impl ConfirmPaymentIntentPaymentMethodOptionsAfterpayClearpay {
     pub fn new() -> Self {
         Self { capture_method: None, reference: None, setup_future_usage: None }
     }
 }
-impl<'a> Default for ConfirmPaymentIntentPaymentMethodOptionsAfterpayClearpay<'a> {
+impl Default for ConfirmPaymentIntentPaymentMethodOptionsAfterpayClearpay {
     fn default() -> Self {
         Self::new()
     }
@@ -20857,12 +20910,12 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// If this is a `blik` PaymentMethod, this sub-hash contains details about the BLIK payment method options.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmPaymentIntentPaymentMethodOptionsBlik<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmPaymentIntentPaymentMethodOptionsBlik {
     /// The 6-digit BLIK code that a customer has generated using their banking application.
     /// Can only be set on confirmation.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub code: Option<&'a str>,
+    pub code: Option<String>,
     /// Indicates that you intend to make future payments with this PaymentIntent's payment method.
     ///
     /// Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete.
@@ -20874,12 +20927,12 @@ pub struct ConfirmPaymentIntentPaymentMethodOptionsBlik<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub setup_future_usage: Option<ConfirmPaymentIntentPaymentMethodOptionsBlikSetupFutureUsage>,
 }
-impl<'a> ConfirmPaymentIntentPaymentMethodOptionsBlik<'a> {
+impl ConfirmPaymentIntentPaymentMethodOptionsBlik {
     pub fn new() -> Self {
         Self { code: None, setup_future_usage: None }
     }
 }
-impl<'a> Default for ConfirmPaymentIntentPaymentMethodOptionsBlik<'a> {
+impl Default for ConfirmPaymentIntentPaymentMethodOptionsBlik {
     fn default() -> Self {
         Self::new()
     }
@@ -21045,8 +21098,8 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// Configuration for any card payments attempted on this PaymentIntent.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmPaymentIntentPaymentMethodOptionsCard<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmPaymentIntentPaymentMethodOptionsCard {
     /// Controls when the funds will be captured from the customer's account.
     ///
     /// If provided, this parameter will override the top level behavior of `capture_method` when finalizing the payment with this payment method type.
@@ -21058,7 +21111,7 @@ pub struct ConfirmPaymentIntentPaymentMethodOptionsCard<'a> {
     /// When provided, the CVC value will be verified during the card payment attempt.
     /// This parameter can only be provided during confirmation.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub cvc_token: Option<&'a str>,
+    pub cvc_token: Option<String>,
     /// Installment configuration for payments attempted on this PaymentIntent (Mexico Only).
     ///
     /// For more information, see the [installments integration guide](https://stripe.com/docs/payments/installments).
@@ -21066,7 +21119,7 @@ pub struct ConfirmPaymentIntentPaymentMethodOptionsCard<'a> {
     pub installments: Option<ConfirmPaymentIntentPaymentMethodOptionsCardInstallments>,
     /// Configuration options for setting up an eMandate for cards issued in India.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub mandate_options: Option<ConfirmPaymentIntentPaymentMethodOptionsCardMandateOptions<'a>>,
+    pub mandate_options: Option<ConfirmPaymentIntentPaymentMethodOptionsCardMandateOptions>,
     /// When specified, this parameter indicates that a transaction will be marked
     /// as MOTO (Mail Order Telephone Order) and thus out of scope for SCA. This
     /// parameter can only be provided during confirmation.
@@ -21118,19 +21171,19 @@ pub struct ConfirmPaymentIntentPaymentMethodOptionsCard<'a> {
     /// Maximum 22 characters.
     /// On card statements, the *concatenation* of both prefix and suffix (including separators) will appear truncated to 22 characters.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub statement_descriptor_suffix_kana: Option<&'a str>,
+    pub statement_descriptor_suffix_kana: Option<String>,
     /// Provides information about a card payment that customers see on their statements.
     /// Concatenated with the Kanji prefix (shortened Kanji descriptor) or Kanji statement descriptor that’s set on the account to form the complete statement descriptor.
     /// Maximum 17 characters.
     /// On card statements, the *concatenation* of both prefix and suffix (including separators) will appear truncated to 17 characters.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub statement_descriptor_suffix_kanji: Option<&'a str>,
+    pub statement_descriptor_suffix_kanji: Option<String>,
     /// If 3D Secure authentication was performed with a third-party provider,
     /// the authentication details to use for this payment.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub three_d_secure: Option<ConfirmPaymentIntentPaymentMethodOptionsCardThreeDSecure<'a>>,
+    pub three_d_secure: Option<ConfirmPaymentIntentPaymentMethodOptionsCardThreeDSecure>,
 }
-impl<'a> ConfirmPaymentIntentPaymentMethodOptionsCard<'a> {
+impl ConfirmPaymentIntentPaymentMethodOptionsCard {
     pub fn new() -> Self {
         Self {
             capture_method: None,
@@ -21152,7 +21205,7 @@ impl<'a> ConfirmPaymentIntentPaymentMethodOptionsCard<'a> {
         }
     }
 }
-impl<'a> Default for ConfirmPaymentIntentPaymentMethodOptionsCard<'a> {
+impl Default for ConfirmPaymentIntentPaymentMethodOptionsCard {
     fn default() -> Self {
         Self::new()
     }
@@ -21256,11 +21309,11 @@ pub struct ConfirmPaymentIntentPaymentMethodOptionsCardInstallmentsPlan {
 }
 impl ConfirmPaymentIntentPaymentMethodOptionsCardInstallmentsPlan {
     pub fn new(
-        count: u64,
-        interval: ConfirmPaymentIntentPaymentMethodOptionsCardInstallmentsPlanInterval,
-        type_: ConfirmPaymentIntentPaymentMethodOptionsCardInstallmentsPlanType,
+        count: impl Into<u64>,
+        interval: impl Into<ConfirmPaymentIntentPaymentMethodOptionsCardInstallmentsPlanInterval>,
+        type_: impl Into<ConfirmPaymentIntentPaymentMethodOptionsCardInstallmentsPlanType>,
     ) -> Self {
-        Self { count, interval, type_ }
+        Self { count: count.into(), interval: interval.into(), type_: type_.into() }
     }
 }
 /// For `fixed_count` installment plans, this is the interval between installment payments your customer will make to their credit card.
@@ -21371,8 +21424,8 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// Configuration options for setting up an eMandate for cards issued in India.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmPaymentIntentPaymentMethodOptionsCardMandateOptions<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmPaymentIntentPaymentMethodOptionsCardMandateOptions {
     /// Amount to be charged for future payments.
     pub amount: i64,
     /// One of `fixed` or `maximum`.
@@ -21381,7 +21434,7 @@ pub struct ConfirmPaymentIntentPaymentMethodOptionsCardMandateOptions<'a> {
     pub amount_type: ConfirmPaymentIntentPaymentMethodOptionsCardMandateOptionsAmountType,
     /// A description of the mandate or subscription that is meant to be displayed to the customer.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<&'a str>,
+    pub description: Option<String>,
     /// End date of the mandate or subscription.
     /// If not provided, the mandate will be active until canceled.
     /// If provided, end date should be after start date.
@@ -21396,31 +21449,31 @@ pub struct ConfirmPaymentIntentPaymentMethodOptionsCardMandateOptions<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub interval_count: Option<u64>,
     /// Unique identifier for the mandate or subscription.
-    pub reference: &'a str,
+    pub reference: String,
     /// Start date of the mandate or subscription. Start date should not be lesser than yesterday.
     pub start_date: stripe_types::Timestamp,
     /// Specifies the type of mandates supported. Possible values are `india`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub supported_types:
-        Option<&'a [ConfirmPaymentIntentPaymentMethodOptionsCardMandateOptionsSupportedTypes]>,
+        Option<Vec<ConfirmPaymentIntentPaymentMethodOptionsCardMandateOptionsSupportedTypes>>,
 }
-impl<'a> ConfirmPaymentIntentPaymentMethodOptionsCardMandateOptions<'a> {
+impl ConfirmPaymentIntentPaymentMethodOptionsCardMandateOptions {
     pub fn new(
-        amount: i64,
-        amount_type: ConfirmPaymentIntentPaymentMethodOptionsCardMandateOptionsAmountType,
-        interval: ConfirmPaymentIntentPaymentMethodOptionsCardMandateOptionsInterval,
-        reference: &'a str,
-        start_date: stripe_types::Timestamp,
+        amount: impl Into<i64>,
+        amount_type: impl Into<ConfirmPaymentIntentPaymentMethodOptionsCardMandateOptionsAmountType>,
+        interval: impl Into<ConfirmPaymentIntentPaymentMethodOptionsCardMandateOptionsInterval>,
+        reference: impl Into<String>,
+        start_date: impl Into<stripe_types::Timestamp>,
     ) -> Self {
         Self {
-            amount,
-            amount_type,
+            amount: amount.into(),
+            amount_type: amount_type.into(),
             description: None,
             end_date: None,
-            interval,
+            interval: interval.into(),
             interval_count: None,
-            reference,
-            start_date,
+            reference: reference.into(),
+            start_date: start_date.into(),
             supported_types: None,
         }
     }
@@ -22072,8 +22125,8 @@ impl<'de> serde::Deserialize<'de> for ConfirmPaymentIntentPaymentMethodOptionsCa
 }
 /// If 3D Secure authentication was performed with a third-party provider,
 /// the authentication details to use for this payment.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmPaymentIntentPaymentMethodOptionsCardThreeDSecure<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmPaymentIntentPaymentMethodOptionsCardThreeDSecure {
     /// The `transStatus` returned from the card Issuer’s ACS in the ARes.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ares_trans_status:
@@ -22082,7 +22135,7 @@ pub struct ConfirmPaymentIntentPaymentMethodOptionsCardThreeDSecure<'a> {
     /// AEVV). This value is 20 bytes, base64-encoded into a 28-character string.
     /// (Most 3D Secure providers will return the base64-encoded version, which
     /// is what you should specify here.)
-    pub cryptogram: &'a str,
+    pub cryptogram: String,
     /// The Electronic Commerce Indicator (ECI) is returned by your 3D Secure
     /// provider and indicates what degree of authentication was performed.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -22097,32 +22150,32 @@ pub struct ConfirmPaymentIntentPaymentMethodOptionsCardThreeDSecure<'a> {
     /// must be populated accordingly
     #[serde(skip_serializing_if = "Option::is_none")]
     pub network_options:
-        Option<ConfirmPaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptions<'a>>,
+        Option<ConfirmPaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptions>,
     /// The challenge indicator (`threeDSRequestorChallengeInd`) which was requested in the
     /// AReq sent to the card Issuer's ACS. A string containing 2 digits from 01-99.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub requestor_challenge_indicator: Option<&'a str>,
+    pub requestor_challenge_indicator: Option<String>,
     /// For 3D Secure 1, the XID. For 3D Secure 2, the Directory Server
     /// Transaction ID (dsTransID).
-    pub transaction_id: &'a str,
+    pub transaction_id: String,
     /// The version of 3D Secure that was performed.
     pub version: ConfirmPaymentIntentPaymentMethodOptionsCardThreeDSecureVersion,
 }
-impl<'a> ConfirmPaymentIntentPaymentMethodOptionsCardThreeDSecure<'a> {
+impl ConfirmPaymentIntentPaymentMethodOptionsCardThreeDSecure {
     pub fn new(
-        cryptogram: &'a str,
-        transaction_id: &'a str,
-        version: ConfirmPaymentIntentPaymentMethodOptionsCardThreeDSecureVersion,
+        cryptogram: impl Into<String>,
+        transaction_id: impl Into<String>,
+        version: impl Into<ConfirmPaymentIntentPaymentMethodOptionsCardThreeDSecureVersion>,
     ) -> Self {
         Self {
             ares_trans_status: None,
-            cryptogram,
+            cryptogram: cryptogram.into(),
             electronic_commerce_indicator: None,
             exemption_indicator: None,
             network_options: None,
             requestor_challenge_indicator: None,
-            transaction_id,
-            version,
+            transaction_id: transaction_id.into(),
+            version: version.into(),
         }
     }
 }
@@ -22338,27 +22391,27 @@ impl<'de> serde::Deserialize<'de>
 /// Network specific 3DS fields. Network specific arguments require an
 /// explicit card brand choice. The parameter `payment_method_options.card.network``
 /// must be populated accordingly
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmPaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptions<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmPaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptions {
     /// Cartes Bancaires-specific 3DS fields.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cartes_bancaires: Option<
-        ConfirmPaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancaires<'a>,
+        ConfirmPaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancaires,
     >,
 }
-impl<'a> ConfirmPaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptions<'a> {
+impl ConfirmPaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptions {
     pub fn new() -> Self {
         Self { cartes_bancaires: None }
     }
 }
-impl<'a> Default for ConfirmPaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptions<'a> {
+impl Default for ConfirmPaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptions {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Cartes Bancaires-specific 3DS fields.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmPaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancaires<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmPaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancaires {
     /// The cryptogram calculation algorithm used by the card Issuer's ACS
     /// to calculate the Authentication cryptogram. Also known as `cavvAlgorithm`.
     /// messageExtension: CB-AVALGO
@@ -22368,18 +22421,18 @@ pub cb_avalgo: ConfirmPaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOp
     /// This is a 3 byte bitmap (low significant byte first and most significant
     /// bit first) that has been Base64 encoded
 #[serde(skip_serializing_if = "Option::is_none")]
-pub cb_exemption: Option<&'a str>,
+pub cb_exemption: Option<String>,
     /// The risk score returned from Cartes Bancaires in the ARes.
     /// message extension: CB-SCORE; numeric value 0-99
 #[serde(skip_serializing_if = "Option::is_none")]
 pub cb_score: Option<i64>,
 
 }
-impl<'a> ConfirmPaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancaires<'a> {
+impl ConfirmPaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancaires {
     pub fn new(
-        cb_avalgo: ConfirmPaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancairesCbAvalgo,
+        cb_avalgo: impl Into<ConfirmPaymentIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancairesCbAvalgo>,
     ) -> Self {
-        Self { cb_avalgo, cb_exemption: None, cb_score: None }
+        Self { cb_avalgo: cb_avalgo.into(), cb_exemption: None, cb_score: None }
     }
 }
 /// The cryptogram calculation algorithm used by the card Issuer's ACS
@@ -22673,12 +22726,11 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// If this is a `customer balance` PaymentMethod, this sub-hash contains details about the customer balance payment method options.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmPaymentIntentPaymentMethodOptionsCustomerBalance<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmPaymentIntentPaymentMethodOptionsCustomerBalance {
     /// Configuration for the bank transfer funding type, if the `funding_type` is set to `bank_transfer`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub bank_transfer:
-        Option<ConfirmPaymentIntentPaymentMethodOptionsCustomerBalanceBankTransfer<'a>>,
+    pub bank_transfer: Option<ConfirmPaymentIntentPaymentMethodOptionsCustomerBalanceBankTransfer>,
     /// The funding method type to be used when there are not enough funds in the customer balance.
     /// Permitted values include: `bank_transfer`.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -22695,38 +22747,38 @@ pub struct ConfirmPaymentIntentPaymentMethodOptionsCustomerBalance<'a> {
     pub setup_future_usage:
         Option<ConfirmPaymentIntentPaymentMethodOptionsCustomerBalanceSetupFutureUsage>,
 }
-impl<'a> ConfirmPaymentIntentPaymentMethodOptionsCustomerBalance<'a> {
+impl ConfirmPaymentIntentPaymentMethodOptionsCustomerBalance {
     pub fn new() -> Self {
         Self { bank_transfer: None, funding_type: None, setup_future_usage: None }
     }
 }
-impl<'a> Default for ConfirmPaymentIntentPaymentMethodOptionsCustomerBalance<'a> {
+impl Default for ConfirmPaymentIntentPaymentMethodOptionsCustomerBalance {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Configuration for the bank transfer funding type, if the `funding_type` is set to `bank_transfer`.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmPaymentIntentPaymentMethodOptionsCustomerBalanceBankTransfer<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmPaymentIntentPaymentMethodOptionsCustomerBalanceBankTransfer {
     /// Configuration for the eu_bank_transfer funding type.
 #[serde(skip_serializing_if = "Option::is_none")]
-pub eu_bank_transfer: Option<EuBankTransferParams<'a>>,
+pub eu_bank_transfer: Option<EuBankTransferParams>,
         /// List of address types that should be returned in the financial_addresses response.
     /// If not specified, all valid types will be returned.
     ///
     /// Permitted values include: `sort_code`, `zengin`, `iban`, or `spei`.
 #[serde(skip_serializing_if = "Option::is_none")]
-pub requested_address_types: Option<&'a [ConfirmPaymentIntentPaymentMethodOptionsCustomerBalanceBankTransferRequestedAddressTypes]>,
+pub requested_address_types: Option<Vec<ConfirmPaymentIntentPaymentMethodOptionsCustomerBalanceBankTransferRequestedAddressTypes>>,
         /// The list of bank transfer types that this PaymentIntent is allowed to use for funding Permitted values include: `eu_bank_transfer`, `gb_bank_transfer`, `jp_bank_transfer`, `mx_bank_transfer`, or `us_bank_transfer`.
 #[serde(rename = "type")]
 pub type_: ConfirmPaymentIntentPaymentMethodOptionsCustomerBalanceBankTransferType,
 
 }
-impl<'a> ConfirmPaymentIntentPaymentMethodOptionsCustomerBalanceBankTransfer<'a> {
+impl ConfirmPaymentIntentPaymentMethodOptionsCustomerBalanceBankTransfer {
     pub fn new(
-        type_: ConfirmPaymentIntentPaymentMethodOptionsCustomerBalanceBankTransferType,
+        type_: impl Into<ConfirmPaymentIntentPaymentMethodOptionsCustomerBalanceBankTransferType>,
     ) -> Self {
-        Self { eu_bank_transfer: None, requested_address_types: None, type_ }
+        Self { eu_bank_transfer: None, requested_address_types: None, type_: type_.into() }
     }
 }
 /// List of address types that should be returned in the financial_addresses response.
@@ -23773,13 +23825,13 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// If this is a `konbini` PaymentMethod, this sub-hash contains details about the Konbini payment method options.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmPaymentIntentPaymentMethodOptionsKonbini<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmPaymentIntentPaymentMethodOptionsKonbini {
     /// An optional 10 to 11 digit numeric-only string determining the confirmation code at applicable convenience stores.
     /// Must not consist of only zeroes and could be rejected in case of insufficient uniqueness.
     /// We recommend to use the customer's phone number.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub confirmation_number: Option<&'a str>,
+    pub confirmation_number: Option<String>,
     /// The number of calendar days (between 1 and 60) after which Konbini payment instructions will expire.
     /// For example, if a PaymentIntent is confirmed with Konbini and `expires_after_days` set to 2 on Monday JST, the instructions will expire on Wednesday 23:59:59 JST.
     /// Defaults to 3 days.
@@ -23791,7 +23843,7 @@ pub struct ConfirmPaymentIntentPaymentMethodOptionsKonbini<'a> {
     pub expires_at: Option<stripe_types::Timestamp>,
     /// A product descriptor of up to 22 characters, which will appear to customers at the convenience store.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub product_description: Option<&'a str>,
+    pub product_description: Option<String>,
     /// Indicates that you intend to make future payments with this PaymentIntent's payment method.
     ///
     /// Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete.
@@ -23803,7 +23855,7 @@ pub struct ConfirmPaymentIntentPaymentMethodOptionsKonbini<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub setup_future_usage: Option<ConfirmPaymentIntentPaymentMethodOptionsKonbiniSetupFutureUsage>,
 }
-impl<'a> ConfirmPaymentIntentPaymentMethodOptionsKonbini<'a> {
+impl ConfirmPaymentIntentPaymentMethodOptionsKonbini {
     pub fn new() -> Self {
         Self {
             confirmation_number: None,
@@ -23814,7 +23866,7 @@ impl<'a> ConfirmPaymentIntentPaymentMethodOptionsKonbini<'a> {
         }
     }
 }
-impl<'a> Default for ConfirmPaymentIntentPaymentMethodOptionsKonbini<'a> {
+impl Default for ConfirmPaymentIntentPaymentMethodOptionsKonbini {
     fn default() -> Self {
         Self::new()
     }
@@ -23884,8 +23936,8 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// If this is a `link` PaymentMethod, this sub-hash contains details about the Link payment method options.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmPaymentIntentPaymentMethodOptionsLink<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmPaymentIntentPaymentMethodOptionsLink {
     /// Controls when the funds will be captured from the customer's account.
     ///
     /// If provided, this parameter will override the top level behavior of `capture_method` when finalizing the payment with this payment method type.
@@ -23895,7 +23947,7 @@ pub struct ConfirmPaymentIntentPaymentMethodOptionsLink<'a> {
     pub capture_method: Option<ConfirmPaymentIntentPaymentMethodOptionsLinkCaptureMethod>,
     /// \[Deprecated\] This is a legacy parameter that no longer has any function.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub persistent_token: Option<&'a str>,
+    pub persistent_token: Option<String>,
     /// Indicates that you intend to make future payments with this PaymentIntent's payment method.
     ///
     /// Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete.
@@ -23907,12 +23959,12 @@ pub struct ConfirmPaymentIntentPaymentMethodOptionsLink<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub setup_future_usage: Option<ConfirmPaymentIntentPaymentMethodOptionsLinkSetupFutureUsage>,
 }
-impl<'a> ConfirmPaymentIntentPaymentMethodOptionsLink<'a> {
+impl ConfirmPaymentIntentPaymentMethodOptionsLink {
     pub fn new() -> Self {
         Self { capture_method: None, persistent_token: None, setup_future_usage: None }
     }
 }
-impl<'a> Default for ConfirmPaymentIntentPaymentMethodOptionsLink<'a> {
+impl Default for ConfirmPaymentIntentPaymentMethodOptionsLink {
     fn default() -> Self {
         Self::new()
     }
@@ -24462,8 +24514,8 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// If this is a `paypal` PaymentMethod, this sub-hash contains details about the PayPal payment method options.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmPaymentIntentPaymentMethodOptionsPaypal<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmPaymentIntentPaymentMethodOptionsPaypal {
     /// Controls when the funds will be captured from the customer's account.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub capture_method: Option<ConfirmPaymentIntentPaymentMethodOptionsPaypalCaptureMethod>,
@@ -24473,10 +24525,10 @@ pub struct ConfirmPaymentIntentPaymentMethodOptionsPaypal<'a> {
     /// A reference of the PayPal transaction visible to customer which is mapped to PayPal's invoice ID.
     /// This must be a globally unique ID if you have configured in your PayPal settings to block multiple payments per invoice ID.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reference: Option<&'a str>,
+    pub reference: Option<String>,
     /// The risk correlation ID for an on-session payment using a saved PayPal payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub risk_correlation_id: Option<&'a str>,
+    pub risk_correlation_id: Option<String>,
     /// Indicates that you intend to make future payments with this PaymentIntent's payment method.
     ///
     /// Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete.
@@ -24488,7 +24540,7 @@ pub struct ConfirmPaymentIntentPaymentMethodOptionsPaypal<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub setup_future_usage: Option<ConfirmPaymentIntentPaymentMethodOptionsPaypalSetupFutureUsage>,
 }
-impl<'a> ConfirmPaymentIntentPaymentMethodOptionsPaypal<'a> {
+impl ConfirmPaymentIntentPaymentMethodOptionsPaypal {
     pub fn new() -> Self {
         Self {
             capture_method: None,
@@ -24499,7 +24551,7 @@ impl<'a> ConfirmPaymentIntentPaymentMethodOptionsPaypal<'a> {
         }
     }
 }
-impl<'a> Default for ConfirmPaymentIntentPaymentMethodOptionsPaypal<'a> {
+impl Default for ConfirmPaymentIntentPaymentMethodOptionsPaypal {
     fn default() -> Self {
         Self::new()
     }
@@ -25339,11 +25391,11 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// If this is a `Swish` PaymentMethod, this sub-hash contains details about the Swish payment method options.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmPaymentIntentPaymentMethodOptionsSwish<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmPaymentIntentPaymentMethodOptionsSwish {
     /// The order ID displayed in the Swish app after the payment is authorized.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reference: Option<&'a str>,
+    pub reference: Option<String>,
     /// Indicates that you intend to make future payments with this PaymentIntent's payment method.
     ///
     /// Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete.
@@ -25355,12 +25407,12 @@ pub struct ConfirmPaymentIntentPaymentMethodOptionsSwish<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub setup_future_usage: Option<ConfirmPaymentIntentPaymentMethodOptionsSwishSetupFutureUsage>,
 }
-impl<'a> ConfirmPaymentIntentPaymentMethodOptionsSwish<'a> {
+impl ConfirmPaymentIntentPaymentMethodOptionsSwish {
     pub fn new() -> Self {
         Self { reference: None, setup_future_usage: None }
     }
 }
-impl<'a> Default for ConfirmPaymentIntentPaymentMethodOptionsSwish<'a> {
+impl Default for ConfirmPaymentIntentPaymentMethodOptionsSwish {
     fn default() -> Self {
         Self::new()
     }
@@ -25430,19 +25482,19 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// If this is a `us_bank_account` PaymentMethod, this sub-hash contains details about the US bank account payment method options.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmPaymentIntentPaymentMethodOptionsUsBankAccount<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmPaymentIntentPaymentMethodOptionsUsBankAccount {
     /// Additional fields for Financial Connections Session creation
     #[serde(skip_serializing_if = "Option::is_none")]
     pub financial_connections:
-        Option<ConfirmPaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnections<'a>>,
+        Option<ConfirmPaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnections>,
     /// Additional fields for Mandate creation
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mandate_options:
         Option<ConfirmPaymentIntentPaymentMethodOptionsUsBankAccountMandateOptions>,
     /// Additional fields for network related functions
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub networks: Option<ConfirmPaymentIntentPaymentMethodOptionsUsBankAccountNetworks<'a>>,
+    pub networks: Option<ConfirmPaymentIntentPaymentMethodOptionsUsBankAccountNetworks>,
     /// Preferred transaction settlement speed
     #[serde(skip_serializing_if = "Option::is_none")]
     pub preferred_settlement_speed:
@@ -25463,7 +25515,7 @@ pub struct ConfirmPaymentIntentPaymentMethodOptionsUsBankAccount<'a> {
     pub verification_method:
         Option<ConfirmPaymentIntentPaymentMethodOptionsUsBankAccountVerificationMethod>,
 }
-impl<'a> ConfirmPaymentIntentPaymentMethodOptionsUsBankAccount<'a> {
+impl ConfirmPaymentIntentPaymentMethodOptionsUsBankAccount {
     pub fn new() -> Self {
         Self {
             financial_connections: None,
@@ -25475,34 +25527,37 @@ impl<'a> ConfirmPaymentIntentPaymentMethodOptionsUsBankAccount<'a> {
         }
     }
 }
-impl<'a> Default for ConfirmPaymentIntentPaymentMethodOptionsUsBankAccount<'a> {
+impl Default for ConfirmPaymentIntentPaymentMethodOptionsUsBankAccount {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Additional fields for Financial Connections Session creation
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmPaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnections<'a> {
-        /// The list of permissions to request.
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmPaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnections {
+    /// The list of permissions to request.
     /// If this parameter is passed, the `payment_method` permission must be included.
     /// Valid permissions include: `balances`, `ownership`, `payment_method`, and `transactions`.
-#[serde(skip_serializing_if = "Option::is_none")]
-pub permissions: Option<&'a [ConfirmPaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPermissions]>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub permissions: Option<
+        Vec<ConfirmPaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPermissions>,
+    >,
     /// List of data features that you would like to retrieve upon account creation.
-#[serde(skip_serializing_if = "Option::is_none")]
-pub prefetch: Option<&'a [ConfirmPaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPrefetch]>,
-        /// For webview integrations only.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prefetch: Option<
+        Vec<ConfirmPaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPrefetch>,
+    >,
+    /// For webview integrations only.
     /// Upon completing OAuth login in the native browser, the user will be redirected to this URL to return to your app.
-#[serde(skip_serializing_if = "Option::is_none")]
-pub return_url: Option<&'a str>,
-
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub return_url: Option<String>,
 }
-impl<'a> ConfirmPaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnections<'a> {
+impl ConfirmPaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnections {
     pub fn new() -> Self {
         Self { permissions: None, prefetch: None, return_url: None }
     }
 }
-impl<'a> Default for ConfirmPaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnections<'a> {
+impl Default for ConfirmPaymentIntentPaymentMethodOptionsUsBankAccountFinancialConnections {
     fn default() -> Self {
         Self::new()
     }
@@ -25726,19 +25781,19 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// Additional fields for network related functions
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmPaymentIntentPaymentMethodOptionsUsBankAccountNetworks<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmPaymentIntentPaymentMethodOptionsUsBankAccountNetworks {
     /// Triggers validations to run across the selected networks
     #[serde(skip_serializing_if = "Option::is_none")]
     pub requested:
-        Option<&'a [ConfirmPaymentIntentPaymentMethodOptionsUsBankAccountNetworksRequested]>,
+        Option<Vec<ConfirmPaymentIntentPaymentMethodOptionsUsBankAccountNetworksRequested>>,
 }
-impl<'a> ConfirmPaymentIntentPaymentMethodOptionsUsBankAccountNetworks<'a> {
+impl ConfirmPaymentIntentPaymentMethodOptionsUsBankAccountNetworks {
     pub fn new() -> Self {
         Self { requested: None }
     }
 }
-impl<'a> Default for ConfirmPaymentIntentPaymentMethodOptionsUsBankAccountNetworks<'a> {
+impl Default for ConfirmPaymentIntentPaymentMethodOptionsUsBankAccountNetworks {
     fn default() -> Self {
         Self::new()
     }
@@ -25989,11 +26044,11 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// If this is a `wechat_pay` PaymentMethod, this sub-hash contains details about the WeChat Pay payment method options.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmPaymentIntentPaymentMethodOptionsWechatPay<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmPaymentIntentPaymentMethodOptionsWechatPay {
     /// The app ID registered with WeChat Pay. Only required when client is ios or android.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub app_id: Option<&'a str>,
+    pub app_id: Option<String>,
     /// The client type that the end customer will pay from
     pub client: ConfirmPaymentIntentPaymentMethodOptionsWechatPayClient,
     /// Indicates that you intend to make future payments with this PaymentIntent's payment method.
@@ -26008,9 +26063,9 @@ pub struct ConfirmPaymentIntentPaymentMethodOptionsWechatPay<'a> {
     pub setup_future_usage:
         Option<ConfirmPaymentIntentPaymentMethodOptionsWechatPaySetupFutureUsage>,
 }
-impl<'a> ConfirmPaymentIntentPaymentMethodOptionsWechatPay<'a> {
-    pub fn new(client: ConfirmPaymentIntentPaymentMethodOptionsWechatPayClient) -> Self {
-        Self { app_id: None, client, setup_future_usage: None }
+impl ConfirmPaymentIntentPaymentMethodOptionsWechatPay {
+    pub fn new(client: impl Into<ConfirmPaymentIntentPaymentMethodOptionsWechatPayClient>) -> Self {
+        Self { app_id: None, client: client.into(), setup_future_usage: None }
     }
 }
 /// The client type that the end customer will pay from
@@ -26221,56 +26276,65 @@ impl<'de> serde::Deserialize<'de> for ConfirmPaymentIntentPaymentMethodOptionsZi
     }
 }
 /// Shipping information for this PaymentIntent.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmPaymentIntentShipping<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmPaymentIntentShipping {
     /// Shipping address.
-    pub address: ConfirmPaymentIntentShippingAddress<'a>,
+    pub address: ConfirmPaymentIntentShippingAddress,
     /// The delivery service that shipped a physical product, such as Fedex, UPS, USPS, etc.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub carrier: Option<&'a str>,
+    pub carrier: Option<String>,
     /// Recipient name.
-    pub name: &'a str,
+    pub name: String,
     /// Recipient phone (including extension).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub phone: Option<&'a str>,
+    pub phone: Option<String>,
     /// The tracking number for a physical product, obtained from the delivery service.
     /// If multiple tracking numbers were generated for this purchase, please separate them with commas.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tracking_number: Option<&'a str>,
+    pub tracking_number: Option<String>,
 }
-impl<'a> ConfirmPaymentIntentShipping<'a> {
-    pub fn new(address: ConfirmPaymentIntentShippingAddress<'a>, name: &'a str) -> Self {
-        Self { address, carrier: None, name, phone: None, tracking_number: None }
+impl ConfirmPaymentIntentShipping {
+    pub fn new(
+        address: impl Into<ConfirmPaymentIntentShippingAddress>,
+        name: impl Into<String>,
+    ) -> Self {
+        Self {
+            address: address.into(),
+            carrier: None,
+            name: name.into(),
+            phone: None,
+            tracking_number: None,
+        }
     }
 }
 /// Shipping address.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmPaymentIntentShippingAddress<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmPaymentIntentShippingAddress {
     /// City, district, suburb, town, or village.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<&'a str>,
+    pub city: Option<String>,
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub country: Option<&'a str>,
+    pub country: Option<String>,
     /// Address line 1 (e.g., street, PO Box, or company name).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line1: Option<&'a str>,
+    pub line1: Option<String>,
     /// Address line 2 (e.g., apartment, suite, unit, or building).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line2: Option<&'a str>,
+    pub line2: Option<String>,
     /// ZIP or postal code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<&'a str>,
+    pub postal_code: Option<String>,
     /// State, county, province, or region.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
 }
-impl<'a> ConfirmPaymentIntentShippingAddress<'a> {
+impl ConfirmPaymentIntentShippingAddress {
     pub fn new() -> Self {
         Self { city: None, country: None, line1: None, line2: None, postal_code: None, state: None }
     }
 }
-impl<'a> Default for ConfirmPaymentIntentShippingAddress<'a> {
+impl Default for ConfirmPaymentIntentShippingAddress {
     fn default() -> Self {
         Self::new()
     }
@@ -26298,59 +26362,62 @@ impl<'a> Default for ConfirmPaymentIntentShippingAddress<'a> {
 /// explicitly re-confirm the PaymentIntent to initiate the next payment
 /// attempt.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ConfirmPaymentIntent<'a> {
-    inner: ConfirmPaymentIntentBuilder<'a>,
-    intent: &'a stripe_shared::PaymentIntentId,
+pub struct ConfirmPaymentIntent {
+    inner: ConfirmPaymentIntentBuilder,
+    intent: stripe_shared::PaymentIntentId,
 }
-impl<'a> ConfirmPaymentIntent<'a> {
+impl ConfirmPaymentIntent {
     /// Construct a new `ConfirmPaymentIntent`.
-    pub fn new(intent: &'a stripe_shared::PaymentIntentId) -> Self {
-        Self { intent, inner: ConfirmPaymentIntentBuilder::new() }
+    pub fn new(intent: impl Into<stripe_shared::PaymentIntentId>) -> Self {
+        Self { intent: intent.into(), inner: ConfirmPaymentIntentBuilder::new() }
     }
     /// Controls when the funds will be captured from the customer's account.
     pub fn capture_method(
         mut self,
-        capture_method: stripe_shared::PaymentIntentCaptureMethod,
+        capture_method: impl Into<stripe_shared::PaymentIntentCaptureMethod>,
     ) -> Self {
-        self.inner.capture_method = Some(capture_method);
+        self.inner.capture_method = Some(capture_method.into());
         self
     }
     /// ID of the ConfirmationToken used to confirm this PaymentIntent.
     ///
     /// If the provided ConfirmationToken contains properties that are also being provided in this request, such as `payment_method`, then the values in this request will take precedence.
-    pub fn confirmation_token(mut self, confirmation_token: &'a str) -> Self {
-        self.inner.confirmation_token = Some(confirmation_token);
+    pub fn confirmation_token(mut self, confirmation_token: impl Into<String>) -> Self {
+        self.inner.confirmation_token = Some(confirmation_token.into());
         self
     }
     /// Set to `true` to fail the payment attempt if the PaymentIntent transitions into `requires_action`.
     /// This parameter is intended for simpler integrations that do not handle customer actions, like [saving cards without authentication](https://stripe.com/docs/payments/save-card-without-authentication).
-    pub fn error_on_requires_action(mut self, error_on_requires_action: bool) -> Self {
-        self.inner.error_on_requires_action = Some(error_on_requires_action);
+    pub fn error_on_requires_action(mut self, error_on_requires_action: impl Into<bool>) -> Self {
+        self.inner.error_on_requires_action = Some(error_on_requires_action.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// ID of the mandate that's used for this payment.
-    pub fn mandate(mut self, mandate: &'a str) -> Self {
-        self.inner.mandate = Some(mandate);
+    pub fn mandate(mut self, mandate: impl Into<String>) -> Self {
+        self.inner.mandate = Some(mandate.into());
         self
     }
-    pub fn mandate_data(mut self, mandate_data: ConfirmPaymentIntentMandateData<'a>) -> Self {
-        self.inner.mandate_data = Some(mandate_data);
+    pub fn mandate_data(
+        mut self,
+        mandate_data: impl Into<ConfirmPaymentIntentMandateData>,
+    ) -> Self {
+        self.inner.mandate_data = Some(mandate_data.into());
         self
     }
     /// Set to `true` to indicate that the customer isn't in your checkout flow during this payment attempt and can't authenticate.
     /// Use this parameter in scenarios where you collect card details and [charge them later](https://stripe.com/docs/payments/cards/charging-saved-cards).
-    pub fn off_session(mut self, off_session: ConfirmPaymentIntentOffSession) -> Self {
-        self.inner.off_session = Some(off_session);
+    pub fn off_session(mut self, off_session: impl Into<ConfirmPaymentIntentOffSession>) -> Self {
+        self.inner.off_session = Some(off_session.into());
         self
     }
     /// ID of the payment method (a PaymentMethod, Card, or [compatible Source](https://stripe.com/docs/payments/payment-methods/transitioning#compatibility) object) to attach to this PaymentIntent.
-    pub fn payment_method(mut self, payment_method: &'a str) -> Self {
-        self.inner.payment_method = Some(payment_method);
+    pub fn payment_method(mut self, payment_method: impl Into<String>) -> Self {
+        self.inner.payment_method = Some(payment_method.into());
         self
     }
     /// If provided, this hash will be used to create a PaymentMethod. The new PaymentMethod will appear
@@ -26358,42 +26425,45 @@ impl<'a> ConfirmPaymentIntent<'a> {
     /// property on the PaymentIntent.
     pub fn payment_method_data(
         mut self,
-        payment_method_data: ConfirmPaymentIntentPaymentMethodData<'a>,
+        payment_method_data: impl Into<ConfirmPaymentIntentPaymentMethodData>,
     ) -> Self {
-        self.inner.payment_method_data = Some(payment_method_data);
+        self.inner.payment_method_data = Some(payment_method_data.into());
         self
     }
     /// Payment method-specific configuration for this PaymentIntent.
     pub fn payment_method_options(
         mut self,
-        payment_method_options: ConfirmPaymentIntentPaymentMethodOptions<'a>,
+        payment_method_options: impl Into<ConfirmPaymentIntentPaymentMethodOptions>,
     ) -> Self {
-        self.inner.payment_method_options = Some(payment_method_options);
+        self.inner.payment_method_options = Some(payment_method_options.into());
         self
     }
     /// The list of payment method types (for example, a card) that this PaymentIntent can use.
     /// Use `automatic_payment_methods` to manage payment methods from the [Stripe Dashboard](https://dashboard.stripe.com/settings/payment_methods).
-    pub fn payment_method_types(mut self, payment_method_types: &'a [&'a str]) -> Self {
-        self.inner.payment_method_types = Some(payment_method_types);
+    pub fn payment_method_types(mut self, payment_method_types: impl Into<Vec<String>>) -> Self {
+        self.inner.payment_method_types = Some(payment_method_types.into());
         self
     }
     /// Options to configure Radar.
     /// Learn more about [Radar Sessions](https://stripe.com/docs/radar/radar-session).
-    pub fn radar_options(mut self, radar_options: RadarOptionsWithHiddenOptions<'a>) -> Self {
-        self.inner.radar_options = Some(radar_options);
+    pub fn radar_options(
+        mut self,
+        radar_options: impl Into<RadarOptionsWithHiddenOptions>,
+    ) -> Self {
+        self.inner.radar_options = Some(radar_options.into());
         self
     }
     /// Email address that the receipt for the resulting payment will be sent to.
     /// If `receipt_email` is specified for a payment in live mode, a receipt will be sent regardless of your [email settings](https://dashboard.stripe.com/account/emails).
-    pub fn receipt_email(mut self, receipt_email: &'a str) -> Self {
-        self.inner.receipt_email = Some(receipt_email);
+    pub fn receipt_email(mut self, receipt_email: impl Into<String>) -> Self {
+        self.inner.receipt_email = Some(receipt_email.into());
         self
     }
     /// The URL to redirect your customer back to after they authenticate or cancel their payment on the payment method's app or site.
     /// If you'd prefer to redirect to a mobile application, you can alternatively supply an application URI scheme.
     /// This parameter is only used for cards and other redirect-based payment methods.
-    pub fn return_url(mut self, return_url: &'a str) -> Self {
-        self.inner.return_url = Some(return_url);
+    pub fn return_url(mut self, return_url: impl Into<String>) -> Self {
+        self.inner.return_url = Some(return_url.into());
         self
     }
     /// Indicates that you intend to make future payments with this PaymentIntent's payment method.
@@ -26406,23 +26476,23 @@ impl<'a> ConfirmPaymentIntent<'a> {
     /// If `setup_future_usage` is already set and you are performing a request using a publishable key, you may only update the value from `on_session` to `off_session`.
     pub fn setup_future_usage(
         mut self,
-        setup_future_usage: stripe_shared::PaymentIntentSetupFutureUsage,
+        setup_future_usage: impl Into<stripe_shared::PaymentIntentSetupFutureUsage>,
     ) -> Self {
-        self.inner.setup_future_usage = Some(setup_future_usage);
+        self.inner.setup_future_usage = Some(setup_future_usage.into());
         self
     }
     /// Shipping information for this PaymentIntent.
-    pub fn shipping(mut self, shipping: ConfirmPaymentIntentShipping<'a>) -> Self {
-        self.inner.shipping = Some(shipping);
+    pub fn shipping(mut self, shipping: impl Into<ConfirmPaymentIntentShipping>) -> Self {
+        self.inner.shipping = Some(shipping.into());
         self
     }
     /// Set to `true` when confirming server-side and using Stripe.js, iOS, or Android client-side SDKs to handle the next actions.
-    pub fn use_stripe_sdk(mut self, use_stripe_sdk: bool) -> Self {
-        self.inner.use_stripe_sdk = Some(use_stripe_sdk);
+    pub fn use_stripe_sdk(mut self, use_stripe_sdk: impl Into<bool>) -> Self {
+        self.inner.use_stripe_sdk = Some(use_stripe_sdk.into());
         self
     }
 }
-impl ConfirmPaymentIntent<'_> {
+impl ConfirmPaymentIntent {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -26440,35 +26510,35 @@ impl ConfirmPaymentIntent<'_> {
     }
 }
 
-impl StripeRequest for ConfirmPaymentIntent<'_> {
+impl StripeRequest for ConfirmPaymentIntent {
     type Output = stripe_shared::PaymentIntent;
 
     fn build(&self) -> RequestBuilder {
-        let intent = self.intent;
+        let intent = &self.intent;
         RequestBuilder::new(StripeMethod::Post, format!("/payment_intents/{intent}/confirm"))
             .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct IncrementAuthorizationPaymentIntentBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct IncrementAuthorizationPaymentIntentBuilder {
     amount: i64,
     #[serde(skip_serializing_if = "Option::is_none")]
     application_fee_amount: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<&'a str>,
+    description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    statement_descriptor: Option<&'a str>,
+    statement_descriptor: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     transfer_data: Option<TransferDataUpdateParams>,
 }
-impl<'a> IncrementAuthorizationPaymentIntentBuilder<'a> {
-    fn new(amount: i64) -> Self {
+impl IncrementAuthorizationPaymentIntentBuilder {
+    fn new(amount: impl Into<i64>) -> Self {
         Self {
-            amount,
+            amount: amount.into(),
             application_fee_amount: None,
             description: None,
             expand: None,
@@ -26503,55 +26573,61 @@ impl<'a> IncrementAuthorizationPaymentIntentBuilder<'a> {
 ///
 /// Learn more about [incremental authorizations](https://stripe.com/docs/terminal/features/incremental-authorizations).
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct IncrementAuthorizationPaymentIntent<'a> {
-    inner: IncrementAuthorizationPaymentIntentBuilder<'a>,
-    intent: &'a stripe_shared::PaymentIntentId,
+pub struct IncrementAuthorizationPaymentIntent {
+    inner: IncrementAuthorizationPaymentIntentBuilder,
+    intent: stripe_shared::PaymentIntentId,
 }
-impl<'a> IncrementAuthorizationPaymentIntent<'a> {
+impl IncrementAuthorizationPaymentIntent {
     /// Construct a new `IncrementAuthorizationPaymentIntent`.
-    pub fn new(intent: &'a stripe_shared::PaymentIntentId, amount: i64) -> Self {
-        Self { intent, inner: IncrementAuthorizationPaymentIntentBuilder::new(amount) }
+    pub fn new(intent: impl Into<stripe_shared::PaymentIntentId>, amount: impl Into<i64>) -> Self {
+        Self {
+            intent: intent.into(),
+            inner: IncrementAuthorizationPaymentIntentBuilder::new(amount.into()),
+        }
     }
     /// The amount of the application fee (if any) that will be requested to be applied to the payment and transferred to the application owner's Stripe account.
     /// The amount of the application fee collected will be capped at the total payment amount.
     /// For more information, see the PaymentIntents [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts).
-    pub fn application_fee_amount(mut self, application_fee_amount: i64) -> Self {
-        self.inner.application_fee_amount = Some(application_fee_amount);
+    pub fn application_fee_amount(mut self, application_fee_amount: impl Into<i64>) -> Self {
+        self.inner.application_fee_amount = Some(application_fee_amount.into());
         self
     }
     /// An arbitrary string attached to the object. Often useful for displaying to users.
-    pub fn description(mut self, description: &'a str) -> Self {
-        self.inner.description = Some(description);
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.inner.description = Some(description.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// For card charges, use [statement_descriptor_suffix](https://stripe.com/docs/payments/account/statement-descriptors#dynamic).
     /// Otherwise, you can use this value as the complete description of a charge on your customers' statements.
     /// It must contain at least one letter and be 1–22 characters long.
-    pub fn statement_descriptor(mut self, statement_descriptor: &'a str) -> Self {
-        self.inner.statement_descriptor = Some(statement_descriptor);
+    pub fn statement_descriptor(mut self, statement_descriptor: impl Into<String>) -> Self {
+        self.inner.statement_descriptor = Some(statement_descriptor.into());
         self
     }
     /// The parameters used to automatically create a transfer after the payment is captured.
     /// Learn more about the [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts).
-    pub fn transfer_data(mut self, transfer_data: TransferDataUpdateParams) -> Self {
-        self.inner.transfer_data = Some(transfer_data);
+    pub fn transfer_data(mut self, transfer_data: impl Into<TransferDataUpdateParams>) -> Self {
+        self.inner.transfer_data = Some(transfer_data.into());
         self
     }
 }
-impl IncrementAuthorizationPaymentIntent<'_> {
+impl IncrementAuthorizationPaymentIntent {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -26569,11 +26645,11 @@ impl IncrementAuthorizationPaymentIntent<'_> {
     }
 }
 
-impl StripeRequest for IncrementAuthorizationPaymentIntent<'_> {
+impl StripeRequest for IncrementAuthorizationPaymentIntent {
     type Output = stripe_shared::PaymentIntent;
 
     fn build(&self) -> RequestBuilder {
-        let intent = self.intent;
+        let intent = &self.intent;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/payment_intents/{intent}/increment_authorization"),
@@ -26581,48 +26657,48 @@ impl StripeRequest for IncrementAuthorizationPaymentIntent<'_> {
         .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct VerifyMicrodepositsPaymentIntentBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct VerifyMicrodepositsPaymentIntentBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    amounts: Option<&'a [i64]>,
+    amounts: Option<Vec<i64>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    descriptor_code: Option<&'a str>,
+    descriptor_code: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> VerifyMicrodepositsPaymentIntentBuilder<'a> {
+impl VerifyMicrodepositsPaymentIntentBuilder {
     fn new() -> Self {
         Self { amounts: None, descriptor_code: None, expand: None }
     }
 }
 /// Verifies microdeposits on a PaymentIntent object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct VerifyMicrodepositsPaymentIntent<'a> {
-    inner: VerifyMicrodepositsPaymentIntentBuilder<'a>,
-    intent: &'a stripe_shared::PaymentIntentId,
+pub struct VerifyMicrodepositsPaymentIntent {
+    inner: VerifyMicrodepositsPaymentIntentBuilder,
+    intent: stripe_shared::PaymentIntentId,
 }
-impl<'a> VerifyMicrodepositsPaymentIntent<'a> {
+impl VerifyMicrodepositsPaymentIntent {
     /// Construct a new `VerifyMicrodepositsPaymentIntent`.
-    pub fn new(intent: &'a stripe_shared::PaymentIntentId) -> Self {
-        Self { intent, inner: VerifyMicrodepositsPaymentIntentBuilder::new() }
+    pub fn new(intent: impl Into<stripe_shared::PaymentIntentId>) -> Self {
+        Self { intent: intent.into(), inner: VerifyMicrodepositsPaymentIntentBuilder::new() }
     }
     /// Two positive integers, in *cents*, equal to the values of the microdeposits sent to the bank account.
-    pub fn amounts(mut self, amounts: &'a [i64]) -> Self {
-        self.inner.amounts = Some(amounts);
+    pub fn amounts(mut self, amounts: impl Into<Vec<i64>>) -> Self {
+        self.inner.amounts = Some(amounts.into());
         self
     }
     /// A six-character code starting with SM present in the microdeposit sent to the bank account.
-    pub fn descriptor_code(mut self, descriptor_code: &'a str) -> Self {
-        self.inner.descriptor_code = Some(descriptor_code);
+    pub fn descriptor_code(mut self, descriptor_code: impl Into<String>) -> Self {
+        self.inner.descriptor_code = Some(descriptor_code.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl VerifyMicrodepositsPaymentIntent<'_> {
+impl VerifyMicrodepositsPaymentIntent {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -26640,11 +26716,11 @@ impl VerifyMicrodepositsPaymentIntent<'_> {
     }
 }
 
-impl StripeRequest for VerifyMicrodepositsPaymentIntent<'_> {
+impl StripeRequest for VerifyMicrodepositsPaymentIntent {
     type Output = stripe_shared::PaymentIntent;
 
     fn build(&self) -> RequestBuilder {
-        let intent = self.intent;
+        let intent = &self.intent;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/payment_intents/{intent}/verify_microdeposits"),
@@ -26653,34 +26729,38 @@ impl StripeRequest for VerifyMicrodepositsPaymentIntent<'_> {
     }
 }
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct OnlineParam<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct OnlineParam {
     /// The IP address from which the Mandate was accepted by the customer.
-    pub ip_address: &'a str,
+    pub ip_address: String,
     /// The user agent of the browser from which the Mandate was accepted by the customer.
-    pub user_agent: &'a str,
+    pub user_agent: String,
 }
-impl<'a> OnlineParam<'a> {
-    pub fn new(ip_address: &'a str, user_agent: &'a str) -> Self {
-        Self { ip_address, user_agent }
+impl OnlineParam {
+    pub fn new(ip_address: impl Into<String>, user_agent: impl Into<String>) -> Self {
+        Self { ip_address: ip_address.into(), user_agent: user_agent.into() }
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct PaymentMethodParam<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct PaymentMethodParam {
     /// Customer's bank account number.
-    pub account_number: &'a str,
+    pub account_number: String,
     /// Institution number of the customer's bank.
-    pub institution_number: &'a str,
+    pub institution_number: String,
     /// Transit number of the customer's bank.
-    pub transit_number: &'a str,
+    pub transit_number: String,
 }
-impl<'a> PaymentMethodParam<'a> {
+impl PaymentMethodParam {
     pub fn new(
-        account_number: &'a str,
-        institution_number: &'a str,
-        transit_number: &'a str,
+        account_number: impl Into<String>,
+        institution_number: impl Into<String>,
+        transit_number: impl Into<String>,
     ) -> Self {
-        Self { account_number, institution_number, transit_number }
+        Self {
+            account_number: account_number.into(),
+            institution_number: institution_number.into(),
+            transit_number: transit_number.into(),
+        }
     }
 }
 #[derive(Copy, Clone, Debug, serde::Serialize)]
@@ -26693,22 +26773,22 @@ pub struct DateOfBirth {
     pub year: i64,
 }
 impl DateOfBirth {
-    pub fn new(day: i64, month: i64, year: i64) -> Self {
-        Self { day, month, year }
+    pub fn new(day: impl Into<i64>, month: impl Into<i64>, year: impl Into<i64>) -> Self {
+        Self { day: day.into(), month: month.into(), year: year.into() }
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct RadarOptionsWithHiddenOptions<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct RadarOptionsWithHiddenOptions {
     /// A [Radar Session](https://stripe.com/docs/radar/radar-session) is a snapshot of the browser metadata and device details that help Radar make more accurate predictions on your payments.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub session: Option<&'a str>,
+    pub session: Option<String>,
 }
-impl<'a> RadarOptionsWithHiddenOptions<'a> {
+impl RadarOptionsWithHiddenOptions {
     pub fn new() -> Self {
         Self { session: None }
     }
 }
-impl<'a> Default for RadarOptionsWithHiddenOptions<'a> {
+impl Default for RadarOptionsWithHiddenOptions {
     fn default() -> Self {
         Self::new()
     }
@@ -26736,15 +26816,15 @@ impl Default for PaymentMethodOptionsParam {
         Self::new()
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct EuBankTransferParams<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct EuBankTransferParams {
     /// The desired country code of the bank account information.
     /// Permitted values include: `BE`, `DE`, `ES`, `FR`, `IE`, or `NL`.
-    pub country: &'a str,
+    pub country: String,
 }
-impl<'a> EuBankTransferParams<'a> {
-    pub fn new(country: &'a str) -> Self {
-        Self { country }
+impl EuBankTransferParams {
+    pub fn new(country: impl Into<String>) -> Self {
+        Self { country: country.into() }
     }
 }
 #[derive(Copy, Clone, Debug, serde::Serialize)]

--- a/generated/async-stripe-core/src/payment_source/requests.rs
+++ b/generated/async-stripe-core/src/payment_source/requests.rs
@@ -2,67 +2,67 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListCustomerPaymentSourceBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListCustomerPaymentSourceBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    object: Option<&'a str>,
+    object: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListCustomerPaymentSourceBuilder<'a> {
+impl ListCustomerPaymentSourceBuilder {
     fn new() -> Self {
         Self { ending_before: None, expand: None, limit: None, object: None, starting_after: None }
     }
 }
 /// List sources for a specified customer.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListCustomerPaymentSource<'a> {
-    inner: ListCustomerPaymentSourceBuilder<'a>,
-    customer: &'a stripe_shared::CustomerId,
+pub struct ListCustomerPaymentSource {
+    inner: ListCustomerPaymentSourceBuilder,
+    customer: stripe_shared::CustomerId,
 }
-impl<'a> ListCustomerPaymentSource<'a> {
+impl ListCustomerPaymentSource {
     /// Construct a new `ListCustomerPaymentSource`.
-    pub fn new(customer: &'a stripe_shared::CustomerId) -> Self {
-        Self { customer, inner: ListCustomerPaymentSourceBuilder::new() }
+    pub fn new(customer: impl Into<stripe_shared::CustomerId>) -> Self {
+        Self { customer: customer.into(), inner: ListCustomerPaymentSourceBuilder::new() }
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// Filter sources according to a particular object type.
-    pub fn object(mut self, object: &'a str) -> Self {
-        self.inner.object = Some(object);
+    pub fn object(mut self, object: impl Into<String>) -> Self {
+        self.inner.object = Some(object.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl ListCustomerPaymentSource<'_> {
+impl ListCustomerPaymentSource {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -82,53 +82,57 @@ impl ListCustomerPaymentSource<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::PaymentSource>> {
-        let customer = self.customer;
+        let customer = &self.customer;
 
         stripe_client_core::ListPaginator::new_list(
             format!("/customers/{customer}/sources"),
-            self.inner,
+            &self.inner,
         )
     }
 }
 
-impl StripeRequest for ListCustomerPaymentSource<'_> {
+impl StripeRequest for ListCustomerPaymentSource {
     type Output = stripe_types::List<stripe_shared::PaymentSource>;
 
     fn build(&self) -> RequestBuilder {
-        let customer = self.customer;
+        let customer = &self.customer;
         RequestBuilder::new(StripeMethod::Get, format!("/customers/{customer}/sources"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrievePaymentSourceBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrievePaymentSourceBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrievePaymentSourceBuilder<'a> {
+impl RetrievePaymentSourceBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieve a specified source for a given customer.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrievePaymentSource<'a> {
-    inner: RetrievePaymentSourceBuilder<'a>,
-    customer: &'a stripe_shared::CustomerId,
-    id: &'a str,
+pub struct RetrievePaymentSource {
+    inner: RetrievePaymentSourceBuilder,
+    customer: stripe_shared::CustomerId,
+    id: String,
 }
-impl<'a> RetrievePaymentSource<'a> {
+impl RetrievePaymentSource {
     /// Construct a new `RetrievePaymentSource`.
-    pub fn new(customer: &'a stripe_shared::CustomerId, id: &'a str) -> Self {
-        Self { customer, id, inner: RetrievePaymentSourceBuilder::new() }
+    pub fn new(customer: impl Into<stripe_shared::CustomerId>, id: impl Into<String>) -> Self {
+        Self {
+            customer: customer.into(),
+            id: id.into(),
+            inner: RetrievePaymentSourceBuilder::new(),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrievePaymentSource<'_> {
+impl RetrievePaymentSource {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -146,29 +150,29 @@ impl RetrievePaymentSource<'_> {
     }
 }
 
-impl StripeRequest for RetrievePaymentSource<'_> {
+impl StripeRequest for RetrievePaymentSource {
     type Output = stripe_shared::PaymentSource;
 
     fn build(&self) -> RequestBuilder {
-        let customer = self.customer;
-        let id = self.id;
+        let customer = &self.customer;
+        let id = &self.id;
         RequestBuilder::new(StripeMethod::Get, format!("/customers/{customer}/sources/{id}"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateCustomerPaymentSourceBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateCustomerPaymentSourceBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
-    source: &'a str,
+    metadata: Option<std::collections::HashMap<String, String>>,
+    source: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     validate: Option<bool>,
 }
-impl<'a> CreateCustomerPaymentSourceBuilder<'a> {
-    fn new(source: &'a str) -> Self {
-        Self { expand: None, metadata: None, source, validate: None }
+impl CreateCustomerPaymentSourceBuilder {
+    fn new(source: impl Into<String>) -> Self {
+        Self { expand: None, metadata: None, source: source.into(), validate: None }
     }
 }
 /// When you create a new credit card, you must specify a customer or recipient on which to create it.
@@ -177,34 +181,40 @@ impl<'a> CreateCustomerPaymentSourceBuilder<'a> {
 /// However, if the owner already has a default, then it will not change.
 /// To change the default, you should [update the customer](https://stripe.com/docs/api#update_customer) to have a new `default_source`.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateCustomerPaymentSource<'a> {
-    inner: CreateCustomerPaymentSourceBuilder<'a>,
-    customer: &'a stripe_shared::CustomerId,
+pub struct CreateCustomerPaymentSource {
+    inner: CreateCustomerPaymentSourceBuilder,
+    customer: stripe_shared::CustomerId,
 }
-impl<'a> CreateCustomerPaymentSource<'a> {
+impl CreateCustomerPaymentSource {
     /// Construct a new `CreateCustomerPaymentSource`.
-    pub fn new(customer: &'a stripe_shared::CustomerId, source: &'a str) -> Self {
-        Self { customer, inner: CreateCustomerPaymentSourceBuilder::new(source) }
+    pub fn new(customer: impl Into<stripe_shared::CustomerId>, source: impl Into<String>) -> Self {
+        Self {
+            customer: customer.into(),
+            inner: CreateCustomerPaymentSourceBuilder::new(source.into()),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
-    pub fn validate(mut self, validate: bool) -> Self {
-        self.inner.validate = Some(validate);
+    pub fn validate(mut self, validate: impl Into<bool>) -> Self {
+        self.inner.validate = Some(validate.into());
         self
     }
 }
-impl CreateCustomerPaymentSource<'_> {
+impl CreateCustomerPaymentSource {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -222,11 +232,11 @@ impl CreateCustomerPaymentSource<'_> {
     }
 }
 
-impl StripeRequest for CreateCustomerPaymentSource<'_> {
+impl StripeRequest for CreateCustomerPaymentSource {
     type Output = stripe_shared::PaymentSource;
 
     fn build(&self) -> RequestBuilder {
-        let customer = self.customer;
+        let customer = &self.customer;
         RequestBuilder::new(StripeMethod::Post, format!("/customers/{customer}/sources"))
             .form(&self.inner)
     }

--- a/generated/async-stripe-core/src/payout/requests.rs
+++ b/generated/async-stripe-core/src/payout/requests.rs
@@ -2,26 +2,26 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListPayoutBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListPayoutBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     arrival_date: Option<stripe_types::RangeQueryTs>,
     #[serde(skip_serializing_if = "Option::is_none")]
     created: Option<stripe_types::RangeQueryTs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    destination: Option<&'a str>,
+    destination: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    status: Option<&'a str>,
+    status: Option<String>,
 }
-impl<'a> ListPayoutBuilder<'a> {
+impl ListPayoutBuilder {
     fn new() -> Self {
         Self {
             arrival_date: None,
@@ -38,66 +38,66 @@ impl<'a> ListPayoutBuilder<'a> {
 /// Returns a list of existing payouts sent to third-party bank accounts or payouts that Stripe sent to you.
 /// The payouts return in sorted order, with the most recently created payouts appearing first.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListPayout<'a> {
-    inner: ListPayoutBuilder<'a>,
+pub struct ListPayout {
+    inner: ListPayoutBuilder,
 }
-impl<'a> ListPayout<'a> {
+impl ListPayout {
     /// Construct a new `ListPayout`.
     pub fn new() -> Self {
         Self { inner: ListPayoutBuilder::new() }
     }
     /// Only return payouts that are expected to arrive during the given date interval.
-    pub fn arrival_date(mut self, arrival_date: stripe_types::RangeQueryTs) -> Self {
-        self.inner.arrival_date = Some(arrival_date);
+    pub fn arrival_date(mut self, arrival_date: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.arrival_date = Some(arrival_date.into());
         self
     }
     /// Only return payouts that were created during the given date interval.
-    pub fn created(mut self, created: stripe_types::RangeQueryTs) -> Self {
-        self.inner.created = Some(created);
+    pub fn created(mut self, created: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.created = Some(created.into());
         self
     }
     /// The ID of an external account - only return payouts sent to this external account.
-    pub fn destination(mut self, destination: &'a str) -> Self {
-        self.inner.destination = Some(destination);
+    pub fn destination(mut self, destination: impl Into<String>) -> Self {
+        self.inner.destination = Some(destination.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
     /// Only return payouts that have the given status: `pending`, `paid`, `failed`, or `canceled`.
-    pub fn status(mut self, status: &'a str) -> Self {
-        self.inner.status = Some(status);
+    pub fn status(mut self, status: impl Into<String>) -> Self {
+        self.inner.status = Some(status.into());
         self
     }
 }
-impl<'a> Default for ListPayout<'a> {
+impl Default for ListPayout {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListPayout<'_> {
+impl ListPayout {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -117,23 +117,23 @@ impl ListPayout<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::Payout>> {
-        stripe_client_core::ListPaginator::new_list("/payouts", self.inner)
+        stripe_client_core::ListPaginator::new_list("/payouts", &self.inner)
     }
 }
 
-impl StripeRequest for ListPayout<'_> {
+impl StripeRequest for ListPayout {
     type Output = stripe_types::List<stripe_shared::Payout>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/payouts").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrievePayoutBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrievePayoutBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrievePayoutBuilder<'a> {
+impl RetrievePayoutBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
@@ -142,22 +142,22 @@ impl<'a> RetrievePayoutBuilder<'a> {
 /// Supply the unique payout ID from either a payout creation request or the payout list.
 /// Stripe returns the corresponding payout information.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrievePayout<'a> {
-    inner: RetrievePayoutBuilder<'a>,
-    payout: &'a stripe_shared::PayoutId,
+pub struct RetrievePayout {
+    inner: RetrievePayoutBuilder,
+    payout: stripe_shared::PayoutId,
 }
-impl<'a> RetrievePayout<'a> {
+impl RetrievePayout {
     /// Construct a new `RetrievePayout`.
-    pub fn new(payout: &'a stripe_shared::PayoutId) -> Self {
-        Self { payout, inner: RetrievePayoutBuilder::new() }
+    pub fn new(payout: impl Into<stripe_shared::PayoutId>) -> Self {
+        Self { payout: payout.into(), inner: RetrievePayoutBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrievePayout<'_> {
+impl RetrievePayout {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -175,38 +175,38 @@ impl RetrievePayout<'_> {
     }
 }
 
-impl StripeRequest for RetrievePayout<'_> {
+impl StripeRequest for RetrievePayout {
     type Output = stripe_shared::Payout;
 
     fn build(&self) -> RequestBuilder {
-        let payout = self.payout;
+        let payout = &self.payout;
         RequestBuilder::new(StripeMethod::Get, format!("/payouts/{payout}")).query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreatePayoutBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreatePayoutBuilder {
     amount: i64,
     currency: stripe_types::Currency,
     #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<&'a str>,
+    description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    destination: Option<&'a str>,
+    destination: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     method: Option<CreatePayoutMethod>,
     #[serde(skip_serializing_if = "Option::is_none")]
     source_type: Option<CreatePayoutSourceType>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    statement_descriptor: Option<&'a str>,
+    statement_descriptor: Option<String>,
 }
-impl<'a> CreatePayoutBuilder<'a> {
-    fn new(amount: i64, currency: stripe_types::Currency) -> Self {
+impl CreatePayoutBuilder {
+    fn new(amount: impl Into<i64>, currency: impl Into<stripe_types::Currency>) -> Self {
         Self {
-            amount,
-            currency,
+            amount: amount.into(),
+            currency: currency.into(),
             description: None,
             destination: None,
             expand: None,
@@ -344,63 +344,66 @@ impl<'de> serde::Deserialize<'de> for CreatePayoutSourceType {
 /// If you create a manual payout on a Stripe account that uses multiple payment source types, you need to specify the source type balance that the payout draws from.
 /// The [balance object](https://stripe.com/docs/api#balance_object) details available and pending amounts by source type.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreatePayout<'a> {
-    inner: CreatePayoutBuilder<'a>,
+pub struct CreatePayout {
+    inner: CreatePayoutBuilder,
 }
-impl<'a> CreatePayout<'a> {
+impl CreatePayout {
     /// Construct a new `CreatePayout`.
-    pub fn new(amount: i64, currency: stripe_types::Currency) -> Self {
-        Self { inner: CreatePayoutBuilder::new(amount, currency) }
+    pub fn new(amount: impl Into<i64>, currency: impl Into<stripe_types::Currency>) -> Self {
+        Self { inner: CreatePayoutBuilder::new(amount.into(), currency.into()) }
     }
     /// An arbitrary string attached to the object. Often useful for displaying to users.
-    pub fn description(mut self, description: &'a str) -> Self {
-        self.inner.description = Some(description);
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.inner.description = Some(description.into());
         self
     }
     /// The ID of a bank account or a card to send the payout to.
     /// If you don't provide a destination, we use the default external account for the specified currency.
-    pub fn destination(mut self, destination: &'a str) -> Self {
-        self.inner.destination = Some(destination);
+    pub fn destination(mut self, destination: impl Into<String>) -> Self {
+        self.inner.destination = Some(destination.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// The method used to send this payout, which is `standard` or `instant`.
     /// We support `instant` for payouts to debit cards and bank accounts in certain countries.
     /// Learn more about [bank support for Instant Payouts](https://stripe.com/docs/payouts/instant-payouts-banks).
-    pub fn method(mut self, method: CreatePayoutMethod) -> Self {
-        self.inner.method = Some(method);
+    pub fn method(mut self, method: impl Into<CreatePayoutMethod>) -> Self {
+        self.inner.method = Some(method.into());
         self
     }
     /// The balance type of your Stripe balance to draw this payout from.
     /// Balances for different payment sources are kept separately.
     /// You can find the amounts with the Balances API.
     /// One of `bank_account`, `card`, or `fpx`.
-    pub fn source_type(mut self, source_type: CreatePayoutSourceType) -> Self {
-        self.inner.source_type = Some(source_type);
+    pub fn source_type(mut self, source_type: impl Into<CreatePayoutSourceType>) -> Self {
+        self.inner.source_type = Some(source_type.into());
         self
     }
     /// A string that displays on the recipient's bank or card statement (up to 22 characters).
     /// A `statement_descriptor` that's longer than 22 characters return an error.
     /// Most banks truncate this information and display it inconsistently.
     /// Some banks might not display it at all.
-    pub fn statement_descriptor(mut self, statement_descriptor: &'a str) -> Self {
-        self.inner.statement_descriptor = Some(statement_descriptor);
+    pub fn statement_descriptor(mut self, statement_descriptor: impl Into<String>) -> Self {
+        self.inner.statement_descriptor = Some(statement_descriptor.into());
         self
     }
 }
-impl CreatePayout<'_> {
+impl CreatePayout {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -418,21 +421,21 @@ impl CreatePayout<'_> {
     }
 }
 
-impl StripeRequest for CreatePayout<'_> {
+impl StripeRequest for CreatePayout {
     type Output = stripe_shared::Payout;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Post, "/payouts").form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdatePayoutBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdatePayoutBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
 }
-impl<'a> UpdatePayoutBuilder<'a> {
+impl UpdatePayoutBuilder {
     fn new() -> Self {
         Self { expand: None, metadata: None }
     }
@@ -441,30 +444,33 @@ impl<'a> UpdatePayoutBuilder<'a> {
 /// We don’t change parameters that you don’t provide.
 /// This request only accepts the metadata as arguments.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdatePayout<'a> {
-    inner: UpdatePayoutBuilder<'a>,
-    payout: &'a stripe_shared::PayoutId,
+pub struct UpdatePayout {
+    inner: UpdatePayoutBuilder,
+    payout: stripe_shared::PayoutId,
 }
-impl<'a> UpdatePayout<'a> {
+impl UpdatePayout {
     /// Construct a new `UpdatePayout`.
-    pub fn new(payout: &'a stripe_shared::PayoutId) -> Self {
-        Self { payout, inner: UpdatePayoutBuilder::new() }
+    pub fn new(payout: impl Into<stripe_shared::PayoutId>) -> Self {
+        Self { payout: payout.into(), inner: UpdatePayoutBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
 }
-impl UpdatePayout<'_> {
+impl UpdatePayout {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -482,20 +488,20 @@ impl UpdatePayout<'_> {
     }
 }
 
-impl StripeRequest for UpdatePayout<'_> {
+impl StripeRequest for UpdatePayout {
     type Output = stripe_shared::Payout;
 
     fn build(&self) -> RequestBuilder {
-        let payout = self.payout;
+        let payout = &self.payout;
         RequestBuilder::new(StripeMethod::Post, format!("/payouts/{payout}")).form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CancelPayoutBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CancelPayoutBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> CancelPayoutBuilder<'a> {
+impl CancelPayoutBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
@@ -504,22 +510,22 @@ impl<'a> CancelPayoutBuilder<'a> {
 /// Stripe refunds the funds to your available balance.
 /// You can’t cancel automatic Stripe payouts.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CancelPayout<'a> {
-    inner: CancelPayoutBuilder<'a>,
-    payout: &'a stripe_shared::PayoutId,
+pub struct CancelPayout {
+    inner: CancelPayoutBuilder,
+    payout: stripe_shared::PayoutId,
 }
-impl<'a> CancelPayout<'a> {
+impl CancelPayout {
     /// Construct a new `CancelPayout`.
-    pub fn new(payout: &'a stripe_shared::PayoutId) -> Self {
-        Self { payout, inner: CancelPayoutBuilder::new() }
+    pub fn new(payout: impl Into<stripe_shared::PayoutId>) -> Self {
+        Self { payout: payout.into(), inner: CancelPayoutBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl CancelPayout<'_> {
+impl CancelPayout {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -537,23 +543,23 @@ impl CancelPayout<'_> {
     }
 }
 
-impl StripeRequest for CancelPayout<'_> {
+impl StripeRequest for CancelPayout {
     type Output = stripe_shared::Payout;
 
     fn build(&self) -> RequestBuilder {
-        let payout = self.payout;
+        let payout = &self.payout;
         RequestBuilder::new(StripeMethod::Post, format!("/payouts/{payout}/cancel"))
             .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ReversePayoutBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ReversePayoutBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
 }
-impl<'a> ReversePayoutBuilder<'a> {
+impl ReversePayoutBuilder {
     fn new() -> Self {
         Self { expand: None, metadata: None }
     }
@@ -564,30 +570,33 @@ impl<'a> ReversePayoutBuilder<'a> {
 ///
 /// By requesting a reversal through `/v1/payouts/:id/reverse`, you confirm that the authorized signatory of the selected bank account authorizes the debit on the bank account and that no other authorization is required.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ReversePayout<'a> {
-    inner: ReversePayoutBuilder<'a>,
-    payout: &'a stripe_shared::PayoutId,
+pub struct ReversePayout {
+    inner: ReversePayoutBuilder,
+    payout: stripe_shared::PayoutId,
 }
-impl<'a> ReversePayout<'a> {
+impl ReversePayout {
     /// Construct a new `ReversePayout`.
-    pub fn new(payout: &'a stripe_shared::PayoutId) -> Self {
-        Self { payout, inner: ReversePayoutBuilder::new() }
+    pub fn new(payout: impl Into<stripe_shared::PayoutId>) -> Self {
+        Self { payout: payout.into(), inner: ReversePayoutBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
 }
-impl ReversePayout<'_> {
+impl ReversePayout {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -605,11 +614,11 @@ impl ReversePayout<'_> {
     }
 }
 
-impl StripeRequest for ReversePayout<'_> {
+impl StripeRequest for ReversePayout {
     type Output = stripe_shared::Payout;
 
     fn build(&self) -> RequestBuilder {
-        let payout = self.payout;
+        let payout = &self.payout;
         RequestBuilder::new(StripeMethod::Post, format!("/payouts/{payout}/reverse"))
             .form(&self.inner)
     }

--- a/generated/async-stripe-core/src/refund/requests.rs
+++ b/generated/async-stripe-core/src/refund/requests.rs
@@ -2,24 +2,24 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListRefundBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListRefundBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    charge: Option<&'a str>,
+    charge: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     created: Option<stripe_types::RangeQueryTs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_intent: Option<&'a str>,
+    payment_intent: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListRefundBuilder<'a> {
+impl ListRefundBuilder {
     fn new() -> Self {
         Self {
             charge: None,
@@ -35,61 +35,61 @@ impl<'a> ListRefundBuilder<'a> {
 /// Returns a list of all refunds you created.
 /// We return the refunds in sorted order, with the most recent refunds appearing first The 10 most recent refunds are always available by default on the Charge object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListRefund<'a> {
-    inner: ListRefundBuilder<'a>,
+pub struct ListRefund {
+    inner: ListRefundBuilder,
 }
-impl<'a> ListRefund<'a> {
+impl ListRefund {
     /// Construct a new `ListRefund`.
     pub fn new() -> Self {
         Self { inner: ListRefundBuilder::new() }
     }
     /// Only return refunds for the charge specified by this charge ID.
-    pub fn charge(mut self, charge: &'a str) -> Self {
-        self.inner.charge = Some(charge);
+    pub fn charge(mut self, charge: impl Into<String>) -> Self {
+        self.inner.charge = Some(charge.into());
         self
     }
     /// Only return refunds that were created during the given date interval.
-    pub fn created(mut self, created: stripe_types::RangeQueryTs) -> Self {
-        self.inner.created = Some(created);
+    pub fn created(mut self, created: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.created = Some(created.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// Only return refunds for the PaymentIntent specified by this ID.
-    pub fn payment_intent(mut self, payment_intent: &'a str) -> Self {
-        self.inner.payment_intent = Some(payment_intent);
+    pub fn payment_intent(mut self, payment_intent: impl Into<String>) -> Self {
+        self.inner.payment_intent = Some(payment_intent.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl<'a> Default for ListRefund<'a> {
+impl Default for ListRefund {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListRefund<'_> {
+impl ListRefund {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -109,45 +109,45 @@ impl ListRefund<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::Refund>> {
-        stripe_client_core::ListPaginator::new_list("/refunds", self.inner)
+        stripe_client_core::ListPaginator::new_list("/refunds", &self.inner)
     }
 }
 
-impl StripeRequest for ListRefund<'_> {
+impl StripeRequest for ListRefund {
     type Output = stripe_types::List<stripe_shared::Refund>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/refunds").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveRefundBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveRefundBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveRefundBuilder<'a> {
+impl RetrieveRefundBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves the details of an existing refund.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveRefund<'a> {
-    inner: RetrieveRefundBuilder<'a>,
-    refund: &'a stripe_shared::RefundId,
+pub struct RetrieveRefund {
+    inner: RetrieveRefundBuilder,
+    refund: stripe_shared::RefundId,
 }
-impl<'a> RetrieveRefund<'a> {
+impl RetrieveRefund {
     /// Construct a new `RetrieveRefund`.
-    pub fn new(refund: &'a stripe_shared::RefundId) -> Self {
-        Self { refund, inner: RetrieveRefundBuilder::new() }
+    pub fn new(refund: impl Into<stripe_shared::RefundId>) -> Self {
+        Self { refund: refund.into(), inner: RetrieveRefundBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveRefund<'_> {
+impl RetrieveRefund {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -165,34 +165,34 @@ impl RetrieveRefund<'_> {
     }
 }
 
-impl StripeRequest for RetrieveRefund<'_> {
+impl StripeRequest for RetrieveRefund {
     type Output = stripe_shared::Refund;
 
     fn build(&self) -> RequestBuilder {
-        let refund = self.refund;
+        let refund = &self.refund;
         RequestBuilder::new(StripeMethod::Get, format!("/refunds/{refund}")).query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateRefundBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateRefundBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     amount: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    charge: Option<&'a str>,
+    charge: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     currency: Option<stripe_types::Currency>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    customer: Option<&'a str>,
+    customer: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    instructions_email: Option<&'a str>,
+    instructions_email: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     origin: Option<CreateRefundOrigin>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_intent: Option<&'a str>,
+    payment_intent: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     reason: Option<CreateRefundReason>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -200,7 +200,7 @@ struct CreateRefundBuilder<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     reverse_transfer: Option<bool>,
 }
-impl<'a> CreateRefundBuilder<'a> {
+impl CreateRefundBuilder {
     fn new() -> Self {
         Self {
             amount: None,
@@ -342,92 +342,95 @@ impl<'de> serde::Deserialize<'de> for CreateRefundReason {
 /// This method will raise an error when called on an already-refunded charge,
 /// or when trying to refund more money than is left on a charge.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateRefund<'a> {
-    inner: CreateRefundBuilder<'a>,
+pub struct CreateRefund {
+    inner: CreateRefundBuilder,
 }
-impl<'a> CreateRefund<'a> {
+impl CreateRefund {
     /// Construct a new `CreateRefund`.
     pub fn new() -> Self {
         Self { inner: CreateRefundBuilder::new() }
     }
-    pub fn amount(mut self, amount: i64) -> Self {
-        self.inner.amount = Some(amount);
+    pub fn amount(mut self, amount: impl Into<i64>) -> Self {
+        self.inner.amount = Some(amount.into());
         self
     }
     /// The identifier of the charge to refund.
-    pub fn charge(mut self, charge: &'a str) -> Self {
-        self.inner.charge = Some(charge);
+    pub fn charge(mut self, charge: impl Into<String>) -> Self {
+        self.inner.charge = Some(charge.into());
         self
     }
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     /// Must be a [supported currency](https://stripe.com/docs/currencies).
-    pub fn currency(mut self, currency: stripe_types::Currency) -> Self {
-        self.inner.currency = Some(currency);
+    pub fn currency(mut self, currency: impl Into<stripe_types::Currency>) -> Self {
+        self.inner.currency = Some(currency.into());
         self
     }
     /// Customer whose customer balance to refund from.
-    pub fn customer(mut self, customer: &'a str) -> Self {
-        self.inner.customer = Some(customer);
+    pub fn customer(mut self, customer: impl Into<String>) -> Self {
+        self.inner.customer = Some(customer.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// For payment methods without native refund support (e.g., Konbini, PromptPay), use this email from the customer to receive refund instructions.
-    pub fn instructions_email(mut self, instructions_email: &'a str) -> Self {
-        self.inner.instructions_email = Some(instructions_email);
+    pub fn instructions_email(mut self, instructions_email: impl Into<String>) -> Self {
+        self.inner.instructions_email = Some(instructions_email.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// Origin of the refund
-    pub fn origin(mut self, origin: CreateRefundOrigin) -> Self {
-        self.inner.origin = Some(origin);
+    pub fn origin(mut self, origin: impl Into<CreateRefundOrigin>) -> Self {
+        self.inner.origin = Some(origin.into());
         self
     }
     /// The identifier of the PaymentIntent to refund.
-    pub fn payment_intent(mut self, payment_intent: &'a str) -> Self {
-        self.inner.payment_intent = Some(payment_intent);
+    pub fn payment_intent(mut self, payment_intent: impl Into<String>) -> Self {
+        self.inner.payment_intent = Some(payment_intent.into());
         self
     }
     /// String indicating the reason for the refund.
     /// If set, possible values are `duplicate`, `fraudulent`, and `requested_by_customer`.
     /// If you believe the charge to be fraudulent, specifying `fraudulent` as the reason will add the associated card and email to your [block lists](https://stripe.com/docs/radar/lists), and will also help us improve our fraud detection algorithms.
-    pub fn reason(mut self, reason: CreateRefundReason) -> Self {
-        self.inner.reason = Some(reason);
+    pub fn reason(mut self, reason: impl Into<CreateRefundReason>) -> Self {
+        self.inner.reason = Some(reason.into());
         self
     }
     /// Boolean indicating whether the application fee should be refunded when refunding this charge.
     /// If a full charge refund is given, the full application fee will be refunded.
     /// Otherwise, the application fee will be refunded in an amount proportional to the amount of the charge refunded.
     /// An application fee can be refunded only by the application that created the charge.
-    pub fn refund_application_fee(mut self, refund_application_fee: bool) -> Self {
-        self.inner.refund_application_fee = Some(refund_application_fee);
+    pub fn refund_application_fee(mut self, refund_application_fee: impl Into<bool>) -> Self {
+        self.inner.refund_application_fee = Some(refund_application_fee.into());
         self
     }
     /// Boolean indicating whether the transfer should be reversed when refunding this charge.
     /// The transfer will be reversed proportionally to the amount being refunded (either the entire or partial amount).
     ///
     /// A transfer can be reversed only by the application that created the charge.
-    pub fn reverse_transfer(mut self, reverse_transfer: bool) -> Self {
-        self.inner.reverse_transfer = Some(reverse_transfer);
+    pub fn reverse_transfer(mut self, reverse_transfer: impl Into<bool>) -> Self {
+        self.inner.reverse_transfer = Some(reverse_transfer.into());
         self
     }
 }
-impl<'a> Default for CreateRefund<'a> {
+impl Default for CreateRefund {
     fn default() -> Self {
         Self::new()
     }
 }
-impl CreateRefund<'_> {
+impl CreateRefund {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -445,21 +448,21 @@ impl CreateRefund<'_> {
     }
 }
 
-impl StripeRequest for CreateRefund<'_> {
+impl StripeRequest for CreateRefund {
     type Output = stripe_shared::Refund;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Post, "/refunds").form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdateRefundBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdateRefundBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
 }
-impl<'a> UpdateRefundBuilder<'a> {
+impl UpdateRefundBuilder {
     fn new() -> Self {
         Self { expand: None, metadata: None }
     }
@@ -469,30 +472,33 @@ impl<'a> UpdateRefundBuilder<'a> {
 ///
 /// This request only accepts `metadata` as an argument.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateRefund<'a> {
-    inner: UpdateRefundBuilder<'a>,
-    refund: &'a stripe_shared::RefundId,
+pub struct UpdateRefund {
+    inner: UpdateRefundBuilder,
+    refund: stripe_shared::RefundId,
 }
-impl<'a> UpdateRefund<'a> {
+impl UpdateRefund {
     /// Construct a new `UpdateRefund`.
-    pub fn new(refund: &'a stripe_shared::RefundId) -> Self {
-        Self { refund, inner: UpdateRefundBuilder::new() }
+    pub fn new(refund: impl Into<stripe_shared::RefundId>) -> Self {
+        Self { refund: refund.into(), inner: UpdateRefundBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
 }
-impl UpdateRefund<'_> {
+impl UpdateRefund {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -510,20 +516,20 @@ impl UpdateRefund<'_> {
     }
 }
 
-impl StripeRequest for UpdateRefund<'_> {
+impl StripeRequest for UpdateRefund {
     type Output = stripe_shared::Refund;
 
     fn build(&self) -> RequestBuilder {
-        let refund = self.refund;
+        let refund = &self.refund;
         RequestBuilder::new(StripeMethod::Post, format!("/refunds/{refund}")).form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CancelRefundBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CancelRefundBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> CancelRefundBuilder<'a> {
+impl CancelRefundBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
@@ -533,22 +539,22 @@ impl<'a> CancelRefundBuilder<'a> {
 /// You can’t cancel refunds in other states.
 /// Only refunds for payment methods that require customer action can enter the `requires_action` state.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CancelRefund<'a> {
-    inner: CancelRefundBuilder<'a>,
-    refund: &'a stripe_shared::RefundId,
+pub struct CancelRefund {
+    inner: CancelRefundBuilder,
+    refund: stripe_shared::RefundId,
 }
-impl<'a> CancelRefund<'a> {
+impl CancelRefund {
     /// Construct a new `CancelRefund`.
-    pub fn new(refund: &'a stripe_shared::RefundId) -> Self {
-        Self { refund, inner: CancelRefundBuilder::new() }
+    pub fn new(refund: impl Into<stripe_shared::RefundId>) -> Self {
+        Self { refund: refund.into(), inner: CancelRefundBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl CancelRefund<'_> {
+impl CancelRefund {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -566,43 +572,43 @@ impl CancelRefund<'_> {
     }
 }
 
-impl StripeRequest for CancelRefund<'_> {
+impl StripeRequest for CancelRefund {
     type Output = stripe_shared::Refund;
 
     fn build(&self) -> RequestBuilder {
-        let refund = self.refund;
+        let refund = &self.refund;
         RequestBuilder::new(StripeMethod::Post, format!("/refunds/{refund}/cancel"))
             .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ExpireRefundBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ExpireRefundBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> ExpireRefundBuilder<'a> {
+impl ExpireRefundBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Expire a refund with a status of `requires_action`.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ExpireRefund<'a> {
-    inner: ExpireRefundBuilder<'a>,
-    refund: &'a str,
+pub struct ExpireRefund {
+    inner: ExpireRefundBuilder,
+    refund: String,
 }
-impl<'a> ExpireRefund<'a> {
+impl ExpireRefund {
     /// Construct a new `ExpireRefund`.
-    pub fn new(refund: &'a str) -> Self {
-        Self { refund, inner: ExpireRefundBuilder::new() }
+    pub fn new(refund: impl Into<String>) -> Self {
+        Self { refund: refund.into(), inner: ExpireRefundBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl ExpireRefund<'_> {
+impl ExpireRefund {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -620,11 +626,11 @@ impl ExpireRefund<'_> {
     }
 }
 
-impl StripeRequest for ExpireRefund<'_> {
+impl StripeRequest for ExpireRefund {
     type Output = stripe_shared::Refund;
 
     fn build(&self) -> RequestBuilder {
-        let refund = self.refund;
+        let refund = &self.refund;
         RequestBuilder::new(StripeMethod::Post, format!("/test_helpers/refunds/{refund}/expire"))
             .form(&self.inner)
     }

--- a/generated/async-stripe-core/src/setup_attempt/requests.rs
+++ b/generated/async-stripe-core/src/setup_attempt/requests.rs
@@ -2,76 +2,76 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListSetupAttemptBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListSetupAttemptBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     created: Option<stripe_types::RangeQueryTs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
-    setup_intent: &'a str,
+    setup_intent: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListSetupAttemptBuilder<'a> {
-    fn new(setup_intent: &'a str) -> Self {
+impl ListSetupAttemptBuilder {
+    fn new(setup_intent: impl Into<String>) -> Self {
         Self {
             created: None,
             ending_before: None,
             expand: None,
             limit: None,
-            setup_intent,
+            setup_intent: setup_intent.into(),
             starting_after: None,
         }
     }
 }
 /// Returns a list of SetupAttempts that associate with a provided SetupIntent.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListSetupAttempt<'a> {
-    inner: ListSetupAttemptBuilder<'a>,
+pub struct ListSetupAttempt {
+    inner: ListSetupAttemptBuilder,
 }
-impl<'a> ListSetupAttempt<'a> {
+impl ListSetupAttempt {
     /// Construct a new `ListSetupAttempt`.
-    pub fn new(setup_intent: &'a str) -> Self {
-        Self { inner: ListSetupAttemptBuilder::new(setup_intent) }
+    pub fn new(setup_intent: impl Into<String>) -> Self {
+        Self { inner: ListSetupAttemptBuilder::new(setup_intent.into()) }
     }
     /// A filter on the list, based on the object `created` field. The value
     /// can be a string with an integer Unix timestamp or a
     /// dictionary with a number of different query options.
-    pub fn created(mut self, created: stripe_types::RangeQueryTs) -> Self {
-        self.inner.created = Some(created);
+    pub fn created(mut self, created: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.created = Some(created.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl ListSetupAttempt<'_> {
+impl ListSetupAttempt {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -91,11 +91,11 @@ impl ListSetupAttempt<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::SetupAttempt>> {
-        stripe_client_core::ListPaginator::new_list("/setup_attempts", self.inner)
+        stripe_client_core::ListPaginator::new_list("/setup_attempts", &self.inner)
     }
 }
 
-impl StripeRequest for ListSetupAttempt<'_> {
+impl StripeRequest for ListSetupAttempt {
     type Output = stripe_types::List<stripe_shared::SetupAttempt>;
 
     fn build(&self) -> RequestBuilder {

--- a/generated/async-stripe-core/src/setup_intent/requests.rs
+++ b/generated/async-stripe-core/src/setup_intent/requests.rs
@@ -2,26 +2,26 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListSetupIntentBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListSetupIntentBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     attach_to_self: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     created: Option<stripe_types::RangeQueryTs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    customer: Option<&'a str>,
+    customer: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_method: Option<&'a str>,
+    payment_method: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListSetupIntentBuilder<'a> {
+impl ListSetupIntentBuilder {
     fn new() -> Self {
         Self {
             attach_to_self: None,
@@ -37,10 +37,10 @@ impl<'a> ListSetupIntentBuilder<'a> {
 }
 /// Returns a list of SetupIntents.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListSetupIntent<'a> {
-    inner: ListSetupIntentBuilder<'a>,
+pub struct ListSetupIntent {
+    inner: ListSetupIntentBuilder,
 }
-impl<'a> ListSetupIntent<'a> {
+impl ListSetupIntent {
     /// Construct a new `ListSetupIntent`.
     pub fn new() -> Self {
         Self { inner: ListSetupIntentBuilder::new() }
@@ -49,58 +49,58 @@ impl<'a> ListSetupIntent<'a> {
     ///
     /// It can only be used for this Stripe Account’s own money movement flows like InboundTransfer and OutboundTransfers.
     /// It cannot be set to true when setting up a PaymentMethod for a Customer, and defaults to false when attaching a PaymentMethod to a Customer.
-    pub fn attach_to_self(mut self, attach_to_self: bool) -> Self {
-        self.inner.attach_to_self = Some(attach_to_self);
+    pub fn attach_to_self(mut self, attach_to_self: impl Into<bool>) -> Self {
+        self.inner.attach_to_self = Some(attach_to_self.into());
         self
     }
     /// A filter on the list, based on the object `created` field.
     /// The value can be a string with an integer Unix timestamp, or it can be a dictionary with a number of different query options.
-    pub fn created(mut self, created: stripe_types::RangeQueryTs) -> Self {
-        self.inner.created = Some(created);
+    pub fn created(mut self, created: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.created = Some(created.into());
         self
     }
     /// Only return SetupIntents for the customer specified by this customer ID.
-    pub fn customer(mut self, customer: &'a str) -> Self {
-        self.inner.customer = Some(customer);
+    pub fn customer(mut self, customer: impl Into<String>) -> Self {
+        self.inner.customer = Some(customer.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// Only return SetupIntents that associate with the specified payment method.
-    pub fn payment_method(mut self, payment_method: &'a str) -> Self {
-        self.inner.payment_method = Some(payment_method);
+    pub fn payment_method(mut self, payment_method: impl Into<String>) -> Self {
+        self.inner.payment_method = Some(payment_method.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl<'a> Default for ListSetupIntent<'a> {
+impl Default for ListSetupIntent {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListSetupIntent<'_> {
+impl ListSetupIntent {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -120,25 +120,25 @@ impl ListSetupIntent<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::SetupIntent>> {
-        stripe_client_core::ListPaginator::new_list("/setup_intents", self.inner)
+        stripe_client_core::ListPaginator::new_list("/setup_intents", &self.inner)
     }
 }
 
-impl StripeRequest for ListSetupIntent<'_> {
+impl StripeRequest for ListSetupIntent {
     type Output = stripe_types::List<stripe_shared::SetupIntent>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/setup_intents").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveSetupIntentBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveSetupIntentBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    client_secret: Option<&'a str>,
+    client_secret: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveSetupIntentBuilder<'a> {
+impl RetrieveSetupIntentBuilder {
     fn new() -> Self {
         Self { client_secret: None, expand: None }
     }
@@ -151,28 +151,28 @@ impl<'a> RetrieveSetupIntentBuilder<'a> {
 /// When retrieved with a publishable key, only a subset of properties will be returned.
 /// Please refer to the [SetupIntent](https://stripe.com/docs/api#setup_intent_object) object reference for more details.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveSetupIntent<'a> {
-    inner: RetrieveSetupIntentBuilder<'a>,
-    intent: &'a stripe_shared::SetupIntentId,
+pub struct RetrieveSetupIntent {
+    inner: RetrieveSetupIntentBuilder,
+    intent: stripe_shared::SetupIntentId,
 }
-impl<'a> RetrieveSetupIntent<'a> {
+impl RetrieveSetupIntent {
     /// Construct a new `RetrieveSetupIntent`.
-    pub fn new(intent: &'a stripe_shared::SetupIntentId) -> Self {
-        Self { intent, inner: RetrieveSetupIntentBuilder::new() }
+    pub fn new(intent: impl Into<stripe_shared::SetupIntentId>) -> Self {
+        Self { intent: intent.into(), inner: RetrieveSetupIntentBuilder::new() }
     }
     /// The client secret of the SetupIntent.
     /// We require this string if you use a publishable key to retrieve the SetupIntent.
-    pub fn client_secret(mut self, client_secret: &'a str) -> Self {
-        self.inner.client_secret = Some(client_secret);
+    pub fn client_secret(mut self, client_secret: impl Into<String>) -> Self {
+        self.inner.client_secret = Some(client_secret.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveSetupIntent<'_> {
+impl RetrieveSetupIntent {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -190,17 +190,17 @@ impl RetrieveSetupIntent<'_> {
     }
 }
 
-impl StripeRequest for RetrieveSetupIntent<'_> {
+impl StripeRequest for RetrieveSetupIntent {
     type Output = stripe_shared::SetupIntent;
 
     fn build(&self) -> RequestBuilder {
-        let intent = self.intent;
+        let intent = &self.intent;
         RequestBuilder::new(StripeMethod::Get, format!("/setup_intents/{intent}"))
             .query(&self.inner)
     }
 }
 #[derive(Clone, Debug, serde::Serialize)]
-struct CreateSetupIntentBuilder<'a> {
+struct CreateSetupIntentBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     attach_to_self: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -208,33 +208,33 @@ struct CreateSetupIntentBuilder<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     confirm: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    confirmation_token: Option<&'a str>,
+    confirmation_token: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    customer: Option<&'a str>,
+    customer: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<&'a str>,
+    description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    flow_directions: Option<&'a [stripe_shared::SetupIntentFlowDirections]>,
+    flow_directions: Option<Vec<stripe_shared::SetupIntentFlowDirections>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    mandate_data: Option<CreateSetupIntentMandateData<'a>>,
+    mandate_data: Option<CreateSetupIntentMandateData>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    on_behalf_of: Option<&'a str>,
+    on_behalf_of: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_method: Option<&'a str>,
+    payment_method: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_method_configuration: Option<&'a str>,
+    payment_method_configuration: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_method_data: Option<CreateSetupIntentPaymentMethodData<'a>>,
+    payment_method_data: Option<CreateSetupIntentPaymentMethodData>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_method_options: Option<CreateSetupIntentPaymentMethodOptions<'a>>,
+    payment_method_options: Option<CreateSetupIntentPaymentMethodOptions>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_method_types: Option<&'a [&'a str]>,
+    payment_method_types: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    return_url: Option<&'a str>,
+    return_url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     single_use: Option<CreateSetupIntentSingleUse>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -242,7 +242,7 @@ struct CreateSetupIntentBuilder<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     use_stripe_sdk: Option<bool>,
 }
-impl<'a> CreateSetupIntentBuilder<'a> {
+impl CreateSetupIntentBuilder {
     fn new() -> Self {
         Self {
             attach_to_self: None,
@@ -281,8 +281,8 @@ pub struct CreateSetupIntentAutomaticPaymentMethods {
     pub enabled: bool,
 }
 impl CreateSetupIntentAutomaticPaymentMethods {
-    pub fn new(enabled: bool) -> Self {
-        Self { allow_redirects: None, enabled }
+    pub fn new(enabled: impl Into<bool>) -> Self {
+        Self { allow_redirects: None, enabled: enabled.into() }
     }
 }
 /// Controls whether this SetupIntent will accept redirect-based payment methods.
@@ -349,18 +349,20 @@ impl<'de> serde::Deserialize<'de> for CreateSetupIntentAutomaticPaymentMethodsAl
 /// This hash contains details about the mandate to create.
 /// This parameter can only be used with [`confirm=true`](https://stripe.com/docs/api/setup_intents/create#create_setup_intent-confirm).
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateSetupIntentMandateData<'a> {
+pub struct CreateSetupIntentMandateData {
     /// This hash contains details about the customer acceptance of the Mandate.
-    pub customer_acceptance: CreateSetupIntentMandateDataCustomerAcceptance<'a>,
+    pub customer_acceptance: CreateSetupIntentMandateDataCustomerAcceptance,
 }
-impl<'a> CreateSetupIntentMandateData<'a> {
-    pub fn new(customer_acceptance: CreateSetupIntentMandateDataCustomerAcceptance<'a>) -> Self {
-        Self { customer_acceptance }
+impl CreateSetupIntentMandateData {
+    pub fn new(
+        customer_acceptance: impl Into<CreateSetupIntentMandateDataCustomerAcceptance>,
+    ) -> Self {
+        Self { customer_acceptance: customer_acceptance.into() }
     }
 }
 /// This hash contains details about the customer acceptance of the Mandate.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateSetupIntentMandateDataCustomerAcceptance<'a> {
+pub struct CreateSetupIntentMandateDataCustomerAcceptance {
     /// The time at which the customer accepted the Mandate.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub accepted_at: Option<stripe_types::Timestamp>,
@@ -370,15 +372,15 @@ pub struct CreateSetupIntentMandateDataCustomerAcceptance<'a> {
     pub offline: Option<miniserde::json::Value>,
     /// If this is a Mandate accepted online, this hash contains details about the online acceptance.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub online: Option<OnlineParam<'a>>,
+    pub online: Option<OnlineParam>,
     /// The type of customer acceptance information included with the Mandate.
     /// One of `online` or `offline`.
     #[serde(rename = "type")]
     pub type_: CreateSetupIntentMandateDataCustomerAcceptanceType,
 }
-impl<'a> CreateSetupIntentMandateDataCustomerAcceptance<'a> {
-    pub fn new(type_: CreateSetupIntentMandateDataCustomerAcceptanceType) -> Self {
-        Self { accepted_at: None, offline: None, online: None, type_ }
+impl CreateSetupIntentMandateDataCustomerAcceptance {
+    pub fn new(type_: impl Into<CreateSetupIntentMandateDataCustomerAcceptanceType>) -> Self {
+        Self { accepted_at: None, offline: None, online: None, type_: type_.into() }
     }
 }
 /// The type of customer acceptance information included with the Mandate.
@@ -443,10 +445,10 @@ impl<'de> serde::Deserialize<'de> for CreateSetupIntentMandateDataCustomerAccept
 /// When included, this hash creates a PaymentMethod that is set as the [`payment_method`](https://stripe.com/docs/api/setup_intents/object#setup_intent_object-payment_method).
 /// value in the SetupIntent.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateSetupIntentPaymentMethodData<'a> {
+pub struct CreateSetupIntentPaymentMethodData {
     /// If this is an `acss_debit` PaymentMethod, this hash contains details about the ACSS Debit payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub acss_debit: Option<PaymentMethodParam<'a>>,
+    pub acss_debit: Option<PaymentMethodParam>,
     /// If this is an `affirm` PaymentMethod, this hash contains details about the Affirm payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
@@ -470,24 +472,24 @@ pub struct CreateSetupIntentPaymentMethodData<'a> {
     pub amazon_pay: Option<miniserde::json::Value>,
     /// If this is an `au_becs_debit` PaymentMethod, this hash contains details about the bank account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub au_becs_debit: Option<CreateSetupIntentPaymentMethodDataAuBecsDebit<'a>>,
+    pub au_becs_debit: Option<CreateSetupIntentPaymentMethodDataAuBecsDebit>,
     /// If this is a `bacs_debit` PaymentMethod, this hash contains details about the Bacs Direct Debit bank account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub bacs_debit: Option<CreateSetupIntentPaymentMethodDataBacsDebit<'a>>,
+    pub bacs_debit: Option<CreateSetupIntentPaymentMethodDataBacsDebit>,
     /// If this is a `bancontact` PaymentMethod, this hash contains details about the Bancontact payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
     pub bancontact: Option<miniserde::json::Value>,
     /// Billing information associated with the PaymentMethod that may be used or required by particular types of payment methods.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub billing_details: Option<BillingDetailsInnerParams<'a>>,
+    pub billing_details: Option<BillingDetailsInnerParams>,
     /// If this is a `blik` PaymentMethod, this hash contains details about the BLIK payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
     pub blik: Option<miniserde::json::Value>,
     /// If this is a `boleto` PaymentMethod, this hash contains details about the Boleto payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub boleto: Option<CreateSetupIntentPaymentMethodDataBoleto<'a>>,
+    pub boleto: Option<CreateSetupIntentPaymentMethodDataBoleto>,
     /// If this is a `cashapp` PaymentMethod, this hash contains details about the Cash App Pay payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
@@ -533,7 +535,7 @@ pub struct CreateSetupIntentPaymentMethodData<'a> {
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// If this is a `mobilepay` PaymentMethod, this hash contains details about the MobilePay payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
@@ -564,14 +566,14 @@ pub struct CreateSetupIntentPaymentMethodData<'a> {
     /// Options to configure Radar.
     /// See [Radar Session](https://stripe.com/docs/radar/radar-session) for more information.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub radar_options: Option<RadarOptionsWithHiddenOptions<'a>>,
+    pub radar_options: Option<RadarOptionsWithHiddenOptions>,
     /// If this is a `Revolut Pay` PaymentMethod, this hash contains details about the Revolut Pay payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
     pub revolut_pay: Option<miniserde::json::Value>,
     /// If this is a `sepa_debit` PaymentMethod, this hash contains details about the SEPA debit bank account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub sepa_debit: Option<CreateSetupIntentPaymentMethodDataSepaDebit<'a>>,
+    pub sepa_debit: Option<CreateSetupIntentPaymentMethodDataSepaDebit>,
     /// If this is a `sofort` PaymentMethod, this hash contains details about the SOFORT payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sofort: Option<CreateSetupIntentPaymentMethodDataSofort>,
@@ -586,7 +588,7 @@ pub struct CreateSetupIntentPaymentMethodData<'a> {
     pub type_: CreateSetupIntentPaymentMethodDataType,
     /// If this is an `us_bank_account` PaymentMethod, this hash contains details about the US bank account payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub us_bank_account: Option<CreateSetupIntentPaymentMethodDataUsBankAccount<'a>>,
+    pub us_bank_account: Option<CreateSetupIntentPaymentMethodDataUsBankAccount>,
     /// If this is an `wechat_pay` PaymentMethod, this hash contains details about the wechat_pay payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
@@ -596,8 +598,8 @@ pub struct CreateSetupIntentPaymentMethodData<'a> {
     #[serde(with = "stripe_types::with_serde_json_opt")]
     pub zip: Option<miniserde::json::Value>,
 }
-impl<'a> CreateSetupIntentPaymentMethodData<'a> {
-    pub fn new(type_: CreateSetupIntentPaymentMethodDataType) -> Self {
+impl CreateSetupIntentPaymentMethodData {
+    pub fn new(type_: impl Into<CreateSetupIntentPaymentMethodDataType>) -> Self {
         Self {
             acss_debit: None,
             affirm: None,
@@ -635,7 +637,7 @@ impl<'a> CreateSetupIntentPaymentMethodData<'a> {
             sepa_debit: None,
             sofort: None,
             swish: None,
-            type_,
+            type_: type_.into(),
             us_bank_account: None,
             wechat_pay: None,
             zip: None,
@@ -706,47 +708,47 @@ impl<'de> serde::Deserialize<'de> for CreateSetupIntentPaymentMethodDataAllowRed
     }
 }
 /// If this is an `au_becs_debit` PaymentMethod, this hash contains details about the bank account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateSetupIntentPaymentMethodDataAuBecsDebit<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateSetupIntentPaymentMethodDataAuBecsDebit {
     /// The account number for the bank account.
-    pub account_number: &'a str,
+    pub account_number: String,
     /// Bank-State-Branch number of the bank account.
-    pub bsb_number: &'a str,
+    pub bsb_number: String,
 }
-impl<'a> CreateSetupIntentPaymentMethodDataAuBecsDebit<'a> {
-    pub fn new(account_number: &'a str, bsb_number: &'a str) -> Self {
-        Self { account_number, bsb_number }
+impl CreateSetupIntentPaymentMethodDataAuBecsDebit {
+    pub fn new(account_number: impl Into<String>, bsb_number: impl Into<String>) -> Self {
+        Self { account_number: account_number.into(), bsb_number: bsb_number.into() }
     }
 }
 /// If this is a `bacs_debit` PaymentMethod, this hash contains details about the Bacs Direct Debit bank account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateSetupIntentPaymentMethodDataBacsDebit<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateSetupIntentPaymentMethodDataBacsDebit {
     /// Account number of the bank account that the funds will be debited from.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account_number: Option<&'a str>,
+    pub account_number: Option<String>,
     /// Sort code of the bank account. (e.g., `10-20-30`)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub sort_code: Option<&'a str>,
+    pub sort_code: Option<String>,
 }
-impl<'a> CreateSetupIntentPaymentMethodDataBacsDebit<'a> {
+impl CreateSetupIntentPaymentMethodDataBacsDebit {
     pub fn new() -> Self {
         Self { account_number: None, sort_code: None }
     }
 }
-impl<'a> Default for CreateSetupIntentPaymentMethodDataBacsDebit<'a> {
+impl Default for CreateSetupIntentPaymentMethodDataBacsDebit {
     fn default() -> Self {
         Self::new()
     }
 }
 /// If this is a `boleto` PaymentMethod, this hash contains details about the Boleto payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateSetupIntentPaymentMethodDataBoleto<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateSetupIntentPaymentMethodDataBoleto {
     /// The tax ID of the customer (CPF for individual consumers or CNPJ for businesses consumers)
-    pub tax_id: &'a str,
+    pub tax_id: String,
 }
-impl<'a> CreateSetupIntentPaymentMethodDataBoleto<'a> {
-    pub fn new(tax_id: &'a str) -> Self {
-        Self { tax_id }
+impl CreateSetupIntentPaymentMethodDataBoleto {
+    pub fn new(tax_id: impl Into<String>) -> Self {
+        Self { tax_id: tax_id.into() }
     }
 }
 /// If this is an `eps` PaymentMethod, this hash contains details about the EPS payment method.
@@ -912,8 +914,8 @@ pub struct CreateSetupIntentPaymentMethodDataFpx {
     pub bank: CreateSetupIntentPaymentMethodDataFpxBank,
 }
 impl CreateSetupIntentPaymentMethodDataFpx {
-    pub fn new(bank: CreateSetupIntentPaymentMethodDataFpxBank) -> Self {
-        Self { account_holder_type: None, bank }
+    pub fn new(bank: impl Into<CreateSetupIntentPaymentMethodDataFpxBank>) -> Self {
+        Self { account_holder_type: None, bank: bank.into() }
     }
 }
 /// Account holder type for FPX transaction
@@ -1374,14 +1376,14 @@ impl<'de> serde::Deserialize<'de> for CreateSetupIntentPaymentMethodDataP24Bank 
     }
 }
 /// If this is a `sepa_debit` PaymentMethod, this hash contains details about the SEPA debit bank account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateSetupIntentPaymentMethodDataSepaDebit<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateSetupIntentPaymentMethodDataSepaDebit {
     /// IBAN of the bank account.
-    pub iban: &'a str,
+    pub iban: String,
 }
-impl<'a> CreateSetupIntentPaymentMethodDataSepaDebit<'a> {
-    pub fn new(iban: &'a str) -> Self {
-        Self { iban }
+impl CreateSetupIntentPaymentMethodDataSepaDebit {
+    pub fn new(iban: impl Into<String>) -> Self {
+        Self { iban: iban.into() }
     }
 }
 /// If this is a `sofort` PaymentMethod, this hash contains details about the SOFORT payment method.
@@ -1391,8 +1393,8 @@ pub struct CreateSetupIntentPaymentMethodDataSofort {
     pub country: CreateSetupIntentPaymentMethodDataSofortCountry,
 }
 impl CreateSetupIntentPaymentMethodDataSofort {
-    pub fn new(country: CreateSetupIntentPaymentMethodDataSofortCountry) -> Self {
-        Self { country }
+    pub fn new(country: impl Into<CreateSetupIntentPaymentMethodDataSofortCountry>) -> Self {
+        Self { country: country.into() }
     }
 }
 /// Two-letter ISO code representing the country the bank account is located in.
@@ -1622,26 +1624,26 @@ impl<'de> serde::Deserialize<'de> for CreateSetupIntentPaymentMethodDataType {
     }
 }
 /// If this is an `us_bank_account` PaymentMethod, this hash contains details about the US bank account payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateSetupIntentPaymentMethodDataUsBankAccount<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateSetupIntentPaymentMethodDataUsBankAccount {
     /// Account holder type: individual or company.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub account_holder_type:
         Option<CreateSetupIntentPaymentMethodDataUsBankAccountAccountHolderType>,
     /// Account number of the bank account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account_number: Option<&'a str>,
+    pub account_number: Option<String>,
     /// Account type: checkings or savings. Defaults to checking if omitted.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub account_type: Option<CreateSetupIntentPaymentMethodDataUsBankAccountAccountType>,
     /// The ID of a Financial Connections Account to use as a payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub financial_connections_account: Option<&'a str>,
+    pub financial_connections_account: Option<String>,
     /// Routing number of the bank account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub routing_number: Option<&'a str>,
+    pub routing_number: Option<String>,
 }
-impl<'a> CreateSetupIntentPaymentMethodDataUsBankAccount<'a> {
+impl CreateSetupIntentPaymentMethodDataUsBankAccount {
     pub fn new() -> Self {
         Self {
             account_holder_type: None,
@@ -1652,7 +1654,7 @@ impl<'a> CreateSetupIntentPaymentMethodDataUsBankAccount<'a> {
         }
     }
 }
-impl<'a> Default for CreateSetupIntentPaymentMethodDataUsBankAccount<'a> {
+impl Default for CreateSetupIntentPaymentMethodDataUsBankAccount {
     fn default() -> Self {
         Self::new()
     }
@@ -1773,35 +1775,35 @@ impl<'de> serde::Deserialize<'de> for CreateSetupIntentPaymentMethodDataUsBankAc
 }
 /// Payment method-specific configuration for this SetupIntent.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateSetupIntentPaymentMethodOptions<'a> {
+pub struct CreateSetupIntentPaymentMethodOptions {
     /// If this is a `acss_debit` SetupIntent, this sub-hash contains details about the ACSS Debit payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub acss_debit: Option<CreateSetupIntentPaymentMethodOptionsAcssDebit<'a>>,
+    pub acss_debit: Option<CreateSetupIntentPaymentMethodOptionsAcssDebit>,
     /// If this is a `amazon_pay` SetupIntent, this sub-hash contains details about the AmazonPay payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
     pub amazon_pay: Option<miniserde::json::Value>,
     /// Configuration for any card setup attempted on this SetupIntent.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub card: Option<CreateSetupIntentPaymentMethodOptionsCard<'a>>,
+    pub card: Option<CreateSetupIntentPaymentMethodOptionsCard>,
     /// If this is a `card_present` PaymentMethod, this sub-hash contains details about the card-present payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
     pub card_present: Option<miniserde::json::Value>,
     /// If this is a `link` PaymentMethod, this sub-hash contains details about the Link payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub link: Option<SetupIntentPaymentMethodOptionsParam<'a>>,
+    pub link: Option<SetupIntentPaymentMethodOptionsParam>,
     /// If this is a `paypal` PaymentMethod, this sub-hash contains details about the PayPal payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub paypal: Option<PaymentMethodOptionsParam<'a>>,
+    pub paypal: Option<PaymentMethodOptionsParam>,
     /// If this is a `sepa_debit` SetupIntent, this sub-hash contains details about the SEPA Debit payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sepa_debit: Option<CreateSetupIntentPaymentMethodOptionsSepaDebit>,
     /// If this is a `us_bank_account` SetupIntent, this sub-hash contains details about the US bank account payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub us_bank_account: Option<CreateSetupIntentPaymentMethodOptionsUsBankAccount<'a>>,
+    pub us_bank_account: Option<CreateSetupIntentPaymentMethodOptionsUsBankAccount>,
 }
-impl<'a> CreateSetupIntentPaymentMethodOptions<'a> {
+impl CreateSetupIntentPaymentMethodOptions {
     pub fn new() -> Self {
         Self {
             acss_debit: None,
@@ -1815,32 +1817,32 @@ impl<'a> CreateSetupIntentPaymentMethodOptions<'a> {
         }
     }
 }
-impl<'a> Default for CreateSetupIntentPaymentMethodOptions<'a> {
+impl Default for CreateSetupIntentPaymentMethodOptions {
     fn default() -> Self {
         Self::new()
     }
 }
 /// If this is a `acss_debit` SetupIntent, this sub-hash contains details about the ACSS Debit payment method options.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateSetupIntentPaymentMethodOptionsAcssDebit<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateSetupIntentPaymentMethodOptionsAcssDebit {
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     /// Must be a [supported currency](https://stripe.com/docs/currencies).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub currency: Option<CreateSetupIntentPaymentMethodOptionsAcssDebitCurrency>,
     /// Additional fields for Mandate creation
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub mandate_options: Option<CreateSetupIntentPaymentMethodOptionsAcssDebitMandateOptions<'a>>,
+    pub mandate_options: Option<CreateSetupIntentPaymentMethodOptionsAcssDebitMandateOptions>,
     /// Bank account verification method.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub verification_method:
         Option<CreateSetupIntentPaymentMethodOptionsAcssDebitVerificationMethod>,
 }
-impl<'a> CreateSetupIntentPaymentMethodOptionsAcssDebit<'a> {
+impl CreateSetupIntentPaymentMethodOptionsAcssDebit {
     pub fn new() -> Self {
         Self { currency: None, mandate_options: None, verification_method: None }
     }
 }
-impl<'a> Default for CreateSetupIntentPaymentMethodOptionsAcssDebit<'a> {
+impl Default for CreateSetupIntentPaymentMethodOptionsAcssDebit {
     fn default() -> Self {
         Self::new()
     }
@@ -1905,21 +1907,21 @@ impl<'de> serde::Deserialize<'de> for CreateSetupIntentPaymentMethodOptionsAcssD
     }
 }
 /// Additional fields for Mandate creation
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateSetupIntentPaymentMethodOptionsAcssDebitMandateOptions<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateSetupIntentPaymentMethodOptionsAcssDebitMandateOptions {
     /// A URL for custom mandate text to render during confirmation step.
     /// The URL will be rendered with additional GET parameters `payment_intent` and `payment_intent_client_secret` when confirming a Payment Intent,.
     /// or `setup_intent` and `setup_intent_client_secret` when confirming a Setup Intent.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub custom_mandate_url: Option<&'a str>,
+    pub custom_mandate_url: Option<String>,
     /// List of Stripe products where this mandate can be selected automatically.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_for:
-        Option<&'a [CreateSetupIntentPaymentMethodOptionsAcssDebitMandateOptionsDefaultFor]>,
+        Option<Vec<CreateSetupIntentPaymentMethodOptionsAcssDebitMandateOptionsDefaultFor>>,
     /// Description of the mandate interval.
     /// Only required if 'payment_schedule' parameter is 'interval' or 'combined'.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub interval_description: Option<&'a str>,
+    pub interval_description: Option<String>,
     /// Payment schedule for the mandate.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub payment_schedule:
@@ -1929,7 +1931,7 @@ pub struct CreateSetupIntentPaymentMethodOptionsAcssDebitMandateOptions<'a> {
     pub transaction_type:
         Option<CreateSetupIntentPaymentMethodOptionsAcssDebitMandateOptionsTransactionType>,
 }
-impl<'a> CreateSetupIntentPaymentMethodOptionsAcssDebitMandateOptions<'a> {
+impl CreateSetupIntentPaymentMethodOptionsAcssDebitMandateOptions {
     pub fn new() -> Self {
         Self {
             custom_mandate_url: None,
@@ -1940,7 +1942,7 @@ impl<'a> CreateSetupIntentPaymentMethodOptionsAcssDebitMandateOptions<'a> {
         }
     }
 }
-impl<'a> Default for CreateSetupIntentPaymentMethodOptionsAcssDebitMandateOptions<'a> {
+impl Default for CreateSetupIntentPaymentMethodOptionsAcssDebitMandateOptions {
     fn default() -> Self {
         Self::new()
     }
@@ -2192,11 +2194,11 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// Configuration for any card setup attempted on this SetupIntent.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateSetupIntentPaymentMethodOptionsCard<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateSetupIntentPaymentMethodOptionsCard {
     /// Configuration options for setting up an eMandate for cards issued in India.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub mandate_options: Option<CreateSetupIntentPaymentMethodOptionsCardMandateOptions<'a>>,
+    pub mandate_options: Option<CreateSetupIntentPaymentMethodOptionsCardMandateOptions>,
     /// When specified, this parameter signals that a card has been collected
     /// as MOTO (Mail Order Telephone Order) and thus out of scope for SCA. This
     /// parameter can only be provided during confirmation.
@@ -2217,9 +2219,9 @@ pub struct CreateSetupIntentPaymentMethodOptionsCard<'a> {
     /// If 3D Secure authentication was performed with a third-party provider,
     /// the authentication details to use for this setup.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub three_d_secure: Option<CreateSetupIntentPaymentMethodOptionsCardThreeDSecure<'a>>,
+    pub three_d_secure: Option<CreateSetupIntentPaymentMethodOptionsCardThreeDSecure>,
 }
-impl<'a> CreateSetupIntentPaymentMethodOptionsCard<'a> {
+impl CreateSetupIntentPaymentMethodOptionsCard {
     pub fn new() -> Self {
         Self {
             mandate_options: None,
@@ -2230,14 +2232,14 @@ impl<'a> CreateSetupIntentPaymentMethodOptionsCard<'a> {
         }
     }
 }
-impl<'a> Default for CreateSetupIntentPaymentMethodOptionsCard<'a> {
+impl Default for CreateSetupIntentPaymentMethodOptionsCard {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Configuration options for setting up an eMandate for cards issued in India.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateSetupIntentPaymentMethodOptionsCardMandateOptions<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateSetupIntentPaymentMethodOptionsCardMandateOptions {
     /// Amount to be charged for future payments.
     pub amount: i64,
     /// One of `fixed` or `maximum`.
@@ -2250,7 +2252,7 @@ pub struct CreateSetupIntentPaymentMethodOptionsCardMandateOptions<'a> {
     pub currency: stripe_types::Currency,
     /// A description of the mandate or subscription that is meant to be displayed to the customer.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<&'a str>,
+    pub description: Option<String>,
     /// End date of the mandate or subscription.
     /// If not provided, the mandate will be active until canceled.
     /// If provided, end date should be after start date.
@@ -2265,33 +2267,33 @@ pub struct CreateSetupIntentPaymentMethodOptionsCardMandateOptions<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub interval_count: Option<u64>,
     /// Unique identifier for the mandate or subscription.
-    pub reference: &'a str,
+    pub reference: String,
     /// Start date of the mandate or subscription. Start date should not be lesser than yesterday.
     pub start_date: stripe_types::Timestamp,
     /// Specifies the type of mandates supported. Possible values are `india`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub supported_types:
-        Option<&'a [CreateSetupIntentPaymentMethodOptionsCardMandateOptionsSupportedTypes]>,
+        Option<Vec<CreateSetupIntentPaymentMethodOptionsCardMandateOptionsSupportedTypes>>,
 }
-impl<'a> CreateSetupIntentPaymentMethodOptionsCardMandateOptions<'a> {
+impl CreateSetupIntentPaymentMethodOptionsCardMandateOptions {
     pub fn new(
-        amount: i64,
-        amount_type: CreateSetupIntentPaymentMethodOptionsCardMandateOptionsAmountType,
-        currency: stripe_types::Currency,
-        interval: CreateSetupIntentPaymentMethodOptionsCardMandateOptionsInterval,
-        reference: &'a str,
-        start_date: stripe_types::Timestamp,
+        amount: impl Into<i64>,
+        amount_type: impl Into<CreateSetupIntentPaymentMethodOptionsCardMandateOptionsAmountType>,
+        currency: impl Into<stripe_types::Currency>,
+        interval: impl Into<CreateSetupIntentPaymentMethodOptionsCardMandateOptionsInterval>,
+        reference: impl Into<String>,
+        start_date: impl Into<stripe_types::Timestamp>,
     ) -> Self {
         Self {
-            amount,
-            amount_type,
-            currency,
+            amount: amount.into(),
+            amount_type: amount_type.into(),
+            currency: currency.into(),
             description: None,
             end_date: None,
-            interval,
+            interval: interval.into(),
             interval_count: None,
-            reference,
-            start_date,
+            reference: reference.into(),
+            start_date: start_date.into(),
             supported_types: None,
         }
     }
@@ -2629,8 +2631,8 @@ impl<'de> serde::Deserialize<'de> for CreateSetupIntentPaymentMethodOptionsCardR
 }
 /// If 3D Secure authentication was performed with a third-party provider,
 /// the authentication details to use for this setup.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateSetupIntentPaymentMethodOptionsCardThreeDSecure<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateSetupIntentPaymentMethodOptionsCardThreeDSecure {
     /// The `transStatus` returned from the card Issuer’s ACS in the ARes.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ares_trans_status:
@@ -2640,7 +2642,7 @@ pub struct CreateSetupIntentPaymentMethodOptionsCardThreeDSecure<'a> {
     /// (Most 3D Secure providers will return the base64-encoded version, which
     /// is what you should specify here.)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub cryptogram: Option<&'a str>,
+    pub cryptogram: Option<String>,
     /// The Electronic Commerce Indicator (ECI) is returned by your 3D Secure
     /// provider and indicates what degree of authentication was performed.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2651,20 +2653,20 @@ pub struct CreateSetupIntentPaymentMethodOptionsCardThreeDSecure<'a> {
     /// must be populated accordingly
     #[serde(skip_serializing_if = "Option::is_none")]
     pub network_options:
-        Option<CreateSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptions<'a>>,
+        Option<CreateSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptions>,
     /// The challenge indicator (`threeDSRequestorChallengeInd`) which was requested in the
     /// AReq sent to the card Issuer's ACS. A string containing 2 digits from 01-99.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub requestor_challenge_indicator: Option<&'a str>,
+    pub requestor_challenge_indicator: Option<String>,
     /// For 3D Secure 1, the XID. For 3D Secure 2, the Directory Server
     /// Transaction ID (dsTransID).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub transaction_id: Option<&'a str>,
+    pub transaction_id: Option<String>,
     /// The version of 3D Secure that was performed.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<CreateSetupIntentPaymentMethodOptionsCardThreeDSecureVersion>,
 }
-impl<'a> CreateSetupIntentPaymentMethodOptionsCardThreeDSecure<'a> {
+impl CreateSetupIntentPaymentMethodOptionsCardThreeDSecure {
     pub fn new() -> Self {
         Self {
             ares_trans_status: None,
@@ -2677,7 +2679,7 @@ impl<'a> CreateSetupIntentPaymentMethodOptionsCardThreeDSecure<'a> {
         }
     }
 }
-impl<'a> Default for CreateSetupIntentPaymentMethodOptionsCardThreeDSecure<'a> {
+impl Default for CreateSetupIntentPaymentMethodOptionsCardThreeDSecure {
     fn default() -> Self {
         Self::new()
     }
@@ -2830,27 +2832,26 @@ impl<'de> serde::Deserialize<'de>
 /// Network specific 3DS fields. Network specific arguments require an
 /// explicit card brand choice. The parameter `payment_method_options.card.network``
 /// must be populated accordingly
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptions<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptions {
     /// Cartes Bancaires-specific 3DS fields.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub cartes_bancaires: Option<
-        CreateSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancaires<'a>,
-    >,
+    pub cartes_bancaires:
+        Option<CreateSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancaires>,
 }
-impl<'a> CreateSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptions<'a> {
+impl CreateSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptions {
     pub fn new() -> Self {
         Self { cartes_bancaires: None }
     }
 }
-impl<'a> Default for CreateSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptions<'a> {
+impl Default for CreateSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptions {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Cartes Bancaires-specific 3DS fields.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancaires<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancaires {
     /// The cryptogram calculation algorithm used by the card Issuer's ACS
     /// to calculate the Authentication cryptogram. Also known as `cavvAlgorithm`.
     /// messageExtension: CB-AVALGO
@@ -2861,17 +2862,17 @@ pub struct CreateSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCa
     /// This is a 3 byte bitmap (low significant byte first and most significant
     /// bit first) that has been Base64 encoded
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub cb_exemption: Option<&'a str>,
+    pub cb_exemption: Option<String>,
     /// The risk score returned from Cartes Bancaires in the ARes.
     /// message extension: CB-SCORE; numeric value 0-99
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cb_score: Option<i64>,
 }
-impl<'a> CreateSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancaires<'a> {
+impl CreateSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancaires {
     pub fn new(
-        cb_avalgo: CreateSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancairesCbAvalgo,
+        cb_avalgo: impl Into<CreateSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancairesCbAvalgo>,
     ) -> Self {
-        Self { cb_avalgo, cb_exemption: None, cb_score: None }
+        Self { cb_avalgo: cb_avalgo.into(), cb_exemption: None, cb_score: None }
     }
 }
 /// The cryptogram calculation algorithm used by the card Issuer's ACS
@@ -3033,24 +3034,24 @@ impl Default for CreateSetupIntentPaymentMethodOptionsSepaDebit {
     }
 }
 /// If this is a `us_bank_account` SetupIntent, this sub-hash contains details about the US bank account payment method options.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateSetupIntentPaymentMethodOptionsUsBankAccount<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateSetupIntentPaymentMethodOptionsUsBankAccount {
     /// Additional fields for Financial Connections Session creation
     #[serde(skip_serializing_if = "Option::is_none")]
     pub financial_connections:
-        Option<CreateSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnections<'a>>,
+        Option<CreateSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnections>,
     /// Additional fields for Mandate creation
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mandate_options: Option<CreateSetupIntentPaymentMethodOptionsUsBankAccountMandateOptions>,
     /// Additional fields for network related functions
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub networks: Option<CreateSetupIntentPaymentMethodOptionsUsBankAccountNetworks<'a>>,
+    pub networks: Option<CreateSetupIntentPaymentMethodOptionsUsBankAccountNetworks>,
     /// Bank account verification method.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub verification_method:
         Option<CreateSetupIntentPaymentMethodOptionsUsBankAccountVerificationMethod>,
 }
-impl<'a> CreateSetupIntentPaymentMethodOptionsUsBankAccount<'a> {
+impl CreateSetupIntentPaymentMethodOptionsUsBankAccount {
     pub fn new() -> Self {
         Self {
             financial_connections: None,
@@ -3060,37 +3061,36 @@ impl<'a> CreateSetupIntentPaymentMethodOptionsUsBankAccount<'a> {
         }
     }
 }
-impl<'a> Default for CreateSetupIntentPaymentMethodOptionsUsBankAccount<'a> {
+impl Default for CreateSetupIntentPaymentMethodOptionsUsBankAccount {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Additional fields for Financial Connections Session creation
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnections<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnections {
     /// The list of permissions to request.
     /// If this parameter is passed, the `payment_method` permission must be included.
     /// Valid permissions include: `balances`, `ownership`, `payment_method`, and `transactions`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub permissions: Option<
-        &'a [CreateSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPermissions],
+        Vec<CreateSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPermissions>,
     >,
     /// List of data features that you would like to retrieve upon account creation.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub prefetch: Option<
-        &'a [CreateSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPrefetch],
-    >,
+    pub prefetch:
+        Option<Vec<CreateSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPrefetch>>,
     /// For webview integrations only.
     /// Upon completing OAuth login in the native browser, the user will be redirected to this URL to return to your app.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub return_url: Option<&'a str>,
+    pub return_url: Option<String>,
 }
-impl<'a> CreateSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnections<'a> {
+impl CreateSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnections {
     pub fn new() -> Self {
         Self { permissions: None, prefetch: None, return_url: None }
     }
 }
-impl<'a> Default for CreateSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnections<'a> {
+impl Default for CreateSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnections {
     fn default() -> Self {
         Self::new()
     }
@@ -3314,19 +3314,18 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// Additional fields for network related functions
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateSetupIntentPaymentMethodOptionsUsBankAccountNetworks<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateSetupIntentPaymentMethodOptionsUsBankAccountNetworks {
     /// Triggers validations to run across the selected networks
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub requested:
-        Option<&'a [CreateSetupIntentPaymentMethodOptionsUsBankAccountNetworksRequested]>,
+    pub requested: Option<Vec<CreateSetupIntentPaymentMethodOptionsUsBankAccountNetworksRequested>>,
 }
-impl<'a> CreateSetupIntentPaymentMethodOptionsUsBankAccountNetworks<'a> {
+impl CreateSetupIntentPaymentMethodOptionsUsBankAccountNetworks {
     pub fn new() -> Self {
         Self { requested: None }
     }
 }
-impl<'a> Default for CreateSetupIntentPaymentMethodOptionsUsBankAccountNetworks<'a> {
+impl Default for CreateSetupIntentPaymentMethodOptionsUsBankAccountNetworks {
     fn default() -> Self {
         Self::new()
     }
@@ -3459,8 +3458,8 @@ pub struct CreateSetupIntentSingleUse {
     pub currency: stripe_types::Currency,
 }
 impl CreateSetupIntentSingleUse {
-    pub fn new(amount: i64, currency: stripe_types::Currency) -> Self {
-        Self { amount, currency }
+    pub fn new(amount: impl Into<i64>, currency: impl Into<stripe_types::Currency>) -> Self {
+        Self { amount: amount.into(), currency: currency.into() }
     }
 }
 /// Indicates how the payment method is intended to be used in the future.
@@ -3524,10 +3523,10 @@ impl<'de> serde::Deserialize<'de> for CreateSetupIntentUsage {
 /// After you create the SetupIntent, attach a payment method and [confirm](https://stripe.com/docs/api/setup_intents/confirm).
 /// it to collect any required permissions to charge the payment method later.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateSetupIntent<'a> {
-    inner: CreateSetupIntentBuilder<'a>,
+pub struct CreateSetupIntent {
+    inner: CreateSetupIntentBuilder,
 }
-impl<'a> CreateSetupIntent<'a> {
+impl CreateSetupIntent {
     /// Construct a new `CreateSetupIntent`.
     pub fn new() -> Self {
         Self { inner: CreateSetupIntentBuilder::new() }
@@ -3536,48 +3535,48 @@ impl<'a> CreateSetupIntent<'a> {
     ///
     /// It can only be used for this Stripe Account’s own money movement flows like InboundTransfer and OutboundTransfers.
     /// It cannot be set to true when setting up a PaymentMethod for a Customer, and defaults to false when attaching a PaymentMethod to a Customer.
-    pub fn attach_to_self(mut self, attach_to_self: bool) -> Self {
-        self.inner.attach_to_self = Some(attach_to_self);
+    pub fn attach_to_self(mut self, attach_to_self: impl Into<bool>) -> Self {
+        self.inner.attach_to_self = Some(attach_to_self.into());
         self
     }
     /// When you enable this parameter, this SetupIntent accepts payment methods that you enable in the Dashboard and that are compatible with its other parameters.
     pub fn automatic_payment_methods(
         mut self,
-        automatic_payment_methods: CreateSetupIntentAutomaticPaymentMethods,
+        automatic_payment_methods: impl Into<CreateSetupIntentAutomaticPaymentMethods>,
     ) -> Self {
-        self.inner.automatic_payment_methods = Some(automatic_payment_methods);
+        self.inner.automatic_payment_methods = Some(automatic_payment_methods.into());
         self
     }
     /// Set to `true` to attempt to confirm this SetupIntent immediately.
     /// This parameter defaults to `false`.
     /// If a card is the attached payment method, you can provide a `return_url` in case further authentication is necessary.
-    pub fn confirm(mut self, confirm: bool) -> Self {
-        self.inner.confirm = Some(confirm);
+    pub fn confirm(mut self, confirm: impl Into<bool>) -> Self {
+        self.inner.confirm = Some(confirm.into());
         self
     }
     /// ID of the ConfirmationToken used to confirm this SetupIntent.
     ///
     /// If the provided ConfirmationToken contains properties that are also being provided in this request, such as `payment_method`, then the values in this request will take precedence.
-    pub fn confirmation_token(mut self, confirmation_token: &'a str) -> Self {
-        self.inner.confirmation_token = Some(confirmation_token);
+    pub fn confirmation_token(mut self, confirmation_token: impl Into<String>) -> Self {
+        self.inner.confirmation_token = Some(confirmation_token.into());
         self
     }
     /// ID of the Customer this SetupIntent belongs to, if one exists.
     ///
     /// If present, the SetupIntent's payment method will be attached to the Customer on successful setup.
     /// Payment methods attached to other Customers cannot be used with this SetupIntent.
-    pub fn customer(mut self, customer: &'a str) -> Self {
-        self.inner.customer = Some(customer);
+    pub fn customer(mut self, customer: impl Into<String>) -> Self {
+        self.inner.customer = Some(customer.into());
         self
     }
     /// An arbitrary string attached to the object. Often useful for displaying to users.
-    pub fn description(mut self, description: &'a str) -> Self {
-        self.inner.description = Some(description);
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.inner.description = Some(description.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Indicates the directions of money movement for which this payment method is intended to be used.
@@ -3587,93 +3586,99 @@ impl<'a> CreateSetupIntent<'a> {
     /// You can include both if you intend to use the payment method for both purposes.
     pub fn flow_directions(
         mut self,
-        flow_directions: &'a [stripe_shared::SetupIntentFlowDirections],
+        flow_directions: impl Into<Vec<stripe_shared::SetupIntentFlowDirections>>,
     ) -> Self {
-        self.inner.flow_directions = Some(flow_directions);
+        self.inner.flow_directions = Some(flow_directions.into());
         self
     }
     /// This hash contains details about the mandate to create.
     /// This parameter can only be used with [`confirm=true`](https://stripe.com/docs/api/setup_intents/create#create_setup_intent-confirm).
-    pub fn mandate_data(mut self, mandate_data: CreateSetupIntentMandateData<'a>) -> Self {
-        self.inner.mandate_data = Some(mandate_data);
+    pub fn mandate_data(mut self, mandate_data: impl Into<CreateSetupIntentMandateData>) -> Self {
+        self.inner.mandate_data = Some(mandate_data.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// The Stripe account ID created for this SetupIntent.
-    pub fn on_behalf_of(mut self, on_behalf_of: &'a str) -> Self {
-        self.inner.on_behalf_of = Some(on_behalf_of);
+    pub fn on_behalf_of(mut self, on_behalf_of: impl Into<String>) -> Self {
+        self.inner.on_behalf_of = Some(on_behalf_of.into());
         self
     }
     /// ID of the payment method (a PaymentMethod, Card, or saved Source object) to attach to this SetupIntent.
-    pub fn payment_method(mut self, payment_method: &'a str) -> Self {
-        self.inner.payment_method = Some(payment_method);
+    pub fn payment_method(mut self, payment_method: impl Into<String>) -> Self {
+        self.inner.payment_method = Some(payment_method.into());
         self
     }
     /// The ID of the payment method configuration to use with this SetupIntent.
-    pub fn payment_method_configuration(mut self, payment_method_configuration: &'a str) -> Self {
-        self.inner.payment_method_configuration = Some(payment_method_configuration);
+    pub fn payment_method_configuration(
+        mut self,
+        payment_method_configuration: impl Into<String>,
+    ) -> Self {
+        self.inner.payment_method_configuration = Some(payment_method_configuration.into());
         self
     }
     /// When included, this hash creates a PaymentMethod that is set as the [`payment_method`](https://stripe.com/docs/api/setup_intents/object#setup_intent_object-payment_method).
     /// value in the SetupIntent.
     pub fn payment_method_data(
         mut self,
-        payment_method_data: CreateSetupIntentPaymentMethodData<'a>,
+        payment_method_data: impl Into<CreateSetupIntentPaymentMethodData>,
     ) -> Self {
-        self.inner.payment_method_data = Some(payment_method_data);
+        self.inner.payment_method_data = Some(payment_method_data.into());
         self
     }
     /// Payment method-specific configuration for this SetupIntent.
     pub fn payment_method_options(
         mut self,
-        payment_method_options: CreateSetupIntentPaymentMethodOptions<'a>,
+        payment_method_options: impl Into<CreateSetupIntentPaymentMethodOptions>,
     ) -> Self {
-        self.inner.payment_method_options = Some(payment_method_options);
+        self.inner.payment_method_options = Some(payment_method_options.into());
         self
     }
     /// The list of payment method types (for example, card) that this SetupIntent can use.
     /// If you don't provide this, it defaults to ["card"].
-    pub fn payment_method_types(mut self, payment_method_types: &'a [&'a str]) -> Self {
-        self.inner.payment_method_types = Some(payment_method_types);
+    pub fn payment_method_types(mut self, payment_method_types: impl Into<Vec<String>>) -> Self {
+        self.inner.payment_method_types = Some(payment_method_types.into());
         self
     }
     /// The URL to redirect your customer back to after they authenticate or cancel their payment on the payment method's app or site.
     /// To redirect to a mobile application, you can alternatively supply an application URI scheme.
     /// This parameter can only be used with [`confirm=true`](https://stripe.com/docs/api/setup_intents/create#create_setup_intent-confirm).
-    pub fn return_url(mut self, return_url: &'a str) -> Self {
-        self.inner.return_url = Some(return_url);
+    pub fn return_url(mut self, return_url: impl Into<String>) -> Self {
+        self.inner.return_url = Some(return_url.into());
         self
     }
     /// If you populate this hash, this SetupIntent generates a `single_use` mandate after successful completion.
-    pub fn single_use(mut self, single_use: CreateSetupIntentSingleUse) -> Self {
-        self.inner.single_use = Some(single_use);
+    pub fn single_use(mut self, single_use: impl Into<CreateSetupIntentSingleUse>) -> Self {
+        self.inner.single_use = Some(single_use.into());
         self
     }
     /// Indicates how the payment method is intended to be used in the future.
     /// If not provided, this value defaults to `off_session`.
-    pub fn usage(mut self, usage: CreateSetupIntentUsage) -> Self {
-        self.inner.usage = Some(usage);
+    pub fn usage(mut self, usage: impl Into<CreateSetupIntentUsage>) -> Self {
+        self.inner.usage = Some(usage.into());
         self
     }
     /// Set to `true` when confirming server-side and using Stripe.js, iOS, or Android client-side SDKs to handle the next actions.
-    pub fn use_stripe_sdk(mut self, use_stripe_sdk: bool) -> Self {
-        self.inner.use_stripe_sdk = Some(use_stripe_sdk);
+    pub fn use_stripe_sdk(mut self, use_stripe_sdk: impl Into<bool>) -> Self {
+        self.inner.use_stripe_sdk = Some(use_stripe_sdk.into());
         self
     }
 }
-impl<'a> Default for CreateSetupIntent<'a> {
+impl Default for CreateSetupIntent {
     fn default() -> Self {
         Self::new()
     }
 }
-impl CreateSetupIntent<'_> {
+impl CreateSetupIntent {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -3691,7 +3696,7 @@ impl CreateSetupIntent<'_> {
     }
 }
 
-impl StripeRequest for CreateSetupIntent<'_> {
+impl StripeRequest for CreateSetupIntent {
     type Output = stripe_shared::SetupIntent;
 
     fn build(&self) -> RequestBuilder {
@@ -3699,31 +3704,31 @@ impl StripeRequest for CreateSetupIntent<'_> {
     }
 }
 #[derive(Clone, Debug, serde::Serialize)]
-struct UpdateSetupIntentBuilder<'a> {
+struct UpdateSetupIntentBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     attach_to_self: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    customer: Option<&'a str>,
+    customer: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<&'a str>,
+    description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    flow_directions: Option<&'a [stripe_shared::SetupIntentFlowDirections]>,
+    flow_directions: Option<Vec<stripe_shared::SetupIntentFlowDirections>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_method: Option<&'a str>,
+    payment_method: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_method_configuration: Option<&'a str>,
+    payment_method_configuration: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_method_data: Option<UpdateSetupIntentPaymentMethodData<'a>>,
+    payment_method_data: Option<UpdateSetupIntentPaymentMethodData>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_method_options: Option<UpdateSetupIntentPaymentMethodOptions<'a>>,
+    payment_method_options: Option<UpdateSetupIntentPaymentMethodOptions>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_method_types: Option<&'a [&'a str]>,
+    payment_method_types: Option<Vec<String>>,
 }
-impl<'a> UpdateSetupIntentBuilder<'a> {
+impl UpdateSetupIntentBuilder {
     fn new() -> Self {
         Self {
             attach_to_self: None,
@@ -3743,10 +3748,10 @@ impl<'a> UpdateSetupIntentBuilder<'a> {
 /// When included, this hash creates a PaymentMethod that is set as the [`payment_method`](https://stripe.com/docs/api/setup_intents/object#setup_intent_object-payment_method).
 /// value in the SetupIntent.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateSetupIntentPaymentMethodData<'a> {
+pub struct UpdateSetupIntentPaymentMethodData {
     /// If this is an `acss_debit` PaymentMethod, this hash contains details about the ACSS Debit payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub acss_debit: Option<PaymentMethodParam<'a>>,
+    pub acss_debit: Option<PaymentMethodParam>,
     /// If this is an `affirm` PaymentMethod, this hash contains details about the Affirm payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
@@ -3770,24 +3775,24 @@ pub struct UpdateSetupIntentPaymentMethodData<'a> {
     pub amazon_pay: Option<miniserde::json::Value>,
     /// If this is an `au_becs_debit` PaymentMethod, this hash contains details about the bank account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub au_becs_debit: Option<UpdateSetupIntentPaymentMethodDataAuBecsDebit<'a>>,
+    pub au_becs_debit: Option<UpdateSetupIntentPaymentMethodDataAuBecsDebit>,
     /// If this is a `bacs_debit` PaymentMethod, this hash contains details about the Bacs Direct Debit bank account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub bacs_debit: Option<UpdateSetupIntentPaymentMethodDataBacsDebit<'a>>,
+    pub bacs_debit: Option<UpdateSetupIntentPaymentMethodDataBacsDebit>,
     /// If this is a `bancontact` PaymentMethod, this hash contains details about the Bancontact payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
     pub bancontact: Option<miniserde::json::Value>,
     /// Billing information associated with the PaymentMethod that may be used or required by particular types of payment methods.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub billing_details: Option<BillingDetailsInnerParams<'a>>,
+    pub billing_details: Option<BillingDetailsInnerParams>,
     /// If this is a `blik` PaymentMethod, this hash contains details about the BLIK payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
     pub blik: Option<miniserde::json::Value>,
     /// If this is a `boleto` PaymentMethod, this hash contains details about the Boleto payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub boleto: Option<UpdateSetupIntentPaymentMethodDataBoleto<'a>>,
+    pub boleto: Option<UpdateSetupIntentPaymentMethodDataBoleto>,
     /// If this is a `cashapp` PaymentMethod, this hash contains details about the Cash App Pay payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
@@ -3833,7 +3838,7 @@ pub struct UpdateSetupIntentPaymentMethodData<'a> {
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// If this is a `mobilepay` PaymentMethod, this hash contains details about the MobilePay payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
@@ -3864,14 +3869,14 @@ pub struct UpdateSetupIntentPaymentMethodData<'a> {
     /// Options to configure Radar.
     /// See [Radar Session](https://stripe.com/docs/radar/radar-session) for more information.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub radar_options: Option<RadarOptionsWithHiddenOptions<'a>>,
+    pub radar_options: Option<RadarOptionsWithHiddenOptions>,
     /// If this is a `Revolut Pay` PaymentMethod, this hash contains details about the Revolut Pay payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
     pub revolut_pay: Option<miniserde::json::Value>,
     /// If this is a `sepa_debit` PaymentMethod, this hash contains details about the SEPA debit bank account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub sepa_debit: Option<UpdateSetupIntentPaymentMethodDataSepaDebit<'a>>,
+    pub sepa_debit: Option<UpdateSetupIntentPaymentMethodDataSepaDebit>,
     /// If this is a `sofort` PaymentMethod, this hash contains details about the SOFORT payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sofort: Option<UpdateSetupIntentPaymentMethodDataSofort>,
@@ -3886,7 +3891,7 @@ pub struct UpdateSetupIntentPaymentMethodData<'a> {
     pub type_: UpdateSetupIntentPaymentMethodDataType,
     /// If this is an `us_bank_account` PaymentMethod, this hash contains details about the US bank account payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub us_bank_account: Option<UpdateSetupIntentPaymentMethodDataUsBankAccount<'a>>,
+    pub us_bank_account: Option<UpdateSetupIntentPaymentMethodDataUsBankAccount>,
     /// If this is an `wechat_pay` PaymentMethod, this hash contains details about the wechat_pay payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
@@ -3896,8 +3901,8 @@ pub struct UpdateSetupIntentPaymentMethodData<'a> {
     #[serde(with = "stripe_types::with_serde_json_opt")]
     pub zip: Option<miniserde::json::Value>,
 }
-impl<'a> UpdateSetupIntentPaymentMethodData<'a> {
-    pub fn new(type_: UpdateSetupIntentPaymentMethodDataType) -> Self {
+impl UpdateSetupIntentPaymentMethodData {
+    pub fn new(type_: impl Into<UpdateSetupIntentPaymentMethodDataType>) -> Self {
         Self {
             acss_debit: None,
             affirm: None,
@@ -3935,7 +3940,7 @@ impl<'a> UpdateSetupIntentPaymentMethodData<'a> {
             sepa_debit: None,
             sofort: None,
             swish: None,
-            type_,
+            type_: type_.into(),
             us_bank_account: None,
             wechat_pay: None,
             zip: None,
@@ -4006,47 +4011,47 @@ impl<'de> serde::Deserialize<'de> for UpdateSetupIntentPaymentMethodDataAllowRed
     }
 }
 /// If this is an `au_becs_debit` PaymentMethod, this hash contains details about the bank account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateSetupIntentPaymentMethodDataAuBecsDebit<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateSetupIntentPaymentMethodDataAuBecsDebit {
     /// The account number for the bank account.
-    pub account_number: &'a str,
+    pub account_number: String,
     /// Bank-State-Branch number of the bank account.
-    pub bsb_number: &'a str,
+    pub bsb_number: String,
 }
-impl<'a> UpdateSetupIntentPaymentMethodDataAuBecsDebit<'a> {
-    pub fn new(account_number: &'a str, bsb_number: &'a str) -> Self {
-        Self { account_number, bsb_number }
+impl UpdateSetupIntentPaymentMethodDataAuBecsDebit {
+    pub fn new(account_number: impl Into<String>, bsb_number: impl Into<String>) -> Self {
+        Self { account_number: account_number.into(), bsb_number: bsb_number.into() }
     }
 }
 /// If this is a `bacs_debit` PaymentMethod, this hash contains details about the Bacs Direct Debit bank account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateSetupIntentPaymentMethodDataBacsDebit<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateSetupIntentPaymentMethodDataBacsDebit {
     /// Account number of the bank account that the funds will be debited from.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account_number: Option<&'a str>,
+    pub account_number: Option<String>,
     /// Sort code of the bank account. (e.g., `10-20-30`)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub sort_code: Option<&'a str>,
+    pub sort_code: Option<String>,
 }
-impl<'a> UpdateSetupIntentPaymentMethodDataBacsDebit<'a> {
+impl UpdateSetupIntentPaymentMethodDataBacsDebit {
     pub fn new() -> Self {
         Self { account_number: None, sort_code: None }
     }
 }
-impl<'a> Default for UpdateSetupIntentPaymentMethodDataBacsDebit<'a> {
+impl Default for UpdateSetupIntentPaymentMethodDataBacsDebit {
     fn default() -> Self {
         Self::new()
     }
 }
 /// If this is a `boleto` PaymentMethod, this hash contains details about the Boleto payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateSetupIntentPaymentMethodDataBoleto<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateSetupIntentPaymentMethodDataBoleto {
     /// The tax ID of the customer (CPF for individual consumers or CNPJ for businesses consumers)
-    pub tax_id: &'a str,
+    pub tax_id: String,
 }
-impl<'a> UpdateSetupIntentPaymentMethodDataBoleto<'a> {
-    pub fn new(tax_id: &'a str) -> Self {
-        Self { tax_id }
+impl UpdateSetupIntentPaymentMethodDataBoleto {
+    pub fn new(tax_id: impl Into<String>) -> Self {
+        Self { tax_id: tax_id.into() }
     }
 }
 /// If this is an `eps` PaymentMethod, this hash contains details about the EPS payment method.
@@ -4212,8 +4217,8 @@ pub struct UpdateSetupIntentPaymentMethodDataFpx {
     pub bank: UpdateSetupIntentPaymentMethodDataFpxBank,
 }
 impl UpdateSetupIntentPaymentMethodDataFpx {
-    pub fn new(bank: UpdateSetupIntentPaymentMethodDataFpxBank) -> Self {
-        Self { account_holder_type: None, bank }
+    pub fn new(bank: impl Into<UpdateSetupIntentPaymentMethodDataFpxBank>) -> Self {
+        Self { account_holder_type: None, bank: bank.into() }
     }
 }
 /// Account holder type for FPX transaction
@@ -4674,14 +4679,14 @@ impl<'de> serde::Deserialize<'de> for UpdateSetupIntentPaymentMethodDataP24Bank 
     }
 }
 /// If this is a `sepa_debit` PaymentMethod, this hash contains details about the SEPA debit bank account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateSetupIntentPaymentMethodDataSepaDebit<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateSetupIntentPaymentMethodDataSepaDebit {
     /// IBAN of the bank account.
-    pub iban: &'a str,
+    pub iban: String,
 }
-impl<'a> UpdateSetupIntentPaymentMethodDataSepaDebit<'a> {
-    pub fn new(iban: &'a str) -> Self {
-        Self { iban }
+impl UpdateSetupIntentPaymentMethodDataSepaDebit {
+    pub fn new(iban: impl Into<String>) -> Self {
+        Self { iban: iban.into() }
     }
 }
 /// If this is a `sofort` PaymentMethod, this hash contains details about the SOFORT payment method.
@@ -4691,8 +4696,8 @@ pub struct UpdateSetupIntentPaymentMethodDataSofort {
     pub country: UpdateSetupIntentPaymentMethodDataSofortCountry,
 }
 impl UpdateSetupIntentPaymentMethodDataSofort {
-    pub fn new(country: UpdateSetupIntentPaymentMethodDataSofortCountry) -> Self {
-        Self { country }
+    pub fn new(country: impl Into<UpdateSetupIntentPaymentMethodDataSofortCountry>) -> Self {
+        Self { country: country.into() }
     }
 }
 /// Two-letter ISO code representing the country the bank account is located in.
@@ -4922,26 +4927,26 @@ impl<'de> serde::Deserialize<'de> for UpdateSetupIntentPaymentMethodDataType {
     }
 }
 /// If this is an `us_bank_account` PaymentMethod, this hash contains details about the US bank account payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateSetupIntentPaymentMethodDataUsBankAccount<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateSetupIntentPaymentMethodDataUsBankAccount {
     /// Account holder type: individual or company.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub account_holder_type:
         Option<UpdateSetupIntentPaymentMethodDataUsBankAccountAccountHolderType>,
     /// Account number of the bank account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account_number: Option<&'a str>,
+    pub account_number: Option<String>,
     /// Account type: checkings or savings. Defaults to checking if omitted.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub account_type: Option<UpdateSetupIntentPaymentMethodDataUsBankAccountAccountType>,
     /// The ID of a Financial Connections Account to use as a payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub financial_connections_account: Option<&'a str>,
+    pub financial_connections_account: Option<String>,
     /// Routing number of the bank account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub routing_number: Option<&'a str>,
+    pub routing_number: Option<String>,
 }
-impl<'a> UpdateSetupIntentPaymentMethodDataUsBankAccount<'a> {
+impl UpdateSetupIntentPaymentMethodDataUsBankAccount {
     pub fn new() -> Self {
         Self {
             account_holder_type: None,
@@ -4952,7 +4957,7 @@ impl<'a> UpdateSetupIntentPaymentMethodDataUsBankAccount<'a> {
         }
     }
 }
-impl<'a> Default for UpdateSetupIntentPaymentMethodDataUsBankAccount<'a> {
+impl Default for UpdateSetupIntentPaymentMethodDataUsBankAccount {
     fn default() -> Self {
         Self::new()
     }
@@ -5073,35 +5078,35 @@ impl<'de> serde::Deserialize<'de> for UpdateSetupIntentPaymentMethodDataUsBankAc
 }
 /// Payment method-specific configuration for this SetupIntent.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateSetupIntentPaymentMethodOptions<'a> {
+pub struct UpdateSetupIntentPaymentMethodOptions {
     /// If this is a `acss_debit` SetupIntent, this sub-hash contains details about the ACSS Debit payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub acss_debit: Option<UpdateSetupIntentPaymentMethodOptionsAcssDebit<'a>>,
+    pub acss_debit: Option<UpdateSetupIntentPaymentMethodOptionsAcssDebit>,
     /// If this is a `amazon_pay` SetupIntent, this sub-hash contains details about the AmazonPay payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
     pub amazon_pay: Option<miniserde::json::Value>,
     /// Configuration for any card setup attempted on this SetupIntent.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub card: Option<UpdateSetupIntentPaymentMethodOptionsCard<'a>>,
+    pub card: Option<UpdateSetupIntentPaymentMethodOptionsCard>,
     /// If this is a `card_present` PaymentMethod, this sub-hash contains details about the card-present payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
     pub card_present: Option<miniserde::json::Value>,
     /// If this is a `link` PaymentMethod, this sub-hash contains details about the Link payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub link: Option<SetupIntentPaymentMethodOptionsParam<'a>>,
+    pub link: Option<SetupIntentPaymentMethodOptionsParam>,
     /// If this is a `paypal` PaymentMethod, this sub-hash contains details about the PayPal payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub paypal: Option<PaymentMethodOptionsParam<'a>>,
+    pub paypal: Option<PaymentMethodOptionsParam>,
     /// If this is a `sepa_debit` SetupIntent, this sub-hash contains details about the SEPA Debit payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sepa_debit: Option<UpdateSetupIntentPaymentMethodOptionsSepaDebit>,
     /// If this is a `us_bank_account` SetupIntent, this sub-hash contains details about the US bank account payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub us_bank_account: Option<UpdateSetupIntentPaymentMethodOptionsUsBankAccount<'a>>,
+    pub us_bank_account: Option<UpdateSetupIntentPaymentMethodOptionsUsBankAccount>,
 }
-impl<'a> UpdateSetupIntentPaymentMethodOptions<'a> {
+impl UpdateSetupIntentPaymentMethodOptions {
     pub fn new() -> Self {
         Self {
             acss_debit: None,
@@ -5115,32 +5120,32 @@ impl<'a> UpdateSetupIntentPaymentMethodOptions<'a> {
         }
     }
 }
-impl<'a> Default for UpdateSetupIntentPaymentMethodOptions<'a> {
+impl Default for UpdateSetupIntentPaymentMethodOptions {
     fn default() -> Self {
         Self::new()
     }
 }
 /// If this is a `acss_debit` SetupIntent, this sub-hash contains details about the ACSS Debit payment method options.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateSetupIntentPaymentMethodOptionsAcssDebit<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateSetupIntentPaymentMethodOptionsAcssDebit {
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     /// Must be a [supported currency](https://stripe.com/docs/currencies).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub currency: Option<UpdateSetupIntentPaymentMethodOptionsAcssDebitCurrency>,
     /// Additional fields for Mandate creation
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub mandate_options: Option<UpdateSetupIntentPaymentMethodOptionsAcssDebitMandateOptions<'a>>,
+    pub mandate_options: Option<UpdateSetupIntentPaymentMethodOptionsAcssDebitMandateOptions>,
     /// Bank account verification method.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub verification_method:
         Option<UpdateSetupIntentPaymentMethodOptionsAcssDebitVerificationMethod>,
 }
-impl<'a> UpdateSetupIntentPaymentMethodOptionsAcssDebit<'a> {
+impl UpdateSetupIntentPaymentMethodOptionsAcssDebit {
     pub fn new() -> Self {
         Self { currency: None, mandate_options: None, verification_method: None }
     }
 }
-impl<'a> Default for UpdateSetupIntentPaymentMethodOptionsAcssDebit<'a> {
+impl Default for UpdateSetupIntentPaymentMethodOptionsAcssDebit {
     fn default() -> Self {
         Self::new()
     }
@@ -5205,21 +5210,21 @@ impl<'de> serde::Deserialize<'de> for UpdateSetupIntentPaymentMethodOptionsAcssD
     }
 }
 /// Additional fields for Mandate creation
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateSetupIntentPaymentMethodOptionsAcssDebitMandateOptions<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateSetupIntentPaymentMethodOptionsAcssDebitMandateOptions {
     /// A URL for custom mandate text to render during confirmation step.
     /// The URL will be rendered with additional GET parameters `payment_intent` and `payment_intent_client_secret` when confirming a Payment Intent,.
     /// or `setup_intent` and `setup_intent_client_secret` when confirming a Setup Intent.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub custom_mandate_url: Option<&'a str>,
+    pub custom_mandate_url: Option<String>,
     /// List of Stripe products where this mandate can be selected automatically.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_for:
-        Option<&'a [UpdateSetupIntentPaymentMethodOptionsAcssDebitMandateOptionsDefaultFor]>,
+        Option<Vec<UpdateSetupIntentPaymentMethodOptionsAcssDebitMandateOptionsDefaultFor>>,
     /// Description of the mandate interval.
     /// Only required if 'payment_schedule' parameter is 'interval' or 'combined'.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub interval_description: Option<&'a str>,
+    pub interval_description: Option<String>,
     /// Payment schedule for the mandate.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub payment_schedule:
@@ -5229,7 +5234,7 @@ pub struct UpdateSetupIntentPaymentMethodOptionsAcssDebitMandateOptions<'a> {
     pub transaction_type:
         Option<UpdateSetupIntentPaymentMethodOptionsAcssDebitMandateOptionsTransactionType>,
 }
-impl<'a> UpdateSetupIntentPaymentMethodOptionsAcssDebitMandateOptions<'a> {
+impl UpdateSetupIntentPaymentMethodOptionsAcssDebitMandateOptions {
     pub fn new() -> Self {
         Self {
             custom_mandate_url: None,
@@ -5240,7 +5245,7 @@ impl<'a> UpdateSetupIntentPaymentMethodOptionsAcssDebitMandateOptions<'a> {
         }
     }
 }
-impl<'a> Default for UpdateSetupIntentPaymentMethodOptionsAcssDebitMandateOptions<'a> {
+impl Default for UpdateSetupIntentPaymentMethodOptionsAcssDebitMandateOptions {
     fn default() -> Self {
         Self::new()
     }
@@ -5492,11 +5497,11 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// Configuration for any card setup attempted on this SetupIntent.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateSetupIntentPaymentMethodOptionsCard<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateSetupIntentPaymentMethodOptionsCard {
     /// Configuration options for setting up an eMandate for cards issued in India.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub mandate_options: Option<UpdateSetupIntentPaymentMethodOptionsCardMandateOptions<'a>>,
+    pub mandate_options: Option<UpdateSetupIntentPaymentMethodOptionsCardMandateOptions>,
     /// When specified, this parameter signals that a card has been collected
     /// as MOTO (Mail Order Telephone Order) and thus out of scope for SCA. This
     /// parameter can only be provided during confirmation.
@@ -5517,9 +5522,9 @@ pub struct UpdateSetupIntentPaymentMethodOptionsCard<'a> {
     /// If 3D Secure authentication was performed with a third-party provider,
     /// the authentication details to use for this setup.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub three_d_secure: Option<UpdateSetupIntentPaymentMethodOptionsCardThreeDSecure<'a>>,
+    pub three_d_secure: Option<UpdateSetupIntentPaymentMethodOptionsCardThreeDSecure>,
 }
-impl<'a> UpdateSetupIntentPaymentMethodOptionsCard<'a> {
+impl UpdateSetupIntentPaymentMethodOptionsCard {
     pub fn new() -> Self {
         Self {
             mandate_options: None,
@@ -5530,14 +5535,14 @@ impl<'a> UpdateSetupIntentPaymentMethodOptionsCard<'a> {
         }
     }
 }
-impl<'a> Default for UpdateSetupIntentPaymentMethodOptionsCard<'a> {
+impl Default for UpdateSetupIntentPaymentMethodOptionsCard {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Configuration options for setting up an eMandate for cards issued in India.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateSetupIntentPaymentMethodOptionsCardMandateOptions<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateSetupIntentPaymentMethodOptionsCardMandateOptions {
     /// Amount to be charged for future payments.
     pub amount: i64,
     /// One of `fixed` or `maximum`.
@@ -5550,7 +5555,7 @@ pub struct UpdateSetupIntentPaymentMethodOptionsCardMandateOptions<'a> {
     pub currency: stripe_types::Currency,
     /// A description of the mandate or subscription that is meant to be displayed to the customer.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<&'a str>,
+    pub description: Option<String>,
     /// End date of the mandate or subscription.
     /// If not provided, the mandate will be active until canceled.
     /// If provided, end date should be after start date.
@@ -5565,33 +5570,33 @@ pub struct UpdateSetupIntentPaymentMethodOptionsCardMandateOptions<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub interval_count: Option<u64>,
     /// Unique identifier for the mandate or subscription.
-    pub reference: &'a str,
+    pub reference: String,
     /// Start date of the mandate or subscription. Start date should not be lesser than yesterday.
     pub start_date: stripe_types::Timestamp,
     /// Specifies the type of mandates supported. Possible values are `india`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub supported_types:
-        Option<&'a [UpdateSetupIntentPaymentMethodOptionsCardMandateOptionsSupportedTypes]>,
+        Option<Vec<UpdateSetupIntentPaymentMethodOptionsCardMandateOptionsSupportedTypes>>,
 }
-impl<'a> UpdateSetupIntentPaymentMethodOptionsCardMandateOptions<'a> {
+impl UpdateSetupIntentPaymentMethodOptionsCardMandateOptions {
     pub fn new(
-        amount: i64,
-        amount_type: UpdateSetupIntentPaymentMethodOptionsCardMandateOptionsAmountType,
-        currency: stripe_types::Currency,
-        interval: UpdateSetupIntentPaymentMethodOptionsCardMandateOptionsInterval,
-        reference: &'a str,
-        start_date: stripe_types::Timestamp,
+        amount: impl Into<i64>,
+        amount_type: impl Into<UpdateSetupIntentPaymentMethodOptionsCardMandateOptionsAmountType>,
+        currency: impl Into<stripe_types::Currency>,
+        interval: impl Into<UpdateSetupIntentPaymentMethodOptionsCardMandateOptionsInterval>,
+        reference: impl Into<String>,
+        start_date: impl Into<stripe_types::Timestamp>,
     ) -> Self {
         Self {
-            amount,
-            amount_type,
-            currency,
+            amount: amount.into(),
+            amount_type: amount_type.into(),
+            currency: currency.into(),
             description: None,
             end_date: None,
-            interval,
+            interval: interval.into(),
             interval_count: None,
-            reference,
-            start_date,
+            reference: reference.into(),
+            start_date: start_date.into(),
             supported_types: None,
         }
     }
@@ -5929,8 +5934,8 @@ impl<'de> serde::Deserialize<'de> for UpdateSetupIntentPaymentMethodOptionsCardR
 }
 /// If 3D Secure authentication was performed with a third-party provider,
 /// the authentication details to use for this setup.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateSetupIntentPaymentMethodOptionsCardThreeDSecure<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateSetupIntentPaymentMethodOptionsCardThreeDSecure {
     /// The `transStatus` returned from the card Issuer’s ACS in the ARes.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ares_trans_status:
@@ -5940,7 +5945,7 @@ pub struct UpdateSetupIntentPaymentMethodOptionsCardThreeDSecure<'a> {
     /// (Most 3D Secure providers will return the base64-encoded version, which
     /// is what you should specify here.)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub cryptogram: Option<&'a str>,
+    pub cryptogram: Option<String>,
     /// The Electronic Commerce Indicator (ECI) is returned by your 3D Secure
     /// provider and indicates what degree of authentication was performed.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -5951,20 +5956,20 @@ pub struct UpdateSetupIntentPaymentMethodOptionsCardThreeDSecure<'a> {
     /// must be populated accordingly
     #[serde(skip_serializing_if = "Option::is_none")]
     pub network_options:
-        Option<UpdateSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptions<'a>>,
+        Option<UpdateSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptions>,
     /// The challenge indicator (`threeDSRequestorChallengeInd`) which was requested in the
     /// AReq sent to the card Issuer's ACS. A string containing 2 digits from 01-99.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub requestor_challenge_indicator: Option<&'a str>,
+    pub requestor_challenge_indicator: Option<String>,
     /// For 3D Secure 1, the XID. For 3D Secure 2, the Directory Server
     /// Transaction ID (dsTransID).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub transaction_id: Option<&'a str>,
+    pub transaction_id: Option<String>,
     /// The version of 3D Secure that was performed.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<UpdateSetupIntentPaymentMethodOptionsCardThreeDSecureVersion>,
 }
-impl<'a> UpdateSetupIntentPaymentMethodOptionsCardThreeDSecure<'a> {
+impl UpdateSetupIntentPaymentMethodOptionsCardThreeDSecure {
     pub fn new() -> Self {
         Self {
             ares_trans_status: None,
@@ -5977,7 +5982,7 @@ impl<'a> UpdateSetupIntentPaymentMethodOptionsCardThreeDSecure<'a> {
         }
     }
 }
-impl<'a> Default for UpdateSetupIntentPaymentMethodOptionsCardThreeDSecure<'a> {
+impl Default for UpdateSetupIntentPaymentMethodOptionsCardThreeDSecure {
     fn default() -> Self {
         Self::new()
     }
@@ -6130,27 +6135,26 @@ impl<'de> serde::Deserialize<'de>
 /// Network specific 3DS fields. Network specific arguments require an
 /// explicit card brand choice. The parameter `payment_method_options.card.network``
 /// must be populated accordingly
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptions<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptions {
     /// Cartes Bancaires-specific 3DS fields.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub cartes_bancaires: Option<
-        UpdateSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancaires<'a>,
-    >,
+    pub cartes_bancaires:
+        Option<UpdateSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancaires>,
 }
-impl<'a> UpdateSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptions<'a> {
+impl UpdateSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptions {
     pub fn new() -> Self {
         Self { cartes_bancaires: None }
     }
 }
-impl<'a> Default for UpdateSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptions<'a> {
+impl Default for UpdateSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptions {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Cartes Bancaires-specific 3DS fields.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancaires<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancaires {
     /// The cryptogram calculation algorithm used by the card Issuer's ACS
     /// to calculate the Authentication cryptogram. Also known as `cavvAlgorithm`.
     /// messageExtension: CB-AVALGO
@@ -6161,17 +6165,17 @@ pub struct UpdateSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCa
     /// This is a 3 byte bitmap (low significant byte first and most significant
     /// bit first) that has been Base64 encoded
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub cb_exemption: Option<&'a str>,
+    pub cb_exemption: Option<String>,
     /// The risk score returned from Cartes Bancaires in the ARes.
     /// message extension: CB-SCORE; numeric value 0-99
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cb_score: Option<i64>,
 }
-impl<'a> UpdateSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancaires<'a> {
+impl UpdateSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancaires {
     pub fn new(
-        cb_avalgo: UpdateSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancairesCbAvalgo,
+        cb_avalgo: impl Into<UpdateSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancairesCbAvalgo>,
     ) -> Self {
-        Self { cb_avalgo, cb_exemption: None, cb_score: None }
+        Self { cb_avalgo: cb_avalgo.into(), cb_exemption: None, cb_score: None }
     }
 }
 /// The cryptogram calculation algorithm used by the card Issuer's ACS
@@ -6333,24 +6337,24 @@ impl Default for UpdateSetupIntentPaymentMethodOptionsSepaDebit {
     }
 }
 /// If this is a `us_bank_account` SetupIntent, this sub-hash contains details about the US bank account payment method options.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateSetupIntentPaymentMethodOptionsUsBankAccount<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateSetupIntentPaymentMethodOptionsUsBankAccount {
     /// Additional fields for Financial Connections Session creation
     #[serde(skip_serializing_if = "Option::is_none")]
     pub financial_connections:
-        Option<UpdateSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnections<'a>>,
+        Option<UpdateSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnections>,
     /// Additional fields for Mandate creation
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mandate_options: Option<UpdateSetupIntentPaymentMethodOptionsUsBankAccountMandateOptions>,
     /// Additional fields for network related functions
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub networks: Option<UpdateSetupIntentPaymentMethodOptionsUsBankAccountNetworks<'a>>,
+    pub networks: Option<UpdateSetupIntentPaymentMethodOptionsUsBankAccountNetworks>,
     /// Bank account verification method.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub verification_method:
         Option<UpdateSetupIntentPaymentMethodOptionsUsBankAccountVerificationMethod>,
 }
-impl<'a> UpdateSetupIntentPaymentMethodOptionsUsBankAccount<'a> {
+impl UpdateSetupIntentPaymentMethodOptionsUsBankAccount {
     pub fn new() -> Self {
         Self {
             financial_connections: None,
@@ -6360,37 +6364,36 @@ impl<'a> UpdateSetupIntentPaymentMethodOptionsUsBankAccount<'a> {
         }
     }
 }
-impl<'a> Default for UpdateSetupIntentPaymentMethodOptionsUsBankAccount<'a> {
+impl Default for UpdateSetupIntentPaymentMethodOptionsUsBankAccount {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Additional fields for Financial Connections Session creation
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnections<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnections {
     /// The list of permissions to request.
     /// If this parameter is passed, the `payment_method` permission must be included.
     /// Valid permissions include: `balances`, `ownership`, `payment_method`, and `transactions`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub permissions: Option<
-        &'a [UpdateSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPermissions],
+        Vec<UpdateSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPermissions>,
     >,
     /// List of data features that you would like to retrieve upon account creation.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub prefetch: Option<
-        &'a [UpdateSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPrefetch],
-    >,
+    pub prefetch:
+        Option<Vec<UpdateSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPrefetch>>,
     /// For webview integrations only.
     /// Upon completing OAuth login in the native browser, the user will be redirected to this URL to return to your app.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub return_url: Option<&'a str>,
+    pub return_url: Option<String>,
 }
-impl<'a> UpdateSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnections<'a> {
+impl UpdateSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnections {
     pub fn new() -> Self {
         Self { permissions: None, prefetch: None, return_url: None }
     }
 }
-impl<'a> Default for UpdateSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnections<'a> {
+impl Default for UpdateSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnections {
     fn default() -> Self {
         Self::new()
     }
@@ -6614,19 +6617,18 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// Additional fields for network related functions
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateSetupIntentPaymentMethodOptionsUsBankAccountNetworks<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateSetupIntentPaymentMethodOptionsUsBankAccountNetworks {
     /// Triggers validations to run across the selected networks
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub requested:
-        Option<&'a [UpdateSetupIntentPaymentMethodOptionsUsBankAccountNetworksRequested]>,
+    pub requested: Option<Vec<UpdateSetupIntentPaymentMethodOptionsUsBankAccountNetworksRequested>>,
 }
-impl<'a> UpdateSetupIntentPaymentMethodOptionsUsBankAccountNetworks<'a> {
+impl UpdateSetupIntentPaymentMethodOptionsUsBankAccountNetworks {
     pub fn new() -> Self {
         Self { requested: None }
     }
 }
-impl<'a> Default for UpdateSetupIntentPaymentMethodOptionsUsBankAccountNetworks<'a> {
+impl Default for UpdateSetupIntentPaymentMethodOptionsUsBankAccountNetworks {
     fn default() -> Self {
         Self::new()
     }
@@ -6748,39 +6750,39 @@ impl<'de> serde::Deserialize<'de>
 }
 /// Updates a SetupIntent object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateSetupIntent<'a> {
-    inner: UpdateSetupIntentBuilder<'a>,
-    intent: &'a stripe_shared::SetupIntentId,
+pub struct UpdateSetupIntent {
+    inner: UpdateSetupIntentBuilder,
+    intent: stripe_shared::SetupIntentId,
 }
-impl<'a> UpdateSetupIntent<'a> {
+impl UpdateSetupIntent {
     /// Construct a new `UpdateSetupIntent`.
-    pub fn new(intent: &'a stripe_shared::SetupIntentId) -> Self {
-        Self { intent, inner: UpdateSetupIntentBuilder::new() }
+    pub fn new(intent: impl Into<stripe_shared::SetupIntentId>) -> Self {
+        Self { intent: intent.into(), inner: UpdateSetupIntentBuilder::new() }
     }
     /// If present, the SetupIntent's payment method will be attached to the in-context Stripe Account.
     ///
     /// It can only be used for this Stripe Account’s own money movement flows like InboundTransfer and OutboundTransfers.
     /// It cannot be set to true when setting up a PaymentMethod for a Customer, and defaults to false when attaching a PaymentMethod to a Customer.
-    pub fn attach_to_self(mut self, attach_to_self: bool) -> Self {
-        self.inner.attach_to_self = Some(attach_to_self);
+    pub fn attach_to_self(mut self, attach_to_self: impl Into<bool>) -> Self {
+        self.inner.attach_to_self = Some(attach_to_self.into());
         self
     }
     /// ID of the Customer this SetupIntent belongs to, if one exists.
     ///
     /// If present, the SetupIntent's payment method will be attached to the Customer on successful setup.
     /// Payment methods attached to other Customers cannot be used with this SetupIntent.
-    pub fn customer(mut self, customer: &'a str) -> Self {
-        self.inner.customer = Some(customer);
+    pub fn customer(mut self, customer: impl Into<String>) -> Self {
+        self.inner.customer = Some(customer.into());
         self
     }
     /// An arbitrary string attached to the object. Often useful for displaying to users.
-    pub fn description(mut self, description: &'a str) -> Self {
-        self.inner.description = Some(description);
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.inner.description = Some(description.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Indicates the directions of money movement for which this payment method is intended to be used.
@@ -6790,54 +6792,60 @@ impl<'a> UpdateSetupIntent<'a> {
     /// You can include both if you intend to use the payment method for both purposes.
     pub fn flow_directions(
         mut self,
-        flow_directions: &'a [stripe_shared::SetupIntentFlowDirections],
+        flow_directions: impl Into<Vec<stripe_shared::SetupIntentFlowDirections>>,
     ) -> Self {
-        self.inner.flow_directions = Some(flow_directions);
+        self.inner.flow_directions = Some(flow_directions.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// ID of the payment method (a PaymentMethod, Card, or saved Source object) to attach to this SetupIntent.
-    pub fn payment_method(mut self, payment_method: &'a str) -> Self {
-        self.inner.payment_method = Some(payment_method);
+    pub fn payment_method(mut self, payment_method: impl Into<String>) -> Self {
+        self.inner.payment_method = Some(payment_method.into());
         self
     }
     /// The ID of the payment method configuration to use with this SetupIntent.
-    pub fn payment_method_configuration(mut self, payment_method_configuration: &'a str) -> Self {
-        self.inner.payment_method_configuration = Some(payment_method_configuration);
+    pub fn payment_method_configuration(
+        mut self,
+        payment_method_configuration: impl Into<String>,
+    ) -> Self {
+        self.inner.payment_method_configuration = Some(payment_method_configuration.into());
         self
     }
     /// When included, this hash creates a PaymentMethod that is set as the [`payment_method`](https://stripe.com/docs/api/setup_intents/object#setup_intent_object-payment_method).
     /// value in the SetupIntent.
     pub fn payment_method_data(
         mut self,
-        payment_method_data: UpdateSetupIntentPaymentMethodData<'a>,
+        payment_method_data: impl Into<UpdateSetupIntentPaymentMethodData>,
     ) -> Self {
-        self.inner.payment_method_data = Some(payment_method_data);
+        self.inner.payment_method_data = Some(payment_method_data.into());
         self
     }
     /// Payment method-specific configuration for this SetupIntent.
     pub fn payment_method_options(
         mut self,
-        payment_method_options: UpdateSetupIntentPaymentMethodOptions<'a>,
+        payment_method_options: impl Into<UpdateSetupIntentPaymentMethodOptions>,
     ) -> Self {
-        self.inner.payment_method_options = Some(payment_method_options);
+        self.inner.payment_method_options = Some(payment_method_options.into());
         self
     }
     /// The list of payment method types (for example, card) that this SetupIntent can set up.
     /// If you don't provide this array, it defaults to ["card"].
-    pub fn payment_method_types(mut self, payment_method_types: &'a [&'a str]) -> Self {
-        self.inner.payment_method_types = Some(payment_method_types);
+    pub fn payment_method_types(mut self, payment_method_types: impl Into<Vec<String>>) -> Self {
+        self.inner.payment_method_types = Some(payment_method_types.into());
         self
     }
 }
-impl UpdateSetupIntent<'_> {
+impl UpdateSetupIntent {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -6855,23 +6863,23 @@ impl UpdateSetupIntent<'_> {
     }
 }
 
-impl StripeRequest for UpdateSetupIntent<'_> {
+impl StripeRequest for UpdateSetupIntent {
     type Output = stripe_shared::SetupIntent;
 
     fn build(&self) -> RequestBuilder {
-        let intent = self.intent;
+        let intent = &self.intent;
         RequestBuilder::new(StripeMethod::Post, format!("/setup_intents/{intent}"))
             .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CancelSetupIntentBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CancelSetupIntentBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     cancellation_reason: Option<stripe_shared::SetupIntentCancellationReason>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> CancelSetupIntentBuilder<'a> {
+impl CancelSetupIntentBuilder {
     fn new() -> Self {
         Self { cancellation_reason: None, expand: None }
     }
@@ -6881,31 +6889,31 @@ impl<'a> CancelSetupIntentBuilder<'a> {
 ///
 /// After you cancel it, setup is abandoned and any operations on the SetupIntent fail with an error.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CancelSetupIntent<'a> {
-    inner: CancelSetupIntentBuilder<'a>,
-    intent: &'a stripe_shared::SetupIntentId,
+pub struct CancelSetupIntent {
+    inner: CancelSetupIntentBuilder,
+    intent: stripe_shared::SetupIntentId,
 }
-impl<'a> CancelSetupIntent<'a> {
+impl CancelSetupIntent {
     /// Construct a new `CancelSetupIntent`.
-    pub fn new(intent: &'a stripe_shared::SetupIntentId) -> Self {
-        Self { intent, inner: CancelSetupIntentBuilder::new() }
+    pub fn new(intent: impl Into<stripe_shared::SetupIntentId>) -> Self {
+        Self { intent: intent.into(), inner: CancelSetupIntentBuilder::new() }
     }
     /// Reason for canceling this SetupIntent.
     /// Possible values are: `abandoned`, `requested_by_customer`, or `duplicate`.
     pub fn cancellation_reason(
         mut self,
-        cancellation_reason: stripe_shared::SetupIntentCancellationReason,
+        cancellation_reason: impl Into<stripe_shared::SetupIntentCancellationReason>,
     ) -> Self {
-        self.inner.cancellation_reason = Some(cancellation_reason);
+        self.inner.cancellation_reason = Some(cancellation_reason.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl CancelSetupIntent<'_> {
+impl CancelSetupIntent {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -6923,35 +6931,35 @@ impl CancelSetupIntent<'_> {
     }
 }
 
-impl StripeRequest for CancelSetupIntent<'_> {
+impl StripeRequest for CancelSetupIntent {
     type Output = stripe_shared::SetupIntent;
 
     fn build(&self) -> RequestBuilder {
-        let intent = self.intent;
+        let intent = &self.intent;
         RequestBuilder::new(StripeMethod::Post, format!("/setup_intents/{intent}/cancel"))
             .form(&self.inner)
     }
 }
 #[derive(Clone, Debug, serde::Serialize)]
-struct ConfirmSetupIntentBuilder<'a> {
+struct ConfirmSetupIntentBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    confirmation_token: Option<&'a str>,
+    confirmation_token: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    mandate_data: Option<ConfirmSetupIntentMandateData<'a>>,
+    mandate_data: Option<ConfirmSetupIntentMandateData>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_method: Option<&'a str>,
+    payment_method: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_method_data: Option<ConfirmSetupIntentPaymentMethodData<'a>>,
+    payment_method_data: Option<ConfirmSetupIntentPaymentMethodData>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_method_options: Option<ConfirmSetupIntentPaymentMethodOptions<'a>>,
+    payment_method_options: Option<ConfirmSetupIntentPaymentMethodOptions>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    return_url: Option<&'a str>,
+    return_url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     use_stripe_sdk: Option<bool>,
 }
-impl<'a> ConfirmSetupIntentBuilder<'a> {
+impl ConfirmSetupIntentBuilder {
     fn new() -> Self {
         Self {
             confirmation_token: None,
@@ -6967,27 +6975,27 @@ impl<'a> ConfirmSetupIntentBuilder<'a> {
 }
 #[derive(Clone, Debug, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
-pub enum ConfirmSetupIntentMandateData<'a> {
+pub enum ConfirmSetupIntentMandateData {
     #[serde(untagged)]
-    SecretKeyParam(ConfirmSetupIntentSecretKeyParam<'a>),
+    SecretKeyParam(ConfirmSetupIntentSecretKeyParam),
     #[serde(untagged)]
-    ClientKeyParam(ConfirmSetupIntentClientKeyParam<'a>),
+    ClientKeyParam(ConfirmSetupIntentClientKeyParam),
 }
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ConfirmSetupIntentSecretKeyParam<'a> {
+pub struct ConfirmSetupIntentSecretKeyParam {
     /// This hash contains details about the customer acceptance of the Mandate.
-    pub customer_acceptance: ConfirmSetupIntentSecretKeyParamCustomerAcceptance<'a>,
+    pub customer_acceptance: ConfirmSetupIntentSecretKeyParamCustomerAcceptance,
 }
-impl<'a> ConfirmSetupIntentSecretKeyParam<'a> {
+impl ConfirmSetupIntentSecretKeyParam {
     pub fn new(
-        customer_acceptance: ConfirmSetupIntentSecretKeyParamCustomerAcceptance<'a>,
+        customer_acceptance: impl Into<ConfirmSetupIntentSecretKeyParamCustomerAcceptance>,
     ) -> Self {
-        Self { customer_acceptance }
+        Self { customer_acceptance: customer_acceptance.into() }
     }
 }
 /// This hash contains details about the customer acceptance of the Mandate.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ConfirmSetupIntentSecretKeyParamCustomerAcceptance<'a> {
+pub struct ConfirmSetupIntentSecretKeyParamCustomerAcceptance {
     /// The time at which the customer accepted the Mandate.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub accepted_at: Option<stripe_types::Timestamp>,
@@ -6997,15 +7005,15 @@ pub struct ConfirmSetupIntentSecretKeyParamCustomerAcceptance<'a> {
     pub offline: Option<miniserde::json::Value>,
     /// If this is a Mandate accepted online, this hash contains details about the online acceptance.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub online: Option<OnlineParam<'a>>,
+    pub online: Option<OnlineParam>,
     /// The type of customer acceptance information included with the Mandate.
     /// One of `online` or `offline`.
     #[serde(rename = "type")]
     pub type_: ConfirmSetupIntentSecretKeyParamCustomerAcceptanceType,
 }
-impl<'a> ConfirmSetupIntentSecretKeyParamCustomerAcceptance<'a> {
-    pub fn new(type_: ConfirmSetupIntentSecretKeyParamCustomerAcceptanceType) -> Self {
-        Self { accepted_at: None, offline: None, online: None, type_ }
+impl ConfirmSetupIntentSecretKeyParamCustomerAcceptance {
+    pub fn new(type_: impl Into<ConfirmSetupIntentSecretKeyParamCustomerAcceptanceType>) -> Self {
+        Self { accepted_at: None, offline: None, online: None, type_: type_.into() }
     }
 }
 /// The type of customer acceptance information included with the Mandate.
@@ -7067,51 +7075,51 @@ impl<'de> serde::Deserialize<'de> for ConfirmSetupIntentSecretKeyParamCustomerAc
         })
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmSetupIntentClientKeyParam<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmSetupIntentClientKeyParam {
     /// This hash contains details about the customer acceptance of the Mandate.
-    pub customer_acceptance: ConfirmSetupIntentClientKeyParamCustomerAcceptance<'a>,
+    pub customer_acceptance: ConfirmSetupIntentClientKeyParamCustomerAcceptance,
 }
-impl<'a> ConfirmSetupIntentClientKeyParam<'a> {
+impl ConfirmSetupIntentClientKeyParam {
     pub fn new(
-        customer_acceptance: ConfirmSetupIntentClientKeyParamCustomerAcceptance<'a>,
+        customer_acceptance: impl Into<ConfirmSetupIntentClientKeyParamCustomerAcceptance>,
     ) -> Self {
-        Self { customer_acceptance }
+        Self { customer_acceptance: customer_acceptance.into() }
     }
 }
 /// This hash contains details about the customer acceptance of the Mandate.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmSetupIntentClientKeyParamCustomerAcceptance<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmSetupIntentClientKeyParamCustomerAcceptance {
     /// If this is a Mandate accepted online, this hash contains details about the online acceptance.
-    pub online: ConfirmSetupIntentClientKeyParamCustomerAcceptanceOnline<'a>,
+    pub online: ConfirmSetupIntentClientKeyParamCustomerAcceptanceOnline,
     /// The type of customer acceptance information included with the Mandate.
     #[serde(rename = "type")]
     pub type_: ConfirmSetupIntentClientKeyParamCustomerAcceptanceType,
 }
-impl<'a> ConfirmSetupIntentClientKeyParamCustomerAcceptance<'a> {
+impl ConfirmSetupIntentClientKeyParamCustomerAcceptance {
     pub fn new(
-        online: ConfirmSetupIntentClientKeyParamCustomerAcceptanceOnline<'a>,
-        type_: ConfirmSetupIntentClientKeyParamCustomerAcceptanceType,
+        online: impl Into<ConfirmSetupIntentClientKeyParamCustomerAcceptanceOnline>,
+        type_: impl Into<ConfirmSetupIntentClientKeyParamCustomerAcceptanceType>,
     ) -> Self {
-        Self { online, type_ }
+        Self { online: online.into(), type_: type_.into() }
     }
 }
 /// If this is a Mandate accepted online, this hash contains details about the online acceptance.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmSetupIntentClientKeyParamCustomerAcceptanceOnline<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmSetupIntentClientKeyParamCustomerAcceptanceOnline {
     /// The IP address from which the Mandate was accepted by the customer.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ip_address: Option<&'a str>,
+    pub ip_address: Option<String>,
     /// The user agent of the browser from which the Mandate was accepted by the customer.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user_agent: Option<&'a str>,
+    pub user_agent: Option<String>,
 }
-impl<'a> ConfirmSetupIntentClientKeyParamCustomerAcceptanceOnline<'a> {
+impl ConfirmSetupIntentClientKeyParamCustomerAcceptanceOnline {
     pub fn new() -> Self {
         Self { ip_address: None, user_agent: None }
     }
 }
-impl<'a> Default for ConfirmSetupIntentClientKeyParamCustomerAcceptanceOnline<'a> {
+impl Default for ConfirmSetupIntentClientKeyParamCustomerAcceptanceOnline {
     fn default() -> Self {
         Self::new()
     }
@@ -7174,10 +7182,10 @@ impl<'de> serde::Deserialize<'de> for ConfirmSetupIntentClientKeyParamCustomerAc
 /// When included, this hash creates a PaymentMethod that is set as the [`payment_method`](https://stripe.com/docs/api/setup_intents/object#setup_intent_object-payment_method).
 /// value in the SetupIntent.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ConfirmSetupIntentPaymentMethodData<'a> {
+pub struct ConfirmSetupIntentPaymentMethodData {
     /// If this is an `acss_debit` PaymentMethod, this hash contains details about the ACSS Debit payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub acss_debit: Option<PaymentMethodParam<'a>>,
+    pub acss_debit: Option<PaymentMethodParam>,
     /// If this is an `affirm` PaymentMethod, this hash contains details about the Affirm payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
@@ -7201,24 +7209,24 @@ pub struct ConfirmSetupIntentPaymentMethodData<'a> {
     pub amazon_pay: Option<miniserde::json::Value>,
     /// If this is an `au_becs_debit` PaymentMethod, this hash contains details about the bank account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub au_becs_debit: Option<ConfirmSetupIntentPaymentMethodDataAuBecsDebit<'a>>,
+    pub au_becs_debit: Option<ConfirmSetupIntentPaymentMethodDataAuBecsDebit>,
     /// If this is a `bacs_debit` PaymentMethod, this hash contains details about the Bacs Direct Debit bank account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub bacs_debit: Option<ConfirmSetupIntentPaymentMethodDataBacsDebit<'a>>,
+    pub bacs_debit: Option<ConfirmSetupIntentPaymentMethodDataBacsDebit>,
     /// If this is a `bancontact` PaymentMethod, this hash contains details about the Bancontact payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
     pub bancontact: Option<miniserde::json::Value>,
     /// Billing information associated with the PaymentMethod that may be used or required by particular types of payment methods.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub billing_details: Option<BillingDetailsInnerParams<'a>>,
+    pub billing_details: Option<BillingDetailsInnerParams>,
     /// If this is a `blik` PaymentMethod, this hash contains details about the BLIK payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
     pub blik: Option<miniserde::json::Value>,
     /// If this is a `boleto` PaymentMethod, this hash contains details about the Boleto payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub boleto: Option<ConfirmSetupIntentPaymentMethodDataBoleto<'a>>,
+    pub boleto: Option<ConfirmSetupIntentPaymentMethodDataBoleto>,
     /// If this is a `cashapp` PaymentMethod, this hash contains details about the Cash App Pay payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
@@ -7264,7 +7272,7 @@ pub struct ConfirmSetupIntentPaymentMethodData<'a> {
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// If this is a `mobilepay` PaymentMethod, this hash contains details about the MobilePay payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
@@ -7295,14 +7303,14 @@ pub struct ConfirmSetupIntentPaymentMethodData<'a> {
     /// Options to configure Radar.
     /// See [Radar Session](https://stripe.com/docs/radar/radar-session) for more information.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub radar_options: Option<RadarOptionsWithHiddenOptions<'a>>,
+    pub radar_options: Option<RadarOptionsWithHiddenOptions>,
     /// If this is a `Revolut Pay` PaymentMethod, this hash contains details about the Revolut Pay payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
     pub revolut_pay: Option<miniserde::json::Value>,
     /// If this is a `sepa_debit` PaymentMethod, this hash contains details about the SEPA debit bank account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub sepa_debit: Option<ConfirmSetupIntentPaymentMethodDataSepaDebit<'a>>,
+    pub sepa_debit: Option<ConfirmSetupIntentPaymentMethodDataSepaDebit>,
     /// If this is a `sofort` PaymentMethod, this hash contains details about the SOFORT payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sofort: Option<ConfirmSetupIntentPaymentMethodDataSofort>,
@@ -7317,7 +7325,7 @@ pub struct ConfirmSetupIntentPaymentMethodData<'a> {
     pub type_: ConfirmSetupIntentPaymentMethodDataType,
     /// If this is an `us_bank_account` PaymentMethod, this hash contains details about the US bank account payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub us_bank_account: Option<ConfirmSetupIntentPaymentMethodDataUsBankAccount<'a>>,
+    pub us_bank_account: Option<ConfirmSetupIntentPaymentMethodDataUsBankAccount>,
     /// If this is an `wechat_pay` PaymentMethod, this hash contains details about the wechat_pay payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
@@ -7327,8 +7335,8 @@ pub struct ConfirmSetupIntentPaymentMethodData<'a> {
     #[serde(with = "stripe_types::with_serde_json_opt")]
     pub zip: Option<miniserde::json::Value>,
 }
-impl<'a> ConfirmSetupIntentPaymentMethodData<'a> {
-    pub fn new(type_: ConfirmSetupIntentPaymentMethodDataType) -> Self {
+impl ConfirmSetupIntentPaymentMethodData {
+    pub fn new(type_: impl Into<ConfirmSetupIntentPaymentMethodDataType>) -> Self {
         Self {
             acss_debit: None,
             affirm: None,
@@ -7366,7 +7374,7 @@ impl<'a> ConfirmSetupIntentPaymentMethodData<'a> {
             sepa_debit: None,
             sofort: None,
             swish: None,
-            type_,
+            type_: type_.into(),
             us_bank_account: None,
             wechat_pay: None,
             zip: None,
@@ -7437,47 +7445,47 @@ impl<'de> serde::Deserialize<'de> for ConfirmSetupIntentPaymentMethodDataAllowRe
     }
 }
 /// If this is an `au_becs_debit` PaymentMethod, this hash contains details about the bank account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmSetupIntentPaymentMethodDataAuBecsDebit<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmSetupIntentPaymentMethodDataAuBecsDebit {
     /// The account number for the bank account.
-    pub account_number: &'a str,
+    pub account_number: String,
     /// Bank-State-Branch number of the bank account.
-    pub bsb_number: &'a str,
+    pub bsb_number: String,
 }
-impl<'a> ConfirmSetupIntentPaymentMethodDataAuBecsDebit<'a> {
-    pub fn new(account_number: &'a str, bsb_number: &'a str) -> Self {
-        Self { account_number, bsb_number }
+impl ConfirmSetupIntentPaymentMethodDataAuBecsDebit {
+    pub fn new(account_number: impl Into<String>, bsb_number: impl Into<String>) -> Self {
+        Self { account_number: account_number.into(), bsb_number: bsb_number.into() }
     }
 }
 /// If this is a `bacs_debit` PaymentMethod, this hash contains details about the Bacs Direct Debit bank account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmSetupIntentPaymentMethodDataBacsDebit<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmSetupIntentPaymentMethodDataBacsDebit {
     /// Account number of the bank account that the funds will be debited from.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account_number: Option<&'a str>,
+    pub account_number: Option<String>,
     /// Sort code of the bank account. (e.g., `10-20-30`)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub sort_code: Option<&'a str>,
+    pub sort_code: Option<String>,
 }
-impl<'a> ConfirmSetupIntentPaymentMethodDataBacsDebit<'a> {
+impl ConfirmSetupIntentPaymentMethodDataBacsDebit {
     pub fn new() -> Self {
         Self { account_number: None, sort_code: None }
     }
 }
-impl<'a> Default for ConfirmSetupIntentPaymentMethodDataBacsDebit<'a> {
+impl Default for ConfirmSetupIntentPaymentMethodDataBacsDebit {
     fn default() -> Self {
         Self::new()
     }
 }
 /// If this is a `boleto` PaymentMethod, this hash contains details about the Boleto payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmSetupIntentPaymentMethodDataBoleto<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmSetupIntentPaymentMethodDataBoleto {
     /// The tax ID of the customer (CPF for individual consumers or CNPJ for businesses consumers)
-    pub tax_id: &'a str,
+    pub tax_id: String,
 }
-impl<'a> ConfirmSetupIntentPaymentMethodDataBoleto<'a> {
-    pub fn new(tax_id: &'a str) -> Self {
-        Self { tax_id }
+impl ConfirmSetupIntentPaymentMethodDataBoleto {
+    pub fn new(tax_id: impl Into<String>) -> Self {
+        Self { tax_id: tax_id.into() }
     }
 }
 /// If this is an `eps` PaymentMethod, this hash contains details about the EPS payment method.
@@ -7643,8 +7651,8 @@ pub struct ConfirmSetupIntentPaymentMethodDataFpx {
     pub bank: ConfirmSetupIntentPaymentMethodDataFpxBank,
 }
 impl ConfirmSetupIntentPaymentMethodDataFpx {
-    pub fn new(bank: ConfirmSetupIntentPaymentMethodDataFpxBank) -> Self {
-        Self { account_holder_type: None, bank }
+    pub fn new(bank: impl Into<ConfirmSetupIntentPaymentMethodDataFpxBank>) -> Self {
+        Self { account_holder_type: None, bank: bank.into() }
     }
 }
 /// Account holder type for FPX transaction
@@ -8105,14 +8113,14 @@ impl<'de> serde::Deserialize<'de> for ConfirmSetupIntentPaymentMethodDataP24Bank
     }
 }
 /// If this is a `sepa_debit` PaymentMethod, this hash contains details about the SEPA debit bank account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmSetupIntentPaymentMethodDataSepaDebit<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmSetupIntentPaymentMethodDataSepaDebit {
     /// IBAN of the bank account.
-    pub iban: &'a str,
+    pub iban: String,
 }
-impl<'a> ConfirmSetupIntentPaymentMethodDataSepaDebit<'a> {
-    pub fn new(iban: &'a str) -> Self {
-        Self { iban }
+impl ConfirmSetupIntentPaymentMethodDataSepaDebit {
+    pub fn new(iban: impl Into<String>) -> Self {
+        Self { iban: iban.into() }
     }
 }
 /// If this is a `sofort` PaymentMethod, this hash contains details about the SOFORT payment method.
@@ -8122,8 +8130,8 @@ pub struct ConfirmSetupIntentPaymentMethodDataSofort {
     pub country: ConfirmSetupIntentPaymentMethodDataSofortCountry,
 }
 impl ConfirmSetupIntentPaymentMethodDataSofort {
-    pub fn new(country: ConfirmSetupIntentPaymentMethodDataSofortCountry) -> Self {
-        Self { country }
+    pub fn new(country: impl Into<ConfirmSetupIntentPaymentMethodDataSofortCountry>) -> Self {
+        Self { country: country.into() }
     }
 }
 /// Two-letter ISO code representing the country the bank account is located in.
@@ -8353,26 +8361,26 @@ impl<'de> serde::Deserialize<'de> for ConfirmSetupIntentPaymentMethodDataType {
     }
 }
 /// If this is an `us_bank_account` PaymentMethod, this hash contains details about the US bank account payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmSetupIntentPaymentMethodDataUsBankAccount<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmSetupIntentPaymentMethodDataUsBankAccount {
     /// Account holder type: individual or company.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub account_holder_type:
         Option<ConfirmSetupIntentPaymentMethodDataUsBankAccountAccountHolderType>,
     /// Account number of the bank account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account_number: Option<&'a str>,
+    pub account_number: Option<String>,
     /// Account type: checkings or savings. Defaults to checking if omitted.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub account_type: Option<ConfirmSetupIntentPaymentMethodDataUsBankAccountAccountType>,
     /// The ID of a Financial Connections Account to use as a payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub financial_connections_account: Option<&'a str>,
+    pub financial_connections_account: Option<String>,
     /// Routing number of the bank account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub routing_number: Option<&'a str>,
+    pub routing_number: Option<String>,
 }
-impl<'a> ConfirmSetupIntentPaymentMethodDataUsBankAccount<'a> {
+impl ConfirmSetupIntentPaymentMethodDataUsBankAccount {
     pub fn new() -> Self {
         Self {
             account_holder_type: None,
@@ -8383,7 +8391,7 @@ impl<'a> ConfirmSetupIntentPaymentMethodDataUsBankAccount<'a> {
         }
     }
 }
-impl<'a> Default for ConfirmSetupIntentPaymentMethodDataUsBankAccount<'a> {
+impl Default for ConfirmSetupIntentPaymentMethodDataUsBankAccount {
     fn default() -> Self {
         Self::new()
     }
@@ -8504,35 +8512,35 @@ impl<'de> serde::Deserialize<'de> for ConfirmSetupIntentPaymentMethodDataUsBankA
 }
 /// Payment method-specific configuration for this SetupIntent.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ConfirmSetupIntentPaymentMethodOptions<'a> {
+pub struct ConfirmSetupIntentPaymentMethodOptions {
     /// If this is a `acss_debit` SetupIntent, this sub-hash contains details about the ACSS Debit payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub acss_debit: Option<ConfirmSetupIntentPaymentMethodOptionsAcssDebit<'a>>,
+    pub acss_debit: Option<ConfirmSetupIntentPaymentMethodOptionsAcssDebit>,
     /// If this is a `amazon_pay` SetupIntent, this sub-hash contains details about the AmazonPay payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
     pub amazon_pay: Option<miniserde::json::Value>,
     /// Configuration for any card setup attempted on this SetupIntent.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub card: Option<ConfirmSetupIntentPaymentMethodOptionsCard<'a>>,
+    pub card: Option<ConfirmSetupIntentPaymentMethodOptionsCard>,
     /// If this is a `card_present` PaymentMethod, this sub-hash contains details about the card-present payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
     pub card_present: Option<miniserde::json::Value>,
     /// If this is a `link` PaymentMethod, this sub-hash contains details about the Link payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub link: Option<SetupIntentPaymentMethodOptionsParam<'a>>,
+    pub link: Option<SetupIntentPaymentMethodOptionsParam>,
     /// If this is a `paypal` PaymentMethod, this sub-hash contains details about the PayPal payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub paypal: Option<PaymentMethodOptionsParam<'a>>,
+    pub paypal: Option<PaymentMethodOptionsParam>,
     /// If this is a `sepa_debit` SetupIntent, this sub-hash contains details about the SEPA Debit payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sepa_debit: Option<ConfirmSetupIntentPaymentMethodOptionsSepaDebit>,
     /// If this is a `us_bank_account` SetupIntent, this sub-hash contains details about the US bank account payment method options.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub us_bank_account: Option<ConfirmSetupIntentPaymentMethodOptionsUsBankAccount<'a>>,
+    pub us_bank_account: Option<ConfirmSetupIntentPaymentMethodOptionsUsBankAccount>,
 }
-impl<'a> ConfirmSetupIntentPaymentMethodOptions<'a> {
+impl ConfirmSetupIntentPaymentMethodOptions {
     pub fn new() -> Self {
         Self {
             acss_debit: None,
@@ -8546,32 +8554,32 @@ impl<'a> ConfirmSetupIntentPaymentMethodOptions<'a> {
         }
     }
 }
-impl<'a> Default for ConfirmSetupIntentPaymentMethodOptions<'a> {
+impl Default for ConfirmSetupIntentPaymentMethodOptions {
     fn default() -> Self {
         Self::new()
     }
 }
 /// If this is a `acss_debit` SetupIntent, this sub-hash contains details about the ACSS Debit payment method options.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmSetupIntentPaymentMethodOptionsAcssDebit<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmSetupIntentPaymentMethodOptionsAcssDebit {
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     /// Must be a [supported currency](https://stripe.com/docs/currencies).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub currency: Option<ConfirmSetupIntentPaymentMethodOptionsAcssDebitCurrency>,
     /// Additional fields for Mandate creation
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub mandate_options: Option<ConfirmSetupIntentPaymentMethodOptionsAcssDebitMandateOptions<'a>>,
+    pub mandate_options: Option<ConfirmSetupIntentPaymentMethodOptionsAcssDebitMandateOptions>,
     /// Bank account verification method.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub verification_method:
         Option<ConfirmSetupIntentPaymentMethodOptionsAcssDebitVerificationMethod>,
 }
-impl<'a> ConfirmSetupIntentPaymentMethodOptionsAcssDebit<'a> {
+impl ConfirmSetupIntentPaymentMethodOptionsAcssDebit {
     pub fn new() -> Self {
         Self { currency: None, mandate_options: None, verification_method: None }
     }
 }
-impl<'a> Default for ConfirmSetupIntentPaymentMethodOptionsAcssDebit<'a> {
+impl Default for ConfirmSetupIntentPaymentMethodOptionsAcssDebit {
     fn default() -> Self {
         Self::new()
     }
@@ -8636,21 +8644,21 @@ impl<'de> serde::Deserialize<'de> for ConfirmSetupIntentPaymentMethodOptionsAcss
     }
 }
 /// Additional fields for Mandate creation
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmSetupIntentPaymentMethodOptionsAcssDebitMandateOptions<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmSetupIntentPaymentMethodOptionsAcssDebitMandateOptions {
     /// A URL for custom mandate text to render during confirmation step.
     /// The URL will be rendered with additional GET parameters `payment_intent` and `payment_intent_client_secret` when confirming a Payment Intent,.
     /// or `setup_intent` and `setup_intent_client_secret` when confirming a Setup Intent.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub custom_mandate_url: Option<&'a str>,
+    pub custom_mandate_url: Option<String>,
     /// List of Stripe products where this mandate can be selected automatically.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_for:
-        Option<&'a [ConfirmSetupIntentPaymentMethodOptionsAcssDebitMandateOptionsDefaultFor]>,
+        Option<Vec<ConfirmSetupIntentPaymentMethodOptionsAcssDebitMandateOptionsDefaultFor>>,
     /// Description of the mandate interval.
     /// Only required if 'payment_schedule' parameter is 'interval' or 'combined'.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub interval_description: Option<&'a str>,
+    pub interval_description: Option<String>,
     /// Payment schedule for the mandate.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub payment_schedule:
@@ -8660,7 +8668,7 @@ pub struct ConfirmSetupIntentPaymentMethodOptionsAcssDebitMandateOptions<'a> {
     pub transaction_type:
         Option<ConfirmSetupIntentPaymentMethodOptionsAcssDebitMandateOptionsTransactionType>,
 }
-impl<'a> ConfirmSetupIntentPaymentMethodOptionsAcssDebitMandateOptions<'a> {
+impl ConfirmSetupIntentPaymentMethodOptionsAcssDebitMandateOptions {
     pub fn new() -> Self {
         Self {
             custom_mandate_url: None,
@@ -8671,7 +8679,7 @@ impl<'a> ConfirmSetupIntentPaymentMethodOptionsAcssDebitMandateOptions<'a> {
         }
     }
 }
-impl<'a> Default for ConfirmSetupIntentPaymentMethodOptionsAcssDebitMandateOptions<'a> {
+impl Default for ConfirmSetupIntentPaymentMethodOptionsAcssDebitMandateOptions {
     fn default() -> Self {
         Self::new()
     }
@@ -8923,11 +8931,11 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// Configuration for any card setup attempted on this SetupIntent.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmSetupIntentPaymentMethodOptionsCard<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmSetupIntentPaymentMethodOptionsCard {
     /// Configuration options for setting up an eMandate for cards issued in India.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub mandate_options: Option<ConfirmSetupIntentPaymentMethodOptionsCardMandateOptions<'a>>,
+    pub mandate_options: Option<ConfirmSetupIntentPaymentMethodOptionsCardMandateOptions>,
     /// When specified, this parameter signals that a card has been collected
     /// as MOTO (Mail Order Telephone Order) and thus out of scope for SCA. This
     /// parameter can only be provided during confirmation.
@@ -8948,9 +8956,9 @@ pub struct ConfirmSetupIntentPaymentMethodOptionsCard<'a> {
     /// If 3D Secure authentication was performed with a third-party provider,
     /// the authentication details to use for this setup.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub three_d_secure: Option<ConfirmSetupIntentPaymentMethodOptionsCardThreeDSecure<'a>>,
+    pub three_d_secure: Option<ConfirmSetupIntentPaymentMethodOptionsCardThreeDSecure>,
 }
-impl<'a> ConfirmSetupIntentPaymentMethodOptionsCard<'a> {
+impl ConfirmSetupIntentPaymentMethodOptionsCard {
     pub fn new() -> Self {
         Self {
             mandate_options: None,
@@ -8961,14 +8969,14 @@ impl<'a> ConfirmSetupIntentPaymentMethodOptionsCard<'a> {
         }
     }
 }
-impl<'a> Default for ConfirmSetupIntentPaymentMethodOptionsCard<'a> {
+impl Default for ConfirmSetupIntentPaymentMethodOptionsCard {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Configuration options for setting up an eMandate for cards issued in India.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmSetupIntentPaymentMethodOptionsCardMandateOptions<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmSetupIntentPaymentMethodOptionsCardMandateOptions {
     /// Amount to be charged for future payments.
     pub amount: i64,
     /// One of `fixed` or `maximum`.
@@ -8981,7 +8989,7 @@ pub struct ConfirmSetupIntentPaymentMethodOptionsCardMandateOptions<'a> {
     pub currency: stripe_types::Currency,
     /// A description of the mandate or subscription that is meant to be displayed to the customer.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<&'a str>,
+    pub description: Option<String>,
     /// End date of the mandate or subscription.
     /// If not provided, the mandate will be active until canceled.
     /// If provided, end date should be after start date.
@@ -8996,33 +9004,33 @@ pub struct ConfirmSetupIntentPaymentMethodOptionsCardMandateOptions<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub interval_count: Option<u64>,
     /// Unique identifier for the mandate or subscription.
-    pub reference: &'a str,
+    pub reference: String,
     /// Start date of the mandate or subscription. Start date should not be lesser than yesterday.
     pub start_date: stripe_types::Timestamp,
     /// Specifies the type of mandates supported. Possible values are `india`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub supported_types:
-        Option<&'a [ConfirmSetupIntentPaymentMethodOptionsCardMandateOptionsSupportedTypes]>,
+        Option<Vec<ConfirmSetupIntentPaymentMethodOptionsCardMandateOptionsSupportedTypes>>,
 }
-impl<'a> ConfirmSetupIntentPaymentMethodOptionsCardMandateOptions<'a> {
+impl ConfirmSetupIntentPaymentMethodOptionsCardMandateOptions {
     pub fn new(
-        amount: i64,
-        amount_type: ConfirmSetupIntentPaymentMethodOptionsCardMandateOptionsAmountType,
-        currency: stripe_types::Currency,
-        interval: ConfirmSetupIntentPaymentMethodOptionsCardMandateOptionsInterval,
-        reference: &'a str,
-        start_date: stripe_types::Timestamp,
+        amount: impl Into<i64>,
+        amount_type: impl Into<ConfirmSetupIntentPaymentMethodOptionsCardMandateOptionsAmountType>,
+        currency: impl Into<stripe_types::Currency>,
+        interval: impl Into<ConfirmSetupIntentPaymentMethodOptionsCardMandateOptionsInterval>,
+        reference: impl Into<String>,
+        start_date: impl Into<stripe_types::Timestamp>,
     ) -> Self {
         Self {
-            amount,
-            amount_type,
-            currency,
+            amount: amount.into(),
+            amount_type: amount_type.into(),
+            currency: currency.into(),
             description: None,
             end_date: None,
-            interval,
+            interval: interval.into(),
             interval_count: None,
-            reference,
-            start_date,
+            reference: reference.into(),
+            start_date: start_date.into(),
             supported_types: None,
         }
     }
@@ -9358,8 +9366,8 @@ impl<'de> serde::Deserialize<'de>
 }
 /// If 3D Secure authentication was performed with a third-party provider,
 /// the authentication details to use for this setup.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmSetupIntentPaymentMethodOptionsCardThreeDSecure<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmSetupIntentPaymentMethodOptionsCardThreeDSecure {
     /// The `transStatus` returned from the card Issuer’s ACS in the ARes.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ares_trans_status:
@@ -9369,7 +9377,7 @@ pub struct ConfirmSetupIntentPaymentMethodOptionsCardThreeDSecure<'a> {
     /// (Most 3D Secure providers will return the base64-encoded version, which
     /// is what you should specify here.)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub cryptogram: Option<&'a str>,
+    pub cryptogram: Option<String>,
     /// The Electronic Commerce Indicator (ECI) is returned by your 3D Secure
     /// provider and indicates what degree of authentication was performed.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -9380,20 +9388,20 @@ pub struct ConfirmSetupIntentPaymentMethodOptionsCardThreeDSecure<'a> {
     /// must be populated accordingly
     #[serde(skip_serializing_if = "Option::is_none")]
     pub network_options:
-        Option<ConfirmSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptions<'a>>,
+        Option<ConfirmSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptions>,
     /// The challenge indicator (`threeDSRequestorChallengeInd`) which was requested in the
     /// AReq sent to the card Issuer's ACS. A string containing 2 digits from 01-99.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub requestor_challenge_indicator: Option<&'a str>,
+    pub requestor_challenge_indicator: Option<String>,
     /// For 3D Secure 1, the XID. For 3D Secure 2, the Directory Server
     /// Transaction ID (dsTransID).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub transaction_id: Option<&'a str>,
+    pub transaction_id: Option<String>,
     /// The version of 3D Secure that was performed.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<ConfirmSetupIntentPaymentMethodOptionsCardThreeDSecureVersion>,
 }
-impl<'a> ConfirmSetupIntentPaymentMethodOptionsCardThreeDSecure<'a> {
+impl ConfirmSetupIntentPaymentMethodOptionsCardThreeDSecure {
     pub fn new() -> Self {
         Self {
             ares_trans_status: None,
@@ -9406,7 +9414,7 @@ impl<'a> ConfirmSetupIntentPaymentMethodOptionsCardThreeDSecure<'a> {
         }
     }
 }
-impl<'a> Default for ConfirmSetupIntentPaymentMethodOptionsCardThreeDSecure<'a> {
+impl Default for ConfirmSetupIntentPaymentMethodOptionsCardThreeDSecure {
     fn default() -> Self {
         Self::new()
     }
@@ -9559,27 +9567,26 @@ impl<'de> serde::Deserialize<'de>
 /// Network specific 3DS fields. Network specific arguments require an
 /// explicit card brand choice. The parameter `payment_method_options.card.network``
 /// must be populated accordingly
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptions<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptions {
     /// Cartes Bancaires-specific 3DS fields.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub cartes_bancaires: Option<
-        ConfirmSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancaires<'a>,
-    >,
+    pub cartes_bancaires:
+        Option<ConfirmSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancaires>,
 }
-impl<'a> ConfirmSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptions<'a> {
+impl ConfirmSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptions {
     pub fn new() -> Self {
         Self { cartes_bancaires: None }
     }
 }
-impl<'a> Default for ConfirmSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptions<'a> {
+impl Default for ConfirmSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptions {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Cartes Bancaires-specific 3DS fields.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancaires<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancaires {
     /// The cryptogram calculation algorithm used by the card Issuer's ACS
     /// to calculate the Authentication cryptogram. Also known as `cavvAlgorithm`.
     /// messageExtension: CB-AVALGO
@@ -9590,17 +9597,17 @@ pub struct ConfirmSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsC
     /// This is a 3 byte bitmap (low significant byte first and most significant
     /// bit first) that has been Base64 encoded
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub cb_exemption: Option<&'a str>,
+    pub cb_exemption: Option<String>,
     /// The risk score returned from Cartes Bancaires in the ARes.
     /// message extension: CB-SCORE; numeric value 0-99
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cb_score: Option<i64>,
 }
-impl<'a> ConfirmSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancaires<'a> {
+impl ConfirmSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancaires {
     pub fn new(
-        cb_avalgo: ConfirmSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancairesCbAvalgo,
+        cb_avalgo: impl Into<ConfirmSetupIntentPaymentMethodOptionsCardThreeDSecureNetworkOptionsCartesBancairesCbAvalgo>,
     ) -> Self {
-        Self { cb_avalgo, cb_exemption: None, cb_score: None }
+        Self { cb_avalgo: cb_avalgo.into(), cb_exemption: None, cb_score: None }
     }
 }
 /// The cryptogram calculation algorithm used by the card Issuer's ACS
@@ -9764,24 +9771,24 @@ impl Default for ConfirmSetupIntentPaymentMethodOptionsSepaDebit {
     }
 }
 /// If this is a `us_bank_account` SetupIntent, this sub-hash contains details about the US bank account payment method options.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmSetupIntentPaymentMethodOptionsUsBankAccount<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmSetupIntentPaymentMethodOptionsUsBankAccount {
     /// Additional fields for Financial Connections Session creation
     #[serde(skip_serializing_if = "Option::is_none")]
     pub financial_connections:
-        Option<ConfirmSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnections<'a>>,
+        Option<ConfirmSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnections>,
     /// Additional fields for Mandate creation
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mandate_options: Option<ConfirmSetupIntentPaymentMethodOptionsUsBankAccountMandateOptions>,
     /// Additional fields for network related functions
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub networks: Option<ConfirmSetupIntentPaymentMethodOptionsUsBankAccountNetworks<'a>>,
+    pub networks: Option<ConfirmSetupIntentPaymentMethodOptionsUsBankAccountNetworks>,
     /// Bank account verification method.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub verification_method:
         Option<ConfirmSetupIntentPaymentMethodOptionsUsBankAccountVerificationMethod>,
 }
-impl<'a> ConfirmSetupIntentPaymentMethodOptionsUsBankAccount<'a> {
+impl ConfirmSetupIntentPaymentMethodOptionsUsBankAccount {
     pub fn new() -> Self {
         Self {
             financial_connections: None,
@@ -9791,37 +9798,37 @@ impl<'a> ConfirmSetupIntentPaymentMethodOptionsUsBankAccount<'a> {
         }
     }
 }
-impl<'a> Default for ConfirmSetupIntentPaymentMethodOptionsUsBankAccount<'a> {
+impl Default for ConfirmSetupIntentPaymentMethodOptionsUsBankAccount {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Additional fields for Financial Connections Session creation
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnections<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnections {
     /// The list of permissions to request.
     /// If this parameter is passed, the `payment_method` permission must be included.
     /// Valid permissions include: `balances`, `ownership`, `payment_method`, and `transactions`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub permissions: Option<
-        &'a [ConfirmSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPermissions],
+        Vec<ConfirmSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPermissions>,
     >,
     /// List of data features that you would like to retrieve upon account creation.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub prefetch: Option<
-        &'a [ConfirmSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPrefetch],
+        Vec<ConfirmSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnectionsPrefetch>,
     >,
     /// For webview integrations only.
     /// Upon completing OAuth login in the native browser, the user will be redirected to this URL to return to your app.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub return_url: Option<&'a str>,
+    pub return_url: Option<String>,
 }
-impl<'a> ConfirmSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnections<'a> {
+impl ConfirmSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnections {
     pub fn new() -> Self {
         Self { permissions: None, prefetch: None, return_url: None }
     }
 }
-impl<'a> Default for ConfirmSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnections<'a> {
+impl Default for ConfirmSetupIntentPaymentMethodOptionsUsBankAccountFinancialConnections {
     fn default() -> Self {
         Self::new()
     }
@@ -10045,19 +10052,19 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// Additional fields for network related functions
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ConfirmSetupIntentPaymentMethodOptionsUsBankAccountNetworks<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ConfirmSetupIntentPaymentMethodOptionsUsBankAccountNetworks {
     /// Triggers validations to run across the selected networks
     #[serde(skip_serializing_if = "Option::is_none")]
     pub requested:
-        Option<&'a [ConfirmSetupIntentPaymentMethodOptionsUsBankAccountNetworksRequested]>,
+        Option<Vec<ConfirmSetupIntentPaymentMethodOptionsUsBankAccountNetworksRequested>>,
 }
-impl<'a> ConfirmSetupIntentPaymentMethodOptionsUsBankAccountNetworks<'a> {
+impl ConfirmSetupIntentPaymentMethodOptionsUsBankAccountNetworks {
     pub fn new() -> Self {
         Self { requested: None }
     }
 }
-impl<'a> Default for ConfirmSetupIntentPaymentMethodOptionsUsBankAccountNetworks<'a> {
+impl Default for ConfirmSetupIntentPaymentMethodOptionsUsBankAccountNetworks {
     fn default() -> Self {
         Self::new()
     }
@@ -10192,67 +10199,67 @@ impl<'de> serde::Deserialize<'de>
 /// `requires_payment_method` status or the `canceled` status if the
 /// confirmation limit is reached.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ConfirmSetupIntent<'a> {
-    inner: ConfirmSetupIntentBuilder<'a>,
-    intent: &'a stripe_shared::SetupIntentId,
+pub struct ConfirmSetupIntent {
+    inner: ConfirmSetupIntentBuilder,
+    intent: stripe_shared::SetupIntentId,
 }
-impl<'a> ConfirmSetupIntent<'a> {
+impl ConfirmSetupIntent {
     /// Construct a new `ConfirmSetupIntent`.
-    pub fn new(intent: &'a stripe_shared::SetupIntentId) -> Self {
-        Self { intent, inner: ConfirmSetupIntentBuilder::new() }
+    pub fn new(intent: impl Into<stripe_shared::SetupIntentId>) -> Self {
+        Self { intent: intent.into(), inner: ConfirmSetupIntentBuilder::new() }
     }
     /// ID of the ConfirmationToken used to confirm this SetupIntent.
     ///
     /// If the provided ConfirmationToken contains properties that are also being provided in this request, such as `payment_method`, then the values in this request will take precedence.
-    pub fn confirmation_token(mut self, confirmation_token: &'a str) -> Self {
-        self.inner.confirmation_token = Some(confirmation_token);
+    pub fn confirmation_token(mut self, confirmation_token: impl Into<String>) -> Self {
+        self.inner.confirmation_token = Some(confirmation_token.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
-    pub fn mandate_data(mut self, mandate_data: ConfirmSetupIntentMandateData<'a>) -> Self {
-        self.inner.mandate_data = Some(mandate_data);
+    pub fn mandate_data(mut self, mandate_data: impl Into<ConfirmSetupIntentMandateData>) -> Self {
+        self.inner.mandate_data = Some(mandate_data.into());
         self
     }
     /// ID of the payment method (a PaymentMethod, Card, or saved Source object) to attach to this SetupIntent.
-    pub fn payment_method(mut self, payment_method: &'a str) -> Self {
-        self.inner.payment_method = Some(payment_method);
+    pub fn payment_method(mut self, payment_method: impl Into<String>) -> Self {
+        self.inner.payment_method = Some(payment_method.into());
         self
     }
     /// When included, this hash creates a PaymentMethod that is set as the [`payment_method`](https://stripe.com/docs/api/setup_intents/object#setup_intent_object-payment_method).
     /// value in the SetupIntent.
     pub fn payment_method_data(
         mut self,
-        payment_method_data: ConfirmSetupIntentPaymentMethodData<'a>,
+        payment_method_data: impl Into<ConfirmSetupIntentPaymentMethodData>,
     ) -> Self {
-        self.inner.payment_method_data = Some(payment_method_data);
+        self.inner.payment_method_data = Some(payment_method_data.into());
         self
     }
     /// Payment method-specific configuration for this SetupIntent.
     pub fn payment_method_options(
         mut self,
-        payment_method_options: ConfirmSetupIntentPaymentMethodOptions<'a>,
+        payment_method_options: impl Into<ConfirmSetupIntentPaymentMethodOptions>,
     ) -> Self {
-        self.inner.payment_method_options = Some(payment_method_options);
+        self.inner.payment_method_options = Some(payment_method_options.into());
         self
     }
     /// The URL to redirect your customer back to after they authenticate on the payment method's app or site.
     /// If you'd prefer to redirect to a mobile application, you can alternatively supply an application URI scheme.
     /// This parameter is only used for cards and other redirect-based payment methods.
-    pub fn return_url(mut self, return_url: &'a str) -> Self {
-        self.inner.return_url = Some(return_url);
+    pub fn return_url(mut self, return_url: impl Into<String>) -> Self {
+        self.inner.return_url = Some(return_url.into());
         self
     }
     /// Set to `true` when confirming server-side and using Stripe.js, iOS, or Android client-side SDKs to handle the next actions.
-    pub fn use_stripe_sdk(mut self, use_stripe_sdk: bool) -> Self {
-        self.inner.use_stripe_sdk = Some(use_stripe_sdk);
+    pub fn use_stripe_sdk(mut self, use_stripe_sdk: impl Into<bool>) -> Self {
+        self.inner.use_stripe_sdk = Some(use_stripe_sdk.into());
         self
     }
 }
-impl ConfirmSetupIntent<'_> {
+impl ConfirmSetupIntent {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -10270,57 +10277,57 @@ impl ConfirmSetupIntent<'_> {
     }
 }
 
-impl StripeRequest for ConfirmSetupIntent<'_> {
+impl StripeRequest for ConfirmSetupIntent {
     type Output = stripe_shared::SetupIntent;
 
     fn build(&self) -> RequestBuilder {
-        let intent = self.intent;
+        let intent = &self.intent;
         RequestBuilder::new(StripeMethod::Post, format!("/setup_intents/{intent}/confirm"))
             .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct VerifyMicrodepositsSetupIntentBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct VerifyMicrodepositsSetupIntentBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    amounts: Option<&'a [i64]>,
+    amounts: Option<Vec<i64>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    descriptor_code: Option<&'a str>,
+    descriptor_code: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> VerifyMicrodepositsSetupIntentBuilder<'a> {
+impl VerifyMicrodepositsSetupIntentBuilder {
     fn new() -> Self {
         Self { amounts: None, descriptor_code: None, expand: None }
     }
 }
 /// Verifies microdeposits on a SetupIntent object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct VerifyMicrodepositsSetupIntent<'a> {
-    inner: VerifyMicrodepositsSetupIntentBuilder<'a>,
-    intent: &'a stripe_shared::SetupIntentId,
+pub struct VerifyMicrodepositsSetupIntent {
+    inner: VerifyMicrodepositsSetupIntentBuilder,
+    intent: stripe_shared::SetupIntentId,
 }
-impl<'a> VerifyMicrodepositsSetupIntent<'a> {
+impl VerifyMicrodepositsSetupIntent {
     /// Construct a new `VerifyMicrodepositsSetupIntent`.
-    pub fn new(intent: &'a stripe_shared::SetupIntentId) -> Self {
-        Self { intent, inner: VerifyMicrodepositsSetupIntentBuilder::new() }
+    pub fn new(intent: impl Into<stripe_shared::SetupIntentId>) -> Self {
+        Self { intent: intent.into(), inner: VerifyMicrodepositsSetupIntentBuilder::new() }
     }
     /// Two positive integers, in *cents*, equal to the values of the microdeposits sent to the bank account.
-    pub fn amounts(mut self, amounts: &'a [i64]) -> Self {
-        self.inner.amounts = Some(amounts);
+    pub fn amounts(mut self, amounts: impl Into<Vec<i64>>) -> Self {
+        self.inner.amounts = Some(amounts.into());
         self
     }
     /// A six-character code starting with SM present in the microdeposit sent to the bank account.
-    pub fn descriptor_code(mut self, descriptor_code: &'a str) -> Self {
-        self.inner.descriptor_code = Some(descriptor_code);
+    pub fn descriptor_code(mut self, descriptor_code: impl Into<String>) -> Self {
+        self.inner.descriptor_code = Some(descriptor_code.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl VerifyMicrodepositsSetupIntent<'_> {
+impl VerifyMicrodepositsSetupIntent {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -10338,11 +10345,11 @@ impl VerifyMicrodepositsSetupIntent<'_> {
     }
 }
 
-impl StripeRequest for VerifyMicrodepositsSetupIntent<'_> {
+impl StripeRequest for VerifyMicrodepositsSetupIntent {
     type Output = stripe_shared::SetupIntent;
 
     fn build(&self) -> RequestBuilder {
-        let intent = self.intent;
+        let intent = &self.intent;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/setup_intents/{intent}/verify_microdeposits"),
@@ -10351,63 +10358,67 @@ impl StripeRequest for VerifyMicrodepositsSetupIntent<'_> {
     }
 }
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct OnlineParam<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct OnlineParam {
     /// The IP address from which the Mandate was accepted by the customer.
-    pub ip_address: &'a str,
+    pub ip_address: String,
     /// The user agent of the browser from which the Mandate was accepted by the customer.
-    pub user_agent: &'a str,
+    pub user_agent: String,
 }
-impl<'a> OnlineParam<'a> {
-    pub fn new(ip_address: &'a str, user_agent: &'a str) -> Self {
-        Self { ip_address, user_agent }
+impl OnlineParam {
+    pub fn new(ip_address: impl Into<String>, user_agent: impl Into<String>) -> Self {
+        Self { ip_address: ip_address.into(), user_agent: user_agent.into() }
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct PaymentMethodParam<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct PaymentMethodParam {
     /// Customer's bank account number.
-    pub account_number: &'a str,
+    pub account_number: String,
     /// Institution number of the customer's bank.
-    pub institution_number: &'a str,
+    pub institution_number: String,
     /// Transit number of the customer's bank.
-    pub transit_number: &'a str,
+    pub transit_number: String,
 }
-impl<'a> PaymentMethodParam<'a> {
+impl PaymentMethodParam {
     pub fn new(
-        account_number: &'a str,
-        institution_number: &'a str,
-        transit_number: &'a str,
+        account_number: impl Into<String>,
+        institution_number: impl Into<String>,
+        transit_number: impl Into<String>,
     ) -> Self {
-        Self { account_number, institution_number, transit_number }
+        Self {
+            account_number: account_number.into(),
+            institution_number: institution_number.into(),
+            transit_number: transit_number.into(),
+        }
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct BillingDetailsAddress<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct BillingDetailsAddress {
     /// City, district, suburb, town, or village.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<&'a str>,
+    pub city: Option<String>,
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub country: Option<&'a str>,
+    pub country: Option<String>,
     /// Address line 1 (e.g., street, PO Box, or company name).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line1: Option<&'a str>,
+    pub line1: Option<String>,
     /// Address line 2 (e.g., apartment, suite, unit, or building).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line2: Option<&'a str>,
+    pub line2: Option<String>,
     /// ZIP or postal code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<&'a str>,
+    pub postal_code: Option<String>,
     /// State, county, province, or region.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
 }
-impl<'a> BillingDetailsAddress<'a> {
+impl BillingDetailsAddress {
     pub fn new() -> Self {
         Self { city: None, country: None, line1: None, line2: None, postal_code: None, state: None }
     }
 }
-impl<'a> Default for BillingDetailsAddress<'a> {
+impl Default for BillingDetailsAddress {
     fn default() -> Self {
         Self::new()
     }
@@ -10422,80 +10433,80 @@ pub struct DateOfBirth {
     pub year: i64,
 }
 impl DateOfBirth {
-    pub fn new(day: i64, month: i64, year: i64) -> Self {
-        Self { day, month, year }
+    pub fn new(day: impl Into<i64>, month: impl Into<i64>, year: impl Into<i64>) -> Self {
+        Self { day: day.into(), month: month.into(), year: year.into() }
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct RadarOptionsWithHiddenOptions<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct RadarOptionsWithHiddenOptions {
     /// A [Radar Session](https://stripe.com/docs/radar/radar-session) is a snapshot of the browser metadata and device details that help Radar make more accurate predictions on your payments.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub session: Option<&'a str>,
+    pub session: Option<String>,
 }
-impl<'a> RadarOptionsWithHiddenOptions<'a> {
+impl RadarOptionsWithHiddenOptions {
     pub fn new() -> Self {
         Self { session: None }
     }
 }
-impl<'a> Default for RadarOptionsWithHiddenOptions<'a> {
+impl Default for RadarOptionsWithHiddenOptions {
     fn default() -> Self {
         Self::new()
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct SetupIntentPaymentMethodOptionsParam<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct SetupIntentPaymentMethodOptionsParam {
     /// \[Deprecated\] This is a legacy parameter that no longer has any function.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub persistent_token: Option<&'a str>,
+    pub persistent_token: Option<String>,
 }
-impl<'a> SetupIntentPaymentMethodOptionsParam<'a> {
+impl SetupIntentPaymentMethodOptionsParam {
     pub fn new() -> Self {
         Self { persistent_token: None }
     }
 }
-impl<'a> Default for SetupIntentPaymentMethodOptionsParam<'a> {
+impl Default for SetupIntentPaymentMethodOptionsParam {
     fn default() -> Self {
         Self::new()
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct PaymentMethodOptionsParam<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct PaymentMethodOptionsParam {
     /// The PayPal Billing Agreement ID (BAID).
     /// This is an ID generated by PayPal which represents the mandate between the merchant and the customer.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub billing_agreement_id: Option<&'a str>,
+    pub billing_agreement_id: Option<String>,
 }
-impl<'a> PaymentMethodOptionsParam<'a> {
+impl PaymentMethodOptionsParam {
     pub fn new() -> Self {
         Self { billing_agreement_id: None }
     }
 }
-impl<'a> Default for PaymentMethodOptionsParam<'a> {
+impl Default for PaymentMethodOptionsParam {
     fn default() -> Self {
         Self::new()
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct BillingDetailsInnerParams<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct BillingDetailsInnerParams {
     /// Billing address.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub address: Option<BillingDetailsAddress<'a>>,
+    pub address: Option<BillingDetailsAddress>,
     /// Email address.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub email: Option<&'a str>,
+    pub email: Option<String>,
     /// Full name.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<&'a str>,
+    pub name: Option<String>,
     /// Billing phone number (including extension).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub phone: Option<&'a str>,
+    pub phone: Option<String>,
 }
-impl<'a> BillingDetailsInnerParams<'a> {
+impl BillingDetailsInnerParams {
     pub fn new() -> Self {
         Self { address: None, email: None, name: None, phone: None }
     }
 }
-impl<'a> Default for BillingDetailsInnerParams<'a> {
+impl Default for BillingDetailsInnerParams {
     fn default() -> Self {
         Self::new()
     }

--- a/generated/async-stripe-core/src/token/requests.rs
+++ b/generated/async-stripe-core/src/token/requests.rs
@@ -2,34 +2,34 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveTokenBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveTokenBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveTokenBuilder<'a> {
+impl RetrieveTokenBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves the token with the given ID.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveToken<'a> {
-    inner: RetrieveTokenBuilder<'a>,
-    token: &'a stripe_core::TokenId,
+pub struct RetrieveToken {
+    inner: RetrieveTokenBuilder,
+    token: stripe_core::TokenId,
 }
-impl<'a> RetrieveToken<'a> {
+impl RetrieveToken {
     /// Construct a new `RetrieveToken`.
-    pub fn new(token: &'a stripe_core::TokenId) -> Self {
-        Self { token, inner: RetrieveTokenBuilder::new() }
+    pub fn new(token: impl Into<stripe_core::TokenId>) -> Self {
+        Self { token: token.into(), inner: RetrieveTokenBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveToken<'_> {
+impl RetrieveToken {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -47,34 +47,34 @@ impl RetrieveToken<'_> {
     }
 }
 
-impl StripeRequest for RetrieveToken<'_> {
+impl StripeRequest for RetrieveToken {
     type Output = stripe_core::Token;
 
     fn build(&self) -> RequestBuilder {
-        let token = self.token;
+        let token = &self.token;
         RequestBuilder::new(StripeMethod::Get, format!("/tokens/{token}")).query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateTokenBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateTokenBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    account: Option<CreateTokenAccount<'a>>,
+    account: Option<CreateTokenAccount>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    bank_account: Option<CreateTokenBankAccount<'a>>,
+    bank_account: Option<CreateTokenBankAccount>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    card: Option<CreateTokenCard<'a>>,
+    card: Option<CreateTokenCard>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    customer: Option<&'a str>,
+    customer: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    cvc_update: Option<CreateTokenCvcUpdate<'a>>,
+    cvc_update: Option<CreateTokenCvcUpdate>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    person: Option<CreateTokenPerson<'a>>,
+    person: Option<CreateTokenPerson>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pii: Option<CreateTokenPii<'a>>,
+    pii: Option<CreateTokenPii>,
 }
-impl<'a> CreateTokenBuilder<'a> {
+impl CreateTokenBuilder {
     fn new() -> Self {
         Self {
             account: None,
@@ -89,28 +89,28 @@ impl<'a> CreateTokenBuilder<'a> {
     }
 }
 /// Information for the account this token represents.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateTokenAccount<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateTokenAccount {
     /// The business type.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub business_type: Option<CreateTokenAccountBusinessType>,
     /// Information about the company or business.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub company: Option<CreateTokenAccountCompany<'a>>,
+    pub company: Option<CreateTokenAccountCompany>,
     /// Information about the person represented by the account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub individual: Option<CreateTokenAccountIndividual<'a>>,
+    pub individual: Option<CreateTokenAccountIndividual>,
     /// Whether the user described by the data in the token has been shown [the Stripe Connected Account Agreement](https://docs.stripe.com/connect/account-tokens#stripe-connected-account-agreement).
     /// When creating an account token to create a new Connect account, this value must be `true`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tos_shown_and_accepted: Option<bool>,
 }
-impl<'a> CreateTokenAccount<'a> {
+impl CreateTokenAccount {
     pub fn new() -> Self {
         Self { business_type: None, company: None, individual: None, tos_shown_and_accepted: None }
     }
 }
-impl<'a> Default for CreateTokenAccount<'a> {
+impl Default for CreateTokenAccount {
     fn default() -> Self {
         Self::new()
     }
@@ -178,17 +178,17 @@ impl<'de> serde::Deserialize<'de> for CreateTokenAccountBusinessType {
     }
 }
 /// Information about the company or business.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateTokenAccountCompany<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateTokenAccountCompany {
     /// The company's primary address.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub address: Option<AddressSpecs<'a>>,
+    pub address: Option<AddressSpecs>,
     /// The Kana variation of the company's primary address (Japan only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub address_kana: Option<CreateTokenAccountCompanyAddressKana<'a>>,
+    pub address_kana: Option<CreateTokenAccountCompanyAddressKana>,
     /// The Kanji variation of the company's primary address (Japan only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub address_kanji: Option<CreateTokenAccountCompanyAddressKanji<'a>>,
+    pub address_kanji: Option<CreateTokenAccountCompanyAddressKanji>,
     /// Whether the company's directors have been provided.
     /// Set this Boolean to `true` after creating all the company's directors with [the Persons API](https://docs.stripe.com/api/persons) for accounts with a `relationship.director` requirement.
     /// This value is not automatically set to `true` after creating directors, so it needs to be updated to indicate all directors have been provided.
@@ -200,36 +200,36 @@ pub struct CreateTokenAccountCompany<'a> {
     pub executives_provided: Option<bool>,
     /// The export license ID number of the company, also referred as Import Export Code (India only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub export_license_id: Option<&'a str>,
+    pub export_license_id: Option<String>,
     /// The purpose code to use for export transactions (India only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub export_purpose_code: Option<&'a str>,
+    pub export_purpose_code: Option<String>,
     /// The company's legal name.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<&'a str>,
+    pub name: Option<String>,
     /// The Kana variation of the company's legal name (Japan only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub name_kana: Option<&'a str>,
+    pub name_kana: Option<String>,
     /// The Kanji variation of the company's legal name (Japan only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub name_kanji: Option<&'a str>,
+    pub name_kanji: Option<String>,
     /// Whether the company's owners have been provided.
     /// Set this Boolean to `true` after creating all the company's owners with [the Persons API](https://docs.stripe.com/api/persons) for accounts with a `relationship.owner` requirement.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub owners_provided: Option<bool>,
     /// This hash is used to attest that the beneficial owner information provided to Stripe is both current and correct.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ownership_declaration: Option<CreateTokenAccountCompanyOwnershipDeclaration<'a>>,
+    pub ownership_declaration: Option<CreateTokenAccountCompanyOwnershipDeclaration>,
     /// Whether the user described by the data in the token has been shown the Ownership Declaration and indicated that it is correct.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ownership_declaration_shown_and_signed: Option<bool>,
     /// The company's phone number (used for verification).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub phone: Option<&'a str>,
+    pub phone: Option<String>,
     /// The identification number given to a company when it is registered or incorporated, if distinct from the identification number used for filing taxes.
     /// (Examples are the CIN for companies and LLP IN for partnerships in India, and the Company Registration Number in Hong Kong).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub registration_number: Option<&'a str>,
+    pub registration_number: Option<String>,
     /// The category identifying the legal structure of the company or legal entity.
     /// See [Business structure](https://docs.stripe.com/connect/identity-verification#business-structure) for more details.
     /// Pass an empty string to unset this value.
@@ -238,18 +238,18 @@ pub struct CreateTokenAccountCompany<'a> {
     /// The business ID number of the company, as appropriate for the company’s country.
     /// (Examples are an Employer ID Number in the U.S., a Business Number in Canada, or a Company Number in the UK.).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_id: Option<&'a str>,
+    pub tax_id: Option<String>,
     /// The jurisdiction in which the `tax_id` is registered (Germany-based companies only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_id_registrar: Option<&'a str>,
+    pub tax_id_registrar: Option<String>,
     /// The VAT number of the company.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub vat_id: Option<&'a str>,
+    pub vat_id: Option<String>,
     /// Information on the verification state of the company.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub verification: Option<CreateTokenAccountCompanyVerification<'a>>,
+    pub verification: Option<CreateTokenAccountCompanyVerification>,
 }
-impl<'a> CreateTokenAccountCompany<'a> {
+impl CreateTokenAccountCompany {
     pub fn new() -> Self {
         Self {
             address: None,
@@ -275,37 +275,37 @@ impl<'a> CreateTokenAccountCompany<'a> {
         }
     }
 }
-impl<'a> Default for CreateTokenAccountCompany<'a> {
+impl Default for CreateTokenAccountCompany {
     fn default() -> Self {
         Self::new()
     }
 }
 /// The Kana variation of the company's primary address (Japan only).
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateTokenAccountCompanyAddressKana<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateTokenAccountCompanyAddressKana {
     /// City or ward.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<&'a str>,
+    pub city: Option<String>,
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub country: Option<&'a str>,
+    pub country: Option<String>,
     /// Block or building number.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line1: Option<&'a str>,
+    pub line1: Option<String>,
     /// Building details.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line2: Option<&'a str>,
+    pub line2: Option<String>,
     /// Postal code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<&'a str>,
+    pub postal_code: Option<String>,
     /// Prefecture.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
     /// Town or cho-me.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub town: Option<&'a str>,
+    pub town: Option<String>,
 }
-impl<'a> CreateTokenAccountCompanyAddressKana<'a> {
+impl CreateTokenAccountCompanyAddressKana {
     pub fn new() -> Self {
         Self {
             city: None,
@@ -318,37 +318,37 @@ impl<'a> CreateTokenAccountCompanyAddressKana<'a> {
         }
     }
 }
-impl<'a> Default for CreateTokenAccountCompanyAddressKana<'a> {
+impl Default for CreateTokenAccountCompanyAddressKana {
     fn default() -> Self {
         Self::new()
     }
 }
 /// The Kanji variation of the company's primary address (Japan only).
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateTokenAccountCompanyAddressKanji<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateTokenAccountCompanyAddressKanji {
     /// City or ward.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<&'a str>,
+    pub city: Option<String>,
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub country: Option<&'a str>,
+    pub country: Option<String>,
     /// Block or building number.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line1: Option<&'a str>,
+    pub line1: Option<String>,
     /// Building details.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line2: Option<&'a str>,
+    pub line2: Option<String>,
     /// Postal code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<&'a str>,
+    pub postal_code: Option<String>,
     /// Prefecture.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
     /// Town or cho-me.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub town: Option<&'a str>,
+    pub town: Option<String>,
 }
-impl<'a> CreateTokenAccountCompanyAddressKanji<'a> {
+impl CreateTokenAccountCompanyAddressKanji {
     pub fn new() -> Self {
         Self {
             city: None,
@@ -361,30 +361,30 @@ impl<'a> CreateTokenAccountCompanyAddressKanji<'a> {
         }
     }
 }
-impl<'a> Default for CreateTokenAccountCompanyAddressKanji<'a> {
+impl Default for CreateTokenAccountCompanyAddressKanji {
     fn default() -> Self {
         Self::new()
     }
 }
 /// This hash is used to attest that the beneficial owner information provided to Stripe is both current and correct.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateTokenAccountCompanyOwnershipDeclaration<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateTokenAccountCompanyOwnershipDeclaration {
     /// The Unix timestamp marking when the beneficial owner attestation was made.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub date: Option<stripe_types::Timestamp>,
     /// The IP address from which the beneficial owner attestation was made.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ip: Option<&'a str>,
+    pub ip: Option<String>,
     /// The user agent of the browser from which the beneficial owner attestation was made.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user_agent: Option<&'a str>,
+    pub user_agent: Option<String>,
 }
-impl<'a> CreateTokenAccountCompanyOwnershipDeclaration<'a> {
+impl CreateTokenAccountCompanyOwnershipDeclaration {
     pub fn new() -> Self {
         Self { date: None, ip: None, user_agent: None }
     }
 }
-impl<'a> Default for CreateTokenAccountCompanyOwnershipDeclaration<'a> {
+impl Default for CreateTokenAccountCompanyOwnershipDeclaration {
     fn default() -> Self {
         Self::new()
     }
@@ -513,125 +513,125 @@ impl<'de> serde::Deserialize<'de> for CreateTokenAccountCompanyStructure {
     }
 }
 /// Information on the verification state of the company.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateTokenAccountCompanyVerification<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateTokenAccountCompanyVerification {
     /// A document verifying the business.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub document: Option<CreateTokenAccountCompanyVerificationDocument<'a>>,
+    pub document: Option<CreateTokenAccountCompanyVerificationDocument>,
 }
-impl<'a> CreateTokenAccountCompanyVerification<'a> {
+impl CreateTokenAccountCompanyVerification {
     pub fn new() -> Self {
         Self { document: None }
     }
 }
-impl<'a> Default for CreateTokenAccountCompanyVerification<'a> {
+impl Default for CreateTokenAccountCompanyVerification {
     fn default() -> Self {
         Self::new()
     }
 }
 /// A document verifying the business.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateTokenAccountCompanyVerificationDocument<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateTokenAccountCompanyVerificationDocument {
     /// The back of a document returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `additional_verification`.
     /// The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG, PNG, or PDF format, and less than 10 MB in size.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub back: Option<&'a str>,
+    pub back: Option<String>,
     /// The front of a document returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `additional_verification`.
     /// The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG, PNG, or PDF format, and less than 10 MB in size.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub front: Option<&'a str>,
+    pub front: Option<String>,
 }
-impl<'a> CreateTokenAccountCompanyVerificationDocument<'a> {
+impl CreateTokenAccountCompanyVerificationDocument {
     pub fn new() -> Self {
         Self { back: None, front: None }
     }
 }
-impl<'a> Default for CreateTokenAccountCompanyVerificationDocument<'a> {
+impl Default for CreateTokenAccountCompanyVerificationDocument {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Information about the person represented by the account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateTokenAccountIndividual<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateTokenAccountIndividual {
     /// The individual's primary address.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub address: Option<AddressSpecs<'a>>,
+    pub address: Option<AddressSpecs>,
     /// The Kana variation of the the individual's primary address (Japan only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub address_kana: Option<CreateTokenAccountIndividualAddressKana<'a>>,
+    pub address_kana: Option<CreateTokenAccountIndividualAddressKana>,
     /// The Kanji variation of the the individual's primary address (Japan only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub address_kanji: Option<CreateTokenAccountIndividualAddressKanji<'a>>,
+    pub address_kanji: Option<CreateTokenAccountIndividualAddressKanji>,
     /// The individual's date of birth.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dob: Option<DateOfBirthSpecs>,
     /// The individual's email address.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub email: Option<&'a str>,
+    pub email: Option<String>,
     /// The individual's first name.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub first_name: Option<&'a str>,
+    pub first_name: Option<String>,
     /// The Kana variation of the the individual's first name (Japan only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub first_name_kana: Option<&'a str>,
+    pub first_name_kana: Option<String>,
     /// The Kanji variation of the individual's first name (Japan only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub first_name_kanji: Option<&'a str>,
+    pub first_name_kanji: Option<String>,
     /// A list of alternate names or aliases that the individual is known by.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub full_name_aliases: Option<&'a [&'a str]>,
+    pub full_name_aliases: Option<Vec<String>>,
     /// The individual's gender (International regulations require either "male" or "female").
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub gender: Option<&'a str>,
+    pub gender: Option<String>,
     /// The government-issued ID number of the individual, as appropriate for the representative's country.
     /// (Examples are a Social Security Number in the U.S., or a Social Insurance Number in Canada).
     /// Instead of the number itself, you can also provide a [PII token created with Stripe.js](https://docs.stripe.com/js/tokens/create_token?type=pii).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub id_number: Option<&'a str>,
+    pub id_number: Option<String>,
     /// The government-issued secondary ID number of the individual, as appropriate for the representative's country, will be used for enhanced verification checks.
     /// In Thailand, this would be the laser code found on the back of an ID card.
     /// Instead of the number itself, you can also provide a [PII token created with Stripe.js](https://docs.stripe.com/js/tokens/create_token?type=pii).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub id_number_secondary: Option<&'a str>,
+    pub id_number_secondary: Option<String>,
     /// The individual's last name.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub last_name: Option<&'a str>,
+    pub last_name: Option<String>,
     /// The Kana variation of the individual's last name (Japan only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub last_name_kana: Option<&'a str>,
+    pub last_name_kana: Option<String>,
     /// The Kanji variation of the individual's last name (Japan only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub last_name_kanji: Option<&'a str>,
+    pub last_name_kanji: Option<String>,
     /// The individual's maiden name.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub maiden_name: Option<&'a str>,
+    pub maiden_name: Option<String>,
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// The individual's phone number.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub phone: Option<&'a str>,
+    pub phone: Option<String>,
     /// Indicates if the person or any of their representatives, family members, or other closely related persons, declares that they hold or have held an important public job or function, in any jurisdiction.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub political_exposure: Option<CreateTokenAccountIndividualPoliticalExposure>,
     /// The individual's registered address.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub registered_address: Option<AddressSpecs<'a>>,
+    pub registered_address: Option<AddressSpecs>,
     /// Describes the person’s relationship to the account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub relationship: Option<CreateTokenAccountIndividualRelationship<'a>>,
+    pub relationship: Option<CreateTokenAccountIndividualRelationship>,
     /// The last four digits of the individual's Social Security Number (U.S. only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ssn_last_4: Option<&'a str>,
+    pub ssn_last_4: Option<String>,
     /// The individual's verification document information.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub verification: Option<PersonVerificationSpecs<'a>>,
+    pub verification: Option<PersonVerificationSpecs>,
 }
-impl<'a> CreateTokenAccountIndividual<'a> {
+impl CreateTokenAccountIndividual {
     pub fn new() -> Self {
         Self {
             address: None,
@@ -660,37 +660,37 @@ impl<'a> CreateTokenAccountIndividual<'a> {
         }
     }
 }
-impl<'a> Default for CreateTokenAccountIndividual<'a> {
+impl Default for CreateTokenAccountIndividual {
     fn default() -> Self {
         Self::new()
     }
 }
 /// The Kana variation of the the individual's primary address (Japan only).
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateTokenAccountIndividualAddressKana<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateTokenAccountIndividualAddressKana {
     /// City or ward.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<&'a str>,
+    pub city: Option<String>,
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub country: Option<&'a str>,
+    pub country: Option<String>,
     /// Block or building number.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line1: Option<&'a str>,
+    pub line1: Option<String>,
     /// Building details.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line2: Option<&'a str>,
+    pub line2: Option<String>,
     /// Postal code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<&'a str>,
+    pub postal_code: Option<String>,
     /// Prefecture.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
     /// Town or cho-me.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub town: Option<&'a str>,
+    pub town: Option<String>,
 }
-impl<'a> CreateTokenAccountIndividualAddressKana<'a> {
+impl CreateTokenAccountIndividualAddressKana {
     pub fn new() -> Self {
         Self {
             city: None,
@@ -703,37 +703,37 @@ impl<'a> CreateTokenAccountIndividualAddressKana<'a> {
         }
     }
 }
-impl<'a> Default for CreateTokenAccountIndividualAddressKana<'a> {
+impl Default for CreateTokenAccountIndividualAddressKana {
     fn default() -> Self {
         Self::new()
     }
 }
 /// The Kanji variation of the the individual's primary address (Japan only).
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateTokenAccountIndividualAddressKanji<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateTokenAccountIndividualAddressKanji {
     /// City or ward.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<&'a str>,
+    pub city: Option<String>,
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub country: Option<&'a str>,
+    pub country: Option<String>,
     /// Block or building number.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line1: Option<&'a str>,
+    pub line1: Option<String>,
     /// Building details.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line2: Option<&'a str>,
+    pub line2: Option<String>,
     /// Postal code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<&'a str>,
+    pub postal_code: Option<String>,
     /// Prefecture.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
     /// Town or cho-me.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub town: Option<&'a str>,
+    pub town: Option<String>,
 }
-impl<'a> CreateTokenAccountIndividualAddressKanji<'a> {
+impl CreateTokenAccountIndividualAddressKanji {
     pub fn new() -> Self {
         Self {
             city: None,
@@ -746,7 +746,7 @@ impl<'a> CreateTokenAccountIndividualAddressKanji<'a> {
         }
     }
 }
-impl<'a> Default for CreateTokenAccountIndividualAddressKanji<'a> {
+impl Default for CreateTokenAccountIndividualAddressKanji {
     fn default() -> Self {
         Self::new()
     }
@@ -810,8 +810,8 @@ impl<'de> serde::Deserialize<'de> for CreateTokenAccountIndividualPoliticalExpos
     }
 }
 /// Describes the person’s relationship to the account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateTokenAccountIndividualRelationship<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateTokenAccountIndividualRelationship {
     /// Whether the person is a director of the account's legal entity.
     /// Directors are typically members of the governing board of the company, or responsible for ensuring the company meets its regulatory obligations.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -827,39 +827,39 @@ pub struct CreateTokenAccountIndividualRelationship<'a> {
     pub percent_ownership: Option<f64>,
     /// The person's title (e.g., CEO, Support Engineer).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub title: Option<&'a str>,
+    pub title: Option<String>,
 }
-impl<'a> CreateTokenAccountIndividualRelationship<'a> {
+impl CreateTokenAccountIndividualRelationship {
     pub fn new() -> Self {
         Self { director: None, executive: None, owner: None, percent_ownership: None, title: None }
     }
 }
-impl<'a> Default for CreateTokenAccountIndividualRelationship<'a> {
+impl Default for CreateTokenAccountIndividualRelationship {
     fn default() -> Self {
         Self::new()
     }
 }
 /// The bank account this token will represent.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateTokenBankAccount<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateTokenBankAccount {
     /// The name of the person or business that owns the bank account.
     /// This field is required when attaching the bank account to a `Customer` object.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account_holder_name: Option<&'a str>,
+    pub account_holder_name: Option<String>,
     /// The type of entity that holds the account.
     /// It can be `company` or `individual`.
     /// This field is required when attaching the bank account to a `Customer` object.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub account_holder_type: Option<CreateTokenBankAccountAccountHolderType>,
     /// The account number for the bank account, in string form. Must be a checking account.
-    pub account_number: &'a str,
+    pub account_number: String,
     /// The bank account type.
     /// This can only be `checking` or `savings` in most countries.
     /// In Japan, this can only be `futsu` or `toza`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub account_type: Option<CreateTokenBankAccountAccountType>,
     /// The country in which the bank account is located.
-    pub country: &'a str,
+    pub country: String,
     /// The currency the bank account is in.
     /// This must be a country/currency pairing that [Stripe supports.](https://stripe.com/docs/payouts).
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -871,21 +871,21 @@ pub struct CreateTokenBankAccount<'a> {
     /// If the Payment Method is not attached to a `Customer` object, it will be consumed and cannot be used again.
     /// You may not use Payment Methods which were created by a Setup Intent with `attach_to_self=true`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub payment_method: Option<&'a str>,
+    pub payment_method: Option<String>,
     /// The routing number, sort code, or other country-appropriateinstitution number for the bank account.
     /// For US bank accounts, this is required and should bethe ACH routing number, not the wire routing number.
     /// If you are providing an IBAN for`account_number`, this field is not required.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub routing_number: Option<&'a str>,
+    pub routing_number: Option<String>,
 }
-impl<'a> CreateTokenBankAccount<'a> {
-    pub fn new(account_number: &'a str, country: &'a str) -> Self {
+impl CreateTokenBankAccount {
+    pub fn new(account_number: impl Into<String>, country: impl Into<String>) -> Self {
         Self {
             account_holder_name: None,
             account_holder_type: None,
-            account_number,
+            account_number: account_number.into(),
             account_type: None,
-            country,
+            country: country.into(),
             currency: None,
             payment_method: None,
             routing_number: None,
@@ -1017,59 +1017,63 @@ impl<'de> serde::Deserialize<'de> for CreateTokenBankAccountAccountType {
 /// The card this token will represent.
 /// If you also pass in a customer, the card must be the ID of a card belonging to the customer.
 /// Otherwise, if you do not pass in a customer, this is a dictionary containing a user's credit card details, with the options described below.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
-pub enum CreateTokenCard<'a> {
+pub enum CreateTokenCard {
     #[serde(untagged)]
-    CreditCardSpecs(CreateTokenCreditCardSpecs<'a>),
+    CreditCardSpecs(CreateTokenCreditCardSpecs),
     #[serde(untagged)]
-    Str(&'a str),
+    String(String),
 }
 /// The card this token will represent.
 /// If you also pass in a customer, the card must be the ID of a card belonging to the customer.
 /// Otherwise, if you do not pass in a customer, this is a dictionary containing a user's credit card details, with the options described below.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateTokenCreditCardSpecs<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateTokenCreditCardSpecs {
     /// City / District / Suburb / Town / Village.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub address_city: Option<&'a str>,
+    pub address_city: Option<String>,
     /// Billing address country, if provided.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub address_country: Option<&'a str>,
+    pub address_country: Option<String>,
     /// Address line 1 (Street address / PO Box / Company name).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub address_line1: Option<&'a str>,
+    pub address_line1: Option<String>,
     /// Address line 2 (Apartment / Suite / Unit / Building).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub address_line2: Option<&'a str>,
+    pub address_line2: Option<String>,
     /// State / County / Province / Region.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub address_state: Option<&'a str>,
+    pub address_state: Option<String>,
     /// ZIP or postal code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub address_zip: Option<&'a str>,
+    pub address_zip: Option<String>,
     /// Required in order to add the card to an account; in all other cases, this parameter is not used.
     /// When added to an account, the card (which must be a debit card) can be used as a transfer destination for funds in this currency.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub currency: Option<stripe_types::Currency>,
     /// Card security code. Highly recommended to always include this value.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub cvc: Option<&'a str>,
+    pub cvc: Option<String>,
     /// Two-digit number representing the card's expiration month.
-    pub exp_month: &'a str,
+    pub exp_month: String,
     /// Two- or four-digit number representing the card's expiration year.
-    pub exp_year: &'a str,
+    pub exp_year: String,
     /// Cardholder's full name.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<&'a str>,
+    pub name: Option<String>,
     /// Contains information about card networks used to process the payment.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub networks: Option<CreateTokenCreditCardSpecsNetworks>,
     /// The card number, as a string without any separators.
-    pub number: &'a str,
+    pub number: String,
 }
-impl<'a> CreateTokenCreditCardSpecs<'a> {
-    pub fn new(exp_month: &'a str, exp_year: &'a str, number: &'a str) -> Self {
+impl CreateTokenCreditCardSpecs {
+    pub fn new(
+        exp_month: impl Into<String>,
+        exp_year: impl Into<String>,
+        number: impl Into<String>,
+    ) -> Self {
         Self {
             address_city: None,
             address_country: None,
@@ -1079,11 +1083,11 @@ impl<'a> CreateTokenCreditCardSpecs<'a> {
             address_zip: None,
             currency: None,
             cvc: None,
-            exp_month,
-            exp_year,
+            exp_month: exp_month.into(),
+            exp_year: exp_year.into(),
             name: None,
             networks: None,
-            number,
+            number: number.into(),
         }
     }
 }
@@ -1170,107 +1174,107 @@ impl<'de> serde::Deserialize<'de> for CreateTokenCreditCardSpecsNetworksPreferre
     }
 }
 /// The updated CVC value this token represents.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateTokenCvcUpdate<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateTokenCvcUpdate {
     /// The CVC value, in string form.
-    pub cvc: &'a str,
+    pub cvc: String,
 }
-impl<'a> CreateTokenCvcUpdate<'a> {
-    pub fn new(cvc: &'a str) -> Self {
-        Self { cvc }
+impl CreateTokenCvcUpdate {
+    pub fn new(cvc: impl Into<String>) -> Self {
+        Self { cvc: cvc.into() }
     }
 }
 /// Information for the person this token represents.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateTokenPerson<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateTokenPerson {
     /// Details on the legal guardian's acceptance of the required Stripe agreements.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub additional_tos_acceptances: Option<CreateTokenPersonAdditionalTosAcceptances<'a>>,
+    pub additional_tos_acceptances: Option<CreateTokenPersonAdditionalTosAcceptances>,
     /// The person's address.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub address: Option<AddressSpecs<'a>>,
+    pub address: Option<AddressSpecs>,
     /// The Kana variation of the person's address (Japan only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub address_kana: Option<CreateTokenPersonAddressKana<'a>>,
+    pub address_kana: Option<CreateTokenPersonAddressKana>,
     /// The Kanji variation of the person's address (Japan only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub address_kanji: Option<CreateTokenPersonAddressKanji<'a>>,
+    pub address_kanji: Option<CreateTokenPersonAddressKanji>,
     /// The person's date of birth.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dob: Option<DateOfBirthSpecs>,
     /// Documents that may be submitted to satisfy various informational requests.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub documents: Option<CreateTokenPersonDocuments<'a>>,
+    pub documents: Option<CreateTokenPersonDocuments>,
     /// The person's email address.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub email: Option<&'a str>,
+    pub email: Option<String>,
     /// The person's first name.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub first_name: Option<&'a str>,
+    pub first_name: Option<String>,
     /// The Kana variation of the person's first name (Japan only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub first_name_kana: Option<&'a str>,
+    pub first_name_kana: Option<String>,
     /// The Kanji variation of the person's first name (Japan only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub first_name_kanji: Option<&'a str>,
+    pub first_name_kanji: Option<String>,
     /// A list of alternate names or aliases that the person is known by.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub full_name_aliases: Option<&'a [&'a str]>,
+    pub full_name_aliases: Option<Vec<String>>,
     /// The person's gender (International regulations require either "male" or "female").
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub gender: Option<&'a str>,
+    pub gender: Option<String>,
     /// The person's ID number, as appropriate for their country.
     /// For example, a social security number in the U.S., social insurance number in Canada, etc.
     /// Instead of the number itself, you can also provide a [PII token provided by Stripe.js](https://docs.stripe.com/js/tokens/create_token?type=pii).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub id_number: Option<&'a str>,
+    pub id_number: Option<String>,
     /// The person's secondary ID number, as appropriate for their country, will be used for enhanced verification checks.
     /// In Thailand, this would be the laser code found on the back of an ID card.
     /// Instead of the number itself, you can also provide a [PII token provided by Stripe.js](https://docs.stripe.com/js/tokens/create_token?type=pii).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub id_number_secondary: Option<&'a str>,
+    pub id_number_secondary: Option<String>,
     /// The person's last name.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub last_name: Option<&'a str>,
+    pub last_name: Option<String>,
     /// The Kana variation of the person's last name (Japan only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub last_name_kana: Option<&'a str>,
+    pub last_name_kana: Option<String>,
     /// The Kanji variation of the person's last name (Japan only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub last_name_kanji: Option<&'a str>,
+    pub last_name_kanji: Option<String>,
     /// The person's maiden name.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub maiden_name: Option<&'a str>,
+    pub maiden_name: Option<String>,
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// The country where the person is a national.
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)), or "XX" if unavailable.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub nationality: Option<&'a str>,
+    pub nationality: Option<String>,
     /// The person's phone number.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub phone: Option<&'a str>,
+    pub phone: Option<String>,
     /// Indicates if the person or any of their representatives, family members, or other closely related persons, declares that they hold or have held an important public job or function, in any jurisdiction.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub political_exposure: Option<&'a str>,
+    pub political_exposure: Option<String>,
     /// The person's registered address.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub registered_address: Option<AddressSpecs<'a>>,
+    pub registered_address: Option<AddressSpecs>,
     /// The relationship that this person has with the account's legal entity.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub relationship: Option<CreateTokenPersonRelationship<'a>>,
+    pub relationship: Option<CreateTokenPersonRelationship>,
     /// The last four digits of the person's Social Security number (U.S. only).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ssn_last_4: Option<&'a str>,
+    pub ssn_last_4: Option<String>,
     /// The person's verification status.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub verification: Option<PersonVerificationSpecs<'a>>,
+    pub verification: Option<PersonVerificationSpecs>,
 }
-impl<'a> CreateTokenPerson<'a> {
+impl CreateTokenPerson {
     pub fn new() -> Self {
         Self {
             additional_tos_acceptances: None,
@@ -1302,77 +1306,77 @@ impl<'a> CreateTokenPerson<'a> {
         }
     }
 }
-impl<'a> Default for CreateTokenPerson<'a> {
+impl Default for CreateTokenPerson {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Details on the legal guardian's acceptance of the required Stripe agreements.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateTokenPersonAdditionalTosAcceptances<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateTokenPersonAdditionalTosAcceptances {
     /// Details on the legal guardian's acceptance of the main Stripe service agreement.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account: Option<CreateTokenPersonAdditionalTosAcceptancesAccount<'a>>,
+    pub account: Option<CreateTokenPersonAdditionalTosAcceptancesAccount>,
 }
-impl<'a> CreateTokenPersonAdditionalTosAcceptances<'a> {
+impl CreateTokenPersonAdditionalTosAcceptances {
     pub fn new() -> Self {
         Self { account: None }
     }
 }
-impl<'a> Default for CreateTokenPersonAdditionalTosAcceptances<'a> {
+impl Default for CreateTokenPersonAdditionalTosAcceptances {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Details on the legal guardian's acceptance of the main Stripe service agreement.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateTokenPersonAdditionalTosAcceptancesAccount<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateTokenPersonAdditionalTosAcceptancesAccount {
     /// The Unix timestamp marking when the account representative accepted the service agreement.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub date: Option<stripe_types::Timestamp>,
     /// The IP address from which the account representative accepted the service agreement.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ip: Option<&'a str>,
+    pub ip: Option<String>,
     /// The user agent of the browser from which the account representative accepted the service agreement.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user_agent: Option<&'a str>,
+    pub user_agent: Option<String>,
 }
-impl<'a> CreateTokenPersonAdditionalTosAcceptancesAccount<'a> {
+impl CreateTokenPersonAdditionalTosAcceptancesAccount {
     pub fn new() -> Self {
         Self { date: None, ip: None, user_agent: None }
     }
 }
-impl<'a> Default for CreateTokenPersonAdditionalTosAcceptancesAccount<'a> {
+impl Default for CreateTokenPersonAdditionalTosAcceptancesAccount {
     fn default() -> Self {
         Self::new()
     }
 }
 /// The Kana variation of the person's address (Japan only).
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateTokenPersonAddressKana<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateTokenPersonAddressKana {
     /// City or ward.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<&'a str>,
+    pub city: Option<String>,
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub country: Option<&'a str>,
+    pub country: Option<String>,
     /// Block or building number.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line1: Option<&'a str>,
+    pub line1: Option<String>,
     /// Building details.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line2: Option<&'a str>,
+    pub line2: Option<String>,
     /// Postal code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<&'a str>,
+    pub postal_code: Option<String>,
     /// Prefecture.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
     /// Town or cho-me.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub town: Option<&'a str>,
+    pub town: Option<String>,
 }
-impl<'a> CreateTokenPersonAddressKana<'a> {
+impl CreateTokenPersonAddressKana {
     pub fn new() -> Self {
         Self {
             city: None,
@@ -1385,37 +1389,37 @@ impl<'a> CreateTokenPersonAddressKana<'a> {
         }
     }
 }
-impl<'a> Default for CreateTokenPersonAddressKana<'a> {
+impl Default for CreateTokenPersonAddressKana {
     fn default() -> Self {
         Self::new()
     }
 }
 /// The Kanji variation of the person's address (Japan only).
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateTokenPersonAddressKanji<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateTokenPersonAddressKanji {
     /// City or ward.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<&'a str>,
+    pub city: Option<String>,
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub country: Option<&'a str>,
+    pub country: Option<String>,
     /// Block or building number.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line1: Option<&'a str>,
+    pub line1: Option<String>,
     /// Building details.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line2: Option<&'a str>,
+    pub line2: Option<String>,
     /// Postal code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<&'a str>,
+    pub postal_code: Option<String>,
     /// Prefecture.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
     /// Town or cho-me.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub town: Option<&'a str>,
+    pub town: Option<String>,
 }
-impl<'a> CreateTokenPersonAddressKanji<'a> {
+impl CreateTokenPersonAddressKanji {
     pub fn new() -> Self {
         Self {
             city: None,
@@ -1428,37 +1432,37 @@ impl<'a> CreateTokenPersonAddressKanji<'a> {
         }
     }
 }
-impl<'a> Default for CreateTokenPersonAddressKanji<'a> {
+impl Default for CreateTokenPersonAddressKanji {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Documents that may be submitted to satisfy various informational requests.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateTokenPersonDocuments<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateTokenPersonDocuments {
     /// One or more documents that demonstrate proof that this person is authorized to represent the company.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub company_authorization: Option<DocumentsParam<'a>>,
+    pub company_authorization: Option<DocumentsParam>,
     /// One or more documents showing the person's passport page with photo and personal data.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub passport: Option<DocumentsParam<'a>>,
+    pub passport: Option<DocumentsParam>,
     /// One or more documents showing the person's visa required for living in the country where they are residing.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub visa: Option<DocumentsParam<'a>>,
+    pub visa: Option<DocumentsParam>,
 }
-impl<'a> CreateTokenPersonDocuments<'a> {
+impl CreateTokenPersonDocuments {
     pub fn new() -> Self {
         Self { company_authorization: None, passport: None, visa: None }
     }
 }
-impl<'a> Default for CreateTokenPersonDocuments<'a> {
+impl Default for CreateTokenPersonDocuments {
     fn default() -> Self {
         Self::new()
     }
 }
 /// The relationship that this person has with the account's legal entity.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateTokenPersonRelationship<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateTokenPersonRelationship {
     /// Whether the person is a director of the account's legal entity.
     /// Directors are typically members of the governing board of the company, or responsible for ensuring the company meets its regulatory obligations.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1483,9 +1487,9 @@ pub struct CreateTokenPersonRelationship<'a> {
     pub representative: Option<bool>,
     /// The person's title (e.g., CEO, Support Engineer).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub title: Option<&'a str>,
+    pub title: Option<String>,
 }
-impl<'a> CreateTokenPersonRelationship<'a> {
+impl CreateTokenPersonRelationship {
     pub fn new() -> Self {
         Self {
             director: None,
@@ -1498,24 +1502,24 @@ impl<'a> CreateTokenPersonRelationship<'a> {
         }
     }
 }
-impl<'a> Default for CreateTokenPersonRelationship<'a> {
+impl Default for CreateTokenPersonRelationship {
     fn default() -> Self {
         Self::new()
     }
 }
 /// The PII this token represents.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateTokenPii<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateTokenPii {
     /// The `id_number` for the PII, in string form.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub id_number: Option<&'a str>,
+    pub id_number: Option<String>,
 }
-impl<'a> CreateTokenPii<'a> {
+impl CreateTokenPii {
     pub fn new() -> Self {
         Self { id_number: None }
     }
 }
-impl<'a> Default for CreateTokenPii<'a> {
+impl Default for CreateTokenPii {
     fn default() -> Self {
         Self::new()
     }
@@ -1525,65 +1529,65 @@ impl<'a> Default for CreateTokenPii<'a> {
 /// You can only use this token once.
 /// To do so, attach it to a [connected account](https://stripe.com/docs/api#accounts) where <a href="/api/accounts/object#account_object-controller-requirement_collection">controller.requirement_collection</a> is `application`, which includes Custom accounts.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateToken<'a> {
-    inner: CreateTokenBuilder<'a>,
+pub struct CreateToken {
+    inner: CreateTokenBuilder,
 }
-impl<'a> CreateToken<'a> {
+impl CreateToken {
     /// Construct a new `CreateToken`.
     pub fn new() -> Self {
         Self { inner: CreateTokenBuilder::new() }
     }
     /// Information for the account this token represents.
-    pub fn account(mut self, account: CreateTokenAccount<'a>) -> Self {
-        self.inner.account = Some(account);
+    pub fn account(mut self, account: impl Into<CreateTokenAccount>) -> Self {
+        self.inner.account = Some(account.into());
         self
     }
     /// The bank account this token will represent.
-    pub fn bank_account(mut self, bank_account: CreateTokenBankAccount<'a>) -> Self {
-        self.inner.bank_account = Some(bank_account);
+    pub fn bank_account(mut self, bank_account: impl Into<CreateTokenBankAccount>) -> Self {
+        self.inner.bank_account = Some(bank_account.into());
         self
     }
     /// The card this token will represent.
     /// If you also pass in a customer, the card must be the ID of a card belonging to the customer.
     /// Otherwise, if you do not pass in a customer, this is a dictionary containing a user's credit card details, with the options described below.
-    pub fn card(mut self, card: CreateTokenCard<'a>) -> Self {
-        self.inner.card = Some(card);
+    pub fn card(mut self, card: impl Into<CreateTokenCard>) -> Self {
+        self.inner.card = Some(card.into());
         self
     }
     /// Create a token for the customer, which is owned by the application's account.
     /// You can only use this with an [OAuth access token](https://stripe.com/docs/connect/standard-accounts) or [Stripe-Account header](https://stripe.com/docs/connect/authentication).
     /// Learn more about [cloning saved payment methods](https://stripe.com/docs/connect/cloning-saved-payment-methods).
-    pub fn customer(mut self, customer: &'a str) -> Self {
-        self.inner.customer = Some(customer);
+    pub fn customer(mut self, customer: impl Into<String>) -> Self {
+        self.inner.customer = Some(customer.into());
         self
     }
     /// The updated CVC value this token represents.
-    pub fn cvc_update(mut self, cvc_update: CreateTokenCvcUpdate<'a>) -> Self {
-        self.inner.cvc_update = Some(cvc_update);
+    pub fn cvc_update(mut self, cvc_update: impl Into<CreateTokenCvcUpdate>) -> Self {
+        self.inner.cvc_update = Some(cvc_update.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Information for the person this token represents.
-    pub fn person(mut self, person: CreateTokenPerson<'a>) -> Self {
-        self.inner.person = Some(person);
+    pub fn person(mut self, person: impl Into<CreateTokenPerson>) -> Self {
+        self.inner.person = Some(person.into());
         self
     }
     /// The PII this token represents.
-    pub fn pii(mut self, pii: CreateTokenPii<'a>) -> Self {
-        self.inner.pii = Some(pii);
+    pub fn pii(mut self, pii: impl Into<CreateTokenPii>) -> Self {
+        self.inner.pii = Some(pii.into());
         self
     }
 }
-impl<'a> Default for CreateToken<'a> {
+impl Default for CreateToken {
     fn default() -> Self {
         Self::new()
     }
 }
-impl CreateToken<'_> {
+impl CreateToken {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -1601,7 +1605,7 @@ impl CreateToken<'_> {
     }
 }
 
-impl StripeRequest for CreateToken<'_> {
+impl StripeRequest for CreateToken {
     type Output = stripe_core::Token;
 
     fn build(&self) -> RequestBuilder {
@@ -1609,33 +1613,33 @@ impl StripeRequest for CreateToken<'_> {
     }
 }
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct AddressSpecs<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct AddressSpecs {
     /// City, district, suburb, town, or village.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<&'a str>,
+    pub city: Option<String>,
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub country: Option<&'a str>,
+    pub country: Option<String>,
     /// Address line 1 (e.g., street, PO Box, or company name).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line1: Option<&'a str>,
+    pub line1: Option<String>,
     /// Address line 2 (e.g., apartment, suite, unit, or building).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line2: Option<&'a str>,
+    pub line2: Option<String>,
     /// ZIP or postal code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<&'a str>,
+    pub postal_code: Option<String>,
     /// State, county, province, or region.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
 }
-impl<'a> AddressSpecs<'a> {
+impl AddressSpecs {
     pub fn new() -> Self {
         Self { city: None, country: None, line1: None, line2: None, postal_code: None, state: None }
     }
 }
-impl<'a> Default for AddressSpecs<'a> {
+impl Default for AddressSpecs {
     fn default() -> Self {
         Self::new()
     }
@@ -1650,62 +1654,62 @@ pub struct DateOfBirthSpecs {
     pub year: i64,
 }
 impl DateOfBirthSpecs {
-    pub fn new(day: i64, month: i64, year: i64) -> Self {
-        Self { day, month, year }
+    pub fn new(day: impl Into<i64>, month: impl Into<i64>, year: impl Into<i64>) -> Self {
+        Self { day: day.into(), month: month.into(), year: year.into() }
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct PersonVerificationDocumentSpecs<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct PersonVerificationDocumentSpecs {
     /// The back of an ID returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `identity_document`.
     /// The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG, PNG, or PDF format, and less than 10 MB in size.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub back: Option<&'a str>,
+    pub back: Option<String>,
     /// The front of an ID returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `identity_document`.
     /// The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG, PNG, or PDF format, and less than 10 MB in size.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub front: Option<&'a str>,
+    pub front: Option<String>,
 }
-impl<'a> PersonVerificationDocumentSpecs<'a> {
+impl PersonVerificationDocumentSpecs {
     pub fn new() -> Self {
         Self { back: None, front: None }
     }
 }
-impl<'a> Default for PersonVerificationDocumentSpecs<'a> {
+impl Default for PersonVerificationDocumentSpecs {
     fn default() -> Self {
         Self::new()
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct DocumentsParam<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct DocumentsParam {
     /// One or more document ids returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `account_requirement`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub files: Option<&'a [&'a str]>,
+    pub files: Option<Vec<String>>,
 }
-impl<'a> DocumentsParam<'a> {
+impl DocumentsParam {
     pub fn new() -> Self {
         Self { files: None }
     }
 }
-impl<'a> Default for DocumentsParam<'a> {
+impl Default for DocumentsParam {
     fn default() -> Self {
         Self::new()
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct PersonVerificationSpecs<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct PersonVerificationSpecs {
     /// A document showing address, either a passport, local ID card, or utility bill from a well-known utility company.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub additional_document: Option<PersonVerificationDocumentSpecs<'a>>,
+    pub additional_document: Option<PersonVerificationDocumentSpecs>,
     /// An identifying document, either a passport or local ID card.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub document: Option<PersonVerificationDocumentSpecs<'a>>,
+    pub document: Option<PersonVerificationDocumentSpecs>,
 }
-impl<'a> PersonVerificationSpecs<'a> {
+impl PersonVerificationSpecs {
     pub fn new() -> Self {
         Self { additional_document: None, document: None }
     }
 }
-impl<'a> Default for PersonVerificationSpecs<'a> {
+impl Default for PersonVerificationSpecs {
     fn default() -> Self {
         Self::new()
     }

--- a/generated/async-stripe-fraud/src/radar_early_fraud_warning/requests.rs
+++ b/generated/async-stripe-fraud/src/radar_early_fraud_warning/requests.rs
@@ -2,24 +2,24 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListRadarEarlyFraudWarningBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListRadarEarlyFraudWarningBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    charge: Option<&'a str>,
+    charge: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     created: Option<stripe_types::RangeQueryTs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_intent: Option<&'a str>,
+    payment_intent: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListRadarEarlyFraudWarningBuilder<'a> {
+impl ListRadarEarlyFraudWarningBuilder {
     fn new() -> Self {
         Self {
             charge: None,
@@ -34,61 +34,61 @@ impl<'a> ListRadarEarlyFraudWarningBuilder<'a> {
 }
 /// Returns a list of early fraud warnings.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListRadarEarlyFraudWarning<'a> {
-    inner: ListRadarEarlyFraudWarningBuilder<'a>,
+pub struct ListRadarEarlyFraudWarning {
+    inner: ListRadarEarlyFraudWarningBuilder,
 }
-impl<'a> ListRadarEarlyFraudWarning<'a> {
+impl ListRadarEarlyFraudWarning {
     /// Construct a new `ListRadarEarlyFraudWarning`.
     pub fn new() -> Self {
         Self { inner: ListRadarEarlyFraudWarningBuilder::new() }
     }
     /// Only return early fraud warnings for the charge specified by this charge ID.
-    pub fn charge(mut self, charge: &'a str) -> Self {
-        self.inner.charge = Some(charge);
+    pub fn charge(mut self, charge: impl Into<String>) -> Self {
+        self.inner.charge = Some(charge.into());
         self
     }
     /// Only return early fraud warnings that were created during the given date interval.
-    pub fn created(mut self, created: stripe_types::RangeQueryTs) -> Self {
-        self.inner.created = Some(created);
+    pub fn created(mut self, created: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.created = Some(created.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// Only return early fraud warnings for charges that were created by the PaymentIntent specified by this PaymentIntent ID.
-    pub fn payment_intent(mut self, payment_intent: &'a str) -> Self {
-        self.inner.payment_intent = Some(payment_intent);
+    pub fn payment_intent(mut self, payment_intent: impl Into<String>) -> Self {
+        self.inner.payment_intent = Some(payment_intent.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl<'a> Default for ListRadarEarlyFraudWarning<'a> {
+impl Default for ListRadarEarlyFraudWarning {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListRadarEarlyFraudWarning<'_> {
+impl ListRadarEarlyFraudWarning {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -109,23 +109,23 @@ impl ListRadarEarlyFraudWarning<'_> {
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_fraud::RadarEarlyFraudWarning>>
     {
-        stripe_client_core::ListPaginator::new_list("/radar/early_fraud_warnings", self.inner)
+        stripe_client_core::ListPaginator::new_list("/radar/early_fraud_warnings", &self.inner)
     }
 }
 
-impl StripeRequest for ListRadarEarlyFraudWarning<'_> {
+impl StripeRequest for ListRadarEarlyFraudWarning {
     type Output = stripe_types::List<stripe_fraud::RadarEarlyFraudWarning>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/radar/early_fraud_warnings").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveRadarEarlyFraudWarningBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveRadarEarlyFraudWarningBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveRadarEarlyFraudWarningBuilder<'a> {
+impl RetrieveRadarEarlyFraudWarningBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
@@ -134,22 +134,25 @@ impl<'a> RetrieveRadarEarlyFraudWarningBuilder<'a> {
 ///
 /// Please refer to the [early fraud warning](https://stripe.com/docs/api#early_fraud_warning_object) object reference for more details.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveRadarEarlyFraudWarning<'a> {
-    inner: RetrieveRadarEarlyFraudWarningBuilder<'a>,
-    early_fraud_warning: &'a stripe_fraud::RadarEarlyFraudWarningId,
+pub struct RetrieveRadarEarlyFraudWarning {
+    inner: RetrieveRadarEarlyFraudWarningBuilder,
+    early_fraud_warning: stripe_fraud::RadarEarlyFraudWarningId,
 }
-impl<'a> RetrieveRadarEarlyFraudWarning<'a> {
+impl RetrieveRadarEarlyFraudWarning {
     /// Construct a new `RetrieveRadarEarlyFraudWarning`.
-    pub fn new(early_fraud_warning: &'a stripe_fraud::RadarEarlyFraudWarningId) -> Self {
-        Self { early_fraud_warning, inner: RetrieveRadarEarlyFraudWarningBuilder::new() }
+    pub fn new(early_fraud_warning: impl Into<stripe_fraud::RadarEarlyFraudWarningId>) -> Self {
+        Self {
+            early_fraud_warning: early_fraud_warning.into(),
+            inner: RetrieveRadarEarlyFraudWarningBuilder::new(),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveRadarEarlyFraudWarning<'_> {
+impl RetrieveRadarEarlyFraudWarning {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -167,11 +170,11 @@ impl RetrieveRadarEarlyFraudWarning<'_> {
     }
 }
 
-impl StripeRequest for RetrieveRadarEarlyFraudWarning<'_> {
+impl StripeRequest for RetrieveRadarEarlyFraudWarning {
     type Output = stripe_fraud::RadarEarlyFraudWarning;
 
     fn build(&self) -> RequestBuilder {
-        let early_fraud_warning = self.early_fraud_warning;
+        let early_fraud_warning = &self.early_fraud_warning;
         RequestBuilder::new(
             StripeMethod::Get,
             format!("/radar/early_fraud_warnings/{early_fraud_warning}"),

--- a/generated/async-stripe-fraud/src/radar_value_list/requests.rs
+++ b/generated/async-stripe-fraud/src/radar_value_list/requests.rs
@@ -5,16 +5,16 @@ use stripe_client_core::{
 /// Deletes a `ValueList` object, also deleting any items contained within the value list.
 /// To be deleted, a value list must not be referenced in any rules.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct DeleteRadarValueList<'a> {
-    value_list: &'a stripe_fraud::RadarValueListId,
+pub struct DeleteRadarValueList {
+    value_list: stripe_fraud::RadarValueListId,
 }
-impl<'a> DeleteRadarValueList<'a> {
+impl DeleteRadarValueList {
     /// Construct a new `DeleteRadarValueList`.
-    pub fn new(value_list: &'a stripe_fraud::RadarValueListId) -> Self {
-        Self { value_list }
+    pub fn new(value_list: impl Into<stripe_fraud::RadarValueListId>) -> Self {
+        Self { value_list: value_list.into() }
     }
 }
-impl DeleteRadarValueList<'_> {
+impl DeleteRadarValueList {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -32,32 +32,32 @@ impl DeleteRadarValueList<'_> {
     }
 }
 
-impl StripeRequest for DeleteRadarValueList<'_> {
+impl StripeRequest for DeleteRadarValueList {
     type Output = stripe_fraud::DeletedRadarValueList;
 
     fn build(&self) -> RequestBuilder {
-        let value_list = self.value_list;
+        let value_list = &self.value_list;
         RequestBuilder::new(StripeMethod::Delete, format!("/radar/value_lists/{value_list}"))
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListRadarValueListBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListRadarValueListBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    alias: Option<&'a str>,
+    alias: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    contains: Option<&'a str>,
+    contains: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     created: Option<stripe_types::RangeQueryTs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListRadarValueListBuilder<'a> {
+impl ListRadarValueListBuilder {
     fn new() -> Self {
         Self {
             alias: None,
@@ -73,61 +73,61 @@ impl<'a> ListRadarValueListBuilder<'a> {
 /// Returns a list of `ValueList` objects.
 /// The objects are sorted in descending order by creation date, with the most recently created object appearing first.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListRadarValueList<'a> {
-    inner: ListRadarValueListBuilder<'a>,
+pub struct ListRadarValueList {
+    inner: ListRadarValueListBuilder,
 }
-impl<'a> ListRadarValueList<'a> {
+impl ListRadarValueList {
     /// Construct a new `ListRadarValueList`.
     pub fn new() -> Self {
         Self { inner: ListRadarValueListBuilder::new() }
     }
     /// The alias used to reference the value list when writing rules.
-    pub fn alias(mut self, alias: &'a str) -> Self {
-        self.inner.alias = Some(alias);
+    pub fn alias(mut self, alias: impl Into<String>) -> Self {
+        self.inner.alias = Some(alias.into());
         self
     }
     /// A value contained within a value list - returns all value lists containing this value.
-    pub fn contains(mut self, contains: &'a str) -> Self {
-        self.inner.contains = Some(contains);
+    pub fn contains(mut self, contains: impl Into<String>) -> Self {
+        self.inner.contains = Some(contains.into());
         self
     }
     /// Only return value lists that were created during the given date interval.
-    pub fn created(mut self, created: stripe_types::RangeQueryTs) -> Self {
-        self.inner.created = Some(created);
+    pub fn created(mut self, created: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.created = Some(created.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl<'a> Default for ListRadarValueList<'a> {
+impl Default for ListRadarValueList {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListRadarValueList<'_> {
+impl ListRadarValueList {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -147,45 +147,45 @@ impl ListRadarValueList<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_fraud::RadarValueList>> {
-        stripe_client_core::ListPaginator::new_list("/radar/value_lists", self.inner)
+        stripe_client_core::ListPaginator::new_list("/radar/value_lists", &self.inner)
     }
 }
 
-impl StripeRequest for ListRadarValueList<'_> {
+impl StripeRequest for ListRadarValueList {
     type Output = stripe_types::List<stripe_fraud::RadarValueList>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/radar/value_lists").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveRadarValueListBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveRadarValueListBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveRadarValueListBuilder<'a> {
+impl RetrieveRadarValueListBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves a `ValueList` object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveRadarValueList<'a> {
-    inner: RetrieveRadarValueListBuilder<'a>,
-    value_list: &'a stripe_fraud::RadarValueListId,
+pub struct RetrieveRadarValueList {
+    inner: RetrieveRadarValueListBuilder,
+    value_list: stripe_fraud::RadarValueListId,
 }
-impl<'a> RetrieveRadarValueList<'a> {
+impl RetrieveRadarValueList {
     /// Construct a new `RetrieveRadarValueList`.
-    pub fn new(value_list: &'a stripe_fraud::RadarValueListId) -> Self {
-        Self { value_list, inner: RetrieveRadarValueListBuilder::new() }
+    pub fn new(value_list: impl Into<stripe_fraud::RadarValueListId>) -> Self {
+        Self { value_list: value_list.into(), inner: RetrieveRadarValueListBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveRadarValueList<'_> {
+impl RetrieveRadarValueList {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -203,63 +203,72 @@ impl RetrieveRadarValueList<'_> {
     }
 }
 
-impl StripeRequest for RetrieveRadarValueList<'_> {
+impl StripeRequest for RetrieveRadarValueList {
     type Output = stripe_fraud::RadarValueList;
 
     fn build(&self) -> RequestBuilder {
-        let value_list = self.value_list;
+        let value_list = &self.value_list;
         RequestBuilder::new(StripeMethod::Get, format!("/radar/value_lists/{value_list}"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateRadarValueListBuilder<'a> {
-    alias: &'a str,
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateRadarValueListBuilder {
+    alias: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     item_type: Option<stripe_fraud::RadarValueListItemType>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
-    name: &'a str,
+    metadata: Option<std::collections::HashMap<String, String>>,
+    name: String,
 }
-impl<'a> CreateRadarValueListBuilder<'a> {
-    fn new(alias: &'a str, name: &'a str) -> Self {
-        Self { alias, expand: None, item_type: None, metadata: None, name }
+impl CreateRadarValueListBuilder {
+    fn new(alias: impl Into<String>, name: impl Into<String>) -> Self {
+        Self {
+            alias: alias.into(),
+            expand: None,
+            item_type: None,
+            metadata: None,
+            name: name.into(),
+        }
     }
 }
 /// Creates a new `ValueList` object, which can then be referenced in rules.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateRadarValueList<'a> {
-    inner: CreateRadarValueListBuilder<'a>,
+pub struct CreateRadarValueList {
+    inner: CreateRadarValueListBuilder,
 }
-impl<'a> CreateRadarValueList<'a> {
+impl CreateRadarValueList {
     /// Construct a new `CreateRadarValueList`.
-    pub fn new(alias: &'a str, name: &'a str) -> Self {
-        Self { inner: CreateRadarValueListBuilder::new(alias, name) }
+    pub fn new(alias: impl Into<String>, name: impl Into<String>) -> Self {
+        Self { inner: CreateRadarValueListBuilder::new(alias.into(), name.into()) }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Type of the items in the value list.
     /// One of `card_fingerprint`, `us_bank_account_fingerprint`, `sepa_debit_fingerprint`, `card_bin`, `email`, `ip_address`, `country`, `string`, `case_sensitive_string`, or `customer_id`.
     /// Use `string` if the item type is unknown or mixed.
-    pub fn item_type(mut self, item_type: stripe_fraud::RadarValueListItemType) -> Self {
-        self.inner.item_type = Some(item_type);
+    pub fn item_type(mut self, item_type: impl Into<stripe_fraud::RadarValueListItemType>) -> Self {
+        self.inner.item_type = Some(item_type.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
 }
-impl CreateRadarValueList<'_> {
+impl CreateRadarValueList {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -277,25 +286,25 @@ impl CreateRadarValueList<'_> {
     }
 }
 
-impl StripeRequest for CreateRadarValueList<'_> {
+impl StripeRequest for CreateRadarValueList {
     type Output = stripe_fraud::RadarValueList;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Post, "/radar/value_lists").form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdateRadarValueListBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdateRadarValueListBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    alias: Option<&'a str>,
+    alias: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    name: Option<&'a str>,
+    name: Option<String>,
 }
-impl<'a> UpdateRadarValueListBuilder<'a> {
+impl UpdateRadarValueListBuilder {
     fn new() -> Self {
         Self { alias: None, expand: None, metadata: None, name: None }
     }
@@ -304,40 +313,43 @@ impl<'a> UpdateRadarValueListBuilder<'a> {
 /// Any parameters not provided will be left unchanged.
 /// Note that `item_type` is immutable.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateRadarValueList<'a> {
-    inner: UpdateRadarValueListBuilder<'a>,
-    value_list: &'a stripe_fraud::RadarValueListId,
+pub struct UpdateRadarValueList {
+    inner: UpdateRadarValueListBuilder,
+    value_list: stripe_fraud::RadarValueListId,
 }
-impl<'a> UpdateRadarValueList<'a> {
+impl UpdateRadarValueList {
     /// Construct a new `UpdateRadarValueList`.
-    pub fn new(value_list: &'a stripe_fraud::RadarValueListId) -> Self {
-        Self { value_list, inner: UpdateRadarValueListBuilder::new() }
+    pub fn new(value_list: impl Into<stripe_fraud::RadarValueListId>) -> Self {
+        Self { value_list: value_list.into(), inner: UpdateRadarValueListBuilder::new() }
     }
     /// The name of the value list for use in rules.
-    pub fn alias(mut self, alias: &'a str) -> Self {
-        self.inner.alias = Some(alias);
+    pub fn alias(mut self, alias: impl Into<String>) -> Self {
+        self.inner.alias = Some(alias.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// The human-readable name of the value list.
-    pub fn name(mut self, name: &'a str) -> Self {
-        self.inner.name = Some(name);
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.inner.name = Some(name.into());
         self
     }
 }
-impl UpdateRadarValueList<'_> {
+impl UpdateRadarValueList {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -355,11 +367,11 @@ impl UpdateRadarValueList<'_> {
     }
 }
 
-impl StripeRequest for UpdateRadarValueList<'_> {
+impl StripeRequest for UpdateRadarValueList {
     type Output = stripe_fraud::RadarValueList;
 
     fn build(&self) -> RequestBuilder {
-        let value_list = self.value_list;
+        let value_list = &self.value_list;
         RequestBuilder::new(StripeMethod::Post, format!("/radar/value_lists/{value_list}"))
             .form(&self.inner)
     }

--- a/generated/async-stripe-fraud/src/radar_value_list_item/requests.rs
+++ b/generated/async-stripe-fraud/src/radar_value_list_item/requests.rs
@@ -4,16 +4,16 @@ use stripe_client_core::{
 
 /// Deletes a `ValueListItem` object, removing it from its parent value list.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct DeleteRadarValueListItem<'a> {
-    item: &'a stripe_fraud::RadarValueListItemId,
+pub struct DeleteRadarValueListItem {
+    item: stripe_fraud::RadarValueListItemId,
 }
-impl<'a> DeleteRadarValueListItem<'a> {
+impl DeleteRadarValueListItem {
     /// Construct a new `DeleteRadarValueListItem`.
-    pub fn new(item: &'a stripe_fraud::RadarValueListItemId) -> Self {
-        Self { item }
+    pub fn new(item: impl Into<stripe_fraud::RadarValueListItemId>) -> Self {
+        Self { item: item.into() }
     }
 }
-impl DeleteRadarValueListItem<'_> {
+impl DeleteRadarValueListItem {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -31,32 +31,32 @@ impl DeleteRadarValueListItem<'_> {
     }
 }
 
-impl StripeRequest for DeleteRadarValueListItem<'_> {
+impl StripeRequest for DeleteRadarValueListItem {
     type Output = stripe_fraud::DeletedRadarValueListItem;
 
     fn build(&self) -> RequestBuilder {
-        let item = self.item;
+        let item = &self.item;
         RequestBuilder::new(StripeMethod::Delete, format!("/radar/value_list_items/{item}"))
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListRadarValueListItemBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListRadarValueListItemBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     created: Option<stripe_types::RangeQueryTs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    value: Option<&'a str>,
-    value_list: &'a str,
+    value: Option<String>,
+    value_list: String,
 }
-impl<'a> ListRadarValueListItemBuilder<'a> {
-    fn new(value_list: &'a str) -> Self {
+impl ListRadarValueListItemBuilder {
+    fn new(value_list: impl Into<String>) -> Self {
         Self {
             created: None,
             ending_before: None,
@@ -64,58 +64,58 @@ impl<'a> ListRadarValueListItemBuilder<'a> {
             limit: None,
             starting_after: None,
             value: None,
-            value_list,
+            value_list: value_list.into(),
         }
     }
 }
 /// Returns a list of `ValueListItem` objects.
 /// The objects are sorted in descending order by creation date, with the most recently created object appearing first.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListRadarValueListItem<'a> {
-    inner: ListRadarValueListItemBuilder<'a>,
+pub struct ListRadarValueListItem {
+    inner: ListRadarValueListItemBuilder,
 }
-impl<'a> ListRadarValueListItem<'a> {
+impl ListRadarValueListItem {
     /// Construct a new `ListRadarValueListItem`.
-    pub fn new(value_list: &'a str) -> Self {
-        Self { inner: ListRadarValueListItemBuilder::new(value_list) }
+    pub fn new(value_list: impl Into<String>) -> Self {
+        Self { inner: ListRadarValueListItemBuilder::new(value_list.into()) }
     }
     /// Only return items that were created during the given date interval.
-    pub fn created(mut self, created: stripe_types::RangeQueryTs) -> Self {
-        self.inner.created = Some(created);
+    pub fn created(mut self, created: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.created = Some(created.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
     /// Return items belonging to the parent list whose value matches the specified value (using an "is like" match).
-    pub fn value(mut self, value: &'a str) -> Self {
-        self.inner.value = Some(value);
+    pub fn value(mut self, value: impl Into<String>) -> Self {
+        self.inner.value = Some(value.into());
         self
     }
 }
-impl ListRadarValueListItem<'_> {
+impl ListRadarValueListItem {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -136,45 +136,45 @@ impl ListRadarValueListItem<'_> {
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_fraud::RadarValueListItem>>
     {
-        stripe_client_core::ListPaginator::new_list("/radar/value_list_items", self.inner)
+        stripe_client_core::ListPaginator::new_list("/radar/value_list_items", &self.inner)
     }
 }
 
-impl StripeRequest for ListRadarValueListItem<'_> {
+impl StripeRequest for ListRadarValueListItem {
     type Output = stripe_types::List<stripe_fraud::RadarValueListItem>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/radar/value_list_items").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveRadarValueListItemBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveRadarValueListItemBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveRadarValueListItemBuilder<'a> {
+impl RetrieveRadarValueListItemBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves a `ValueListItem` object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveRadarValueListItem<'a> {
-    inner: RetrieveRadarValueListItemBuilder<'a>,
-    item: &'a stripe_fraud::RadarValueListItemId,
+pub struct RetrieveRadarValueListItem {
+    inner: RetrieveRadarValueListItemBuilder,
+    item: stripe_fraud::RadarValueListItemId,
 }
-impl<'a> RetrieveRadarValueListItem<'a> {
+impl RetrieveRadarValueListItem {
     /// Construct a new `RetrieveRadarValueListItem`.
-    pub fn new(item: &'a stripe_fraud::RadarValueListItemId) -> Self {
-        Self { item, inner: RetrieveRadarValueListItemBuilder::new() }
+    pub fn new(item: impl Into<stripe_fraud::RadarValueListItemId>) -> Self {
+        Self { item: item.into(), inner: RetrieveRadarValueListItemBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveRadarValueListItem<'_> {
+impl RetrieveRadarValueListItem {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -192,44 +192,44 @@ impl RetrieveRadarValueListItem<'_> {
     }
 }
 
-impl StripeRequest for RetrieveRadarValueListItem<'_> {
+impl StripeRequest for RetrieveRadarValueListItem {
     type Output = stripe_fraud::RadarValueListItem;
 
     fn build(&self) -> RequestBuilder {
-        let item = self.item;
+        let item = &self.item;
         RequestBuilder::new(StripeMethod::Get, format!("/radar/value_list_items/{item}"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateRadarValueListItemBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateRadarValueListItemBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
-    value: &'a str,
-    value_list: &'a str,
+    expand: Option<Vec<String>>,
+    value: String,
+    value_list: String,
 }
-impl<'a> CreateRadarValueListItemBuilder<'a> {
-    fn new(value: &'a str, value_list: &'a str) -> Self {
-        Self { expand: None, value, value_list }
+impl CreateRadarValueListItemBuilder {
+    fn new(value: impl Into<String>, value_list: impl Into<String>) -> Self {
+        Self { expand: None, value: value.into(), value_list: value_list.into() }
     }
 }
 /// Creates a new `ValueListItem` object, which is added to the specified parent value list.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateRadarValueListItem<'a> {
-    inner: CreateRadarValueListItemBuilder<'a>,
+pub struct CreateRadarValueListItem {
+    inner: CreateRadarValueListItemBuilder,
 }
-impl<'a> CreateRadarValueListItem<'a> {
+impl CreateRadarValueListItem {
     /// Construct a new `CreateRadarValueListItem`.
-    pub fn new(value: &'a str, value_list: &'a str) -> Self {
-        Self { inner: CreateRadarValueListItemBuilder::new(value, value_list) }
+    pub fn new(value: impl Into<String>, value_list: impl Into<String>) -> Self {
+        Self { inner: CreateRadarValueListItemBuilder::new(value.into(), value_list.into()) }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl CreateRadarValueListItem<'_> {
+impl CreateRadarValueListItem {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -247,7 +247,7 @@ impl CreateRadarValueListItem<'_> {
     }
 }
 
-impl StripeRequest for CreateRadarValueListItem<'_> {
+impl StripeRequest for CreateRadarValueListItem {
     type Output = stripe_fraud::RadarValueListItem;
 
     fn build(&self) -> RequestBuilder {

--- a/generated/async-stripe-fraud/src/review/requests.rs
+++ b/generated/async-stripe-fraud/src/review/requests.rs
@@ -2,20 +2,20 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListReviewBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListReviewBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     created: Option<stripe_types::RangeQueryTs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListReviewBuilder<'a> {
+impl ListReviewBuilder {
     fn new() -> Self {
         Self { created: None, ending_before: None, expand: None, limit: None, starting_after: None }
     }
@@ -23,51 +23,51 @@ impl<'a> ListReviewBuilder<'a> {
 /// Returns a list of `Review` objects that have `open` set to `true`.
 /// The objects are sorted in descending order by creation date, with the most recently created object appearing first.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListReview<'a> {
-    inner: ListReviewBuilder<'a>,
+pub struct ListReview {
+    inner: ListReviewBuilder,
 }
-impl<'a> ListReview<'a> {
+impl ListReview {
     /// Construct a new `ListReview`.
     pub fn new() -> Self {
         Self { inner: ListReviewBuilder::new() }
     }
     /// Only return reviews that were created during the given date interval.
-    pub fn created(mut self, created: stripe_types::RangeQueryTs) -> Self {
-        self.inner.created = Some(created);
+    pub fn created(mut self, created: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.created = Some(created.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl<'a> Default for ListReview<'a> {
+impl Default for ListReview {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListReview<'_> {
+impl ListReview {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -87,45 +87,45 @@ impl ListReview<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::Review>> {
-        stripe_client_core::ListPaginator::new_list("/reviews", self.inner)
+        stripe_client_core::ListPaginator::new_list("/reviews", &self.inner)
     }
 }
 
-impl StripeRequest for ListReview<'_> {
+impl StripeRequest for ListReview {
     type Output = stripe_types::List<stripe_shared::Review>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/reviews").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveReviewBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveReviewBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveReviewBuilder<'a> {
+impl RetrieveReviewBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves a `Review` object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveReview<'a> {
-    inner: RetrieveReviewBuilder<'a>,
-    review: &'a stripe_shared::ReviewId,
+pub struct RetrieveReview {
+    inner: RetrieveReviewBuilder,
+    review: stripe_shared::ReviewId,
 }
-impl<'a> RetrieveReview<'a> {
+impl RetrieveReview {
     /// Construct a new `RetrieveReview`.
-    pub fn new(review: &'a stripe_shared::ReviewId) -> Self {
-        Self { review, inner: RetrieveReviewBuilder::new() }
+    pub fn new(review: impl Into<stripe_shared::ReviewId>) -> Self {
+        Self { review: review.into(), inner: RetrieveReviewBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveReview<'_> {
+impl RetrieveReview {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -143,42 +143,42 @@ impl RetrieveReview<'_> {
     }
 }
 
-impl StripeRequest for RetrieveReview<'_> {
+impl StripeRequest for RetrieveReview {
     type Output = stripe_shared::Review;
 
     fn build(&self) -> RequestBuilder {
-        let review = self.review;
+        let review = &self.review;
         RequestBuilder::new(StripeMethod::Get, format!("/reviews/{review}")).query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ApproveReviewBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ApproveReviewBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> ApproveReviewBuilder<'a> {
+impl ApproveReviewBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Approves a `Review` object, closing it and removing it from the list of reviews.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ApproveReview<'a> {
-    inner: ApproveReviewBuilder<'a>,
-    review: &'a stripe_shared::ReviewId,
+pub struct ApproveReview {
+    inner: ApproveReviewBuilder,
+    review: stripe_shared::ReviewId,
 }
-impl<'a> ApproveReview<'a> {
+impl ApproveReview {
     /// Construct a new `ApproveReview`.
-    pub fn new(review: &'a stripe_shared::ReviewId) -> Self {
-        Self { review, inner: ApproveReviewBuilder::new() }
+    pub fn new(review: impl Into<stripe_shared::ReviewId>) -> Self {
+        Self { review: review.into(), inner: ApproveReviewBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl ApproveReview<'_> {
+impl ApproveReview {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -196,11 +196,11 @@ impl ApproveReview<'_> {
     }
 }
 
-impl StripeRequest for ApproveReview<'_> {
+impl StripeRequest for ApproveReview {
     type Output = stripe_shared::Review;
 
     fn build(&self) -> RequestBuilder {
-        let review = self.review;
+        let review = &self.review;
         RequestBuilder::new(StripeMethod::Post, format!("/reviews/{review}/approve"))
             .form(&self.inner)
     }

--- a/generated/async-stripe-issuing/src/issuing_authorization/requests.rs
+++ b/generated/async-stripe-issuing/src/issuing_authorization/requests.rs
@@ -2,26 +2,26 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListIssuingAuthorizationBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListIssuingAuthorizationBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    card: Option<&'a str>,
+    card: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    cardholder: Option<&'a str>,
+    cardholder: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     created: Option<stripe_types::RangeQueryTs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     status: Option<stripe_shared::IssuingAuthorizationStatus>,
 }
-impl<'a> ListIssuingAuthorizationBuilder<'a> {
+impl ListIssuingAuthorizationBuilder {
     fn new() -> Self {
         Self {
             card: None,
@@ -38,66 +38,66 @@ impl<'a> ListIssuingAuthorizationBuilder<'a> {
 /// Returns a list of Issuing `Authorization` objects.
 /// The objects are sorted in descending order by creation date, with the most recently created object appearing first.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListIssuingAuthorization<'a> {
-    inner: ListIssuingAuthorizationBuilder<'a>,
+pub struct ListIssuingAuthorization {
+    inner: ListIssuingAuthorizationBuilder,
 }
-impl<'a> ListIssuingAuthorization<'a> {
+impl ListIssuingAuthorization {
     /// Construct a new `ListIssuingAuthorization`.
     pub fn new() -> Self {
         Self { inner: ListIssuingAuthorizationBuilder::new() }
     }
     /// Only return authorizations that belong to the given card.
-    pub fn card(mut self, card: &'a str) -> Self {
-        self.inner.card = Some(card);
+    pub fn card(mut self, card: impl Into<String>) -> Self {
+        self.inner.card = Some(card.into());
         self
     }
     /// Only return authorizations that belong to the given cardholder.
-    pub fn cardholder(mut self, cardholder: &'a str) -> Self {
-        self.inner.cardholder = Some(cardholder);
+    pub fn cardholder(mut self, cardholder: impl Into<String>) -> Self {
+        self.inner.cardholder = Some(cardholder.into());
         self
     }
     /// Only return authorizations that were created during the given date interval.
-    pub fn created(mut self, created: stripe_types::RangeQueryTs) -> Self {
-        self.inner.created = Some(created);
+    pub fn created(mut self, created: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.created = Some(created.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
     /// Only return authorizations with the given status. One of `pending`, `closed`, or `reversed`.
-    pub fn status(mut self, status: stripe_shared::IssuingAuthorizationStatus) -> Self {
-        self.inner.status = Some(status);
+    pub fn status(mut self, status: impl Into<stripe_shared::IssuingAuthorizationStatus>) -> Self {
+        self.inner.status = Some(status.into());
         self
     }
 }
-impl<'a> Default for ListIssuingAuthorization<'a> {
+impl Default for ListIssuingAuthorization {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListIssuingAuthorization<'_> {
+impl ListIssuingAuthorization {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -118,45 +118,48 @@ impl ListIssuingAuthorization<'_> {
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::IssuingAuthorization>>
     {
-        stripe_client_core::ListPaginator::new_list("/issuing/authorizations", self.inner)
+        stripe_client_core::ListPaginator::new_list("/issuing/authorizations", &self.inner)
     }
 }
 
-impl StripeRequest for ListIssuingAuthorization<'_> {
+impl StripeRequest for ListIssuingAuthorization {
     type Output = stripe_types::List<stripe_shared::IssuingAuthorization>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/issuing/authorizations").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveIssuingAuthorizationBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveIssuingAuthorizationBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveIssuingAuthorizationBuilder<'a> {
+impl RetrieveIssuingAuthorizationBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves an Issuing `Authorization` object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveIssuingAuthorization<'a> {
-    inner: RetrieveIssuingAuthorizationBuilder<'a>,
-    authorization: &'a stripe_shared::IssuingAuthorizationId,
+pub struct RetrieveIssuingAuthorization {
+    inner: RetrieveIssuingAuthorizationBuilder,
+    authorization: stripe_shared::IssuingAuthorizationId,
 }
-impl<'a> RetrieveIssuingAuthorization<'a> {
+impl RetrieveIssuingAuthorization {
     /// Construct a new `RetrieveIssuingAuthorization`.
-    pub fn new(authorization: &'a stripe_shared::IssuingAuthorizationId) -> Self {
-        Self { authorization, inner: RetrieveIssuingAuthorizationBuilder::new() }
+    pub fn new(authorization: impl Into<stripe_shared::IssuingAuthorizationId>) -> Self {
+        Self {
+            authorization: authorization.into(),
+            inner: RetrieveIssuingAuthorizationBuilder::new(),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveIssuingAuthorization<'_> {
+impl RetrieveIssuingAuthorization {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -174,23 +177,23 @@ impl RetrieveIssuingAuthorization<'_> {
     }
 }
 
-impl StripeRequest for RetrieveIssuingAuthorization<'_> {
+impl StripeRequest for RetrieveIssuingAuthorization {
     type Output = stripe_shared::IssuingAuthorization;
 
     fn build(&self) -> RequestBuilder {
-        let authorization = self.authorization;
+        let authorization = &self.authorization;
         RequestBuilder::new(StripeMethod::Get, format!("/issuing/authorizations/{authorization}"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdateIssuingAuthorizationBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdateIssuingAuthorizationBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
 }
-impl<'a> UpdateIssuingAuthorizationBuilder<'a> {
+impl UpdateIssuingAuthorizationBuilder {
     fn new() -> Self {
         Self { expand: None, metadata: None }
     }
@@ -198,30 +201,36 @@ impl<'a> UpdateIssuingAuthorizationBuilder<'a> {
 /// Updates the specified Issuing `Authorization` object by setting the values of the parameters passed.
 /// Any parameters not provided will be left unchanged.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateIssuingAuthorization<'a> {
-    inner: UpdateIssuingAuthorizationBuilder<'a>,
-    authorization: &'a stripe_shared::IssuingAuthorizationId,
+pub struct UpdateIssuingAuthorization {
+    inner: UpdateIssuingAuthorizationBuilder,
+    authorization: stripe_shared::IssuingAuthorizationId,
 }
-impl<'a> UpdateIssuingAuthorization<'a> {
+impl UpdateIssuingAuthorization {
     /// Construct a new `UpdateIssuingAuthorization`.
-    pub fn new(authorization: &'a stripe_shared::IssuingAuthorizationId) -> Self {
-        Self { authorization, inner: UpdateIssuingAuthorizationBuilder::new() }
+    pub fn new(authorization: impl Into<stripe_shared::IssuingAuthorizationId>) -> Self {
+        Self {
+            authorization: authorization.into(),
+            inner: UpdateIssuingAuthorizationBuilder::new(),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
 }
-impl UpdateIssuingAuthorization<'_> {
+impl UpdateIssuingAuthorization {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -239,25 +248,25 @@ impl UpdateIssuingAuthorization<'_> {
     }
 }
 
-impl StripeRequest for UpdateIssuingAuthorization<'_> {
+impl StripeRequest for UpdateIssuingAuthorization {
     type Output = stripe_shared::IssuingAuthorization;
 
     fn build(&self) -> RequestBuilder {
-        let authorization = self.authorization;
+        let authorization = &self.authorization;
         RequestBuilder::new(StripeMethod::Post, format!("/issuing/authorizations/{authorization}"))
             .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ApproveIssuingAuthorizationBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ApproveIssuingAuthorizationBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     amount: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
 }
-impl<'a> ApproveIssuingAuthorizationBuilder<'a> {
+impl ApproveIssuingAuthorizationBuilder {
     fn new() -> Self {
         Self { amount: None, expand: None, metadata: None }
     }
@@ -268,36 +277,42 @@ impl<'a> ApproveIssuingAuthorizationBuilder<'a> {
 /// This method is deprecated.
 /// Instead, [respond directly to the webhook request to approve an authorization](https://stripe.com/docs/issuing/controls/real-time-authorizations#authorization-handling).
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ApproveIssuingAuthorization<'a> {
-    inner: ApproveIssuingAuthorizationBuilder<'a>,
-    authorization: &'a stripe_shared::IssuingAuthorizationId,
+pub struct ApproveIssuingAuthorization {
+    inner: ApproveIssuingAuthorizationBuilder,
+    authorization: stripe_shared::IssuingAuthorizationId,
 }
-impl<'a> ApproveIssuingAuthorization<'a> {
+impl ApproveIssuingAuthorization {
     /// Construct a new `ApproveIssuingAuthorization`.
-    pub fn new(authorization: &'a stripe_shared::IssuingAuthorizationId) -> Self {
-        Self { authorization, inner: ApproveIssuingAuthorizationBuilder::new() }
+    pub fn new(authorization: impl Into<stripe_shared::IssuingAuthorizationId>) -> Self {
+        Self {
+            authorization: authorization.into(),
+            inner: ApproveIssuingAuthorizationBuilder::new(),
+        }
     }
     /// If the authorization's `pending_request.is_amount_controllable` property is `true`, you may provide this value to control how much to hold for the authorization.
     /// Must be positive (use [`decline`](https://stripe.com/docs/api/issuing/authorizations/decline) to decline an authorization request).
-    pub fn amount(mut self, amount: i64) -> Self {
-        self.inner.amount = Some(amount);
+    pub fn amount(mut self, amount: impl Into<i64>) -> Self {
+        self.inner.amount = Some(amount.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
 }
-impl ApproveIssuingAuthorization<'_> {
+impl ApproveIssuingAuthorization {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -315,11 +330,11 @@ impl ApproveIssuingAuthorization<'_> {
     }
 }
 
-impl StripeRequest for ApproveIssuingAuthorization<'_> {
+impl StripeRequest for ApproveIssuingAuthorization {
     type Output = stripe_shared::IssuingAuthorization;
 
     fn build(&self) -> RequestBuilder {
-        let authorization = self.authorization;
+        let authorization = &self.authorization;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/issuing/authorizations/{authorization}/approve"),
@@ -327,14 +342,14 @@ impl StripeRequest for ApproveIssuingAuthorization<'_> {
         .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct DeclineIssuingAuthorizationBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct DeclineIssuingAuthorizationBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
 }
-impl<'a> DeclineIssuingAuthorizationBuilder<'a> {
+impl DeclineIssuingAuthorizationBuilder {
     fn new() -> Self {
         Self { expand: None, metadata: None }
     }
@@ -344,30 +359,36 @@ impl<'a> DeclineIssuingAuthorizationBuilder<'a> {
 /// This method is deprecated.
 /// Instead, [respond directly to the webhook request to decline an authorization](https://stripe.com/docs/issuing/controls/real-time-authorizations#authorization-handling).
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct DeclineIssuingAuthorization<'a> {
-    inner: DeclineIssuingAuthorizationBuilder<'a>,
-    authorization: &'a stripe_shared::IssuingAuthorizationId,
+pub struct DeclineIssuingAuthorization {
+    inner: DeclineIssuingAuthorizationBuilder,
+    authorization: stripe_shared::IssuingAuthorizationId,
 }
-impl<'a> DeclineIssuingAuthorization<'a> {
+impl DeclineIssuingAuthorization {
     /// Construct a new `DeclineIssuingAuthorization`.
-    pub fn new(authorization: &'a stripe_shared::IssuingAuthorizationId) -> Self {
-        Self { authorization, inner: DeclineIssuingAuthorizationBuilder::new() }
+    pub fn new(authorization: impl Into<stripe_shared::IssuingAuthorizationId>) -> Self {
+        Self {
+            authorization: authorization.into(),
+            inner: DeclineIssuingAuthorizationBuilder::new(),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
 }
-impl DeclineIssuingAuthorization<'_> {
+impl DeclineIssuingAuthorization {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -385,11 +406,11 @@ impl DeclineIssuingAuthorization<'_> {
     }
 }
 
-impl StripeRequest for DeclineIssuingAuthorization<'_> {
+impl StripeRequest for DeclineIssuingAuthorization {
     type Output = stripe_shared::IssuingAuthorization;
 
     fn build(&self) -> RequestBuilder {
-        let authorization = self.authorization;
+        let authorization = &self.authorization;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/issuing/authorizations/{authorization}/decline"),
@@ -397,36 +418,36 @@ impl StripeRequest for DeclineIssuingAuthorization<'_> {
         .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateIssuingAuthorizationBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateIssuingAuthorizationBuilder {
     amount: i64,
     #[serde(skip_serializing_if = "Option::is_none")]
     amount_details: Option<CreateIssuingAuthorizationAmountDetails>,
     #[serde(skip_serializing_if = "Option::is_none")]
     authorization_method: Option<stripe_shared::IssuingAuthorizationAuthorizationMethod>,
-    card: &'a str,
+    card: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     currency: Option<stripe_types::Currency>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     is_amount_controllable: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    merchant_data: Option<CreateIssuingAuthorizationMerchantData<'a>>,
+    merchant_data: Option<CreateIssuingAuthorizationMerchantData>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    network_data: Option<CreateIssuingAuthorizationNetworkData<'a>>,
+    network_data: Option<CreateIssuingAuthorizationNetworkData>,
     #[serde(skip_serializing_if = "Option::is_none")]
     verification_data: Option<CreateIssuingAuthorizationVerificationData>,
     #[serde(skip_serializing_if = "Option::is_none")]
     wallet: Option<CreateIssuingAuthorizationWallet>,
 }
-impl<'a> CreateIssuingAuthorizationBuilder<'a> {
-    fn new(amount: i64, card: &'a str) -> Self {
+impl CreateIssuingAuthorizationBuilder {
+    fn new(amount: impl Into<i64>, card: impl Into<String>) -> Self {
         Self {
-            amount,
+            amount: amount.into(),
             amount_details: None,
             authorization_method: None,
-            card,
+            card: card.into(),
             currency: None,
             expand: None,
             is_amount_controllable: None,
@@ -459,39 +480,39 @@ impl Default for CreateIssuingAuthorizationAmountDetails {
     }
 }
 /// Details about the seller (grocery store, e-commerce website, etc.) where the card authorization happened.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateIssuingAuthorizationMerchantData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateIssuingAuthorizationMerchantData {
     /// A categorization of the seller's type of business.
     /// See our [merchant categories guide](https://stripe.com/docs/issuing/merchant-categories) for a list of possible values.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub category: Option<CreateIssuingAuthorizationMerchantDataCategory>,
     /// City where the seller is located
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<&'a str>,
+    pub city: Option<String>,
     /// Country where the seller is located
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub country: Option<&'a str>,
+    pub country: Option<String>,
     /// Name of the seller
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<&'a str>,
+    pub name: Option<String>,
     /// Identifier assigned to the seller by the card network.
     /// Different card networks may assign different network_id fields to the same merchant.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub network_id: Option<&'a str>,
+    pub network_id: Option<String>,
     /// Postal code where the seller is located
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<&'a str>,
+    pub postal_code: Option<String>,
     /// State where the seller is located
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
     /// An ID assigned by the seller to the location of the sale.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub terminal_id: Option<&'a str>,
+    pub terminal_id: Option<String>,
     /// URL provided by the merchant on a 3DS request
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub url: Option<&'a str>,
+    pub url: Option<String>,
 }
-impl<'a> CreateIssuingAuthorizationMerchantData<'a> {
+impl CreateIssuingAuthorizationMerchantData {
     pub fn new() -> Self {
         Self {
             category: None,
@@ -506,7 +527,7 @@ impl<'a> CreateIssuingAuthorizationMerchantData<'a> {
         }
     }
 }
-impl<'a> Default for CreateIssuingAuthorizationMerchantData<'a> {
+impl Default for CreateIssuingAuthorizationMerchantData {
     fn default() -> Self {
         Self::new()
     }
@@ -1539,18 +1560,18 @@ impl<'de> serde::Deserialize<'de> for CreateIssuingAuthorizationMerchantDataCate
     }
 }
 /// Details about the authorization, such as identifiers, set by the card network.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateIssuingAuthorizationNetworkData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateIssuingAuthorizationNetworkData {
     /// Identifier assigned to the acquirer by the card network.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub acquiring_institution_id: Option<&'a str>,
+    pub acquiring_institution_id: Option<String>,
 }
-impl<'a> CreateIssuingAuthorizationNetworkData<'a> {
+impl CreateIssuingAuthorizationNetworkData {
     pub fn new() -> Self {
         Self { acquiring_institution_id: None }
     }
 }
-impl<'a> Default for CreateIssuingAuthorizationNetworkData<'a> {
+impl Default for CreateIssuingAuthorizationNetworkData {
     fn default() -> Self {
         Self::new()
     }
@@ -1727,10 +1748,12 @@ pub struct CreateIssuingAuthorizationVerificationDataAuthenticationExemption {
 }
 impl CreateIssuingAuthorizationVerificationDataAuthenticationExemption {
     pub fn new(
-        claimed_by: CreateIssuingAuthorizationVerificationDataAuthenticationExemptionClaimedBy,
-        type_: CreateIssuingAuthorizationVerificationDataAuthenticationExemptionType,
+        claimed_by: impl Into<
+            CreateIssuingAuthorizationVerificationDataAuthenticationExemptionClaimedBy,
+        >,
+        type_: impl Into<CreateIssuingAuthorizationVerificationDataAuthenticationExemptionType>,
     ) -> Self {
-        Self { claimed_by, type_ }
+        Self { claimed_by: claimed_by.into(), type_: type_.into() }
     }
 }
 /// The entity that requested the exemption, either the acquiring merchant or the Issuing user.
@@ -1985,8 +2008,10 @@ pub struct CreateIssuingAuthorizationVerificationDataThreeDSecure {
     pub result: CreateIssuingAuthorizationVerificationDataThreeDSecureResult,
 }
 impl CreateIssuingAuthorizationVerificationDataThreeDSecure {
-    pub fn new(result: CreateIssuingAuthorizationVerificationDataThreeDSecureResult) -> Self {
-        Self { result }
+    pub fn new(
+        result: impl Into<CreateIssuingAuthorizationVerificationDataThreeDSecureResult>,
+    ) -> Self {
+        Self { result: result.into() }
     }
 }
 /// The outcome of the 3D Secure authentication request.
@@ -2116,79 +2141,82 @@ impl<'de> serde::Deserialize<'de> for CreateIssuingAuthorizationWallet {
 }
 /// Create a test-mode authorization.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateIssuingAuthorization<'a> {
-    inner: CreateIssuingAuthorizationBuilder<'a>,
+pub struct CreateIssuingAuthorization {
+    inner: CreateIssuingAuthorizationBuilder,
 }
-impl<'a> CreateIssuingAuthorization<'a> {
+impl CreateIssuingAuthorization {
     /// Construct a new `CreateIssuingAuthorization`.
-    pub fn new(amount: i64, card: &'a str) -> Self {
-        Self { inner: CreateIssuingAuthorizationBuilder::new(amount, card) }
+    pub fn new(amount: impl Into<i64>, card: impl Into<String>) -> Self {
+        Self { inner: CreateIssuingAuthorizationBuilder::new(amount.into(), card.into()) }
     }
     /// Detailed breakdown of amount components.
     /// These amounts are denominated in `currency` and in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal).
     pub fn amount_details(
         mut self,
-        amount_details: CreateIssuingAuthorizationAmountDetails,
+        amount_details: impl Into<CreateIssuingAuthorizationAmountDetails>,
     ) -> Self {
-        self.inner.amount_details = Some(amount_details);
+        self.inner.amount_details = Some(amount_details.into());
         self
     }
     /// How the card details were provided. Defaults to online.
     pub fn authorization_method(
         mut self,
-        authorization_method: stripe_shared::IssuingAuthorizationAuthorizationMethod,
+        authorization_method: impl Into<stripe_shared::IssuingAuthorizationAuthorizationMethod>,
     ) -> Self {
-        self.inner.authorization_method = Some(authorization_method);
+        self.inner.authorization_method = Some(authorization_method.into());
         self
     }
     /// The currency of the authorization.
     /// If not provided, defaults to the currency of the card.
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     /// Must be a [supported currency](https://stripe.com/docs/currencies).
-    pub fn currency(mut self, currency: stripe_types::Currency) -> Self {
-        self.inner.currency = Some(currency);
+    pub fn currency(mut self, currency: impl Into<stripe_types::Currency>) -> Self {
+        self.inner.currency = Some(currency.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// If set `true`, you may provide [amount](https://stripe.com/docs/api/issuing/authorizations/approve#approve_issuing_authorization-amount) to control how much to hold for the authorization.
-    pub fn is_amount_controllable(mut self, is_amount_controllable: bool) -> Self {
-        self.inner.is_amount_controllable = Some(is_amount_controllable);
+    pub fn is_amount_controllable(mut self, is_amount_controllable: impl Into<bool>) -> Self {
+        self.inner.is_amount_controllable = Some(is_amount_controllable.into());
         self
     }
     /// Details about the seller (grocery store, e-commerce website, etc.) where the card authorization happened.
     pub fn merchant_data(
         mut self,
-        merchant_data: CreateIssuingAuthorizationMerchantData<'a>,
+        merchant_data: impl Into<CreateIssuingAuthorizationMerchantData>,
     ) -> Self {
-        self.inner.merchant_data = Some(merchant_data);
+        self.inner.merchant_data = Some(merchant_data.into());
         self
     }
     /// Details about the authorization, such as identifiers, set by the card network.
-    pub fn network_data(mut self, network_data: CreateIssuingAuthorizationNetworkData<'a>) -> Self {
-        self.inner.network_data = Some(network_data);
+    pub fn network_data(
+        mut self,
+        network_data: impl Into<CreateIssuingAuthorizationNetworkData>,
+    ) -> Self {
+        self.inner.network_data = Some(network_data.into());
         self
     }
     /// Verifications that Stripe performed on information that the cardholder provided to the merchant.
     pub fn verification_data(
         mut self,
-        verification_data: CreateIssuingAuthorizationVerificationData,
+        verification_data: impl Into<CreateIssuingAuthorizationVerificationData>,
     ) -> Self {
-        self.inner.verification_data = Some(verification_data);
+        self.inner.verification_data = Some(verification_data.into());
         self
     }
     /// The digital wallet used for this transaction.
     /// One of `apple_pay`, `google_pay`, or `samsung_pay`.
     /// Will populate as `null` when no digital wallet was utilized.
-    pub fn wallet(mut self, wallet: CreateIssuingAuthorizationWallet) -> Self {
-        self.inner.wallet = Some(wallet);
+    pub fn wallet(mut self, wallet: impl Into<CreateIssuingAuthorizationWallet>) -> Self {
+        self.inner.wallet = Some(wallet.into());
         self
     }
 }
-impl CreateIssuingAuthorization<'_> {
+impl CreateIssuingAuthorization {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -2206,7 +2234,7 @@ impl CreateIssuingAuthorization<'_> {
     }
 }
 
-impl StripeRequest for CreateIssuingAuthorization<'_> {
+impl StripeRequest for CreateIssuingAuthorization {
     type Output = stripe_shared::IssuingAuthorization;
 
     fn build(&self) -> RequestBuilder {
@@ -2214,18 +2242,18 @@ impl StripeRequest for CreateIssuingAuthorization<'_> {
             .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CaptureIssuingAuthorizationBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CaptureIssuingAuthorizationBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     capture_amount: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     close_authorization: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    purchase_details: Option<CaptureIssuingAuthorizationPurchaseDetails<'a>>,
+    purchase_details: Option<CaptureIssuingAuthorizationPurchaseDetails>,
 }
-impl<'a> CaptureIssuingAuthorizationBuilder<'a> {
+impl CaptureIssuingAuthorizationBuilder {
     fn new() -> Self {
         Self {
             capture_amount: None,
@@ -2236,54 +2264,54 @@ impl<'a> CaptureIssuingAuthorizationBuilder<'a> {
     }
 }
 /// Additional purchase information that is optionally provided by the merchant.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CaptureIssuingAuthorizationPurchaseDetails<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CaptureIssuingAuthorizationPurchaseDetails {
     /// Information about the flight that was purchased with this transaction.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub flight: Option<CaptureIssuingAuthorizationPurchaseDetailsFlight<'a>>,
+    pub flight: Option<CaptureIssuingAuthorizationPurchaseDetailsFlight>,
     /// Information about fuel that was purchased with this transaction.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub fuel: Option<CaptureIssuingAuthorizationPurchaseDetailsFuel<'a>>,
+    pub fuel: Option<CaptureIssuingAuthorizationPurchaseDetailsFuel>,
     /// Information about lodging that was purchased with this transaction.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lodging: Option<CaptureIssuingAuthorizationPurchaseDetailsLodging>,
     /// The line items in the purchase.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub receipt: Option<&'a [CaptureIssuingAuthorizationPurchaseDetailsReceipt<'a>]>,
+    pub receipt: Option<Vec<CaptureIssuingAuthorizationPurchaseDetailsReceipt>>,
     /// A merchant-specific order number.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reference: Option<&'a str>,
+    pub reference: Option<String>,
 }
-impl<'a> CaptureIssuingAuthorizationPurchaseDetails<'a> {
+impl CaptureIssuingAuthorizationPurchaseDetails {
     pub fn new() -> Self {
         Self { flight: None, fuel: None, lodging: None, receipt: None, reference: None }
     }
 }
-impl<'a> Default for CaptureIssuingAuthorizationPurchaseDetails<'a> {
+impl Default for CaptureIssuingAuthorizationPurchaseDetails {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Information about the flight that was purchased with this transaction.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CaptureIssuingAuthorizationPurchaseDetailsFlight<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CaptureIssuingAuthorizationPurchaseDetailsFlight {
     /// The time that the flight departed.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub departure_at: Option<stripe_types::Timestamp>,
     /// The name of the passenger.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub passenger_name: Option<&'a str>,
+    pub passenger_name: Option<String>,
     /// Whether the ticket is refundable.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub refundable: Option<bool>,
     /// The legs of the trip.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub segments: Option<&'a [CaptureIssuingAuthorizationPurchaseDetailsFlightSegments<'a>]>,
+    pub segments: Option<Vec<CaptureIssuingAuthorizationPurchaseDetailsFlightSegments>>,
     /// The travel agency that issued the ticket.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub travel_agency: Option<&'a str>,
+    pub travel_agency: Option<String>,
 }
-impl<'a> CaptureIssuingAuthorizationPurchaseDetailsFlight<'a> {
+impl CaptureIssuingAuthorizationPurchaseDetailsFlight {
     pub fn new() -> Self {
         Self {
             departure_at: None,
@@ -2294,34 +2322,34 @@ impl<'a> CaptureIssuingAuthorizationPurchaseDetailsFlight<'a> {
         }
     }
 }
-impl<'a> Default for CaptureIssuingAuthorizationPurchaseDetailsFlight<'a> {
+impl Default for CaptureIssuingAuthorizationPurchaseDetailsFlight {
     fn default() -> Self {
         Self::new()
     }
 }
 /// The legs of the trip.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CaptureIssuingAuthorizationPurchaseDetailsFlightSegments<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CaptureIssuingAuthorizationPurchaseDetailsFlightSegments {
     /// The three-letter IATA airport code of the flight's destination.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub arrival_airport_code: Option<&'a str>,
+    pub arrival_airport_code: Option<String>,
     /// The airline carrier code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub carrier: Option<&'a str>,
+    pub carrier: Option<String>,
     /// The three-letter IATA airport code that the flight departed from.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub departure_airport_code: Option<&'a str>,
+    pub departure_airport_code: Option<String>,
     /// The flight number.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub flight_number: Option<&'a str>,
+    pub flight_number: Option<String>,
     /// The flight's service class.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub service_class: Option<&'a str>,
+    pub service_class: Option<String>,
     /// Whether a stopover is allowed on this flight.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stopover_allowed: Option<bool>,
 }
-impl<'a> CaptureIssuingAuthorizationPurchaseDetailsFlightSegments<'a> {
+impl CaptureIssuingAuthorizationPurchaseDetailsFlightSegments {
     pub fn new() -> Self {
         Self {
             arrival_airport_code: None,
@@ -2333,14 +2361,14 @@ impl<'a> CaptureIssuingAuthorizationPurchaseDetailsFlightSegments<'a> {
         }
     }
 }
-impl<'a> Default for CaptureIssuingAuthorizationPurchaseDetailsFlightSegments<'a> {
+impl Default for CaptureIssuingAuthorizationPurchaseDetailsFlightSegments {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Information about fuel that was purchased with this transaction.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CaptureIssuingAuthorizationPurchaseDetailsFuel<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CaptureIssuingAuthorizationPurchaseDetailsFuel {
     /// The type of fuel that was purchased.
     /// One of `diesel`, `unleaded_plus`, `unleaded_regular`, `unleaded_super`, or `other`.
     #[serde(rename = "type")]
@@ -2351,17 +2379,17 @@ pub struct CaptureIssuingAuthorizationPurchaseDetailsFuel<'a> {
     pub unit: Option<CaptureIssuingAuthorizationPurchaseDetailsFuelUnit>,
     /// The cost in cents per each unit of fuel, represented as a decimal string with at most 12 decimal places.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub unit_cost_decimal: Option<&'a str>,
+    pub unit_cost_decimal: Option<String>,
     /// The volume of the fuel that was pumped, represented as a decimal string with at most 12 decimal places.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub volume_decimal: Option<&'a str>,
+    pub volume_decimal: Option<String>,
 }
-impl<'a> CaptureIssuingAuthorizationPurchaseDetailsFuel<'a> {
+impl CaptureIssuingAuthorizationPurchaseDetailsFuel {
     pub fn new() -> Self {
         Self { type_: None, unit: None, unit_cost_decimal: None, volume_decimal: None }
     }
 }
-impl<'a> Default for CaptureIssuingAuthorizationPurchaseDetailsFuel<'a> {
+impl Default for CaptureIssuingAuthorizationPurchaseDetailsFuel {
     fn default() -> Self {
         Self::new()
     }
@@ -2516,67 +2544,70 @@ impl Default for CaptureIssuingAuthorizationPurchaseDetailsLodging {
     }
 }
 /// The line items in the purchase.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CaptureIssuingAuthorizationPurchaseDetailsReceipt<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CaptureIssuingAuthorizationPurchaseDetailsReceipt {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<&'a str>,
+    pub description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub quantity: Option<&'a str>,
+    pub quantity: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub total: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub unit_cost: Option<i64>,
 }
-impl<'a> CaptureIssuingAuthorizationPurchaseDetailsReceipt<'a> {
+impl CaptureIssuingAuthorizationPurchaseDetailsReceipt {
     pub fn new() -> Self {
         Self { description: None, quantity: None, total: None, unit_cost: None }
     }
 }
-impl<'a> Default for CaptureIssuingAuthorizationPurchaseDetailsReceipt<'a> {
+impl Default for CaptureIssuingAuthorizationPurchaseDetailsReceipt {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Capture a test-mode authorization.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CaptureIssuingAuthorization<'a> {
-    inner: CaptureIssuingAuthorizationBuilder<'a>,
-    authorization: &'a str,
+pub struct CaptureIssuingAuthorization {
+    inner: CaptureIssuingAuthorizationBuilder,
+    authorization: String,
 }
-impl<'a> CaptureIssuingAuthorization<'a> {
+impl CaptureIssuingAuthorization {
     /// Construct a new `CaptureIssuingAuthorization`.
-    pub fn new(authorization: &'a str) -> Self {
-        Self { authorization, inner: CaptureIssuingAuthorizationBuilder::new() }
+    pub fn new(authorization: impl Into<String>) -> Self {
+        Self {
+            authorization: authorization.into(),
+            inner: CaptureIssuingAuthorizationBuilder::new(),
+        }
     }
     /// The amount to capture from the authorization.
     /// If not provided, the full amount of the authorization will be captured.
     /// This amount is in the authorization currency and in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal).
-    pub fn capture_amount(mut self, capture_amount: i64) -> Self {
-        self.inner.capture_amount = Some(capture_amount);
+    pub fn capture_amount(mut self, capture_amount: impl Into<i64>) -> Self {
+        self.inner.capture_amount = Some(capture_amount.into());
         self
     }
     /// Whether to close the authorization after capture.
     /// Defaults to true.
     /// Set to false to enable multi-capture flows.
-    pub fn close_authorization(mut self, close_authorization: bool) -> Self {
-        self.inner.close_authorization = Some(close_authorization);
+    pub fn close_authorization(mut self, close_authorization: impl Into<bool>) -> Self {
+        self.inner.close_authorization = Some(close_authorization.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Additional purchase information that is optionally provided by the merchant.
     pub fn purchase_details(
         mut self,
-        purchase_details: CaptureIssuingAuthorizationPurchaseDetails<'a>,
+        purchase_details: impl Into<CaptureIssuingAuthorizationPurchaseDetails>,
     ) -> Self {
-        self.inner.purchase_details = Some(purchase_details);
+        self.inner.purchase_details = Some(purchase_details.into());
         self
     }
 }
-impl CaptureIssuingAuthorization<'_> {
+impl CaptureIssuingAuthorization {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -2594,11 +2625,11 @@ impl CaptureIssuingAuthorization<'_> {
     }
 }
 
-impl StripeRequest for CaptureIssuingAuthorization<'_> {
+impl StripeRequest for CaptureIssuingAuthorization {
     type Output = stripe_shared::IssuingAuthorization;
 
     fn build(&self) -> RequestBuilder {
-        let authorization = self.authorization;
+        let authorization = &self.authorization;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/test_helpers/issuing/authorizations/{authorization}/capture"),
@@ -2606,34 +2637,37 @@ impl StripeRequest for CaptureIssuingAuthorization<'_> {
         .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ExpireIssuingAuthorizationBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ExpireIssuingAuthorizationBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> ExpireIssuingAuthorizationBuilder<'a> {
+impl ExpireIssuingAuthorizationBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Expire a test-mode Authorization.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ExpireIssuingAuthorization<'a> {
-    inner: ExpireIssuingAuthorizationBuilder<'a>,
-    authorization: &'a str,
+pub struct ExpireIssuingAuthorization {
+    inner: ExpireIssuingAuthorizationBuilder,
+    authorization: String,
 }
-impl<'a> ExpireIssuingAuthorization<'a> {
+impl ExpireIssuingAuthorization {
     /// Construct a new `ExpireIssuingAuthorization`.
-    pub fn new(authorization: &'a str) -> Self {
-        Self { authorization, inner: ExpireIssuingAuthorizationBuilder::new() }
+    pub fn new(authorization: impl Into<String>) -> Self {
+        Self {
+            authorization: authorization.into(),
+            inner: ExpireIssuingAuthorizationBuilder::new(),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl ExpireIssuingAuthorization<'_> {
+impl ExpireIssuingAuthorization {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -2651,11 +2685,11 @@ impl ExpireIssuingAuthorization<'_> {
     }
 }
 
-impl StripeRequest for ExpireIssuingAuthorization<'_> {
+impl StripeRequest for ExpireIssuingAuthorization {
     type Output = stripe_shared::IssuingAuthorization;
 
     fn build(&self) -> RequestBuilder {
-        let authorization = self.authorization;
+        let authorization = &self.authorization;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/test_helpers/issuing/authorizations/{authorization}/expire"),
@@ -2663,42 +2697,49 @@ impl StripeRequest for ExpireIssuingAuthorization<'_> {
         .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct IncrementIssuingAuthorizationBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct IncrementIssuingAuthorizationBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     increment_amount: i64,
     #[serde(skip_serializing_if = "Option::is_none")]
     is_amount_controllable: Option<bool>,
 }
-impl<'a> IncrementIssuingAuthorizationBuilder<'a> {
-    fn new(increment_amount: i64) -> Self {
-        Self { expand: None, increment_amount, is_amount_controllable: None }
+impl IncrementIssuingAuthorizationBuilder {
+    fn new(increment_amount: impl Into<i64>) -> Self {
+        Self {
+            expand: None,
+            increment_amount: increment_amount.into(),
+            is_amount_controllable: None,
+        }
     }
 }
 /// Increment a test-mode Authorization.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct IncrementIssuingAuthorization<'a> {
-    inner: IncrementIssuingAuthorizationBuilder<'a>,
-    authorization: &'a str,
+pub struct IncrementIssuingAuthorization {
+    inner: IncrementIssuingAuthorizationBuilder,
+    authorization: String,
 }
-impl<'a> IncrementIssuingAuthorization<'a> {
+impl IncrementIssuingAuthorization {
     /// Construct a new `IncrementIssuingAuthorization`.
-    pub fn new(authorization: &'a str, increment_amount: i64) -> Self {
-        Self { authorization, inner: IncrementIssuingAuthorizationBuilder::new(increment_amount) }
+    pub fn new(authorization: impl Into<String>, increment_amount: impl Into<i64>) -> Self {
+        Self {
+            authorization: authorization.into(),
+            inner: IncrementIssuingAuthorizationBuilder::new(increment_amount.into()),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// If set `true`, you may provide [amount](https://stripe.com/docs/api/issuing/authorizations/approve#approve_issuing_authorization-amount) to control how much to hold for the authorization.
-    pub fn is_amount_controllable(mut self, is_amount_controllable: bool) -> Self {
-        self.inner.is_amount_controllable = Some(is_amount_controllable);
+    pub fn is_amount_controllable(mut self, is_amount_controllable: impl Into<bool>) -> Self {
+        self.inner.is_amount_controllable = Some(is_amount_controllable.into());
         self
     }
 }
-impl IncrementIssuingAuthorization<'_> {
+impl IncrementIssuingAuthorization {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -2716,11 +2757,11 @@ impl IncrementIssuingAuthorization<'_> {
     }
 }
 
-impl StripeRequest for IncrementIssuingAuthorization<'_> {
+impl StripeRequest for IncrementIssuingAuthorization {
     type Output = stripe_shared::IssuingAuthorization;
 
     fn build(&self) -> RequestBuilder {
-        let authorization = self.authorization;
+        let authorization = &self.authorization;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/test_helpers/issuing/authorizations/{authorization}/increment"),
@@ -2728,43 +2769,46 @@ impl StripeRequest for IncrementIssuingAuthorization<'_> {
         .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ReverseIssuingAuthorizationBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ReverseIssuingAuthorizationBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     reverse_amount: Option<i64>,
 }
-impl<'a> ReverseIssuingAuthorizationBuilder<'a> {
+impl ReverseIssuingAuthorizationBuilder {
     fn new() -> Self {
         Self { expand: None, reverse_amount: None }
     }
 }
 /// Reverse a test-mode Authorization.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ReverseIssuingAuthorization<'a> {
-    inner: ReverseIssuingAuthorizationBuilder<'a>,
-    authorization: &'a str,
+pub struct ReverseIssuingAuthorization {
+    inner: ReverseIssuingAuthorizationBuilder,
+    authorization: String,
 }
-impl<'a> ReverseIssuingAuthorization<'a> {
+impl ReverseIssuingAuthorization {
     /// Construct a new `ReverseIssuingAuthorization`.
-    pub fn new(authorization: &'a str) -> Self {
-        Self { authorization, inner: ReverseIssuingAuthorizationBuilder::new() }
+    pub fn new(authorization: impl Into<String>) -> Self {
+        Self {
+            authorization: authorization.into(),
+            inner: ReverseIssuingAuthorizationBuilder::new(),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// The amount to reverse from the authorization.
     /// If not provided, the full amount of the authorization will be reversed.
     /// This amount is in the authorization currency and in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal).
-    pub fn reverse_amount(mut self, reverse_amount: i64) -> Self {
-        self.inner.reverse_amount = Some(reverse_amount);
+    pub fn reverse_amount(mut self, reverse_amount: impl Into<i64>) -> Self {
+        self.inner.reverse_amount = Some(reverse_amount.into());
         self
     }
 }
-impl ReverseIssuingAuthorization<'_> {
+impl ReverseIssuingAuthorization {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -2782,11 +2826,11 @@ impl ReverseIssuingAuthorization<'_> {
     }
 }
 
-impl StripeRequest for ReverseIssuingAuthorization<'_> {
+impl StripeRequest for ReverseIssuingAuthorization {
     type Output = stripe_shared::IssuingAuthorization;
 
     fn build(&self) -> RequestBuilder {
-        let authorization = self.authorization;
+        let authorization = &self.authorization;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/test_helpers/issuing/authorizations/{authorization}/reverse"),

--- a/generated/async-stripe-issuing/src/issuing_card/requests.rs
+++ b/generated/async-stripe-issuing/src/issuing_card/requests.rs
@@ -2,35 +2,35 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListIssuingCardBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListIssuingCardBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    cardholder: Option<&'a str>,
+    cardholder: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     created: Option<stripe_types::RangeQueryTs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     exp_month: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     exp_year: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    last4: Option<&'a str>,
+    last4: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    personalization_design: Option<&'a str>,
+    personalization_design: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     status: Option<stripe_shared::IssuingCardStatus>,
     #[serde(rename = "type")]
     #[serde(skip_serializing_if = "Option::is_none")]
     type_: Option<stripe_shared::IssuingCardType>,
 }
-impl<'a> ListIssuingCardBuilder<'a> {
+impl ListIssuingCardBuilder {
     fn new() -> Self {
         Self {
             cardholder: None,
@@ -51,85 +51,85 @@ impl<'a> ListIssuingCardBuilder<'a> {
 /// Returns a list of Issuing `Card` objects.
 /// The objects are sorted in descending order by creation date, with the most recently created object appearing first.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListIssuingCard<'a> {
-    inner: ListIssuingCardBuilder<'a>,
+pub struct ListIssuingCard {
+    inner: ListIssuingCardBuilder,
 }
-impl<'a> ListIssuingCard<'a> {
+impl ListIssuingCard {
     /// Construct a new `ListIssuingCard`.
     pub fn new() -> Self {
         Self { inner: ListIssuingCardBuilder::new() }
     }
     /// Only return cards belonging to the Cardholder with the provided ID.
-    pub fn cardholder(mut self, cardholder: &'a str) -> Self {
-        self.inner.cardholder = Some(cardholder);
+    pub fn cardholder(mut self, cardholder: impl Into<String>) -> Self {
+        self.inner.cardholder = Some(cardholder.into());
         self
     }
     /// Only return cards that were issued during the given date interval.
-    pub fn created(mut self, created: stripe_types::RangeQueryTs) -> Self {
-        self.inner.created = Some(created);
+    pub fn created(mut self, created: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.created = Some(created.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Only return cards that have the given expiration month.
-    pub fn exp_month(mut self, exp_month: i64) -> Self {
-        self.inner.exp_month = Some(exp_month);
+    pub fn exp_month(mut self, exp_month: impl Into<i64>) -> Self {
+        self.inner.exp_month = Some(exp_month.into());
         self
     }
     /// Only return cards that have the given expiration year.
-    pub fn exp_year(mut self, exp_year: i64) -> Self {
-        self.inner.exp_year = Some(exp_year);
+    pub fn exp_year(mut self, exp_year: impl Into<i64>) -> Self {
+        self.inner.exp_year = Some(exp_year.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Only return cards that have the given last four digits.
-    pub fn last4(mut self, last4: &'a str) -> Self {
-        self.inner.last4 = Some(last4);
+    pub fn last4(mut self, last4: impl Into<String>) -> Self {
+        self.inner.last4 = Some(last4.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
-    pub fn personalization_design(mut self, personalization_design: &'a str) -> Self {
-        self.inner.personalization_design = Some(personalization_design);
+    pub fn personalization_design(mut self, personalization_design: impl Into<String>) -> Self {
+        self.inner.personalization_design = Some(personalization_design.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
     /// Only return cards that have the given status. One of `active`, `inactive`, or `canceled`.
-    pub fn status(mut self, status: stripe_shared::IssuingCardStatus) -> Self {
-        self.inner.status = Some(status);
+    pub fn status(mut self, status: impl Into<stripe_shared::IssuingCardStatus>) -> Self {
+        self.inner.status = Some(status.into());
         self
     }
     /// Only return cards that have the given type. One of `virtual` or `physical`.
-    pub fn type_(mut self, type_: stripe_shared::IssuingCardType) -> Self {
-        self.inner.type_ = Some(type_);
+    pub fn type_(mut self, type_: impl Into<stripe_shared::IssuingCardType>) -> Self {
+        self.inner.type_ = Some(type_.into());
         self
     }
 }
-impl<'a> Default for ListIssuingCard<'a> {
+impl Default for ListIssuingCard {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListIssuingCard<'_> {
+impl ListIssuingCard {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -149,45 +149,45 @@ impl ListIssuingCard<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::IssuingCard>> {
-        stripe_client_core::ListPaginator::new_list("/issuing/cards", self.inner)
+        stripe_client_core::ListPaginator::new_list("/issuing/cards", &self.inner)
     }
 }
 
-impl StripeRequest for ListIssuingCard<'_> {
+impl StripeRequest for ListIssuingCard {
     type Output = stripe_types::List<stripe_shared::IssuingCard>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/issuing/cards").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveIssuingCardBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveIssuingCardBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveIssuingCardBuilder<'a> {
+impl RetrieveIssuingCardBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves an Issuing `Card` object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveIssuingCard<'a> {
-    inner: RetrieveIssuingCardBuilder<'a>,
-    card: &'a stripe_shared::IssuingCardId,
+pub struct RetrieveIssuingCard {
+    inner: RetrieveIssuingCardBuilder,
+    card: stripe_shared::IssuingCardId,
 }
-impl<'a> RetrieveIssuingCard<'a> {
+impl RetrieveIssuingCard {
     /// Construct a new `RetrieveIssuingCard`.
-    pub fn new(card: &'a stripe_shared::IssuingCardId) -> Self {
-        Self { card, inner: RetrieveIssuingCardBuilder::new() }
+    pub fn new(card: impl Into<stripe_shared::IssuingCardId>) -> Self {
+        Self { card: card.into(), inner: RetrieveIssuingCardBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveIssuingCard<'_> {
+impl RetrieveIssuingCard {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -205,49 +205,52 @@ impl RetrieveIssuingCard<'_> {
     }
 }
 
-impl StripeRequest for RetrieveIssuingCard<'_> {
+impl StripeRequest for RetrieveIssuingCard {
     type Output = stripe_shared::IssuingCard;
 
     fn build(&self) -> RequestBuilder {
-        let card = self.card;
+        let card = &self.card;
         RequestBuilder::new(StripeMethod::Get, format!("/issuing/cards/{card}")).query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateIssuingCardBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateIssuingCardBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    cardholder: Option<&'a str>,
+    cardholder: Option<String>,
     currency: stripe_types::Currency,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    financial_account: Option<&'a str>,
+    financial_account: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    personalization_design: Option<&'a str>,
+    personalization_design: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pin: Option<EncryptedPinParam<'a>>,
+    pin: Option<EncryptedPinParam>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    replacement_for: Option<&'a str>,
+    replacement_for: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     replacement_reason: Option<stripe_shared::IssuingCardReplacementReason>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    second_line: Option<&'a str>,
+    second_line: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    shipping: Option<CreateIssuingCardShipping<'a>>,
+    shipping: Option<CreateIssuingCardShipping>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    spending_controls: Option<CreateIssuingCardSpendingControls<'a>>,
+    spending_controls: Option<CreateIssuingCardSpendingControls>,
     #[serde(skip_serializing_if = "Option::is_none")]
     status: Option<CreateIssuingCardStatus>,
     #[serde(rename = "type")]
     type_: stripe_shared::IssuingCardType,
 }
-impl<'a> CreateIssuingCardBuilder<'a> {
-    fn new(currency: stripe_types::Currency, type_: stripe_shared::IssuingCardType) -> Self {
+impl CreateIssuingCardBuilder {
+    fn new(
+        currency: impl Into<stripe_types::Currency>,
+        type_: impl Into<stripe_shared::IssuingCardType>,
+    ) -> Self {
         Self {
             cardholder: None,
-            currency,
+            currency: currency.into(),
             expand: None,
             financial_account: None,
             metadata: None,
@@ -259,23 +262,23 @@ impl<'a> CreateIssuingCardBuilder<'a> {
             shipping: None,
             spending_controls: None,
             status: None,
-            type_,
+            type_: type_.into(),
         }
     }
 }
 /// The address where the card will be shipped.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateIssuingCardShipping<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateIssuingCardShipping {
     /// The address that the card is shipped to.
-    pub address: CreateIssuingCardShippingAddress<'a>,
+    pub address: CreateIssuingCardShippingAddress,
     /// Customs information for the shipment.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub customs: Option<CreateIssuingCardShippingCustoms<'a>>,
+    pub customs: Option<CreateIssuingCardShippingCustoms>,
     /// The name printed on the shipping label when shipping the card.
-    pub name: &'a str,
+    pub name: String,
     /// Phone number of the recipient of the shipment.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub phone_number: Option<&'a str>,
+    pub phone_number: Option<String>,
     /// Whether a signature is required for card delivery.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub require_signature: Option<bool>,
@@ -287,12 +290,15 @@ pub struct CreateIssuingCardShipping<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub type_: Option<CreateIssuingCardShippingType>,
 }
-impl<'a> CreateIssuingCardShipping<'a> {
-    pub fn new(address: CreateIssuingCardShippingAddress<'a>, name: &'a str) -> Self {
+impl CreateIssuingCardShipping {
+    pub fn new(
+        address: impl Into<CreateIssuingCardShippingAddress>,
+        name: impl Into<String>,
+    ) -> Self {
         Self {
-            address,
+            address: address.into(),
             customs: None,
-            name,
+            name: name.into(),
             phone_number: None,
             require_signature: None,
             service: None,
@@ -301,42 +307,54 @@ impl<'a> CreateIssuingCardShipping<'a> {
     }
 }
 /// The address that the card is shipped to.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateIssuingCardShippingAddress<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateIssuingCardShippingAddress {
     /// City, district, suburb, town, or village.
-    pub city: &'a str,
+    pub city: String,
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
-    pub country: &'a str,
+    pub country: String,
     /// Address line 1 (e.g., street, PO Box, or company name).
-    pub line1: &'a str,
+    pub line1: String,
     /// Address line 2 (e.g., apartment, suite, unit, or building).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line2: Option<&'a str>,
+    pub line2: Option<String>,
     /// ZIP or postal code.
-    pub postal_code: &'a str,
+    pub postal_code: String,
     /// State, county, province, or region.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
 }
-impl<'a> CreateIssuingCardShippingAddress<'a> {
-    pub fn new(city: &'a str, country: &'a str, line1: &'a str, postal_code: &'a str) -> Self {
-        Self { city, country, line1, line2: None, postal_code, state: None }
+impl CreateIssuingCardShippingAddress {
+    pub fn new(
+        city: impl Into<String>,
+        country: impl Into<String>,
+        line1: impl Into<String>,
+        postal_code: impl Into<String>,
+    ) -> Self {
+        Self {
+            city: city.into(),
+            country: country.into(),
+            line1: line1.into(),
+            line2: None,
+            postal_code: postal_code.into(),
+            state: None,
+        }
     }
 }
 /// Customs information for the shipment.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateIssuingCardShippingCustoms<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateIssuingCardShippingCustoms {
     /// The Economic Operators Registration and Identification (EORI) number to use for Customs.
     /// Required for bulk shipments to Europe.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub eori_number: Option<&'a str>,
+    pub eori_number: Option<String>,
 }
-impl<'a> CreateIssuingCardShippingCustoms<'a> {
+impl CreateIssuingCardShippingCustoms {
     pub fn new() -> Self {
         Self { eori_number: None }
     }
 }
-impl<'a> Default for CreateIssuingCardShippingCustoms<'a> {
+impl Default for CreateIssuingCardShippingCustoms {
     fn default() -> Self {
         Self::new()
     }
@@ -458,13 +476,13 @@ impl<'de> serde::Deserialize<'de> for CreateIssuingCardShippingType {
 }
 /// Rules that control spending for this card.
 /// Refer to our [documentation](https://stripe.com/docs/issuing/controls/spending-controls) for more details.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateIssuingCardSpendingControls<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateIssuingCardSpendingControls {
     /// Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to allow.
     /// All other categories will be blocked.
     /// Cannot be set with `blocked_categories`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub allowed_categories: Option<&'a [CreateIssuingCardSpendingControlsAllowedCategories]>,
+    pub allowed_categories: Option<Vec<CreateIssuingCardSpendingControlsAllowedCategories>>,
     /// Array of strings containing representing countries from which authorizations will be allowed.
     /// Authorizations from merchants in all other countries will be declined.
     /// Country codes should be ISO 3166 alpha-2 country codes (e.g.
@@ -472,24 +490,24 @@ pub struct CreateIssuingCardSpendingControls<'a> {
     /// Cannot be set with `blocked_merchant_countries`.
     /// Provide an empty value to unset this control.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub allowed_merchant_countries: Option<&'a [&'a str]>,
+    pub allowed_merchant_countries: Option<Vec<String>>,
     /// Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to decline.
     /// All other categories will be allowed.
     /// Cannot be set with `allowed_categories`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub blocked_categories: Option<&'a [CreateIssuingCardSpendingControlsBlockedCategories]>,
+    pub blocked_categories: Option<Vec<CreateIssuingCardSpendingControlsBlockedCategories>>,
     /// Array of strings containing representing countries from which authorizations will be declined.
     /// Country codes should be ISO 3166 alpha-2 country codes (e.g.
     /// `US`).
     /// Cannot be set with `allowed_merchant_countries`.
     /// Provide an empty value to unset this control.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub blocked_merchant_countries: Option<&'a [&'a str]>,
+    pub blocked_merchant_countries: Option<Vec<String>>,
     /// Limit spending with amount-based rules that apply across any cards this card replaced (i.e., its `replacement_for` card and _that_ card's `replacement_for` card, up the chain).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub spending_limits: Option<&'a [CreateIssuingCardSpendingControlsSpendingLimits<'a>]>,
+    pub spending_limits: Option<Vec<CreateIssuingCardSpendingControlsSpendingLimits>>,
 }
-impl<'a> CreateIssuingCardSpendingControls<'a> {
+impl CreateIssuingCardSpendingControls {
     pub fn new() -> Self {
         Self {
             allowed_categories: None,
@@ -500,7 +518,7 @@ impl<'a> CreateIssuingCardSpendingControls<'a> {
         }
     }
 }
-impl<'a> Default for CreateIssuingCardSpendingControls<'a> {
+impl Default for CreateIssuingCardSpendingControls {
     fn default() -> Self {
         Self::new()
     }
@@ -2568,23 +2586,23 @@ impl<'de> serde::Deserialize<'de> for CreateIssuingCardSpendingControlsBlockedCa
     }
 }
 /// Limit spending with amount-based rules that apply across any cards this card replaced (i.e., its `replacement_for` card and _that_ card's `replacement_for` card, up the chain).
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateIssuingCardSpendingControlsSpendingLimits<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateIssuingCardSpendingControlsSpendingLimits {
     /// Maximum amount allowed to spend per interval.
     pub amount: i64,
     /// Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) this limit applies to.
     /// Omitting this field will apply the limit to all categories.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub categories: Option<&'a [CreateIssuingCardSpendingControlsSpendingLimitsCategories]>,
+    pub categories: Option<Vec<CreateIssuingCardSpendingControlsSpendingLimitsCategories>>,
     /// Interval (or event) to which the amount applies.
     pub interval: CreateIssuingCardSpendingControlsSpendingLimitsInterval,
 }
-impl<'a> CreateIssuingCardSpendingControlsSpendingLimits<'a> {
+impl CreateIssuingCardSpendingControlsSpendingLimits {
     pub fn new(
-        amount: i64,
-        interval: CreateIssuingCardSpendingControlsSpendingLimitsInterval,
+        amount: impl Into<i64>,
+        interval: impl Into<CreateIssuingCardSpendingControlsSpendingLimitsInterval>,
     ) -> Self {
-        Self { amount, categories: None, interval }
+        Self { amount: amount.into(), categories: None, interval: interval.into() }
     }
 }
 /// Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) this limit applies to.
@@ -3746,87 +3764,93 @@ impl<'de> serde::Deserialize<'de> for CreateIssuingCardStatus {
 }
 /// Creates an Issuing `Card` object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateIssuingCard<'a> {
-    inner: CreateIssuingCardBuilder<'a>,
+pub struct CreateIssuingCard {
+    inner: CreateIssuingCardBuilder,
 }
-impl<'a> CreateIssuingCard<'a> {
+impl CreateIssuingCard {
     /// Construct a new `CreateIssuingCard`.
-    pub fn new(currency: stripe_types::Currency, type_: stripe_shared::IssuingCardType) -> Self {
-        Self { inner: CreateIssuingCardBuilder::new(currency, type_) }
+    pub fn new(
+        currency: impl Into<stripe_types::Currency>,
+        type_: impl Into<stripe_shared::IssuingCardType>,
+    ) -> Self {
+        Self { inner: CreateIssuingCardBuilder::new(currency.into(), type_.into()) }
     }
     /// The [Cardholder](https://stripe.com/docs/api#issuing_cardholder_object) object with which the card will be associated.
-    pub fn cardholder(mut self, cardholder: &'a str) -> Self {
-        self.inner.cardholder = Some(cardholder);
+    pub fn cardholder(mut self, cardholder: impl Into<String>) -> Self {
+        self.inner.cardholder = Some(cardholder.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
-    pub fn financial_account(mut self, financial_account: &'a str) -> Self {
-        self.inner.financial_account = Some(financial_account);
+    pub fn financial_account(mut self, financial_account: impl Into<String>) -> Self {
+        self.inner.financial_account = Some(financial_account.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// The personalization design object belonging to this card.
-    pub fn personalization_design(mut self, personalization_design: &'a str) -> Self {
-        self.inner.personalization_design = Some(personalization_design);
+    pub fn personalization_design(mut self, personalization_design: impl Into<String>) -> Self {
+        self.inner.personalization_design = Some(personalization_design.into());
         self
     }
     /// The desired PIN for this card.
-    pub fn pin(mut self, pin: EncryptedPinParam<'a>) -> Self {
-        self.inner.pin = Some(pin);
+    pub fn pin(mut self, pin: impl Into<EncryptedPinParam>) -> Self {
+        self.inner.pin = Some(pin.into());
         self
     }
     /// The card this is meant to be a replacement for (if any).
-    pub fn replacement_for(mut self, replacement_for: &'a str) -> Self {
-        self.inner.replacement_for = Some(replacement_for);
+    pub fn replacement_for(mut self, replacement_for: impl Into<String>) -> Self {
+        self.inner.replacement_for = Some(replacement_for.into());
         self
     }
     /// If `replacement_for` is specified, this should indicate why that card is being replaced.
     pub fn replacement_reason(
         mut self,
-        replacement_reason: stripe_shared::IssuingCardReplacementReason,
+        replacement_reason: impl Into<stripe_shared::IssuingCardReplacementReason>,
     ) -> Self {
-        self.inner.replacement_reason = Some(replacement_reason);
+        self.inner.replacement_reason = Some(replacement_reason.into());
         self
     }
     /// The second line to print on the card.
-    pub fn second_line(mut self, second_line: &'a str) -> Self {
-        self.inner.second_line = Some(second_line);
+    pub fn second_line(mut self, second_line: impl Into<String>) -> Self {
+        self.inner.second_line = Some(second_line.into());
         self
     }
     /// The address where the card will be shipped.
-    pub fn shipping(mut self, shipping: CreateIssuingCardShipping<'a>) -> Self {
-        self.inner.shipping = Some(shipping);
+    pub fn shipping(mut self, shipping: impl Into<CreateIssuingCardShipping>) -> Self {
+        self.inner.shipping = Some(shipping.into());
         self
     }
     /// Rules that control spending for this card.
     /// Refer to our [documentation](https://stripe.com/docs/issuing/controls/spending-controls) for more details.
     pub fn spending_controls(
         mut self,
-        spending_controls: CreateIssuingCardSpendingControls<'a>,
+        spending_controls: impl Into<CreateIssuingCardSpendingControls>,
     ) -> Self {
-        self.inner.spending_controls = Some(spending_controls);
+        self.inner.spending_controls = Some(spending_controls.into());
         self
     }
     /// Whether authorizations can be approved on this card.
     /// May be blocked from activating cards depending on past-due Cardholder requirements.
     /// Defaults to `inactive`.
-    pub fn status(mut self, status: CreateIssuingCardStatus) -> Self {
-        self.inner.status = Some(status);
+    pub fn status(mut self, status: impl Into<CreateIssuingCardStatus>) -> Self {
+        self.inner.status = Some(status.into());
         self
     }
 }
-impl CreateIssuingCard<'_> {
+impl CreateIssuingCard {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -3844,31 +3868,31 @@ impl CreateIssuingCard<'_> {
     }
 }
 
-impl StripeRequest for CreateIssuingCard<'_> {
+impl StripeRequest for CreateIssuingCard {
     type Output = stripe_shared::IssuingCard;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Post, "/issuing/cards").form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdateIssuingCardBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdateIssuingCardBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     cancellation_reason: Option<UpdateIssuingCardCancellationReason>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    personalization_design: Option<&'a str>,
+    personalization_design: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pin: Option<EncryptedPinParam<'a>>,
+    pin: Option<EncryptedPinParam>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    spending_controls: Option<UpdateIssuingCardSpendingControls<'a>>,
+    spending_controls: Option<UpdateIssuingCardSpendingControls>,
     #[serde(skip_serializing_if = "Option::is_none")]
     status: Option<stripe_shared::IssuingCardStatus>,
 }
-impl<'a> UpdateIssuingCardBuilder<'a> {
+impl UpdateIssuingCardBuilder {
     fn new() -> Self {
         Self {
             cancellation_reason: None,
@@ -3939,13 +3963,13 @@ impl<'de> serde::Deserialize<'de> for UpdateIssuingCardCancellationReason {
 }
 /// Rules that control spending for this card.
 /// Refer to our [documentation](https://stripe.com/docs/issuing/controls/spending-controls) for more details.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateIssuingCardSpendingControls<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateIssuingCardSpendingControls {
     /// Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to allow.
     /// All other categories will be blocked.
     /// Cannot be set with `blocked_categories`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub allowed_categories: Option<&'a [UpdateIssuingCardSpendingControlsAllowedCategories]>,
+    pub allowed_categories: Option<Vec<UpdateIssuingCardSpendingControlsAllowedCategories>>,
     /// Array of strings containing representing countries from which authorizations will be allowed.
     /// Authorizations from merchants in all other countries will be declined.
     /// Country codes should be ISO 3166 alpha-2 country codes (e.g.
@@ -3953,24 +3977,24 @@ pub struct UpdateIssuingCardSpendingControls<'a> {
     /// Cannot be set with `blocked_merchant_countries`.
     /// Provide an empty value to unset this control.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub allowed_merchant_countries: Option<&'a [&'a str]>,
+    pub allowed_merchant_countries: Option<Vec<String>>,
     /// Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to decline.
     /// All other categories will be allowed.
     /// Cannot be set with `allowed_categories`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub blocked_categories: Option<&'a [UpdateIssuingCardSpendingControlsBlockedCategories]>,
+    pub blocked_categories: Option<Vec<UpdateIssuingCardSpendingControlsBlockedCategories>>,
     /// Array of strings containing representing countries from which authorizations will be declined.
     /// Country codes should be ISO 3166 alpha-2 country codes (e.g.
     /// `US`).
     /// Cannot be set with `allowed_merchant_countries`.
     /// Provide an empty value to unset this control.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub blocked_merchant_countries: Option<&'a [&'a str]>,
+    pub blocked_merchant_countries: Option<Vec<String>>,
     /// Limit spending with amount-based rules that apply across any cards this card replaced (i.e., its `replacement_for` card and _that_ card's `replacement_for` card, up the chain).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub spending_limits: Option<&'a [UpdateIssuingCardSpendingControlsSpendingLimits<'a>]>,
+    pub spending_limits: Option<Vec<UpdateIssuingCardSpendingControlsSpendingLimits>>,
 }
-impl<'a> UpdateIssuingCardSpendingControls<'a> {
+impl UpdateIssuingCardSpendingControls {
     pub fn new() -> Self {
         Self {
             allowed_categories: None,
@@ -3981,7 +4005,7 @@ impl<'a> UpdateIssuingCardSpendingControls<'a> {
         }
     }
 }
-impl<'a> Default for UpdateIssuingCardSpendingControls<'a> {
+impl Default for UpdateIssuingCardSpendingControls {
     fn default() -> Self {
         Self::new()
     }
@@ -6049,23 +6073,23 @@ impl<'de> serde::Deserialize<'de> for UpdateIssuingCardSpendingControlsBlockedCa
     }
 }
 /// Limit spending with amount-based rules that apply across any cards this card replaced (i.e., its `replacement_for` card and _that_ card's `replacement_for` card, up the chain).
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateIssuingCardSpendingControlsSpendingLimits<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateIssuingCardSpendingControlsSpendingLimits {
     /// Maximum amount allowed to spend per interval.
     pub amount: i64,
     /// Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) this limit applies to.
     /// Omitting this field will apply the limit to all categories.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub categories: Option<&'a [UpdateIssuingCardSpendingControlsSpendingLimitsCategories]>,
+    pub categories: Option<Vec<UpdateIssuingCardSpendingControlsSpendingLimitsCategories>>,
     /// Interval (or event) to which the amount applies.
     pub interval: UpdateIssuingCardSpendingControlsSpendingLimitsInterval,
 }
-impl<'a> UpdateIssuingCardSpendingControlsSpendingLimits<'a> {
+impl UpdateIssuingCardSpendingControlsSpendingLimits {
     pub fn new(
-        amount: i64,
-        interval: UpdateIssuingCardSpendingControlsSpendingLimitsInterval,
+        amount: impl Into<i64>,
+        interval: impl Into<UpdateIssuingCardSpendingControlsSpendingLimitsInterval>,
     ) -> Self {
-        Self { amount, categories: None, interval }
+        Self { amount: amount.into(), categories: None, interval: interval.into() }
     }
 }
 /// Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) this limit applies to.
@@ -7171,64 +7195,67 @@ impl<'de> serde::Deserialize<'de> for UpdateIssuingCardSpendingControlsSpendingL
 /// Updates the specified Issuing `Card` object by setting the values of the parameters passed.
 /// Any parameters not provided will be left unchanged.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateIssuingCard<'a> {
-    inner: UpdateIssuingCardBuilder<'a>,
-    card: &'a stripe_shared::IssuingCardId,
+pub struct UpdateIssuingCard {
+    inner: UpdateIssuingCardBuilder,
+    card: stripe_shared::IssuingCardId,
 }
-impl<'a> UpdateIssuingCard<'a> {
+impl UpdateIssuingCard {
     /// Construct a new `UpdateIssuingCard`.
-    pub fn new(card: &'a stripe_shared::IssuingCardId) -> Self {
-        Self { card, inner: UpdateIssuingCardBuilder::new() }
+    pub fn new(card: impl Into<stripe_shared::IssuingCardId>) -> Self {
+        Self { card: card.into(), inner: UpdateIssuingCardBuilder::new() }
     }
     /// Reason why the `status` of this card is `canceled`.
     pub fn cancellation_reason(
         mut self,
-        cancellation_reason: UpdateIssuingCardCancellationReason,
+        cancellation_reason: impl Into<UpdateIssuingCardCancellationReason>,
     ) -> Self {
-        self.inner.cancellation_reason = Some(cancellation_reason);
+        self.inner.cancellation_reason = Some(cancellation_reason.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
-    pub fn personalization_design(mut self, personalization_design: &'a str) -> Self {
-        self.inner.personalization_design = Some(personalization_design);
+    pub fn personalization_design(mut self, personalization_design: impl Into<String>) -> Self {
+        self.inner.personalization_design = Some(personalization_design.into());
         self
     }
     /// The desired new PIN for this card.
-    pub fn pin(mut self, pin: EncryptedPinParam<'a>) -> Self {
-        self.inner.pin = Some(pin);
+    pub fn pin(mut self, pin: impl Into<EncryptedPinParam>) -> Self {
+        self.inner.pin = Some(pin.into());
         self
     }
     /// Rules that control spending for this card.
     /// Refer to our [documentation](https://stripe.com/docs/issuing/controls/spending-controls) for more details.
     pub fn spending_controls(
         mut self,
-        spending_controls: UpdateIssuingCardSpendingControls<'a>,
+        spending_controls: impl Into<UpdateIssuingCardSpendingControls>,
     ) -> Self {
-        self.inner.spending_controls = Some(spending_controls);
+        self.inner.spending_controls = Some(spending_controls.into());
         self
     }
     /// Dictates whether authorizations can be approved on this card.
     /// May be blocked from activating cards depending on past-due Cardholder requirements.
     /// Defaults to `inactive`.
     /// If this card is being canceled because it was lost or stolen, this information should be provided as `cancellation_reason`.
-    pub fn status(mut self, status: stripe_shared::IssuingCardStatus) -> Self {
-        self.inner.status = Some(status);
+    pub fn status(mut self, status: impl Into<stripe_shared::IssuingCardStatus>) -> Self {
+        self.inner.status = Some(status.into());
         self
     }
 }
-impl UpdateIssuingCard<'_> {
+impl UpdateIssuingCard {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -7246,42 +7273,42 @@ impl UpdateIssuingCard<'_> {
     }
 }
 
-impl StripeRequest for UpdateIssuingCard<'_> {
+impl StripeRequest for UpdateIssuingCard {
     type Output = stripe_shared::IssuingCard;
 
     fn build(&self) -> RequestBuilder {
-        let card = self.card;
+        let card = &self.card;
         RequestBuilder::new(StripeMethod::Post, format!("/issuing/cards/{card}")).form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct DeliverCardIssuingCardBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct DeliverCardIssuingCardBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> DeliverCardIssuingCardBuilder<'a> {
+impl DeliverCardIssuingCardBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Updates the shipping status of the specified Issuing `Card` object to `delivered`.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct DeliverCardIssuingCard<'a> {
-    inner: DeliverCardIssuingCardBuilder<'a>,
-    card: &'a str,
+pub struct DeliverCardIssuingCard {
+    inner: DeliverCardIssuingCardBuilder,
+    card: String,
 }
-impl<'a> DeliverCardIssuingCard<'a> {
+impl DeliverCardIssuingCard {
     /// Construct a new `DeliverCardIssuingCard`.
-    pub fn new(card: &'a str) -> Self {
-        Self { card, inner: DeliverCardIssuingCardBuilder::new() }
+    pub fn new(card: impl Into<String>) -> Self {
+        Self { card: card.into(), inner: DeliverCardIssuingCardBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl DeliverCardIssuingCard<'_> {
+impl DeliverCardIssuingCard {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -7299,11 +7326,11 @@ impl DeliverCardIssuingCard<'_> {
     }
 }
 
-impl StripeRequest for DeliverCardIssuingCard<'_> {
+impl StripeRequest for DeliverCardIssuingCard {
     type Output = stripe_shared::IssuingCard;
 
     fn build(&self) -> RequestBuilder {
-        let card = self.card;
+        let card = &self.card;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/test_helpers/issuing/cards/{card}/shipping/deliver"),
@@ -7311,34 +7338,34 @@ impl StripeRequest for DeliverCardIssuingCard<'_> {
         .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct FailCardIssuingCardBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct FailCardIssuingCardBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> FailCardIssuingCardBuilder<'a> {
+impl FailCardIssuingCardBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Updates the shipping status of the specified Issuing `Card` object to `failure`.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct FailCardIssuingCard<'a> {
-    inner: FailCardIssuingCardBuilder<'a>,
-    card: &'a str,
+pub struct FailCardIssuingCard {
+    inner: FailCardIssuingCardBuilder,
+    card: String,
 }
-impl<'a> FailCardIssuingCard<'a> {
+impl FailCardIssuingCard {
     /// Construct a new `FailCardIssuingCard`.
-    pub fn new(card: &'a str) -> Self {
-        Self { card, inner: FailCardIssuingCardBuilder::new() }
+    pub fn new(card: impl Into<String>) -> Self {
+        Self { card: card.into(), inner: FailCardIssuingCardBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl FailCardIssuingCard<'_> {
+impl FailCardIssuingCard {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -7356,11 +7383,11 @@ impl FailCardIssuingCard<'_> {
     }
 }
 
-impl StripeRequest for FailCardIssuingCard<'_> {
+impl StripeRequest for FailCardIssuingCard {
     type Output = stripe_shared::IssuingCard;
 
     fn build(&self) -> RequestBuilder {
-        let card = self.card;
+        let card = &self.card;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/test_helpers/issuing/cards/{card}/shipping/fail"),
@@ -7368,34 +7395,34 @@ impl StripeRequest for FailCardIssuingCard<'_> {
         .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ReturnCardIssuingCardBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ReturnCardIssuingCardBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> ReturnCardIssuingCardBuilder<'a> {
+impl ReturnCardIssuingCardBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Updates the shipping status of the specified Issuing `Card` object to `returned`.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ReturnCardIssuingCard<'a> {
-    inner: ReturnCardIssuingCardBuilder<'a>,
-    card: &'a str,
+pub struct ReturnCardIssuingCard {
+    inner: ReturnCardIssuingCardBuilder,
+    card: String,
 }
-impl<'a> ReturnCardIssuingCard<'a> {
+impl ReturnCardIssuingCard {
     /// Construct a new `ReturnCardIssuingCard`.
-    pub fn new(card: &'a str) -> Self {
-        Self { card, inner: ReturnCardIssuingCardBuilder::new() }
+    pub fn new(card: impl Into<String>) -> Self {
+        Self { card: card.into(), inner: ReturnCardIssuingCardBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl ReturnCardIssuingCard<'_> {
+impl ReturnCardIssuingCard {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -7413,11 +7440,11 @@ impl ReturnCardIssuingCard<'_> {
     }
 }
 
-impl StripeRequest for ReturnCardIssuingCard<'_> {
+impl StripeRequest for ReturnCardIssuingCard {
     type Output = stripe_shared::IssuingCard;
 
     fn build(&self) -> RequestBuilder {
-        let card = self.card;
+        let card = &self.card;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/test_helpers/issuing/cards/{card}/shipping/return"),
@@ -7425,34 +7452,34 @@ impl StripeRequest for ReturnCardIssuingCard<'_> {
         .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ShipCardIssuingCardBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ShipCardIssuingCardBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> ShipCardIssuingCardBuilder<'a> {
+impl ShipCardIssuingCardBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Updates the shipping status of the specified Issuing `Card` object to `shipped`.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ShipCardIssuingCard<'a> {
-    inner: ShipCardIssuingCardBuilder<'a>,
-    card: &'a str,
+pub struct ShipCardIssuingCard {
+    inner: ShipCardIssuingCardBuilder,
+    card: String,
 }
-impl<'a> ShipCardIssuingCard<'a> {
+impl ShipCardIssuingCard {
     /// Construct a new `ShipCardIssuingCard`.
-    pub fn new(card: &'a str) -> Self {
-        Self { card, inner: ShipCardIssuingCardBuilder::new() }
+    pub fn new(card: impl Into<String>) -> Self {
+        Self { card: card.into(), inner: ShipCardIssuingCardBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl ShipCardIssuingCard<'_> {
+impl ShipCardIssuingCard {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -7470,11 +7497,11 @@ impl ShipCardIssuingCard<'_> {
     }
 }
 
-impl StripeRequest for ShipCardIssuingCard<'_> {
+impl StripeRequest for ShipCardIssuingCard {
     type Output = stripe_shared::IssuingCard;
 
     fn build(&self) -> RequestBuilder {
-        let card = self.card;
+        let card = &self.card;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/test_helpers/issuing/cards/{card}/shipping/ship"),
@@ -7483,18 +7510,18 @@ impl StripeRequest for ShipCardIssuingCard<'_> {
     }
 }
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct EncryptedPinParam<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct EncryptedPinParam {
     /// The card's desired new PIN, encrypted under Stripe's public key.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub encrypted_number: Option<&'a str>,
+    pub encrypted_number: Option<String>,
 }
-impl<'a> EncryptedPinParam<'a> {
+impl EncryptedPinParam {
     pub fn new() -> Self {
         Self { encrypted_number: None }
     }
 }
-impl<'a> Default for EncryptedPinParam<'a> {
+impl Default for EncryptedPinParam {
     fn default() -> Self {
         Self::new()
     }

--- a/generated/async-stripe-issuing/src/issuing_cardholder/requests.rs
+++ b/generated/async-stripe-issuing/src/issuing_cardholder/requests.rs
@@ -2,29 +2,29 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListIssuingCardholderBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListIssuingCardholderBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     created: Option<stripe_types::RangeQueryTs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    email: Option<&'a str>,
+    email: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    phone_number: Option<&'a str>,
+    phone_number: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     status: Option<stripe_shared::IssuingCardholderStatus>,
     #[serde(rename = "type")]
     #[serde(skip_serializing_if = "Option::is_none")]
     type_: Option<stripe_shared::IssuingCardholderType>,
 }
-impl<'a> ListIssuingCardholderBuilder<'a> {
+impl ListIssuingCardholderBuilder {
     fn new() -> Self {
         Self {
             created: None,
@@ -42,71 +42,71 @@ impl<'a> ListIssuingCardholderBuilder<'a> {
 /// Returns a list of Issuing `Cardholder` objects.
 /// The objects are sorted in descending order by creation date, with the most recently created object appearing first.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListIssuingCardholder<'a> {
-    inner: ListIssuingCardholderBuilder<'a>,
+pub struct ListIssuingCardholder {
+    inner: ListIssuingCardholderBuilder,
 }
-impl<'a> ListIssuingCardholder<'a> {
+impl ListIssuingCardholder {
     /// Construct a new `ListIssuingCardholder`.
     pub fn new() -> Self {
         Self { inner: ListIssuingCardholderBuilder::new() }
     }
     /// Only return cardholders that were created during the given date interval.
-    pub fn created(mut self, created: stripe_types::RangeQueryTs) -> Self {
-        self.inner.created = Some(created);
+    pub fn created(mut self, created: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.created = Some(created.into());
         self
     }
     /// Only return cardholders that have the given email address.
-    pub fn email(mut self, email: &'a str) -> Self {
-        self.inner.email = Some(email);
+    pub fn email(mut self, email: impl Into<String>) -> Self {
+        self.inner.email = Some(email.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// Only return cardholders that have the given phone number.
-    pub fn phone_number(mut self, phone_number: &'a str) -> Self {
-        self.inner.phone_number = Some(phone_number);
+    pub fn phone_number(mut self, phone_number: impl Into<String>) -> Self {
+        self.inner.phone_number = Some(phone_number.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
     /// Only return cardholders that have the given status. One of `active`, `inactive`, or `blocked`.
-    pub fn status(mut self, status: stripe_shared::IssuingCardholderStatus) -> Self {
-        self.inner.status = Some(status);
+    pub fn status(mut self, status: impl Into<stripe_shared::IssuingCardholderStatus>) -> Self {
+        self.inner.status = Some(status.into());
         self
     }
     /// Only return cardholders that have the given type. One of `individual` or `company`.
-    pub fn type_(mut self, type_: stripe_shared::IssuingCardholderType) -> Self {
-        self.inner.type_ = Some(type_);
+    pub fn type_(mut self, type_: impl Into<stripe_shared::IssuingCardholderType>) -> Self {
+        self.inner.type_ = Some(type_.into());
         self
     }
 }
-impl<'a> Default for ListIssuingCardholder<'a> {
+impl Default for ListIssuingCardholder {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListIssuingCardholder<'_> {
+impl ListIssuingCardholder {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -127,45 +127,45 @@ impl ListIssuingCardholder<'_> {
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::IssuingCardholder>>
     {
-        stripe_client_core::ListPaginator::new_list("/issuing/cardholders", self.inner)
+        stripe_client_core::ListPaginator::new_list("/issuing/cardholders", &self.inner)
     }
 }
 
-impl StripeRequest for ListIssuingCardholder<'_> {
+impl StripeRequest for ListIssuingCardholder {
     type Output = stripe_types::List<stripe_shared::IssuingCardholder>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/issuing/cardholders").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveIssuingCardholderBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveIssuingCardholderBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveIssuingCardholderBuilder<'a> {
+impl RetrieveIssuingCardholderBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves an Issuing `Cardholder` object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveIssuingCardholder<'a> {
-    inner: RetrieveIssuingCardholderBuilder<'a>,
-    cardholder: &'a stripe_shared::IssuingCardholderId,
+pub struct RetrieveIssuingCardholder {
+    inner: RetrieveIssuingCardholderBuilder,
+    cardholder: stripe_shared::IssuingCardholderId,
 }
-impl<'a> RetrieveIssuingCardholder<'a> {
+impl RetrieveIssuingCardholder {
     /// Construct a new `RetrieveIssuingCardholder`.
-    pub fn new(cardholder: &'a stripe_shared::IssuingCardholderId) -> Self {
-        Self { cardholder, inner: RetrieveIssuingCardholderBuilder::new() }
+    pub fn new(cardholder: impl Into<stripe_shared::IssuingCardholderId>) -> Self {
+        Self { cardholder: cardholder.into(), inner: RetrieveIssuingCardholderBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveIssuingCardholder<'_> {
+impl RetrieveIssuingCardholder {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -183,51 +183,51 @@ impl RetrieveIssuingCardholder<'_> {
     }
 }
 
-impl StripeRequest for RetrieveIssuingCardholder<'_> {
+impl StripeRequest for RetrieveIssuingCardholder {
     type Output = stripe_shared::IssuingCardholder;
 
     fn build(&self) -> RequestBuilder {
-        let cardholder = self.cardholder;
+        let cardholder = &self.cardholder;
         RequestBuilder::new(StripeMethod::Get, format!("/issuing/cardholders/{cardholder}"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateIssuingCardholderBuilder<'a> {
-    billing: BillingSpecs<'a>,
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateIssuingCardholderBuilder {
+    billing: BillingSpecs,
     #[serde(skip_serializing_if = "Option::is_none")]
-    company: Option<CompanyParam<'a>>,
+    company: Option<CompanyParam>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    email: Option<&'a str>,
+    email: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    individual: Option<IndividualParam<'a>>,
+    individual: Option<IndividualParam>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
-    name: &'a str,
+    metadata: Option<std::collections::HashMap<String, String>>,
+    name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    phone_number: Option<&'a str>,
+    phone_number: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    preferred_locales: Option<&'a [stripe_shared::IssuingCardholderPreferredLocales]>,
+    preferred_locales: Option<Vec<stripe_shared::IssuingCardholderPreferredLocales>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    spending_controls: Option<CreateIssuingCardholderSpendingControls<'a>>,
+    spending_controls: Option<CreateIssuingCardholderSpendingControls>,
     #[serde(skip_serializing_if = "Option::is_none")]
     status: Option<CreateIssuingCardholderStatus>,
     #[serde(rename = "type")]
     #[serde(skip_serializing_if = "Option::is_none")]
     type_: Option<stripe_shared::IssuingCardholderType>,
 }
-impl<'a> CreateIssuingCardholderBuilder<'a> {
-    fn new(billing: BillingSpecs<'a>, name: &'a str) -> Self {
+impl CreateIssuingCardholderBuilder {
+    fn new(billing: impl Into<BillingSpecs>, name: impl Into<String>) -> Self {
         Self {
-            billing,
+            billing: billing.into(),
             company: None,
             email: None,
             expand: None,
             individual: None,
             metadata: None,
-            name,
+            name: name.into(),
             phone_number: None,
             preferred_locales: None,
             spending_controls: None,
@@ -238,13 +238,13 @@ impl<'a> CreateIssuingCardholderBuilder<'a> {
 }
 /// Rules that control spending across this cardholder's cards.
 /// Refer to our [documentation](https://stripe.com/docs/issuing/controls/spending-controls) for more details.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateIssuingCardholderSpendingControls<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateIssuingCardholderSpendingControls {
     /// Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to allow.
     /// All other categories will be blocked.
     /// Cannot be set with `blocked_categories`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub allowed_categories: Option<&'a [CreateIssuingCardholderSpendingControlsAllowedCategories]>,
+    pub allowed_categories: Option<Vec<CreateIssuingCardholderSpendingControlsAllowedCategories>>,
     /// Array of strings containing representing countries from which authorizations will be allowed.
     /// Authorizations from merchants in all other countries will be declined.
     /// Country codes should be ISO 3166 alpha-2 country codes (e.g.
@@ -252,27 +252,27 @@ pub struct CreateIssuingCardholderSpendingControls<'a> {
     /// Cannot be set with `blocked_merchant_countries`.
     /// Provide an empty value to unset this control.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub allowed_merchant_countries: Option<&'a [&'a str]>,
+    pub allowed_merchant_countries: Option<Vec<String>>,
     /// Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to decline.
     /// All other categories will be allowed.
     /// Cannot be set with `allowed_categories`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub blocked_categories: Option<&'a [CreateIssuingCardholderSpendingControlsBlockedCategories]>,
+    pub blocked_categories: Option<Vec<CreateIssuingCardholderSpendingControlsBlockedCategories>>,
     /// Array of strings containing representing countries from which authorizations will be declined.
     /// Country codes should be ISO 3166 alpha-2 country codes (e.g.
     /// `US`).
     /// Cannot be set with `allowed_merchant_countries`.
     /// Provide an empty value to unset this control.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub blocked_merchant_countries: Option<&'a [&'a str]>,
+    pub blocked_merchant_countries: Option<Vec<String>>,
     /// Limit spending with amount-based rules that apply across this cardholder's cards.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub spending_limits: Option<&'a [CreateIssuingCardholderSpendingControlsSpendingLimits<'a>]>,
+    pub spending_limits: Option<Vec<CreateIssuingCardholderSpendingControlsSpendingLimits>>,
     /// Currency of amounts within `spending_limits`. Defaults to your merchant country's currency.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub spending_limits_currency: Option<stripe_types::Currency>,
 }
-impl<'a> CreateIssuingCardholderSpendingControls<'a> {
+impl CreateIssuingCardholderSpendingControls {
     pub fn new() -> Self {
         Self {
             allowed_categories: None,
@@ -284,7 +284,7 @@ impl<'a> CreateIssuingCardholderSpendingControls<'a> {
         }
     }
 }
-impl<'a> Default for CreateIssuingCardholderSpendingControls<'a> {
+impl Default for CreateIssuingCardholderSpendingControls {
     fn default() -> Self {
         Self::new()
     }
@@ -2352,23 +2352,23 @@ impl<'de> serde::Deserialize<'de> for CreateIssuingCardholderSpendingControlsBlo
     }
 }
 /// Limit spending with amount-based rules that apply across this cardholder's cards.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateIssuingCardholderSpendingControlsSpendingLimits<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateIssuingCardholderSpendingControlsSpendingLimits {
     /// Maximum amount allowed to spend per interval.
     pub amount: i64,
     /// Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) this limit applies to.
     /// Omitting this field will apply the limit to all categories.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub categories: Option<&'a [CreateIssuingCardholderSpendingControlsSpendingLimitsCategories]>,
+    pub categories: Option<Vec<CreateIssuingCardholderSpendingControlsSpendingLimitsCategories>>,
     /// Interval (or event) to which the amount applies.
     pub interval: CreateIssuingCardholderSpendingControlsSpendingLimitsInterval,
 }
-impl<'a> CreateIssuingCardholderSpendingControlsSpendingLimits<'a> {
+impl CreateIssuingCardholderSpendingControlsSpendingLimits {
     pub fn new(
-        amount: i64,
-        interval: CreateIssuingCardholderSpendingControlsSpendingLimitsInterval,
+        amount: impl Into<i64>,
+        interval: impl Into<CreateIssuingCardholderSpendingControlsSpendingLimitsInterval>,
     ) -> Self {
-        Self { amount, categories: None, interval }
+        Self { amount: amount.into(), categories: None, interval: interval.into() }
     }
 }
 /// Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) this limit applies to.
@@ -3533,48 +3533,51 @@ impl<'de> serde::Deserialize<'de> for CreateIssuingCardholderStatus {
 }
 /// Creates a new Issuing `Cardholder` object that can be issued cards.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateIssuingCardholder<'a> {
-    inner: CreateIssuingCardholderBuilder<'a>,
+pub struct CreateIssuingCardholder {
+    inner: CreateIssuingCardholderBuilder,
 }
-impl<'a> CreateIssuingCardholder<'a> {
+impl CreateIssuingCardholder {
     /// Construct a new `CreateIssuingCardholder`.
-    pub fn new(billing: BillingSpecs<'a>, name: &'a str) -> Self {
-        Self { inner: CreateIssuingCardholderBuilder::new(billing, name) }
+    pub fn new(billing: impl Into<BillingSpecs>, name: impl Into<String>) -> Self {
+        Self { inner: CreateIssuingCardholderBuilder::new(billing.into(), name.into()) }
     }
     /// Additional information about a `company` cardholder.
-    pub fn company(mut self, company: CompanyParam<'a>) -> Self {
-        self.inner.company = Some(company);
+    pub fn company(mut self, company: impl Into<CompanyParam>) -> Self {
+        self.inner.company = Some(company.into());
         self
     }
     /// The cardholder's email address.
-    pub fn email(mut self, email: &'a str) -> Self {
-        self.inner.email = Some(email);
+    pub fn email(mut self, email: impl Into<String>) -> Self {
+        self.inner.email = Some(email.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Additional information about an `individual` cardholder.
-    pub fn individual(mut self, individual: IndividualParam<'a>) -> Self {
-        self.inner.individual = Some(individual);
+    pub fn individual(mut self, individual: impl Into<IndividualParam>) -> Self {
+        self.inner.individual = Some(individual.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// The cardholder's phone number.
     /// This will be transformed to [E.164](https://en.wikipedia.org/wiki/E.164) if it is not provided in that format already.
     /// This is required for all cardholders who will be creating EU cards.
     /// See the [3D Secure documentation](https://stripe.com/docs/issuing/3d-secure#when-is-3d-secure-applied) for more details.
-    pub fn phone_number(mut self, phone_number: &'a str) -> Self {
-        self.inner.phone_number = Some(phone_number);
+    pub fn phone_number(mut self, phone_number: impl Into<String>) -> Self {
+        self.inner.phone_number = Some(phone_number.into());
         self
     }
     /// The cardholder’s preferred locales (languages), ordered by preference.
@@ -3582,33 +3585,33 @@ impl<'a> CreateIssuingCardholder<'a> {
     /// This changes the language of the [3D Secure flow](https://stripe.com/docs/issuing/3d-secure) and one-time password messages sent to the cardholder.
     pub fn preferred_locales(
         mut self,
-        preferred_locales: &'a [stripe_shared::IssuingCardholderPreferredLocales],
+        preferred_locales: impl Into<Vec<stripe_shared::IssuingCardholderPreferredLocales>>,
     ) -> Self {
-        self.inner.preferred_locales = Some(preferred_locales);
+        self.inner.preferred_locales = Some(preferred_locales.into());
         self
     }
     /// Rules that control spending across this cardholder's cards.
     /// Refer to our [documentation](https://stripe.com/docs/issuing/controls/spending-controls) for more details.
     pub fn spending_controls(
         mut self,
-        spending_controls: CreateIssuingCardholderSpendingControls<'a>,
+        spending_controls: impl Into<CreateIssuingCardholderSpendingControls>,
     ) -> Self {
-        self.inner.spending_controls = Some(spending_controls);
+        self.inner.spending_controls = Some(spending_controls.into());
         self
     }
     /// Specifies whether to permit authorizations on this cardholder's cards. Defaults to `active`.
-    pub fn status(mut self, status: CreateIssuingCardholderStatus) -> Self {
-        self.inner.status = Some(status);
+    pub fn status(mut self, status: impl Into<CreateIssuingCardholderStatus>) -> Self {
+        self.inner.status = Some(status.into());
         self
     }
     /// One of `individual` or `company`.
     /// See [Choose a cardholder type](https://stripe.com/docs/issuing/other/choose-cardholder) for more details.
-    pub fn type_(mut self, type_: stripe_shared::IssuingCardholderType) -> Self {
-        self.inner.type_ = Some(type_);
+    pub fn type_(mut self, type_: impl Into<stripe_shared::IssuingCardholderType>) -> Self {
+        self.inner.type_ = Some(type_.into());
         self
     }
 }
-impl CreateIssuingCardholder<'_> {
+impl CreateIssuingCardholder {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -3626,37 +3629,37 @@ impl CreateIssuingCardholder<'_> {
     }
 }
 
-impl StripeRequest for CreateIssuingCardholder<'_> {
+impl StripeRequest for CreateIssuingCardholder {
     type Output = stripe_shared::IssuingCardholder;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Post, "/issuing/cardholders").form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdateIssuingCardholderBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdateIssuingCardholderBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    billing: Option<BillingSpecs<'a>>,
+    billing: Option<BillingSpecs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    company: Option<CompanyParam<'a>>,
+    company: Option<CompanyParam>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    email: Option<&'a str>,
+    email: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    individual: Option<IndividualParam<'a>>,
+    individual: Option<IndividualParam>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    phone_number: Option<&'a str>,
+    phone_number: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    preferred_locales: Option<&'a [stripe_shared::IssuingCardholderPreferredLocales]>,
+    preferred_locales: Option<Vec<stripe_shared::IssuingCardholderPreferredLocales>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    spending_controls: Option<UpdateIssuingCardholderSpendingControls<'a>>,
+    spending_controls: Option<UpdateIssuingCardholderSpendingControls>,
     #[serde(skip_serializing_if = "Option::is_none")]
     status: Option<UpdateIssuingCardholderStatus>,
 }
-impl<'a> UpdateIssuingCardholderBuilder<'a> {
+impl UpdateIssuingCardholderBuilder {
     fn new() -> Self {
         Self {
             billing: None,
@@ -3674,13 +3677,13 @@ impl<'a> UpdateIssuingCardholderBuilder<'a> {
 }
 /// Rules that control spending across this cardholder's cards.
 /// Refer to our [documentation](https://stripe.com/docs/issuing/controls/spending-controls) for more details.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateIssuingCardholderSpendingControls<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateIssuingCardholderSpendingControls {
     /// Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to allow.
     /// All other categories will be blocked.
     /// Cannot be set with `blocked_categories`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub allowed_categories: Option<&'a [UpdateIssuingCardholderSpendingControlsAllowedCategories]>,
+    pub allowed_categories: Option<Vec<UpdateIssuingCardholderSpendingControlsAllowedCategories>>,
     /// Array of strings containing representing countries from which authorizations will be allowed.
     /// Authorizations from merchants in all other countries will be declined.
     /// Country codes should be ISO 3166 alpha-2 country codes (e.g.
@@ -3688,27 +3691,27 @@ pub struct UpdateIssuingCardholderSpendingControls<'a> {
     /// Cannot be set with `blocked_merchant_countries`.
     /// Provide an empty value to unset this control.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub allowed_merchant_countries: Option<&'a [&'a str]>,
+    pub allowed_merchant_countries: Option<Vec<String>>,
     /// Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to decline.
     /// All other categories will be allowed.
     /// Cannot be set with `allowed_categories`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub blocked_categories: Option<&'a [UpdateIssuingCardholderSpendingControlsBlockedCategories]>,
+    pub blocked_categories: Option<Vec<UpdateIssuingCardholderSpendingControlsBlockedCategories>>,
     /// Array of strings containing representing countries from which authorizations will be declined.
     /// Country codes should be ISO 3166 alpha-2 country codes (e.g.
     /// `US`).
     /// Cannot be set with `allowed_merchant_countries`.
     /// Provide an empty value to unset this control.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub blocked_merchant_countries: Option<&'a [&'a str]>,
+    pub blocked_merchant_countries: Option<Vec<String>>,
     /// Limit spending with amount-based rules that apply across this cardholder's cards.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub spending_limits: Option<&'a [UpdateIssuingCardholderSpendingControlsSpendingLimits<'a>]>,
+    pub spending_limits: Option<Vec<UpdateIssuingCardholderSpendingControlsSpendingLimits>>,
     /// Currency of amounts within `spending_limits`. Defaults to your merchant country's currency.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub spending_limits_currency: Option<stripe_types::Currency>,
 }
-impl<'a> UpdateIssuingCardholderSpendingControls<'a> {
+impl UpdateIssuingCardholderSpendingControls {
     pub fn new() -> Self {
         Self {
             allowed_categories: None,
@@ -3720,7 +3723,7 @@ impl<'a> UpdateIssuingCardholderSpendingControls<'a> {
         }
     }
 }
-impl<'a> Default for UpdateIssuingCardholderSpendingControls<'a> {
+impl Default for UpdateIssuingCardholderSpendingControls {
     fn default() -> Self {
         Self::new()
     }
@@ -5788,23 +5791,23 @@ impl<'de> serde::Deserialize<'de> for UpdateIssuingCardholderSpendingControlsBlo
     }
 }
 /// Limit spending with amount-based rules that apply across this cardholder's cards.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateIssuingCardholderSpendingControlsSpendingLimits<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateIssuingCardholderSpendingControlsSpendingLimits {
     /// Maximum amount allowed to spend per interval.
     pub amount: i64,
     /// Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) this limit applies to.
     /// Omitting this field will apply the limit to all categories.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub categories: Option<&'a [UpdateIssuingCardholderSpendingControlsSpendingLimitsCategories]>,
+    pub categories: Option<Vec<UpdateIssuingCardholderSpendingControlsSpendingLimitsCategories>>,
     /// Interval (or event) to which the amount applies.
     pub interval: UpdateIssuingCardholderSpendingControlsSpendingLimitsInterval,
 }
-impl<'a> UpdateIssuingCardholderSpendingControlsSpendingLimits<'a> {
+impl UpdateIssuingCardholderSpendingControlsSpendingLimits {
     pub fn new(
-        amount: i64,
-        interval: UpdateIssuingCardholderSpendingControlsSpendingLimitsInterval,
+        amount: impl Into<i64>,
+        interval: impl Into<UpdateIssuingCardholderSpendingControlsSpendingLimitsInterval>,
     ) -> Self {
-        Self { amount, categories: None, interval }
+        Self { amount: amount.into(), categories: None, interval: interval.into() }
     }
 }
 /// Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) this limit applies to.
@@ -6970,53 +6973,56 @@ impl<'de> serde::Deserialize<'de> for UpdateIssuingCardholderStatus {
 /// Updates the specified Issuing `Cardholder` object by setting the values of the parameters passed.
 /// Any parameters not provided will be left unchanged.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateIssuingCardholder<'a> {
-    inner: UpdateIssuingCardholderBuilder<'a>,
-    cardholder: &'a stripe_shared::IssuingCardholderId,
+pub struct UpdateIssuingCardholder {
+    inner: UpdateIssuingCardholderBuilder,
+    cardholder: stripe_shared::IssuingCardholderId,
 }
-impl<'a> UpdateIssuingCardholder<'a> {
+impl UpdateIssuingCardholder {
     /// Construct a new `UpdateIssuingCardholder`.
-    pub fn new(cardholder: &'a stripe_shared::IssuingCardholderId) -> Self {
-        Self { cardholder, inner: UpdateIssuingCardholderBuilder::new() }
+    pub fn new(cardholder: impl Into<stripe_shared::IssuingCardholderId>) -> Self {
+        Self { cardholder: cardholder.into(), inner: UpdateIssuingCardholderBuilder::new() }
     }
     /// The cardholder's billing address.
-    pub fn billing(mut self, billing: BillingSpecs<'a>) -> Self {
-        self.inner.billing = Some(billing);
+    pub fn billing(mut self, billing: impl Into<BillingSpecs>) -> Self {
+        self.inner.billing = Some(billing.into());
         self
     }
     /// Additional information about a `company` cardholder.
-    pub fn company(mut self, company: CompanyParam<'a>) -> Self {
-        self.inner.company = Some(company);
+    pub fn company(mut self, company: impl Into<CompanyParam>) -> Self {
+        self.inner.company = Some(company.into());
         self
     }
     /// The cardholder's email address.
-    pub fn email(mut self, email: &'a str) -> Self {
-        self.inner.email = Some(email);
+    pub fn email(mut self, email: impl Into<String>) -> Self {
+        self.inner.email = Some(email.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Additional information about an `individual` cardholder.
-    pub fn individual(mut self, individual: IndividualParam<'a>) -> Self {
-        self.inner.individual = Some(individual);
+    pub fn individual(mut self, individual: impl Into<IndividualParam>) -> Self {
+        self.inner.individual = Some(individual.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// The cardholder's phone number.
     /// This is required for all cardholders who will be creating EU cards.
     /// See the [3D Secure documentation](https://stripe.com/docs/issuing/3d-secure) for more details.
-    pub fn phone_number(mut self, phone_number: &'a str) -> Self {
-        self.inner.phone_number = Some(phone_number);
+    pub fn phone_number(mut self, phone_number: impl Into<String>) -> Self {
+        self.inner.phone_number = Some(phone_number.into());
         self
     }
     /// The cardholder’s preferred locales (languages), ordered by preference.
@@ -7024,27 +7030,27 @@ impl<'a> UpdateIssuingCardholder<'a> {
     /// This changes the language of the [3D Secure flow](https://stripe.com/docs/issuing/3d-secure) and one-time password messages sent to the cardholder.
     pub fn preferred_locales(
         mut self,
-        preferred_locales: &'a [stripe_shared::IssuingCardholderPreferredLocales],
+        preferred_locales: impl Into<Vec<stripe_shared::IssuingCardholderPreferredLocales>>,
     ) -> Self {
-        self.inner.preferred_locales = Some(preferred_locales);
+        self.inner.preferred_locales = Some(preferred_locales.into());
         self
     }
     /// Rules that control spending across this cardholder's cards.
     /// Refer to our [documentation](https://stripe.com/docs/issuing/controls/spending-controls) for more details.
     pub fn spending_controls(
         mut self,
-        spending_controls: UpdateIssuingCardholderSpendingControls<'a>,
+        spending_controls: impl Into<UpdateIssuingCardholderSpendingControls>,
     ) -> Self {
-        self.inner.spending_controls = Some(spending_controls);
+        self.inner.spending_controls = Some(spending_controls.into());
         self
     }
     /// Specifies whether to permit authorizations on this cardholder's cards.
-    pub fn status(mut self, status: UpdateIssuingCardholderStatus) -> Self {
-        self.inner.status = Some(status);
+    pub fn status(mut self, status: impl Into<UpdateIssuingCardholderStatus>) -> Self {
+        self.inner.status = Some(status.into());
         self
     }
 }
-impl UpdateIssuingCardholder<'_> {
+impl UpdateIssuingCardholder {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -7062,56 +7068,68 @@ impl UpdateIssuingCardholder<'_> {
     }
 }
 
-impl StripeRequest for UpdateIssuingCardholder<'_> {
+impl StripeRequest for UpdateIssuingCardholder {
     type Output = stripe_shared::IssuingCardholder;
 
     fn build(&self) -> RequestBuilder {
-        let cardholder = self.cardholder;
+        let cardholder = &self.cardholder;
         RequestBuilder::new(StripeMethod::Post, format!("/issuing/cardholders/{cardholder}"))
             .form(&self.inner)
     }
 }
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct RequiredAddress<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct RequiredAddress {
     /// City, district, suburb, town, or village.
-    pub city: &'a str,
+    pub city: String,
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
-    pub country: &'a str,
+    pub country: String,
     /// Address line 1 (e.g., street, PO Box, or company name).
-    pub line1: &'a str,
+    pub line1: String,
     /// Address line 2 (e.g., apartment, suite, unit, or building).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line2: Option<&'a str>,
+    pub line2: Option<String>,
     /// ZIP or postal code.
-    pub postal_code: &'a str,
+    pub postal_code: String,
     /// State, county, province, or region.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
 }
-impl<'a> RequiredAddress<'a> {
-    pub fn new(city: &'a str, country: &'a str, line1: &'a str, postal_code: &'a str) -> Self {
-        Self { city, country, line1, line2: None, postal_code, state: None }
+impl RequiredAddress {
+    pub fn new(
+        city: impl Into<String>,
+        country: impl Into<String>,
+        line1: impl Into<String>,
+        postal_code: impl Into<String>,
+    ) -> Self {
+        Self {
+            city: city.into(),
+            country: country.into(),
+            line1: line1.into(),
+            line2: None,
+            postal_code: postal_code.into(),
+            state: None,
+        }
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CompanyParam<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CompanyParam {
     /// The entity's business ID number.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_id: Option<&'a str>,
+    pub tax_id: Option<String>,
 }
-impl<'a> CompanyParam<'a> {
+impl CompanyParam {
     pub fn new() -> Self {
         Self { tax_id: None }
     }
 }
-impl<'a> Default for CompanyParam<'a> {
+impl Default for CompanyParam {
     fn default() -> Self {
         Self::new()
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct TermsAcceptanceParam<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct TermsAcceptanceParam {
     /// The Unix timestamp marking when the cardholder accepted the Authorized User Terms.
     /// Required for Celtic Spend Card users.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -7119,17 +7137,17 @@ pub struct TermsAcceptanceParam<'a> {
     /// The IP address from which the cardholder accepted the Authorized User Terms.
     /// Required for Celtic Spend Card users.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ip: Option<&'a str>,
+    pub ip: Option<String>,
     /// The user agent of the browser from which the cardholder accepted the Authorized User Terms.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user_agent: Option<&'a str>,
+    pub user_agent: Option<String>,
 }
-impl<'a> TermsAcceptanceParam<'a> {
+impl TermsAcceptanceParam {
     pub fn new() -> Self {
         Self { date: None, ip: None, user_agent: None }
     }
 }
-impl<'a> Default for TermsAcceptanceParam<'a> {
+impl Default for TermsAcceptanceParam {
     fn default() -> Self {
         Self::new()
     }
@@ -7144,77 +7162,77 @@ pub struct DateOfBirthSpecs {
     pub year: i64,
 }
 impl DateOfBirthSpecs {
-    pub fn new(day: i64, month: i64, year: i64) -> Self {
-        Self { day, month, year }
+    pub fn new(day: impl Into<i64>, month: impl Into<i64>, year: impl Into<i64>) -> Self {
+        Self { day: day.into(), month: month.into(), year: year.into() }
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct PersonVerificationDocumentParam<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct PersonVerificationDocumentParam {
     /// The back of an ID returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `identity_document`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub back: Option<&'a str>,
+    pub back: Option<String>,
     /// The front of an ID returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `identity_document`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub front: Option<&'a str>,
+    pub front: Option<String>,
 }
-impl<'a> PersonVerificationDocumentParam<'a> {
+impl PersonVerificationDocumentParam {
     pub fn new() -> Self {
         Self { back: None, front: None }
     }
 }
-impl<'a> Default for PersonVerificationDocumentParam<'a> {
+impl Default for PersonVerificationDocumentParam {
     fn default() -> Self {
         Self::new()
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct BillingSpecs<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct BillingSpecs {
     /// The cardholder’s billing address.
-    pub address: RequiredAddress<'a>,
+    pub address: RequiredAddress,
 }
-impl<'a> BillingSpecs<'a> {
-    pub fn new(address: RequiredAddress<'a>) -> Self {
-        Self { address }
+impl BillingSpecs {
+    pub fn new(address: impl Into<RequiredAddress>) -> Self {
+        Self { address: address.into() }
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CardIssuingParam<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CardIssuingParam {
     /// Information about cardholder acceptance of Celtic [Authorized User Terms](https://stripe.com/docs/issuing/cards#accept-authorized-user-terms).
     /// Required for cards backed by a Celtic program.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user_terms_acceptance: Option<TermsAcceptanceParam<'a>>,
+    pub user_terms_acceptance: Option<TermsAcceptanceParam>,
 }
-impl<'a> CardIssuingParam<'a> {
+impl CardIssuingParam {
     pub fn new() -> Self {
         Self { user_terms_acceptance: None }
     }
 }
-impl<'a> Default for CardIssuingParam<'a> {
+impl Default for CardIssuingParam {
     fn default() -> Self {
         Self::new()
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct PersonVerificationParam<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct PersonVerificationParam {
     /// An identifying document, either a passport or local ID card.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub document: Option<PersonVerificationDocumentParam<'a>>,
+    pub document: Option<PersonVerificationDocumentParam>,
 }
-impl<'a> PersonVerificationParam<'a> {
+impl PersonVerificationParam {
     pub fn new() -> Self {
         Self { document: None }
     }
 }
-impl<'a> Default for PersonVerificationParam<'a> {
+impl Default for PersonVerificationParam {
     fn default() -> Self {
         Self::new()
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct IndividualParam<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct IndividualParam {
     /// Information related to the card_issuing program for this cardholder.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub card_issuing: Option<CardIssuingParam<'a>>,
+    pub card_issuing: Option<CardIssuingParam>,
     /// The date of birth of this cardholder. Cardholders must be older than 13 years old.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub dob: Option<DateOfBirthSpecs>,
@@ -7222,17 +7240,17 @@ pub struct IndividualParam<'a> {
     /// Required before activating Cards.
     /// This field cannot contain any numbers, special characters (except periods, commas, hyphens, spaces and apostrophes) or non-latin letters.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub first_name: Option<&'a str>,
+    pub first_name: Option<String>,
     /// The last name of this cardholder.
     /// Required before activating Cards.
     /// This field cannot contain any numbers, special characters (except periods, commas, hyphens, spaces and apostrophes) or non-latin letters.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub last_name: Option<&'a str>,
+    pub last_name: Option<String>,
     /// Government-issued ID document for this cardholder.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub verification: Option<PersonVerificationParam<'a>>,
+    pub verification: Option<PersonVerificationParam>,
 }
-impl<'a> IndividualParam<'a> {
+impl IndividualParam {
     pub fn new() -> Self {
         Self {
             card_issuing: None,
@@ -7243,7 +7261,7 @@ impl<'a> IndividualParam<'a> {
         }
     }
 }
-impl<'a> Default for IndividualParam<'a> {
+impl Default for IndividualParam {
     fn default() -> Self {
         Self::new()
     }

--- a/generated/async-stripe-issuing/src/issuing_dispute/requests.rs
+++ b/generated/async-stripe-issuing/src/issuing_dispute/requests.rs
@@ -2,24 +2,24 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListIssuingDisputeBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListIssuingDisputeBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     created: Option<stripe_types::RangeQueryTs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     status: Option<stripe_shared::IssuingDisputeStatus>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    transaction: Option<&'a str>,
+    transaction: Option<String>,
 }
-impl<'a> ListIssuingDisputeBuilder<'a> {
+impl ListIssuingDisputeBuilder {
     fn new() -> Self {
         Self {
             created: None,
@@ -35,61 +35,61 @@ impl<'a> ListIssuingDisputeBuilder<'a> {
 /// Returns a list of Issuing `Dispute` objects.
 /// The objects are sorted in descending order by creation date, with the most recently created object appearing first.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListIssuingDispute<'a> {
-    inner: ListIssuingDisputeBuilder<'a>,
+pub struct ListIssuingDispute {
+    inner: ListIssuingDisputeBuilder,
 }
-impl<'a> ListIssuingDispute<'a> {
+impl ListIssuingDispute {
     /// Construct a new `ListIssuingDispute`.
     pub fn new() -> Self {
         Self { inner: ListIssuingDisputeBuilder::new() }
     }
     /// Only return Issuing disputes that were created during the given date interval.
-    pub fn created(mut self, created: stripe_types::RangeQueryTs) -> Self {
-        self.inner.created = Some(created);
+    pub fn created(mut self, created: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.created = Some(created.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
     /// Select Issuing disputes with the given status.
-    pub fn status(mut self, status: stripe_shared::IssuingDisputeStatus) -> Self {
-        self.inner.status = Some(status);
+    pub fn status(mut self, status: impl Into<stripe_shared::IssuingDisputeStatus>) -> Self {
+        self.inner.status = Some(status.into());
         self
     }
     /// Select the Issuing dispute for the given transaction.
-    pub fn transaction(mut self, transaction: &'a str) -> Self {
-        self.inner.transaction = Some(transaction);
+    pub fn transaction(mut self, transaction: impl Into<String>) -> Self {
+        self.inner.transaction = Some(transaction.into());
         self
     }
 }
-impl<'a> Default for ListIssuingDispute<'a> {
+impl Default for ListIssuingDispute {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListIssuingDispute<'_> {
+impl ListIssuingDispute {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -109,45 +109,45 @@ impl ListIssuingDispute<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::IssuingDispute>> {
-        stripe_client_core::ListPaginator::new_list("/issuing/disputes", self.inner)
+        stripe_client_core::ListPaginator::new_list("/issuing/disputes", &self.inner)
     }
 }
 
-impl StripeRequest for ListIssuingDispute<'_> {
+impl StripeRequest for ListIssuingDispute {
     type Output = stripe_types::List<stripe_shared::IssuingDispute>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/issuing/disputes").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveIssuingDisputeBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveIssuingDisputeBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveIssuingDisputeBuilder<'a> {
+impl RetrieveIssuingDisputeBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves an Issuing `Dispute` object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveIssuingDispute<'a> {
-    inner: RetrieveIssuingDisputeBuilder<'a>,
-    dispute: &'a stripe_shared::IssuingDisputeId,
+pub struct RetrieveIssuingDispute {
+    inner: RetrieveIssuingDisputeBuilder,
+    dispute: stripe_shared::IssuingDisputeId,
 }
-impl<'a> RetrieveIssuingDispute<'a> {
+impl RetrieveIssuingDispute {
     /// Construct a new `RetrieveIssuingDispute`.
-    pub fn new(dispute: &'a stripe_shared::IssuingDisputeId) -> Self {
-        Self { dispute, inner: RetrieveIssuingDisputeBuilder::new() }
+    pub fn new(dispute: impl Into<stripe_shared::IssuingDisputeId>) -> Self {
+        Self { dispute: dispute.into(), inner: RetrieveIssuingDisputeBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveIssuingDispute<'_> {
+impl RetrieveIssuingDispute {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -165,31 +165,31 @@ impl RetrieveIssuingDispute<'_> {
     }
 }
 
-impl StripeRequest for RetrieveIssuingDispute<'_> {
+impl StripeRequest for RetrieveIssuingDispute {
     type Output = stripe_shared::IssuingDispute;
 
     fn build(&self) -> RequestBuilder {
-        let dispute = self.dispute;
+        let dispute = &self.dispute;
         RequestBuilder::new(StripeMethod::Get, format!("/issuing/disputes/{dispute}"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateIssuingDisputeBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateIssuingDisputeBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     amount: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    evidence: Option<CreateIssuingDisputeEvidence<'a>>,
+    evidence: Option<CreateIssuingDisputeEvidence>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    transaction: Option<&'a str>,
+    transaction: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    treasury: Option<CreateIssuingDisputeTreasury<'a>>,
+    treasury: Option<CreateIssuingDisputeTreasury>,
 }
-impl<'a> CreateIssuingDisputeBuilder<'a> {
+impl CreateIssuingDisputeBuilder {
     fn new() -> Self {
         Self {
             amount: None,
@@ -202,35 +202,34 @@ impl<'a> CreateIssuingDisputeBuilder<'a> {
     }
 }
 /// Evidence provided for the dispute.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateIssuingDisputeEvidence<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateIssuingDisputeEvidence {
     /// Evidence provided when `reason` is 'canceled'.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub canceled: Option<CreateIssuingDisputeEvidenceCanceled<'a>>,
+    pub canceled: Option<CreateIssuingDisputeEvidenceCanceled>,
     /// Evidence provided when `reason` is 'duplicate'.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub duplicate: Option<Duplicate<'a>>,
+    pub duplicate: Option<Duplicate>,
     /// Evidence provided when `reason` is 'fraudulent'.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub fraudulent: Option<Fraudulent<'a>>,
+    pub fraudulent: Option<Fraudulent>,
     /// Evidence provided when `reason` is 'merchandise_not_as_described'.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub merchandise_not_as_described:
-        Option<CreateIssuingDisputeEvidenceMerchandiseNotAsDescribed<'a>>,
+    pub merchandise_not_as_described: Option<CreateIssuingDisputeEvidenceMerchandiseNotAsDescribed>,
     /// Evidence provided when `reason` is 'not_received'.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub not_received: Option<CreateIssuingDisputeEvidenceNotReceived<'a>>,
+    pub not_received: Option<CreateIssuingDisputeEvidenceNotReceived>,
     /// Evidence provided when `reason` is 'other'.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub other: Option<CreateIssuingDisputeEvidenceOther<'a>>,
+    pub other: Option<CreateIssuingDisputeEvidenceOther>,
     /// The reason for filing the dispute. The evidence should be submitted in the field of the same name.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reason: Option<CreateIssuingDisputeEvidenceReason>,
     /// Evidence provided when `reason` is 'service_not_as_described'.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub service_not_as_described: Option<ServiceNotAsDescribed<'a>>,
+    pub service_not_as_described: Option<ServiceNotAsDescribed>,
 }
-impl<'a> CreateIssuingDisputeEvidence<'a> {
+impl CreateIssuingDisputeEvidence {
     pub fn new() -> Self {
         Self {
             canceled: None,
@@ -244,17 +243,17 @@ impl<'a> CreateIssuingDisputeEvidence<'a> {
         }
     }
 }
-impl<'a> Default for CreateIssuingDisputeEvidence<'a> {
+impl Default for CreateIssuingDisputeEvidence {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Evidence provided when `reason` is 'canceled'.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateIssuingDisputeEvidenceCanceled<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateIssuingDisputeEvidenceCanceled {
     /// (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Additional documentation supporting the dispute.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub additional_documentation: Option<&'a str>,
+    pub additional_documentation: Option<String>,
     /// Date when order was canceled.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub canceled_at: Option<stripe_types::Timestamp>,
@@ -263,16 +262,16 @@ pub struct CreateIssuingDisputeEvidenceCanceled<'a> {
     pub cancellation_policy_provided: Option<bool>,
     /// Reason for canceling the order.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub cancellation_reason: Option<&'a str>,
+    pub cancellation_reason: Option<String>,
     /// Date when the cardholder expected to receive the product.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expected_at: Option<stripe_types::Timestamp>,
     /// Explanation of why the cardholder is disputing this transaction.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub explanation: Option<&'a str>,
+    pub explanation: Option<String>,
     /// Description of the merchandise or service that was purchased.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub product_description: Option<&'a str>,
+    pub product_description: Option<String>,
     /// Whether the product was a merchandise or service.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub product_type: Option<CreateIssuingDisputeEvidenceCanceledProductType>,
@@ -283,7 +282,7 @@ pub struct CreateIssuingDisputeEvidenceCanceled<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub returned_at: Option<stripe_types::Timestamp>,
 }
-impl<'a> CreateIssuingDisputeEvidenceCanceled<'a> {
+impl CreateIssuingDisputeEvidenceCanceled {
     pub fn new() -> Self {
         Self {
             additional_documentation: None,
@@ -299,7 +298,7 @@ impl<'a> CreateIssuingDisputeEvidenceCanceled<'a> {
         }
     }
 }
-impl<'a> Default for CreateIssuingDisputeEvidenceCanceled<'a> {
+impl Default for CreateIssuingDisputeEvidenceCanceled {
     fn default() -> Self {
         Self::new()
     }
@@ -421,20 +420,20 @@ impl<'de> serde::Deserialize<'de> for CreateIssuingDisputeEvidenceCanceledReturn
     }
 }
 /// Evidence provided when `reason` is 'merchandise_not_as_described'.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateIssuingDisputeEvidenceMerchandiseNotAsDescribed<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateIssuingDisputeEvidenceMerchandiseNotAsDescribed {
     /// (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Additional documentation supporting the dispute.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub additional_documentation: Option<&'a str>,
+    pub additional_documentation: Option<String>,
     /// Explanation of why the cardholder is disputing this transaction.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub explanation: Option<&'a str>,
+    pub explanation: Option<String>,
     /// Date when the product was received.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub received_at: Option<stripe_types::Timestamp>,
     /// Description of the cardholder's attempt to return the product.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub return_description: Option<&'a str>,
+    pub return_description: Option<String>,
     /// Result of cardholder's attempt to return the product.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub return_status: Option<CreateIssuingDisputeEvidenceMerchandiseNotAsDescribedReturnStatus>,
@@ -442,7 +441,7 @@ pub struct CreateIssuingDisputeEvidenceMerchandiseNotAsDescribed<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub returned_at: Option<stripe_types::Timestamp>,
 }
-impl<'a> CreateIssuingDisputeEvidenceMerchandiseNotAsDescribed<'a> {
+impl CreateIssuingDisputeEvidenceMerchandiseNotAsDescribed {
     pub fn new() -> Self {
         Self {
             additional_documentation: None,
@@ -454,7 +453,7 @@ impl<'a> CreateIssuingDisputeEvidenceMerchandiseNotAsDescribed<'a> {
         }
     }
 }
-impl<'a> Default for CreateIssuingDisputeEvidenceMerchandiseNotAsDescribed<'a> {
+impl Default for CreateIssuingDisputeEvidenceMerchandiseNotAsDescribed {
     fn default() -> Self {
         Self::new()
     }
@@ -516,25 +515,25 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// Evidence provided when `reason` is 'not_received'.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateIssuingDisputeEvidenceNotReceived<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateIssuingDisputeEvidenceNotReceived {
     /// (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Additional documentation supporting the dispute.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub additional_documentation: Option<&'a str>,
+    pub additional_documentation: Option<String>,
     /// Date when the cardholder expected to receive the product.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expected_at: Option<stripe_types::Timestamp>,
     /// Explanation of why the cardholder is disputing this transaction.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub explanation: Option<&'a str>,
+    pub explanation: Option<String>,
     /// Description of the merchandise or service that was purchased.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub product_description: Option<&'a str>,
+    pub product_description: Option<String>,
     /// Whether the product was a merchandise or service.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub product_type: Option<CreateIssuingDisputeEvidenceNotReceivedProductType>,
 }
-impl<'a> CreateIssuingDisputeEvidenceNotReceived<'a> {
+impl CreateIssuingDisputeEvidenceNotReceived {
     pub fn new() -> Self {
         Self {
             additional_documentation: None,
@@ -545,7 +544,7 @@ impl<'a> CreateIssuingDisputeEvidenceNotReceived<'a> {
         }
     }
 }
-impl<'a> Default for CreateIssuingDisputeEvidenceNotReceived<'a> {
+impl Default for CreateIssuingDisputeEvidenceNotReceived {
     fn default() -> Self {
         Self::new()
     }
@@ -609,22 +608,22 @@ impl<'de> serde::Deserialize<'de> for CreateIssuingDisputeEvidenceNotReceivedPro
     }
 }
 /// Evidence provided when `reason` is 'other'.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateIssuingDisputeEvidenceOther<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateIssuingDisputeEvidenceOther {
     /// (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Additional documentation supporting the dispute.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub additional_documentation: Option<&'a str>,
+    pub additional_documentation: Option<String>,
     /// Explanation of why the cardholder is disputing this transaction.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub explanation: Option<&'a str>,
+    pub explanation: Option<String>,
     /// Description of the merchandise or service that was purchased.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub product_description: Option<&'a str>,
+    pub product_description: Option<String>,
     /// Whether the product was a merchandise or service.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub product_type: Option<CreateIssuingDisputeEvidenceOtherProductType>,
 }
-impl<'a> CreateIssuingDisputeEvidenceOther<'a> {
+impl CreateIssuingDisputeEvidenceOther {
     pub fn new() -> Self {
         Self {
             additional_documentation: None,
@@ -634,7 +633,7 @@ impl<'a> CreateIssuingDisputeEvidenceOther<'a> {
         }
     }
 }
-impl<'a> Default for CreateIssuingDisputeEvidenceOther<'a> {
+impl Default for CreateIssuingDisputeEvidenceOther {
     fn default() -> Self {
         Self::new()
     }
@@ -769,14 +768,14 @@ impl<'de> serde::Deserialize<'de> for CreateIssuingDisputeEvidenceReason {
     }
 }
 /// Params for disputes related to Treasury FinancialAccounts
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateIssuingDisputeTreasury<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateIssuingDisputeTreasury {
     /// The ID of the ReceivedDebit to initiate an Issuings dispute for.
-    pub received_debit: &'a str,
+    pub received_debit: String,
 }
-impl<'a> CreateIssuingDisputeTreasury<'a> {
-    pub fn new(received_debit: &'a str) -> Self {
-        Self { received_debit }
+impl CreateIssuingDisputeTreasury {
+    pub fn new(received_debit: impl Into<String>) -> Self {
+        Self { received_debit: received_debit.into() }
     }
 }
 /// Creates an Issuing `Dispute` object.
@@ -784,56 +783,59 @@ impl<'a> CreateIssuingDisputeTreasury<'a> {
 /// Stripe only validates that required evidence is present during submission.
 /// Refer to [Dispute reasons and evidence](https://stripe.com/docs/issuing/purchases/disputes#dispute-reasons-and-evidence) for more details about evidence requirements.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateIssuingDispute<'a> {
-    inner: CreateIssuingDisputeBuilder<'a>,
+pub struct CreateIssuingDispute {
+    inner: CreateIssuingDisputeBuilder,
 }
-impl<'a> CreateIssuingDispute<'a> {
+impl CreateIssuingDispute {
     /// Construct a new `CreateIssuingDispute`.
     pub fn new() -> Self {
         Self { inner: CreateIssuingDisputeBuilder::new() }
     }
     /// The dispute amount in the card's currency and in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal).
     /// If not set, defaults to the full transaction amount.
-    pub fn amount(mut self, amount: i64) -> Self {
-        self.inner.amount = Some(amount);
+    pub fn amount(mut self, amount: impl Into<i64>) -> Self {
+        self.inner.amount = Some(amount.into());
         self
     }
     /// Evidence provided for the dispute.
-    pub fn evidence(mut self, evidence: CreateIssuingDisputeEvidence<'a>) -> Self {
-        self.inner.evidence = Some(evidence);
+    pub fn evidence(mut self, evidence: impl Into<CreateIssuingDisputeEvidence>) -> Self {
+        self.inner.evidence = Some(evidence.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// The ID of the issuing transaction to create a dispute for.
     /// For transaction on Treasury FinancialAccounts, use `treasury.received_debit`.
-    pub fn transaction(mut self, transaction: &'a str) -> Self {
-        self.inner.transaction = Some(transaction);
+    pub fn transaction(mut self, transaction: impl Into<String>) -> Self {
+        self.inner.transaction = Some(transaction.into());
         self
     }
     /// Params for disputes related to Treasury FinancialAccounts
-    pub fn treasury(mut self, treasury: CreateIssuingDisputeTreasury<'a>) -> Self {
-        self.inner.treasury = Some(treasury);
+    pub fn treasury(mut self, treasury: impl Into<CreateIssuingDisputeTreasury>) -> Self {
+        self.inner.treasury = Some(treasury.into());
         self
     }
 }
-impl<'a> Default for CreateIssuingDispute<'a> {
+impl Default for CreateIssuingDispute {
     fn default() -> Self {
         Self::new()
     }
 }
-impl CreateIssuingDispute<'_> {
+impl CreateIssuingDispute {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -851,59 +853,58 @@ impl CreateIssuingDispute<'_> {
     }
 }
 
-impl StripeRequest for CreateIssuingDispute<'_> {
+impl StripeRequest for CreateIssuingDispute {
     type Output = stripe_shared::IssuingDispute;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Post, "/issuing/disputes").form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdateIssuingDisputeBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdateIssuingDisputeBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     amount: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    evidence: Option<UpdateIssuingDisputeEvidence<'a>>,
+    evidence: Option<UpdateIssuingDisputeEvidence>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
 }
-impl<'a> UpdateIssuingDisputeBuilder<'a> {
+impl UpdateIssuingDisputeBuilder {
     fn new() -> Self {
         Self { amount: None, evidence: None, expand: None, metadata: None }
     }
 }
 /// Evidence provided for the dispute.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateIssuingDisputeEvidence<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateIssuingDisputeEvidence {
     /// Evidence provided when `reason` is 'canceled'.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub canceled: Option<UpdateIssuingDisputeEvidenceCanceled<'a>>,
+    pub canceled: Option<UpdateIssuingDisputeEvidenceCanceled>,
     /// Evidence provided when `reason` is 'duplicate'.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub duplicate: Option<Duplicate<'a>>,
+    pub duplicate: Option<Duplicate>,
     /// Evidence provided when `reason` is 'fraudulent'.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub fraudulent: Option<Fraudulent<'a>>,
+    pub fraudulent: Option<Fraudulent>,
     /// Evidence provided when `reason` is 'merchandise_not_as_described'.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub merchandise_not_as_described:
-        Option<UpdateIssuingDisputeEvidenceMerchandiseNotAsDescribed<'a>>,
+    pub merchandise_not_as_described: Option<UpdateIssuingDisputeEvidenceMerchandiseNotAsDescribed>,
     /// Evidence provided when `reason` is 'not_received'.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub not_received: Option<UpdateIssuingDisputeEvidenceNotReceived<'a>>,
+    pub not_received: Option<UpdateIssuingDisputeEvidenceNotReceived>,
     /// Evidence provided when `reason` is 'other'.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub other: Option<UpdateIssuingDisputeEvidenceOther<'a>>,
+    pub other: Option<UpdateIssuingDisputeEvidenceOther>,
     /// The reason for filing the dispute. The evidence should be submitted in the field of the same name.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reason: Option<UpdateIssuingDisputeEvidenceReason>,
     /// Evidence provided when `reason` is 'service_not_as_described'.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub service_not_as_described: Option<ServiceNotAsDescribed<'a>>,
+    pub service_not_as_described: Option<ServiceNotAsDescribed>,
 }
-impl<'a> UpdateIssuingDisputeEvidence<'a> {
+impl UpdateIssuingDisputeEvidence {
     pub fn new() -> Self {
         Self {
             canceled: None,
@@ -917,17 +918,17 @@ impl<'a> UpdateIssuingDisputeEvidence<'a> {
         }
     }
 }
-impl<'a> Default for UpdateIssuingDisputeEvidence<'a> {
+impl Default for UpdateIssuingDisputeEvidence {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Evidence provided when `reason` is 'canceled'.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateIssuingDisputeEvidenceCanceled<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateIssuingDisputeEvidenceCanceled {
     /// (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Additional documentation supporting the dispute.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub additional_documentation: Option<&'a str>,
+    pub additional_documentation: Option<String>,
     /// Date when order was canceled.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub canceled_at: Option<stripe_types::Timestamp>,
@@ -936,16 +937,16 @@ pub struct UpdateIssuingDisputeEvidenceCanceled<'a> {
     pub cancellation_policy_provided: Option<bool>,
     /// Reason for canceling the order.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub cancellation_reason: Option<&'a str>,
+    pub cancellation_reason: Option<String>,
     /// Date when the cardholder expected to receive the product.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expected_at: Option<stripe_types::Timestamp>,
     /// Explanation of why the cardholder is disputing this transaction.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub explanation: Option<&'a str>,
+    pub explanation: Option<String>,
     /// Description of the merchandise or service that was purchased.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub product_description: Option<&'a str>,
+    pub product_description: Option<String>,
     /// Whether the product was a merchandise or service.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub product_type: Option<UpdateIssuingDisputeEvidenceCanceledProductType>,
@@ -956,7 +957,7 @@ pub struct UpdateIssuingDisputeEvidenceCanceled<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub returned_at: Option<stripe_types::Timestamp>,
 }
-impl<'a> UpdateIssuingDisputeEvidenceCanceled<'a> {
+impl UpdateIssuingDisputeEvidenceCanceled {
     pub fn new() -> Self {
         Self {
             additional_documentation: None,
@@ -972,7 +973,7 @@ impl<'a> UpdateIssuingDisputeEvidenceCanceled<'a> {
         }
     }
 }
-impl<'a> Default for UpdateIssuingDisputeEvidenceCanceled<'a> {
+impl Default for UpdateIssuingDisputeEvidenceCanceled {
     fn default() -> Self {
         Self::new()
     }
@@ -1094,20 +1095,20 @@ impl<'de> serde::Deserialize<'de> for UpdateIssuingDisputeEvidenceCanceledReturn
     }
 }
 /// Evidence provided when `reason` is 'merchandise_not_as_described'.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateIssuingDisputeEvidenceMerchandiseNotAsDescribed<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateIssuingDisputeEvidenceMerchandiseNotAsDescribed {
     /// (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Additional documentation supporting the dispute.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub additional_documentation: Option<&'a str>,
+    pub additional_documentation: Option<String>,
     /// Explanation of why the cardholder is disputing this transaction.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub explanation: Option<&'a str>,
+    pub explanation: Option<String>,
     /// Date when the product was received.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub received_at: Option<stripe_types::Timestamp>,
     /// Description of the cardholder's attempt to return the product.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub return_description: Option<&'a str>,
+    pub return_description: Option<String>,
     /// Result of cardholder's attempt to return the product.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub return_status: Option<UpdateIssuingDisputeEvidenceMerchandiseNotAsDescribedReturnStatus>,
@@ -1115,7 +1116,7 @@ pub struct UpdateIssuingDisputeEvidenceMerchandiseNotAsDescribed<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub returned_at: Option<stripe_types::Timestamp>,
 }
-impl<'a> UpdateIssuingDisputeEvidenceMerchandiseNotAsDescribed<'a> {
+impl UpdateIssuingDisputeEvidenceMerchandiseNotAsDescribed {
     pub fn new() -> Self {
         Self {
             additional_documentation: None,
@@ -1127,7 +1128,7 @@ impl<'a> UpdateIssuingDisputeEvidenceMerchandiseNotAsDescribed<'a> {
         }
     }
 }
-impl<'a> Default for UpdateIssuingDisputeEvidenceMerchandiseNotAsDescribed<'a> {
+impl Default for UpdateIssuingDisputeEvidenceMerchandiseNotAsDescribed {
     fn default() -> Self {
         Self::new()
     }
@@ -1189,25 +1190,25 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// Evidence provided when `reason` is 'not_received'.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateIssuingDisputeEvidenceNotReceived<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateIssuingDisputeEvidenceNotReceived {
     /// (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Additional documentation supporting the dispute.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub additional_documentation: Option<&'a str>,
+    pub additional_documentation: Option<String>,
     /// Date when the cardholder expected to receive the product.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expected_at: Option<stripe_types::Timestamp>,
     /// Explanation of why the cardholder is disputing this transaction.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub explanation: Option<&'a str>,
+    pub explanation: Option<String>,
     /// Description of the merchandise or service that was purchased.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub product_description: Option<&'a str>,
+    pub product_description: Option<String>,
     /// Whether the product was a merchandise or service.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub product_type: Option<UpdateIssuingDisputeEvidenceNotReceivedProductType>,
 }
-impl<'a> UpdateIssuingDisputeEvidenceNotReceived<'a> {
+impl UpdateIssuingDisputeEvidenceNotReceived {
     pub fn new() -> Self {
         Self {
             additional_documentation: None,
@@ -1218,7 +1219,7 @@ impl<'a> UpdateIssuingDisputeEvidenceNotReceived<'a> {
         }
     }
 }
-impl<'a> Default for UpdateIssuingDisputeEvidenceNotReceived<'a> {
+impl Default for UpdateIssuingDisputeEvidenceNotReceived {
     fn default() -> Self {
         Self::new()
     }
@@ -1282,22 +1283,22 @@ impl<'de> serde::Deserialize<'de> for UpdateIssuingDisputeEvidenceNotReceivedPro
     }
 }
 /// Evidence provided when `reason` is 'other'.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateIssuingDisputeEvidenceOther<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateIssuingDisputeEvidenceOther {
     /// (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Additional documentation supporting the dispute.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub additional_documentation: Option<&'a str>,
+    pub additional_documentation: Option<String>,
     /// Explanation of why the cardholder is disputing this transaction.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub explanation: Option<&'a str>,
+    pub explanation: Option<String>,
     /// Description of the merchandise or service that was purchased.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub product_description: Option<&'a str>,
+    pub product_description: Option<String>,
     /// Whether the product was a merchandise or service.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub product_type: Option<UpdateIssuingDisputeEvidenceOtherProductType>,
 }
-impl<'a> UpdateIssuingDisputeEvidenceOther<'a> {
+impl UpdateIssuingDisputeEvidenceOther {
     pub fn new() -> Self {
         Self {
             additional_documentation: None,
@@ -1307,7 +1308,7 @@ impl<'a> UpdateIssuingDisputeEvidenceOther<'a> {
         }
     }
 }
-impl<'a> Default for UpdateIssuingDisputeEvidenceOther<'a> {
+impl Default for UpdateIssuingDisputeEvidenceOther {
     fn default() -> Self {
         Self::new()
     }
@@ -1445,40 +1446,43 @@ impl<'de> serde::Deserialize<'de> for UpdateIssuingDisputeEvidenceReason {
 /// Any parameters not provided will be left unchanged.
 /// Properties on the `evidence` object can be unset by passing in an empty string.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateIssuingDispute<'a> {
-    inner: UpdateIssuingDisputeBuilder<'a>,
-    dispute: &'a stripe_shared::IssuingDisputeId,
+pub struct UpdateIssuingDispute {
+    inner: UpdateIssuingDisputeBuilder,
+    dispute: stripe_shared::IssuingDisputeId,
 }
-impl<'a> UpdateIssuingDispute<'a> {
+impl UpdateIssuingDispute {
     /// Construct a new `UpdateIssuingDispute`.
-    pub fn new(dispute: &'a stripe_shared::IssuingDisputeId) -> Self {
-        Self { dispute, inner: UpdateIssuingDisputeBuilder::new() }
+    pub fn new(dispute: impl Into<stripe_shared::IssuingDisputeId>) -> Self {
+        Self { dispute: dispute.into(), inner: UpdateIssuingDisputeBuilder::new() }
     }
     /// The dispute amount in the card's currency and in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal).
-    pub fn amount(mut self, amount: i64) -> Self {
-        self.inner.amount = Some(amount);
+    pub fn amount(mut self, amount: impl Into<i64>) -> Self {
+        self.inner.amount = Some(amount.into());
         self
     }
     /// Evidence provided for the dispute.
-    pub fn evidence(mut self, evidence: UpdateIssuingDisputeEvidence<'a>) -> Self {
-        self.inner.evidence = Some(evidence);
+    pub fn evidence(mut self, evidence: impl Into<UpdateIssuingDisputeEvidence>) -> Self {
+        self.inner.evidence = Some(evidence.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
 }
-impl UpdateIssuingDispute<'_> {
+impl UpdateIssuingDispute {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -1496,23 +1500,23 @@ impl UpdateIssuingDispute<'_> {
     }
 }
 
-impl StripeRequest for UpdateIssuingDispute<'_> {
+impl StripeRequest for UpdateIssuingDispute {
     type Output = stripe_shared::IssuingDispute;
 
     fn build(&self) -> RequestBuilder {
-        let dispute = self.dispute;
+        let dispute = &self.dispute;
         RequestBuilder::new(StripeMethod::Post, format!("/issuing/disputes/{dispute}"))
             .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct SubmitIssuingDisputeBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct SubmitIssuingDisputeBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
 }
-impl<'a> SubmitIssuingDisputeBuilder<'a> {
+impl SubmitIssuingDisputeBuilder {
     fn new() -> Self {
         Self { expand: None, metadata: None }
     }
@@ -1521,30 +1525,33 @@ impl<'a> SubmitIssuingDisputeBuilder<'a> {
 /// Stripe validates that all evidence fields required for the dispute’s reason are present.
 /// For more details, see [Dispute reasons and evidence](https://stripe.com/docs/issuing/purchases/disputes#dispute-reasons-and-evidence).
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct SubmitIssuingDispute<'a> {
-    inner: SubmitIssuingDisputeBuilder<'a>,
-    dispute: &'a stripe_shared::IssuingDisputeId,
+pub struct SubmitIssuingDispute {
+    inner: SubmitIssuingDisputeBuilder,
+    dispute: stripe_shared::IssuingDisputeId,
 }
-impl<'a> SubmitIssuingDispute<'a> {
+impl SubmitIssuingDispute {
     /// Construct a new `SubmitIssuingDispute`.
-    pub fn new(dispute: &'a stripe_shared::IssuingDisputeId) -> Self {
-        Self { dispute, inner: SubmitIssuingDisputeBuilder::new() }
+    pub fn new(dispute: impl Into<stripe_shared::IssuingDisputeId>) -> Self {
+        Self { dispute: dispute.into(), inner: SubmitIssuingDisputeBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
 }
-impl SubmitIssuingDispute<'_> {
+impl SubmitIssuingDispute {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -1562,39 +1569,39 @@ impl SubmitIssuingDispute<'_> {
     }
 }
 
-impl StripeRequest for SubmitIssuingDispute<'_> {
+impl StripeRequest for SubmitIssuingDispute {
     type Output = stripe_shared::IssuingDispute;
 
     fn build(&self) -> RequestBuilder {
-        let dispute = self.dispute;
+        let dispute = &self.dispute;
         RequestBuilder::new(StripeMethod::Post, format!("/issuing/disputes/{dispute}/submit"))
             .form(&self.inner)
     }
 }
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct Duplicate<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct Duplicate {
     /// (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Additional documentation supporting the dispute.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub additional_documentation: Option<&'a str>,
+    pub additional_documentation: Option<String>,
     /// (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Copy of the card statement showing that the product had already been paid for.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub card_statement: Option<&'a str>,
+    pub card_statement: Option<String>,
     /// (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Copy of the receipt showing that the product had been paid for in cash.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub cash_receipt: Option<&'a str>,
+    pub cash_receipt: Option<String>,
     /// (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Image of the front and back of the check that was used to pay for the product.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub check_image: Option<&'a str>,
+    pub check_image: Option<String>,
     /// Explanation of why the cardholder is disputing this transaction.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub explanation: Option<&'a str>,
+    pub explanation: Option<String>,
     /// Transaction (e.g., ipi_...) that the disputed transaction is a duplicate of.
     /// Of the two or more transactions that are copies of each other, this is original undisputed one.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub original_transaction: Option<&'a str>,
+    pub original_transaction: Option<String>,
 }
-impl<'a> Duplicate<'a> {
+impl Duplicate {
     pub fn new() -> Self {
         Self {
             additional_documentation: None,
@@ -1606,49 +1613,49 @@ impl<'a> Duplicate<'a> {
         }
     }
 }
-impl<'a> Default for Duplicate<'a> {
+impl Default for Duplicate {
     fn default() -> Self {
         Self::new()
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct Fraudulent<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct Fraudulent {
     /// (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Additional documentation supporting the dispute.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub additional_documentation: Option<&'a str>,
+    pub additional_documentation: Option<String>,
     /// Explanation of why the cardholder is disputing this transaction.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub explanation: Option<&'a str>,
+    pub explanation: Option<String>,
 }
-impl<'a> Fraudulent<'a> {
+impl Fraudulent {
     pub fn new() -> Self {
         Self { additional_documentation: None, explanation: None }
     }
 }
-impl<'a> Default for Fraudulent<'a> {
+impl Default for Fraudulent {
     fn default() -> Self {
         Self::new()
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ServiceNotAsDescribed<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ServiceNotAsDescribed {
     /// (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Additional documentation supporting the dispute.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub additional_documentation: Option<&'a str>,
+    pub additional_documentation: Option<String>,
     /// Date when order was canceled.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub canceled_at: Option<stripe_types::Timestamp>,
     /// Reason for canceling the order.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub cancellation_reason: Option<&'a str>,
+    pub cancellation_reason: Option<String>,
     /// Explanation of why the cardholder is disputing this transaction.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub explanation: Option<&'a str>,
+    pub explanation: Option<String>,
     /// Date when the product was received.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub received_at: Option<stripe_types::Timestamp>,
 }
-impl<'a> ServiceNotAsDescribed<'a> {
+impl ServiceNotAsDescribed {
     pub fn new() -> Self {
         Self {
             additional_documentation: None,
@@ -1659,7 +1666,7 @@ impl<'a> ServiceNotAsDescribed<'a> {
         }
     }
 }
-impl<'a> Default for ServiceNotAsDescribed<'a> {
+impl Default for ServiceNotAsDescribed {
     fn default() -> Self {
         Self::new()
     }

--- a/generated/async-stripe-issuing/src/issuing_personalization_design/requests.rs
+++ b/generated/async-stripe-issuing/src/issuing_personalization_design/requests.rs
@@ -2,24 +2,24 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListIssuingPersonalizationDesignBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListIssuingPersonalizationDesignBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    lookup_keys: Option<&'a [&'a str]>,
+    lookup_keys: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     preferences: Option<ListIssuingPersonalizationDesignPreferences>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     status: Option<stripe_shared::IssuingPersonalizationDesignStatus>,
 }
-impl<'a> ListIssuingPersonalizationDesignBuilder<'a> {
+impl ListIssuingPersonalizationDesignBuilder {
     fn new() -> Self {
         Self {
             ending_before: None,
@@ -57,10 +57,10 @@ impl Default for ListIssuingPersonalizationDesignPreferences {
 /// Returns a list of personalization design objects.
 /// The objects are sorted in descending order by creation date, with the most recently created object appearing first.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListIssuingPersonalizationDesign<'a> {
-    inner: ListIssuingPersonalizationDesignBuilder<'a>,
+pub struct ListIssuingPersonalizationDesign {
+    inner: ListIssuingPersonalizationDesignBuilder,
 }
-impl<'a> ListIssuingPersonalizationDesign<'a> {
+impl ListIssuingPersonalizationDesign {
     /// Construct a new `ListIssuingPersonalizationDesign`.
     pub fn new() -> Self {
         Self { inner: ListIssuingPersonalizationDesignBuilder::new() }
@@ -68,50 +68,56 @@ impl<'a> ListIssuingPersonalizationDesign<'a> {
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// Only return personalization designs with the given lookup keys.
-    pub fn lookup_keys(mut self, lookup_keys: &'a [&'a str]) -> Self {
-        self.inner.lookup_keys = Some(lookup_keys);
+    pub fn lookup_keys(mut self, lookup_keys: impl Into<Vec<String>>) -> Self {
+        self.inner.lookup_keys = Some(lookup_keys.into());
         self
     }
     /// Only return personalization designs with the given preferences.
-    pub fn preferences(mut self, preferences: ListIssuingPersonalizationDesignPreferences) -> Self {
-        self.inner.preferences = Some(preferences);
+    pub fn preferences(
+        mut self,
+        preferences: impl Into<ListIssuingPersonalizationDesignPreferences>,
+    ) -> Self {
+        self.inner.preferences = Some(preferences.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
     /// Only return personalization designs with the given status.
-    pub fn status(mut self, status: stripe_shared::IssuingPersonalizationDesignStatus) -> Self {
-        self.inner.status = Some(status);
+    pub fn status(
+        mut self,
+        status: impl Into<stripe_shared::IssuingPersonalizationDesignStatus>,
+    ) -> Self {
+        self.inner.status = Some(status.into());
         self
     }
 }
-impl<'a> Default for ListIssuingPersonalizationDesign<'a> {
+impl Default for ListIssuingPersonalizationDesign {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListIssuingPersonalizationDesign<'_> {
+impl ListIssuingPersonalizationDesign {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -133,11 +139,11 @@ impl ListIssuingPersonalizationDesign<'_> {
     ) -> stripe_client_core::ListPaginator<
         stripe_types::List<stripe_shared::IssuingPersonalizationDesign>,
     > {
-        stripe_client_core::ListPaginator::new_list("/issuing/personalization_designs", self.inner)
+        stripe_client_core::ListPaginator::new_list("/issuing/personalization_designs", &self.inner)
     }
 }
 
-impl StripeRequest for ListIssuingPersonalizationDesign<'_> {
+impl StripeRequest for ListIssuingPersonalizationDesign {
     type Output = stripe_types::List<stripe_shared::IssuingPersonalizationDesign>;
 
     fn build(&self) -> RequestBuilder {
@@ -145,34 +151,39 @@ impl StripeRequest for ListIssuingPersonalizationDesign<'_> {
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveIssuingPersonalizationDesignBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveIssuingPersonalizationDesignBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveIssuingPersonalizationDesignBuilder<'a> {
+impl RetrieveIssuingPersonalizationDesignBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves a personalization design object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveIssuingPersonalizationDesign<'a> {
-    inner: RetrieveIssuingPersonalizationDesignBuilder<'a>,
-    personalization_design: &'a stripe_shared::IssuingPersonalizationDesignId,
+pub struct RetrieveIssuingPersonalizationDesign {
+    inner: RetrieveIssuingPersonalizationDesignBuilder,
+    personalization_design: stripe_shared::IssuingPersonalizationDesignId,
 }
-impl<'a> RetrieveIssuingPersonalizationDesign<'a> {
+impl RetrieveIssuingPersonalizationDesign {
     /// Construct a new `RetrieveIssuingPersonalizationDesign`.
-    pub fn new(personalization_design: &'a stripe_shared::IssuingPersonalizationDesignId) -> Self {
-        Self { personalization_design, inner: RetrieveIssuingPersonalizationDesignBuilder::new() }
+    pub fn new(
+        personalization_design: impl Into<stripe_shared::IssuingPersonalizationDesignId>,
+    ) -> Self {
+        Self {
+            personalization_design: personalization_design.into(),
+            inner: RetrieveIssuingPersonalizationDesignBuilder::new(),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveIssuingPersonalizationDesign<'_> {
+impl RetrieveIssuingPersonalizationDesign {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -190,11 +201,11 @@ impl RetrieveIssuingPersonalizationDesign<'_> {
     }
 }
 
-impl StripeRequest for RetrieveIssuingPersonalizationDesign<'_> {
+impl StripeRequest for RetrieveIssuingPersonalizationDesign {
     type Output = stripe_shared::IssuingPersonalizationDesign;
 
     fn build(&self) -> RequestBuilder {
-        let personalization_design = self.personalization_design;
+        let personalization_design = &self.personalization_design;
         RequestBuilder::new(
             StripeMethod::Get,
             format!("/issuing/personalization_designs/{personalization_design}"),
@@ -202,28 +213,28 @@ impl StripeRequest for RetrieveIssuingPersonalizationDesign<'_> {
         .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateIssuingPersonalizationDesignBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateIssuingPersonalizationDesignBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    card_logo: Option<&'a str>,
+    card_logo: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    carrier_text: Option<CarrierTextParam<'a>>,
+    carrier_text: Option<CarrierTextParam>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    lookup_key: Option<&'a str>,
+    lookup_key: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    name: Option<&'a str>,
-    physical_bundle: &'a str,
+    name: Option<String>,
+    physical_bundle: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     preferences: Option<PreferencesParam>,
     #[serde(skip_serializing_if = "Option::is_none")]
     transfer_lookup_key: Option<bool>,
 }
-impl<'a> CreateIssuingPersonalizationDesignBuilder<'a> {
-    fn new(physical_bundle: &'a str) -> Self {
+impl CreateIssuingPersonalizationDesignBuilder {
+    fn new(physical_bundle: impl Into<String>) -> Self {
         Self {
             card_logo: None,
             carrier_text: None,
@@ -231,7 +242,7 @@ impl<'a> CreateIssuingPersonalizationDesignBuilder<'a> {
             lookup_key: None,
             metadata: None,
             name: None,
-            physical_bundle,
+            physical_bundle: physical_bundle.into(),
             preferences: None,
             transfer_lookup_key: None,
         }
@@ -239,61 +250,64 @@ impl<'a> CreateIssuingPersonalizationDesignBuilder<'a> {
 }
 /// Creates a personalization design object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateIssuingPersonalizationDesign<'a> {
-    inner: CreateIssuingPersonalizationDesignBuilder<'a>,
+pub struct CreateIssuingPersonalizationDesign {
+    inner: CreateIssuingPersonalizationDesignBuilder,
 }
-impl<'a> CreateIssuingPersonalizationDesign<'a> {
+impl CreateIssuingPersonalizationDesign {
     /// Construct a new `CreateIssuingPersonalizationDesign`.
-    pub fn new(physical_bundle: &'a str) -> Self {
-        Self { inner: CreateIssuingPersonalizationDesignBuilder::new(physical_bundle) }
+    pub fn new(physical_bundle: impl Into<String>) -> Self {
+        Self { inner: CreateIssuingPersonalizationDesignBuilder::new(physical_bundle.into()) }
     }
     /// The file for the card logo, for use with physical bundles that support card logos.
     /// Must have a `purpose` value of `issuing_logo`.
-    pub fn card_logo(mut self, card_logo: &'a str) -> Self {
-        self.inner.card_logo = Some(card_logo);
+    pub fn card_logo(mut self, card_logo: impl Into<String>) -> Self {
+        self.inner.card_logo = Some(card_logo.into());
         self
     }
     /// Hash containing carrier text, for use with physical bundles that support carrier text.
-    pub fn carrier_text(mut self, carrier_text: CarrierTextParam<'a>) -> Self {
-        self.inner.carrier_text = Some(carrier_text);
+    pub fn carrier_text(mut self, carrier_text: impl Into<CarrierTextParam>) -> Self {
+        self.inner.carrier_text = Some(carrier_text.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A lookup key used to retrieve personalization designs dynamically from a static string.
     /// This may be up to 200 characters.
-    pub fn lookup_key(mut self, lookup_key: &'a str) -> Self {
-        self.inner.lookup_key = Some(lookup_key);
+    pub fn lookup_key(mut self, lookup_key: impl Into<String>) -> Self {
+        self.inner.lookup_key = Some(lookup_key.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// Friendly display name.
-    pub fn name(mut self, name: &'a str) -> Self {
-        self.inner.name = Some(name);
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.inner.name = Some(name.into());
         self
     }
     /// Information on whether this personalization design is used to create cards when one is not specified.
-    pub fn preferences(mut self, preferences: PreferencesParam) -> Self {
-        self.inner.preferences = Some(preferences);
+    pub fn preferences(mut self, preferences: impl Into<PreferencesParam>) -> Self {
+        self.inner.preferences = Some(preferences.into());
         self
     }
     /// If set to true, will atomically remove the lookup key from the existing personalization design, and assign it to this personalization design.
-    pub fn transfer_lookup_key(mut self, transfer_lookup_key: bool) -> Self {
-        self.inner.transfer_lookup_key = Some(transfer_lookup_key);
+    pub fn transfer_lookup_key(mut self, transfer_lookup_key: impl Into<bool>) -> Self {
+        self.inner.transfer_lookup_key = Some(transfer_lookup_key.into());
         self
     }
 }
-impl CreateIssuingPersonalizationDesign<'_> {
+impl CreateIssuingPersonalizationDesign {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -311,7 +325,7 @@ impl CreateIssuingPersonalizationDesign<'_> {
     }
 }
 
-impl StripeRequest for CreateIssuingPersonalizationDesign<'_> {
+impl StripeRequest for CreateIssuingPersonalizationDesign {
     type Output = stripe_shared::IssuingPersonalizationDesign;
 
     fn build(&self) -> RequestBuilder {
@@ -319,28 +333,28 @@ impl StripeRequest for CreateIssuingPersonalizationDesign<'_> {
             .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdateIssuingPersonalizationDesignBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdateIssuingPersonalizationDesignBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    card_logo: Option<&'a str>,
+    card_logo: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    carrier_text: Option<CarrierTextParam<'a>>,
+    carrier_text: Option<CarrierTextParam>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    lookup_key: Option<&'a str>,
+    lookup_key: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    name: Option<&'a str>,
+    name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    physical_bundle: Option<&'a str>,
+    physical_bundle: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     preferences: Option<PreferencesParam>,
     #[serde(skip_serializing_if = "Option::is_none")]
     transfer_lookup_key: Option<bool>,
 }
-impl<'a> UpdateIssuingPersonalizationDesignBuilder<'a> {
+impl UpdateIssuingPersonalizationDesignBuilder {
     fn new() -> Self {
         Self {
             card_logo: None,
@@ -357,67 +371,75 @@ impl<'a> UpdateIssuingPersonalizationDesignBuilder<'a> {
 }
 /// Updates a card personalization object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateIssuingPersonalizationDesign<'a> {
-    inner: UpdateIssuingPersonalizationDesignBuilder<'a>,
-    personalization_design: &'a stripe_shared::IssuingPersonalizationDesignId,
+pub struct UpdateIssuingPersonalizationDesign {
+    inner: UpdateIssuingPersonalizationDesignBuilder,
+    personalization_design: stripe_shared::IssuingPersonalizationDesignId,
 }
-impl<'a> UpdateIssuingPersonalizationDesign<'a> {
+impl UpdateIssuingPersonalizationDesign {
     /// Construct a new `UpdateIssuingPersonalizationDesign`.
-    pub fn new(personalization_design: &'a stripe_shared::IssuingPersonalizationDesignId) -> Self {
-        Self { personalization_design, inner: UpdateIssuingPersonalizationDesignBuilder::new() }
+    pub fn new(
+        personalization_design: impl Into<stripe_shared::IssuingPersonalizationDesignId>,
+    ) -> Self {
+        Self {
+            personalization_design: personalization_design.into(),
+            inner: UpdateIssuingPersonalizationDesignBuilder::new(),
+        }
     }
     /// The file for the card logo, for use with physical bundles that support card logos.
     /// Must have a `purpose` value of `issuing_logo`.
-    pub fn card_logo(mut self, card_logo: &'a str) -> Self {
-        self.inner.card_logo = Some(card_logo);
+    pub fn card_logo(mut self, card_logo: impl Into<String>) -> Self {
+        self.inner.card_logo = Some(card_logo.into());
         self
     }
     /// Hash containing carrier text, for use with physical bundles that support carrier text.
-    pub fn carrier_text(mut self, carrier_text: CarrierTextParam<'a>) -> Self {
-        self.inner.carrier_text = Some(carrier_text);
+    pub fn carrier_text(mut self, carrier_text: impl Into<CarrierTextParam>) -> Self {
+        self.inner.carrier_text = Some(carrier_text.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A lookup key used to retrieve personalization designs dynamically from a static string.
     /// This may be up to 200 characters.
-    pub fn lookup_key(mut self, lookup_key: &'a str) -> Self {
-        self.inner.lookup_key = Some(lookup_key);
+    pub fn lookup_key(mut self, lookup_key: impl Into<String>) -> Self {
+        self.inner.lookup_key = Some(lookup_key.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// Friendly display name. Providing an empty string will set the field to null.
-    pub fn name(mut self, name: &'a str) -> Self {
-        self.inner.name = Some(name);
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.inner.name = Some(name.into());
         self
     }
     /// The physical bundle object belonging to this personalization design.
-    pub fn physical_bundle(mut self, physical_bundle: &'a str) -> Self {
-        self.inner.physical_bundle = Some(physical_bundle);
+    pub fn physical_bundle(mut self, physical_bundle: impl Into<String>) -> Self {
+        self.inner.physical_bundle = Some(physical_bundle.into());
         self
     }
     /// Information on whether this personalization design is used to create cards when one is not specified.
-    pub fn preferences(mut self, preferences: PreferencesParam) -> Self {
-        self.inner.preferences = Some(preferences);
+    pub fn preferences(mut self, preferences: impl Into<PreferencesParam>) -> Self {
+        self.inner.preferences = Some(preferences.into());
         self
     }
     /// If set to true, will atomically remove the lookup key from the existing personalization design, and assign it to this personalization design.
-    pub fn transfer_lookup_key(mut self, transfer_lookup_key: bool) -> Self {
-        self.inner.transfer_lookup_key = Some(transfer_lookup_key);
+    pub fn transfer_lookup_key(mut self, transfer_lookup_key: impl Into<bool>) -> Self {
+        self.inner.transfer_lookup_key = Some(transfer_lookup_key.into());
         self
     }
 }
-impl UpdateIssuingPersonalizationDesign<'_> {
+impl UpdateIssuingPersonalizationDesign {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -435,11 +457,11 @@ impl UpdateIssuingPersonalizationDesign<'_> {
     }
 }
 
-impl StripeRequest for UpdateIssuingPersonalizationDesign<'_> {
+impl StripeRequest for UpdateIssuingPersonalizationDesign {
     type Output = stripe_shared::IssuingPersonalizationDesign;
 
     fn build(&self) -> RequestBuilder {
-        let personalization_design = self.personalization_design;
+        let personalization_design = &self.personalization_design;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/issuing/personalization_designs/{personalization_design}"),
@@ -447,34 +469,37 @@ impl StripeRequest for UpdateIssuingPersonalizationDesign<'_> {
         .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ActivateIssuingPersonalizationDesignBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ActivateIssuingPersonalizationDesignBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> ActivateIssuingPersonalizationDesignBuilder<'a> {
+impl ActivateIssuingPersonalizationDesignBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Updates the `status` of the specified testmode personalization design object to `active`.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ActivateIssuingPersonalizationDesign<'a> {
-    inner: ActivateIssuingPersonalizationDesignBuilder<'a>,
-    personalization_design: &'a str,
+pub struct ActivateIssuingPersonalizationDesign {
+    inner: ActivateIssuingPersonalizationDesignBuilder,
+    personalization_design: String,
 }
-impl<'a> ActivateIssuingPersonalizationDesign<'a> {
+impl ActivateIssuingPersonalizationDesign {
     /// Construct a new `ActivateIssuingPersonalizationDesign`.
-    pub fn new(personalization_design: &'a str) -> Self {
-        Self { personalization_design, inner: ActivateIssuingPersonalizationDesignBuilder::new() }
+    pub fn new(personalization_design: impl Into<String>) -> Self {
+        Self {
+            personalization_design: personalization_design.into(),
+            inner: ActivateIssuingPersonalizationDesignBuilder::new(),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl ActivateIssuingPersonalizationDesign<'_> {
+impl ActivateIssuingPersonalizationDesign {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -492,11 +517,11 @@ impl ActivateIssuingPersonalizationDesign<'_> {
     }
 }
 
-impl StripeRequest for ActivateIssuingPersonalizationDesign<'_> {
+impl StripeRequest for ActivateIssuingPersonalizationDesign {
     type Output = stripe_shared::IssuingPersonalizationDesign;
 
     fn build(&self) -> RequestBuilder {
-        let personalization_design = self.personalization_design;
+        let personalization_design = &self.personalization_design;
         RequestBuilder::new(
             StripeMethod::Post,
             format!(
@@ -506,34 +531,37 @@ impl StripeRequest for ActivateIssuingPersonalizationDesign<'_> {
         .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct DeactivateIssuingPersonalizationDesignBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct DeactivateIssuingPersonalizationDesignBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> DeactivateIssuingPersonalizationDesignBuilder<'a> {
+impl DeactivateIssuingPersonalizationDesignBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Updates the `status` of the specified testmode personalization design object to `inactive`.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct DeactivateIssuingPersonalizationDesign<'a> {
-    inner: DeactivateIssuingPersonalizationDesignBuilder<'a>,
-    personalization_design: &'a str,
+pub struct DeactivateIssuingPersonalizationDesign {
+    inner: DeactivateIssuingPersonalizationDesignBuilder,
+    personalization_design: String,
 }
-impl<'a> DeactivateIssuingPersonalizationDesign<'a> {
+impl DeactivateIssuingPersonalizationDesign {
     /// Construct a new `DeactivateIssuingPersonalizationDesign`.
-    pub fn new(personalization_design: &'a str) -> Self {
-        Self { personalization_design, inner: DeactivateIssuingPersonalizationDesignBuilder::new() }
+    pub fn new(personalization_design: impl Into<String>) -> Self {
+        Self {
+            personalization_design: personalization_design.into(),
+            inner: DeactivateIssuingPersonalizationDesignBuilder::new(),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl DeactivateIssuingPersonalizationDesign<'_> {
+impl DeactivateIssuingPersonalizationDesign {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -551,11 +579,11 @@ impl DeactivateIssuingPersonalizationDesign<'_> {
     }
 }
 
-impl StripeRequest for DeactivateIssuingPersonalizationDesign<'_> {
+impl StripeRequest for DeactivateIssuingPersonalizationDesign {
     type Output = stripe_shared::IssuingPersonalizationDesign;
 
     fn build(&self) -> RequestBuilder {
-        let personalization_design = self.personalization_design;
+        let personalization_design = &self.personalization_design;
         RequestBuilder::new(
             StripeMethod::Post,
             format!(
@@ -565,33 +593,35 @@ impl StripeRequest for DeactivateIssuingPersonalizationDesign<'_> {
         .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RejectIssuingPersonalizationDesignBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RejectIssuingPersonalizationDesignBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
-    rejection_reasons: RejectIssuingPersonalizationDesignRejectionReasons<'a>,
+    expand: Option<Vec<String>>,
+    rejection_reasons: RejectIssuingPersonalizationDesignRejectionReasons,
 }
-impl<'a> RejectIssuingPersonalizationDesignBuilder<'a> {
-    fn new(rejection_reasons: RejectIssuingPersonalizationDesignRejectionReasons<'a>) -> Self {
-        Self { expand: None, rejection_reasons }
+impl RejectIssuingPersonalizationDesignBuilder {
+    fn new(
+        rejection_reasons: impl Into<RejectIssuingPersonalizationDesignRejectionReasons>,
+    ) -> Self {
+        Self { expand: None, rejection_reasons: rejection_reasons.into() }
     }
 }
 /// The reason(s) the personalization design was rejected.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct RejectIssuingPersonalizationDesignRejectionReasons<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct RejectIssuingPersonalizationDesignRejectionReasons {
     /// The reason(s) the card logo was rejected.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub card_logo: Option<&'a [RejectIssuingPersonalizationDesignRejectionReasonsCardLogo]>,
+    pub card_logo: Option<Vec<RejectIssuingPersonalizationDesignRejectionReasonsCardLogo>>,
     /// The reason(s) the carrier text was rejected.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub carrier_text: Option<&'a [RejectIssuingPersonalizationDesignRejectionReasonsCarrierText]>,
+    pub carrier_text: Option<Vec<RejectIssuingPersonalizationDesignRejectionReasonsCarrierText>>,
 }
-impl<'a> RejectIssuingPersonalizationDesignRejectionReasons<'a> {
+impl RejectIssuingPersonalizationDesignRejectionReasons {
     pub fn new() -> Self {
         Self { card_logo: None, carrier_text: None }
     }
 }
-impl<'a> Default for RejectIssuingPersonalizationDesignRejectionReasons<'a> {
+impl Default for RejectIssuingPersonalizationDesignRejectionReasons {
     fn default() -> Self {
         Self::new()
     }
@@ -749,28 +779,28 @@ impl<'de> serde::Deserialize<'de>
 }
 /// Updates the `status` of the specified testmode personalization design object to `rejected`.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RejectIssuingPersonalizationDesign<'a> {
-    inner: RejectIssuingPersonalizationDesignBuilder<'a>,
-    personalization_design: &'a str,
+pub struct RejectIssuingPersonalizationDesign {
+    inner: RejectIssuingPersonalizationDesignBuilder,
+    personalization_design: String,
 }
-impl<'a> RejectIssuingPersonalizationDesign<'a> {
+impl RejectIssuingPersonalizationDesign {
     /// Construct a new `RejectIssuingPersonalizationDesign`.
     pub fn new(
-        personalization_design: &'a str,
-        rejection_reasons: RejectIssuingPersonalizationDesignRejectionReasons<'a>,
+        personalization_design: impl Into<String>,
+        rejection_reasons: impl Into<RejectIssuingPersonalizationDesignRejectionReasons>,
     ) -> Self {
         Self {
-            personalization_design,
-            inner: RejectIssuingPersonalizationDesignBuilder::new(rejection_reasons),
+            personalization_design: personalization_design.into(),
+            inner: RejectIssuingPersonalizationDesignBuilder::new(rejection_reasons.into()),
         }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RejectIssuingPersonalizationDesign<'_> {
+impl RejectIssuingPersonalizationDesign {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -788,11 +818,11 @@ impl RejectIssuingPersonalizationDesign<'_> {
     }
 }
 
-impl StripeRequest for RejectIssuingPersonalizationDesign<'_> {
+impl StripeRequest for RejectIssuingPersonalizationDesign {
     type Output = stripe_shared::IssuingPersonalizationDesign;
 
     fn build(&self) -> RequestBuilder {
-        let personalization_design = self.personalization_design;
+        let personalization_design = &self.personalization_design;
         RequestBuilder::new(
             StripeMethod::Post,
             format!(
@@ -803,27 +833,27 @@ impl StripeRequest for RejectIssuingPersonalizationDesign<'_> {
     }
 }
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CarrierTextParam<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CarrierTextParam {
     /// The footer body text of the carrier letter.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub footer_body: Option<&'a str>,
+    pub footer_body: Option<String>,
     /// The footer title text of the carrier letter.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub footer_title: Option<&'a str>,
+    pub footer_title: Option<String>,
     /// The header body text of the carrier letter.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub header_body: Option<&'a str>,
+    pub header_body: Option<String>,
     /// The header title text of the carrier letter.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub header_title: Option<&'a str>,
+    pub header_title: Option<String>,
 }
-impl<'a> CarrierTextParam<'a> {
+impl CarrierTextParam {
     pub fn new() -> Self {
         Self { footer_body: None, footer_title: None, header_body: None, header_title: None }
     }
 }
-impl<'a> Default for CarrierTextParam<'a> {
+impl Default for CarrierTextParam {
     fn default() -> Self {
         Self::new()
     }
@@ -835,7 +865,7 @@ pub struct PreferencesParam {
     pub is_default: bool,
 }
 impl PreferencesParam {
-    pub fn new(is_default: bool) -> Self {
-        Self { is_default }
+    pub fn new(is_default: impl Into<bool>) -> Self {
+        Self { is_default: is_default.into() }
     }
 }

--- a/generated/async-stripe-issuing/src/issuing_physical_bundle/requests.rs
+++ b/generated/async-stripe-issuing/src/issuing_physical_bundle/requests.rs
@@ -2,23 +2,23 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListIssuingPhysicalBundleBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListIssuingPhysicalBundleBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     status: Option<stripe_shared::IssuingPhysicalBundleStatus>,
     #[serde(rename = "type")]
     #[serde(skip_serializing_if = "Option::is_none")]
     type_: Option<stripe_shared::IssuingPhysicalBundleType>,
 }
-impl<'a> ListIssuingPhysicalBundleBuilder<'a> {
+impl ListIssuingPhysicalBundleBuilder {
     fn new() -> Self {
         Self {
             ending_before: None,
@@ -33,10 +33,10 @@ impl<'a> ListIssuingPhysicalBundleBuilder<'a> {
 /// Returns a list of physical bundle objects.
 /// The objects are sorted in descending order by creation date, with the most recently created object appearing first.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListIssuingPhysicalBundle<'a> {
-    inner: ListIssuingPhysicalBundleBuilder<'a>,
+pub struct ListIssuingPhysicalBundle {
+    inner: ListIssuingPhysicalBundleBuilder,
 }
-impl<'a> ListIssuingPhysicalBundle<'a> {
+impl ListIssuingPhysicalBundle {
     /// Construct a new `ListIssuingPhysicalBundle`.
     pub fn new() -> Self {
         Self { inner: ListIssuingPhysicalBundleBuilder::new() }
@@ -44,45 +44,45 @@ impl<'a> ListIssuingPhysicalBundle<'a> {
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
     /// Only return physical bundles with the given status.
-    pub fn status(mut self, status: stripe_shared::IssuingPhysicalBundleStatus) -> Self {
-        self.inner.status = Some(status);
+    pub fn status(mut self, status: impl Into<stripe_shared::IssuingPhysicalBundleStatus>) -> Self {
+        self.inner.status = Some(status.into());
         self
     }
     /// Only return physical bundles with the given type.
-    pub fn type_(mut self, type_: stripe_shared::IssuingPhysicalBundleType) -> Self {
-        self.inner.type_ = Some(type_);
+    pub fn type_(mut self, type_: impl Into<stripe_shared::IssuingPhysicalBundleType>) -> Self {
+        self.inner.type_ = Some(type_.into());
         self
     }
 }
-impl<'a> Default for ListIssuingPhysicalBundle<'a> {
+impl Default for ListIssuingPhysicalBundle {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListIssuingPhysicalBundle<'_> {
+impl ListIssuingPhysicalBundle {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -103,45 +103,48 @@ impl ListIssuingPhysicalBundle<'_> {
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::IssuingPhysicalBundle>>
     {
-        stripe_client_core::ListPaginator::new_list("/issuing/physical_bundles", self.inner)
+        stripe_client_core::ListPaginator::new_list("/issuing/physical_bundles", &self.inner)
     }
 }
 
-impl StripeRequest for ListIssuingPhysicalBundle<'_> {
+impl StripeRequest for ListIssuingPhysicalBundle {
     type Output = stripe_types::List<stripe_shared::IssuingPhysicalBundle>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/issuing/physical_bundles").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveIssuingPhysicalBundleBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveIssuingPhysicalBundleBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveIssuingPhysicalBundleBuilder<'a> {
+impl RetrieveIssuingPhysicalBundleBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves a physical bundle object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveIssuingPhysicalBundle<'a> {
-    inner: RetrieveIssuingPhysicalBundleBuilder<'a>,
-    physical_bundle: &'a stripe_shared::IssuingPhysicalBundleId,
+pub struct RetrieveIssuingPhysicalBundle {
+    inner: RetrieveIssuingPhysicalBundleBuilder,
+    physical_bundle: stripe_shared::IssuingPhysicalBundleId,
 }
-impl<'a> RetrieveIssuingPhysicalBundle<'a> {
+impl RetrieveIssuingPhysicalBundle {
     /// Construct a new `RetrieveIssuingPhysicalBundle`.
-    pub fn new(physical_bundle: &'a stripe_shared::IssuingPhysicalBundleId) -> Self {
-        Self { physical_bundle, inner: RetrieveIssuingPhysicalBundleBuilder::new() }
+    pub fn new(physical_bundle: impl Into<stripe_shared::IssuingPhysicalBundleId>) -> Self {
+        Self {
+            physical_bundle: physical_bundle.into(),
+            inner: RetrieveIssuingPhysicalBundleBuilder::new(),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveIssuingPhysicalBundle<'_> {
+impl RetrieveIssuingPhysicalBundle {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -159,11 +162,11 @@ impl RetrieveIssuingPhysicalBundle<'_> {
     }
 }
 
-impl StripeRequest for RetrieveIssuingPhysicalBundle<'_> {
+impl StripeRequest for RetrieveIssuingPhysicalBundle {
     type Output = stripe_shared::IssuingPhysicalBundle;
 
     fn build(&self) -> RequestBuilder {
-        let physical_bundle = self.physical_bundle;
+        let physical_bundle = &self.physical_bundle;
         RequestBuilder::new(
             StripeMethod::Get,
             format!("/issuing/physical_bundles/{physical_bundle}"),

--- a/generated/async-stripe-issuing/src/issuing_token/requests.rs
+++ b/generated/async-stripe-issuing/src/issuing_token/requests.rs
@@ -2,26 +2,26 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListIssuingTokenBuilder<'a> {
-    card: &'a str,
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListIssuingTokenBuilder {
+    card: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     created: Option<stripe_types::RangeQueryTs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     status: Option<stripe_shared::IssuingTokenStatus>,
 }
-impl<'a> ListIssuingTokenBuilder<'a> {
-    fn new(card: &'a str) -> Self {
+impl ListIssuingTokenBuilder {
+    fn new(card: impl Into<String>) -> Self {
         Self {
-            card,
+            card: card.into(),
             created: None,
             ending_before: None,
             expand: None,
@@ -33,51 +33,51 @@ impl<'a> ListIssuingTokenBuilder<'a> {
 }
 /// Lists all Issuing `Token` objects for a given card.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListIssuingToken<'a> {
-    inner: ListIssuingTokenBuilder<'a>,
+pub struct ListIssuingToken {
+    inner: ListIssuingTokenBuilder,
 }
-impl<'a> ListIssuingToken<'a> {
+impl ListIssuingToken {
     /// Construct a new `ListIssuingToken`.
-    pub fn new(card: &'a str) -> Self {
-        Self { inner: ListIssuingTokenBuilder::new(card) }
+    pub fn new(card: impl Into<String>) -> Self {
+        Self { inner: ListIssuingTokenBuilder::new(card.into()) }
     }
     /// Only return Issuing tokens that were created during the given date interval.
-    pub fn created(mut self, created: stripe_types::RangeQueryTs) -> Self {
-        self.inner.created = Some(created);
+    pub fn created(mut self, created: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.created = Some(created.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
     /// Select Issuing tokens with the given status.
-    pub fn status(mut self, status: stripe_shared::IssuingTokenStatus) -> Self {
-        self.inner.status = Some(status);
+    pub fn status(mut self, status: impl Into<stripe_shared::IssuingTokenStatus>) -> Self {
+        self.inner.status = Some(status.into());
         self
     }
 }
-impl ListIssuingToken<'_> {
+impl ListIssuingToken {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -97,45 +97,45 @@ impl ListIssuingToken<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::IssuingToken>> {
-        stripe_client_core::ListPaginator::new_list("/issuing/tokens", self.inner)
+        stripe_client_core::ListPaginator::new_list("/issuing/tokens", &self.inner)
     }
 }
 
-impl StripeRequest for ListIssuingToken<'_> {
+impl StripeRequest for ListIssuingToken {
     type Output = stripe_types::List<stripe_shared::IssuingToken>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/issuing/tokens").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveIssuingTokenBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveIssuingTokenBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveIssuingTokenBuilder<'a> {
+impl RetrieveIssuingTokenBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves an Issuing `Token` object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveIssuingToken<'a> {
-    inner: RetrieveIssuingTokenBuilder<'a>,
-    token: &'a stripe_shared::IssuingTokenId,
+pub struct RetrieveIssuingToken {
+    inner: RetrieveIssuingTokenBuilder,
+    token: stripe_shared::IssuingTokenId,
 }
-impl<'a> RetrieveIssuingToken<'a> {
+impl RetrieveIssuingToken {
     /// Construct a new `RetrieveIssuingToken`.
-    pub fn new(token: &'a stripe_shared::IssuingTokenId) -> Self {
-        Self { token, inner: RetrieveIssuingTokenBuilder::new() }
+    pub fn new(token: impl Into<stripe_shared::IssuingTokenId>) -> Self {
+        Self { token: token.into(), inner: RetrieveIssuingTokenBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveIssuingToken<'_> {
+impl RetrieveIssuingToken {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -153,24 +153,24 @@ impl RetrieveIssuingToken<'_> {
     }
 }
 
-impl StripeRequest for RetrieveIssuingToken<'_> {
+impl StripeRequest for RetrieveIssuingToken {
     type Output = stripe_shared::IssuingToken;
 
     fn build(&self) -> RequestBuilder {
-        let token = self.token;
+        let token = &self.token;
         RequestBuilder::new(StripeMethod::Get, format!("/issuing/tokens/{token}"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdateIssuingTokenBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdateIssuingTokenBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     status: UpdateIssuingTokenStatus,
 }
-impl<'a> UpdateIssuingTokenBuilder<'a> {
-    fn new(status: UpdateIssuingTokenStatus) -> Self {
-        Self { expand: None, status }
+impl UpdateIssuingTokenBuilder {
+    fn new(status: impl Into<UpdateIssuingTokenStatus>) -> Self {
+        Self { expand: None, status: status.into() }
     }
 }
 /// Specifies which status the token should be updated to.
@@ -233,22 +233,25 @@ impl<'de> serde::Deserialize<'de> for UpdateIssuingTokenStatus {
 }
 /// Attempts to update the specified Issuing `Token` object to the status specified.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateIssuingToken<'a> {
-    inner: UpdateIssuingTokenBuilder<'a>,
-    token: &'a stripe_shared::IssuingTokenId,
+pub struct UpdateIssuingToken {
+    inner: UpdateIssuingTokenBuilder,
+    token: stripe_shared::IssuingTokenId,
 }
-impl<'a> UpdateIssuingToken<'a> {
+impl UpdateIssuingToken {
     /// Construct a new `UpdateIssuingToken`.
-    pub fn new(token: &'a stripe_shared::IssuingTokenId, status: UpdateIssuingTokenStatus) -> Self {
-        Self { token, inner: UpdateIssuingTokenBuilder::new(status) }
+    pub fn new(
+        token: impl Into<stripe_shared::IssuingTokenId>,
+        status: impl Into<UpdateIssuingTokenStatus>,
+    ) -> Self {
+        Self { token: token.into(), inner: UpdateIssuingTokenBuilder::new(status.into()) }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl UpdateIssuingToken<'_> {
+impl UpdateIssuingToken {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -266,11 +269,11 @@ impl UpdateIssuingToken<'_> {
     }
 }
 
-impl StripeRequest for UpdateIssuingToken<'_> {
+impl StripeRequest for UpdateIssuingToken {
     type Output = stripe_shared::IssuingToken;
 
     fn build(&self) -> RequestBuilder {
-        let token = self.token;
+        let token = &self.token;
         RequestBuilder::new(StripeMethod::Post, format!("/issuing/tokens/{token}"))
             .form(&self.inner)
     }

--- a/generated/async-stripe-issuing/src/issuing_transaction/requests.rs
+++ b/generated/async-stripe-issuing/src/issuing_transaction/requests.rs
@@ -2,27 +2,27 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListIssuingTransactionBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListIssuingTransactionBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    card: Option<&'a str>,
+    card: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    cardholder: Option<&'a str>,
+    cardholder: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     created: Option<stripe_types::RangeQueryTs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
     #[serde(rename = "type")]
     #[serde(skip_serializing_if = "Option::is_none")]
     type_: Option<stripe_shared::IssuingTransactionType>,
 }
-impl<'a> ListIssuingTransactionBuilder<'a> {
+impl ListIssuingTransactionBuilder {
     fn new() -> Self {
         Self {
             card: None,
@@ -39,66 +39,66 @@ impl<'a> ListIssuingTransactionBuilder<'a> {
 /// Returns a list of Issuing `Transaction` objects.
 /// The objects are sorted in descending order by creation date, with the most recently created object appearing first.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListIssuingTransaction<'a> {
-    inner: ListIssuingTransactionBuilder<'a>,
+pub struct ListIssuingTransaction {
+    inner: ListIssuingTransactionBuilder,
 }
-impl<'a> ListIssuingTransaction<'a> {
+impl ListIssuingTransaction {
     /// Construct a new `ListIssuingTransaction`.
     pub fn new() -> Self {
         Self { inner: ListIssuingTransactionBuilder::new() }
     }
     /// Only return transactions that belong to the given card.
-    pub fn card(mut self, card: &'a str) -> Self {
-        self.inner.card = Some(card);
+    pub fn card(mut self, card: impl Into<String>) -> Self {
+        self.inner.card = Some(card.into());
         self
     }
     /// Only return transactions that belong to the given cardholder.
-    pub fn cardholder(mut self, cardholder: &'a str) -> Self {
-        self.inner.cardholder = Some(cardholder);
+    pub fn cardholder(mut self, cardholder: impl Into<String>) -> Self {
+        self.inner.cardholder = Some(cardholder.into());
         self
     }
     /// Only return transactions that were created during the given date interval.
-    pub fn created(mut self, created: stripe_types::RangeQueryTs) -> Self {
-        self.inner.created = Some(created);
+    pub fn created(mut self, created: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.created = Some(created.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
     /// Only return transactions that have the given type. One of `capture` or `refund`.
-    pub fn type_(mut self, type_: stripe_shared::IssuingTransactionType) -> Self {
-        self.inner.type_ = Some(type_);
+    pub fn type_(mut self, type_: impl Into<stripe_shared::IssuingTransactionType>) -> Self {
+        self.inner.type_ = Some(type_.into());
         self
     }
 }
-impl<'a> Default for ListIssuingTransaction<'a> {
+impl Default for ListIssuingTransaction {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListIssuingTransaction<'_> {
+impl ListIssuingTransaction {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -119,45 +119,45 @@ impl ListIssuingTransaction<'_> {
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::IssuingTransaction>>
     {
-        stripe_client_core::ListPaginator::new_list("/issuing/transactions", self.inner)
+        stripe_client_core::ListPaginator::new_list("/issuing/transactions", &self.inner)
     }
 }
 
-impl StripeRequest for ListIssuingTransaction<'_> {
+impl StripeRequest for ListIssuingTransaction {
     type Output = stripe_types::List<stripe_shared::IssuingTransaction>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/issuing/transactions").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveIssuingTransactionBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveIssuingTransactionBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveIssuingTransactionBuilder<'a> {
+impl RetrieveIssuingTransactionBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves an Issuing `Transaction` object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveIssuingTransaction<'a> {
-    inner: RetrieveIssuingTransactionBuilder<'a>,
-    transaction: &'a stripe_shared::IssuingTransactionId,
+pub struct RetrieveIssuingTransaction {
+    inner: RetrieveIssuingTransactionBuilder,
+    transaction: stripe_shared::IssuingTransactionId,
 }
-impl<'a> RetrieveIssuingTransaction<'a> {
+impl RetrieveIssuingTransaction {
     /// Construct a new `RetrieveIssuingTransaction`.
-    pub fn new(transaction: &'a stripe_shared::IssuingTransactionId) -> Self {
-        Self { transaction, inner: RetrieveIssuingTransactionBuilder::new() }
+    pub fn new(transaction: impl Into<stripe_shared::IssuingTransactionId>) -> Self {
+        Self { transaction: transaction.into(), inner: RetrieveIssuingTransactionBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveIssuingTransaction<'_> {
+impl RetrieveIssuingTransaction {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -175,23 +175,23 @@ impl RetrieveIssuingTransaction<'_> {
     }
 }
 
-impl StripeRequest for RetrieveIssuingTransaction<'_> {
+impl StripeRequest for RetrieveIssuingTransaction {
     type Output = stripe_shared::IssuingTransaction;
 
     fn build(&self) -> RequestBuilder {
-        let transaction = self.transaction;
+        let transaction = &self.transaction;
         RequestBuilder::new(StripeMethod::Get, format!("/issuing/transactions/{transaction}"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdateIssuingTransactionBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdateIssuingTransactionBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
 }
-impl<'a> UpdateIssuingTransactionBuilder<'a> {
+impl UpdateIssuingTransactionBuilder {
     fn new() -> Self {
         Self { expand: None, metadata: None }
     }
@@ -199,30 +199,33 @@ impl<'a> UpdateIssuingTransactionBuilder<'a> {
 /// Updates the specified Issuing `Transaction` object by setting the values of the parameters passed.
 /// Any parameters not provided will be left unchanged.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateIssuingTransaction<'a> {
-    inner: UpdateIssuingTransactionBuilder<'a>,
-    transaction: &'a stripe_shared::IssuingTransactionId,
+pub struct UpdateIssuingTransaction {
+    inner: UpdateIssuingTransactionBuilder,
+    transaction: stripe_shared::IssuingTransactionId,
 }
-impl<'a> UpdateIssuingTransaction<'a> {
+impl UpdateIssuingTransaction {
     /// Construct a new `UpdateIssuingTransaction`.
-    pub fn new(transaction: &'a stripe_shared::IssuingTransactionId) -> Self {
-        Self { transaction, inner: UpdateIssuingTransactionBuilder::new() }
+    pub fn new(transaction: impl Into<stripe_shared::IssuingTransactionId>) -> Self {
+        Self { transaction: transaction.into(), inner: UpdateIssuingTransactionBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
 }
-impl UpdateIssuingTransaction<'_> {
+impl UpdateIssuingTransaction {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -240,51 +243,51 @@ impl UpdateIssuingTransaction<'_> {
     }
 }
 
-impl StripeRequest for UpdateIssuingTransaction<'_> {
+impl StripeRequest for UpdateIssuingTransaction {
     type Output = stripe_shared::IssuingTransaction;
 
     fn build(&self) -> RequestBuilder {
-        let transaction = self.transaction;
+        let transaction = &self.transaction;
         RequestBuilder::new(StripeMethod::Post, format!("/issuing/transactions/{transaction}"))
             .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RefundIssuingTransactionBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RefundIssuingTransactionBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     refund_amount: Option<i64>,
 }
-impl<'a> RefundIssuingTransactionBuilder<'a> {
+impl RefundIssuingTransactionBuilder {
     fn new() -> Self {
         Self { expand: None, refund_amount: None }
     }
 }
 /// Refund a test-mode Transaction.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RefundIssuingTransaction<'a> {
-    inner: RefundIssuingTransactionBuilder<'a>,
-    transaction: &'a str,
+pub struct RefundIssuingTransaction {
+    inner: RefundIssuingTransactionBuilder,
+    transaction: String,
 }
-impl<'a> RefundIssuingTransaction<'a> {
+impl RefundIssuingTransaction {
     /// Construct a new `RefundIssuingTransaction`.
-    pub fn new(transaction: &'a str) -> Self {
-        Self { transaction, inner: RefundIssuingTransactionBuilder::new() }
+    pub fn new(transaction: impl Into<String>) -> Self {
+        Self { transaction: transaction.into(), inner: RefundIssuingTransactionBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// The total amount to attempt to refund.
     /// This amount is in the provided currency, or defaults to the cards currency, and in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal).
-    pub fn refund_amount(mut self, refund_amount: i64) -> Self {
-        self.inner.refund_amount = Some(refund_amount);
+    pub fn refund_amount(mut self, refund_amount: impl Into<i64>) -> Self {
+        self.inner.refund_amount = Some(refund_amount.into());
         self
     }
 }
-impl RefundIssuingTransaction<'_> {
+impl RefundIssuingTransaction {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -302,11 +305,11 @@ impl RefundIssuingTransaction<'_> {
     }
 }
 
-impl StripeRequest for RefundIssuingTransaction<'_> {
+impl StripeRequest for RefundIssuingTransaction {
     type Output = stripe_shared::IssuingTransaction;
 
     fn build(&self) -> RequestBuilder {
-        let transaction = self.transaction;
+        let transaction = &self.transaction;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/test_helpers/issuing/transactions/{transaction}/refund"),
@@ -314,24 +317,24 @@ impl StripeRequest for RefundIssuingTransaction<'_> {
         .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateForceCaptureIssuingTransactionBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateForceCaptureIssuingTransactionBuilder {
     amount: i64,
-    card: &'a str,
+    card: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     currency: Option<stripe_types::Currency>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    merchant_data: Option<CreateForceCaptureIssuingTransactionMerchantData<'a>>,
+    merchant_data: Option<CreateForceCaptureIssuingTransactionMerchantData>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    purchase_details: Option<CreateForceCaptureIssuingTransactionPurchaseDetails<'a>>,
+    purchase_details: Option<CreateForceCaptureIssuingTransactionPurchaseDetails>,
 }
-impl<'a> CreateForceCaptureIssuingTransactionBuilder<'a> {
-    fn new(amount: i64, card: &'a str) -> Self {
+impl CreateForceCaptureIssuingTransactionBuilder {
+    fn new(amount: impl Into<i64>, card: impl Into<String>) -> Self {
         Self {
-            amount,
-            card,
+            amount: amount.into(),
+            card: card.into(),
             currency: None,
             expand: None,
             merchant_data: None,
@@ -340,39 +343,39 @@ impl<'a> CreateForceCaptureIssuingTransactionBuilder<'a> {
     }
 }
 /// Details about the seller (grocery store, e-commerce website, etc.) where the card authorization happened.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateForceCaptureIssuingTransactionMerchantData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateForceCaptureIssuingTransactionMerchantData {
     /// A categorization of the seller's type of business.
     /// See our [merchant categories guide](https://stripe.com/docs/issuing/merchant-categories) for a list of possible values.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub category: Option<CreateForceCaptureIssuingTransactionMerchantDataCategory>,
     /// City where the seller is located
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<&'a str>,
+    pub city: Option<String>,
     /// Country where the seller is located
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub country: Option<&'a str>,
+    pub country: Option<String>,
     /// Name of the seller
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<&'a str>,
+    pub name: Option<String>,
     /// Identifier assigned to the seller by the card network.
     /// Different card networks may assign different network_id fields to the same merchant.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub network_id: Option<&'a str>,
+    pub network_id: Option<String>,
     /// Postal code where the seller is located
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<&'a str>,
+    pub postal_code: Option<String>,
     /// State where the seller is located
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
     /// An ID assigned by the seller to the location of the sale.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub terminal_id: Option<&'a str>,
+    pub terminal_id: Option<String>,
     /// URL provided by the merchant on a 3DS request
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub url: Option<&'a str>,
+    pub url: Option<String>,
 }
-impl<'a> CreateForceCaptureIssuingTransactionMerchantData<'a> {
+impl CreateForceCaptureIssuingTransactionMerchantData {
     pub fn new() -> Self {
         Self {
             category: None,
@@ -387,7 +390,7 @@ impl<'a> CreateForceCaptureIssuingTransactionMerchantData<'a> {
         }
     }
 }
-impl<'a> Default for CreateForceCaptureIssuingTransactionMerchantData<'a> {
+impl Default for CreateForceCaptureIssuingTransactionMerchantData {
     fn default() -> Self {
         Self::new()
     }
@@ -1420,37 +1423,37 @@ impl<'de> serde::Deserialize<'de> for CreateForceCaptureIssuingTransactionMercha
     }
 }
 /// Additional purchase information that is optionally provided by the merchant.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateForceCaptureIssuingTransactionPurchaseDetails<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateForceCaptureIssuingTransactionPurchaseDetails {
     /// Information about the flight that was purchased with this transaction.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub flight: Option<FlightSpecs<'a>>,
+    pub flight: Option<FlightSpecs>,
     /// Information about fuel that was purchased with this transaction.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub fuel: Option<CreateForceCaptureIssuingTransactionPurchaseDetailsFuel<'a>>,
+    pub fuel: Option<CreateForceCaptureIssuingTransactionPurchaseDetailsFuel>,
     /// Information about lodging that was purchased with this transaction.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lodging: Option<LodgingSpecs>,
     /// The line items in the purchase.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub receipt: Option<&'a [ReceiptSpecs<'a>]>,
+    pub receipt: Option<Vec<ReceiptSpecs>>,
     /// A merchant-specific order number.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reference: Option<&'a str>,
+    pub reference: Option<String>,
 }
-impl<'a> CreateForceCaptureIssuingTransactionPurchaseDetails<'a> {
+impl CreateForceCaptureIssuingTransactionPurchaseDetails {
     pub fn new() -> Self {
         Self { flight: None, fuel: None, lodging: None, receipt: None, reference: None }
     }
 }
-impl<'a> Default for CreateForceCaptureIssuingTransactionPurchaseDetails<'a> {
+impl Default for CreateForceCaptureIssuingTransactionPurchaseDetails {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Information about fuel that was purchased with this transaction.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateForceCaptureIssuingTransactionPurchaseDetailsFuel<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateForceCaptureIssuingTransactionPurchaseDetailsFuel {
     /// The type of fuel that was purchased.
     /// One of `diesel`, `unleaded_plus`, `unleaded_regular`, `unleaded_super`, or `other`.
     #[serde(rename = "type")]
@@ -1461,17 +1464,17 @@ pub struct CreateForceCaptureIssuingTransactionPurchaseDetailsFuel<'a> {
     pub unit: Option<CreateForceCaptureIssuingTransactionPurchaseDetailsFuelUnit>,
     /// The cost in cents per each unit of fuel, represented as a decimal string with at most 12 decimal places.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub unit_cost_decimal: Option<&'a str>,
+    pub unit_cost_decimal: Option<String>,
     /// The volume of the fuel that was pumped, represented as a decimal string with at most 12 decimal places.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub volume_decimal: Option<&'a str>,
+    pub volume_decimal: Option<String>,
 }
-impl<'a> CreateForceCaptureIssuingTransactionPurchaseDetailsFuel<'a> {
+impl CreateForceCaptureIssuingTransactionPurchaseDetailsFuel {
     pub fn new() -> Self {
         Self { type_: None, unit: None, unit_cost_decimal: None, volume_decimal: None }
     }
 }
-impl<'a> Default for CreateForceCaptureIssuingTransactionPurchaseDetailsFuel<'a> {
+impl Default for CreateForceCaptureIssuingTransactionPurchaseDetailsFuel {
     fn default() -> Self {
         Self::new()
     }
@@ -1607,45 +1610,45 @@ impl<'de> serde::Deserialize<'de> for CreateForceCaptureIssuingTransactionPurcha
 }
 /// Allows the user to capture an arbitrary amount, also known as a forced capture.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateForceCaptureIssuingTransaction<'a> {
-    inner: CreateForceCaptureIssuingTransactionBuilder<'a>,
+pub struct CreateForceCaptureIssuingTransaction {
+    inner: CreateForceCaptureIssuingTransactionBuilder,
 }
-impl<'a> CreateForceCaptureIssuingTransaction<'a> {
+impl CreateForceCaptureIssuingTransaction {
     /// Construct a new `CreateForceCaptureIssuingTransaction`.
-    pub fn new(amount: i64, card: &'a str) -> Self {
-        Self { inner: CreateForceCaptureIssuingTransactionBuilder::new(amount, card) }
+    pub fn new(amount: impl Into<i64>, card: impl Into<String>) -> Self {
+        Self { inner: CreateForceCaptureIssuingTransactionBuilder::new(amount.into(), card.into()) }
     }
     /// The currency of the capture.
     /// If not provided, defaults to the currency of the card.
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     /// Must be a [supported currency](https://stripe.com/docs/currencies).
-    pub fn currency(mut self, currency: stripe_types::Currency) -> Self {
-        self.inner.currency = Some(currency);
+    pub fn currency(mut self, currency: impl Into<stripe_types::Currency>) -> Self {
+        self.inner.currency = Some(currency.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Details about the seller (grocery store, e-commerce website, etc.) where the card authorization happened.
     pub fn merchant_data(
         mut self,
-        merchant_data: CreateForceCaptureIssuingTransactionMerchantData<'a>,
+        merchant_data: impl Into<CreateForceCaptureIssuingTransactionMerchantData>,
     ) -> Self {
-        self.inner.merchant_data = Some(merchant_data);
+        self.inner.merchant_data = Some(merchant_data.into());
         self
     }
     /// Additional purchase information that is optionally provided by the merchant.
     pub fn purchase_details(
         mut self,
-        purchase_details: CreateForceCaptureIssuingTransactionPurchaseDetails<'a>,
+        purchase_details: impl Into<CreateForceCaptureIssuingTransactionPurchaseDetails>,
     ) -> Self {
-        self.inner.purchase_details = Some(purchase_details);
+        self.inner.purchase_details = Some(purchase_details.into());
         self
     }
 }
-impl CreateForceCaptureIssuingTransaction<'_> {
+impl CreateForceCaptureIssuingTransaction {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -1663,7 +1666,7 @@ impl CreateForceCaptureIssuingTransaction<'_> {
     }
 }
 
-impl StripeRequest for CreateForceCaptureIssuingTransaction<'_> {
+impl StripeRequest for CreateForceCaptureIssuingTransaction {
     type Output = stripe_shared::IssuingTransaction;
 
     fn build(&self) -> RequestBuilder {
@@ -1674,24 +1677,24 @@ impl StripeRequest for CreateForceCaptureIssuingTransaction<'_> {
         .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateUnlinkedRefundIssuingTransactionBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateUnlinkedRefundIssuingTransactionBuilder {
     amount: i64,
-    card: &'a str,
+    card: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     currency: Option<stripe_types::Currency>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    merchant_data: Option<CreateUnlinkedRefundIssuingTransactionMerchantData<'a>>,
+    merchant_data: Option<CreateUnlinkedRefundIssuingTransactionMerchantData>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    purchase_details: Option<CreateUnlinkedRefundIssuingTransactionPurchaseDetails<'a>>,
+    purchase_details: Option<CreateUnlinkedRefundIssuingTransactionPurchaseDetails>,
 }
-impl<'a> CreateUnlinkedRefundIssuingTransactionBuilder<'a> {
-    fn new(amount: i64, card: &'a str) -> Self {
+impl CreateUnlinkedRefundIssuingTransactionBuilder {
+    fn new(amount: impl Into<i64>, card: impl Into<String>) -> Self {
         Self {
-            amount,
-            card,
+            amount: amount.into(),
+            card: card.into(),
             currency: None,
             expand: None,
             merchant_data: None,
@@ -1700,39 +1703,39 @@ impl<'a> CreateUnlinkedRefundIssuingTransactionBuilder<'a> {
     }
 }
 /// Details about the seller (grocery store, e-commerce website, etc.) where the card authorization happened.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateUnlinkedRefundIssuingTransactionMerchantData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateUnlinkedRefundIssuingTransactionMerchantData {
     /// A categorization of the seller's type of business.
     /// See our [merchant categories guide](https://stripe.com/docs/issuing/merchant-categories) for a list of possible values.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub category: Option<CreateUnlinkedRefundIssuingTransactionMerchantDataCategory>,
     /// City where the seller is located
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<&'a str>,
+    pub city: Option<String>,
     /// Country where the seller is located
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub country: Option<&'a str>,
+    pub country: Option<String>,
     /// Name of the seller
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<&'a str>,
+    pub name: Option<String>,
     /// Identifier assigned to the seller by the card network.
     /// Different card networks may assign different network_id fields to the same merchant.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub network_id: Option<&'a str>,
+    pub network_id: Option<String>,
     /// Postal code where the seller is located
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<&'a str>,
+    pub postal_code: Option<String>,
     /// State where the seller is located
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
     /// An ID assigned by the seller to the location of the sale.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub terminal_id: Option<&'a str>,
+    pub terminal_id: Option<String>,
     /// URL provided by the merchant on a 3DS request
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub url: Option<&'a str>,
+    pub url: Option<String>,
 }
-impl<'a> CreateUnlinkedRefundIssuingTransactionMerchantData<'a> {
+impl CreateUnlinkedRefundIssuingTransactionMerchantData {
     pub fn new() -> Self {
         Self {
             category: None,
@@ -1747,7 +1750,7 @@ impl<'a> CreateUnlinkedRefundIssuingTransactionMerchantData<'a> {
         }
     }
 }
-impl<'a> Default for CreateUnlinkedRefundIssuingTransactionMerchantData<'a> {
+impl Default for CreateUnlinkedRefundIssuingTransactionMerchantData {
     fn default() -> Self {
         Self::new()
     }
@@ -2780,37 +2783,37 @@ impl<'de> serde::Deserialize<'de> for CreateUnlinkedRefundIssuingTransactionMerc
     }
 }
 /// Additional purchase information that is optionally provided by the merchant.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateUnlinkedRefundIssuingTransactionPurchaseDetails<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateUnlinkedRefundIssuingTransactionPurchaseDetails {
     /// Information about the flight that was purchased with this transaction.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub flight: Option<FlightSpecs<'a>>,
+    pub flight: Option<FlightSpecs>,
     /// Information about fuel that was purchased with this transaction.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub fuel: Option<CreateUnlinkedRefundIssuingTransactionPurchaseDetailsFuel<'a>>,
+    pub fuel: Option<CreateUnlinkedRefundIssuingTransactionPurchaseDetailsFuel>,
     /// Information about lodging that was purchased with this transaction.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub lodging: Option<LodgingSpecs>,
     /// The line items in the purchase.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub receipt: Option<&'a [ReceiptSpecs<'a>]>,
+    pub receipt: Option<Vec<ReceiptSpecs>>,
     /// A merchant-specific order number.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reference: Option<&'a str>,
+    pub reference: Option<String>,
 }
-impl<'a> CreateUnlinkedRefundIssuingTransactionPurchaseDetails<'a> {
+impl CreateUnlinkedRefundIssuingTransactionPurchaseDetails {
     pub fn new() -> Self {
         Self { flight: None, fuel: None, lodging: None, receipt: None, reference: None }
     }
 }
-impl<'a> Default for CreateUnlinkedRefundIssuingTransactionPurchaseDetails<'a> {
+impl Default for CreateUnlinkedRefundIssuingTransactionPurchaseDetails {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Information about fuel that was purchased with this transaction.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateUnlinkedRefundIssuingTransactionPurchaseDetailsFuel<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateUnlinkedRefundIssuingTransactionPurchaseDetailsFuel {
     /// The type of fuel that was purchased.
     /// One of `diesel`, `unleaded_plus`, `unleaded_regular`, `unleaded_super`, or `other`.
     #[serde(rename = "type")]
@@ -2821,17 +2824,17 @@ pub struct CreateUnlinkedRefundIssuingTransactionPurchaseDetailsFuel<'a> {
     pub unit: Option<CreateUnlinkedRefundIssuingTransactionPurchaseDetailsFuelUnit>,
     /// The cost in cents per each unit of fuel, represented as a decimal string with at most 12 decimal places.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub unit_cost_decimal: Option<&'a str>,
+    pub unit_cost_decimal: Option<String>,
     /// The volume of the fuel that was pumped, represented as a decimal string with at most 12 decimal places.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub volume_decimal: Option<&'a str>,
+    pub volume_decimal: Option<String>,
 }
-impl<'a> CreateUnlinkedRefundIssuingTransactionPurchaseDetailsFuel<'a> {
+impl CreateUnlinkedRefundIssuingTransactionPurchaseDetailsFuel {
     pub fn new() -> Self {
         Self { type_: None, unit: None, unit_cost_decimal: None, volume_decimal: None }
     }
 }
-impl<'a> Default for CreateUnlinkedRefundIssuingTransactionPurchaseDetailsFuel<'a> {
+impl Default for CreateUnlinkedRefundIssuingTransactionPurchaseDetailsFuel {
     fn default() -> Self {
         Self::new()
     }
@@ -2971,45 +2974,47 @@ impl<'de> serde::Deserialize<'de>
 }
 /// Allows the user to refund an arbitrary amount, also known as a unlinked refund.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateUnlinkedRefundIssuingTransaction<'a> {
-    inner: CreateUnlinkedRefundIssuingTransactionBuilder<'a>,
+pub struct CreateUnlinkedRefundIssuingTransaction {
+    inner: CreateUnlinkedRefundIssuingTransactionBuilder,
 }
-impl<'a> CreateUnlinkedRefundIssuingTransaction<'a> {
+impl CreateUnlinkedRefundIssuingTransaction {
     /// Construct a new `CreateUnlinkedRefundIssuingTransaction`.
-    pub fn new(amount: i64, card: &'a str) -> Self {
-        Self { inner: CreateUnlinkedRefundIssuingTransactionBuilder::new(amount, card) }
+    pub fn new(amount: impl Into<i64>, card: impl Into<String>) -> Self {
+        Self {
+            inner: CreateUnlinkedRefundIssuingTransactionBuilder::new(amount.into(), card.into()),
+        }
     }
     /// The currency of the unlinked refund.
     /// If not provided, defaults to the currency of the card.
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     /// Must be a [supported currency](https://stripe.com/docs/currencies).
-    pub fn currency(mut self, currency: stripe_types::Currency) -> Self {
-        self.inner.currency = Some(currency);
+    pub fn currency(mut self, currency: impl Into<stripe_types::Currency>) -> Self {
+        self.inner.currency = Some(currency.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Details about the seller (grocery store, e-commerce website, etc.) where the card authorization happened.
     pub fn merchant_data(
         mut self,
-        merchant_data: CreateUnlinkedRefundIssuingTransactionMerchantData<'a>,
+        merchant_data: impl Into<CreateUnlinkedRefundIssuingTransactionMerchantData>,
     ) -> Self {
-        self.inner.merchant_data = Some(merchant_data);
+        self.inner.merchant_data = Some(merchant_data.into());
         self
     }
     /// Additional purchase information that is optionally provided by the merchant.
     pub fn purchase_details(
         mut self,
-        purchase_details: CreateUnlinkedRefundIssuingTransactionPurchaseDetails<'a>,
+        purchase_details: impl Into<CreateUnlinkedRefundIssuingTransactionPurchaseDetails>,
     ) -> Self {
-        self.inner.purchase_details = Some(purchase_details);
+        self.inner.purchase_details = Some(purchase_details.into());
         self
     }
 }
-impl CreateUnlinkedRefundIssuingTransaction<'_> {
+impl CreateUnlinkedRefundIssuingTransaction {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -3027,7 +3032,7 @@ impl CreateUnlinkedRefundIssuingTransaction<'_> {
     }
 }
 
-impl StripeRequest for CreateUnlinkedRefundIssuingTransaction<'_> {
+impl StripeRequest for CreateUnlinkedRefundIssuingTransaction {
     type Output = stripe_shared::IssuingTransaction;
 
     fn build(&self) -> RequestBuilder {
@@ -3039,28 +3044,28 @@ impl StripeRequest for CreateUnlinkedRefundIssuingTransaction<'_> {
     }
 }
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct FlightSegmentSpecs<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct FlightSegmentSpecs {
     /// The three-letter IATA airport code of the flight's destination.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub arrival_airport_code: Option<&'a str>,
+    pub arrival_airport_code: Option<String>,
     /// The airline carrier code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub carrier: Option<&'a str>,
+    pub carrier: Option<String>,
     /// The three-letter IATA airport code that the flight departed from.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub departure_airport_code: Option<&'a str>,
+    pub departure_airport_code: Option<String>,
     /// The flight number.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub flight_number: Option<&'a str>,
+    pub flight_number: Option<String>,
     /// The flight's service class.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub service_class: Option<&'a str>,
+    pub service_class: Option<String>,
     /// Whether a stopover is allowed on this flight.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stopover_allowed: Option<bool>,
 }
-impl<'a> FlightSegmentSpecs<'a> {
+impl FlightSegmentSpecs {
     pub fn new() -> Self {
         Self {
             arrival_airport_code: None,
@@ -3072,7 +3077,7 @@ impl<'a> FlightSegmentSpecs<'a> {
         }
     }
 }
-impl<'a> Default for FlightSegmentSpecs<'a> {
+impl Default for FlightSegmentSpecs {
     fn default() -> Self {
         Self::new()
     }
@@ -3096,46 +3101,46 @@ impl Default for LodgingSpecs {
         Self::new()
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ReceiptSpecs<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ReceiptSpecs {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<&'a str>,
+    pub description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub quantity: Option<&'a str>,
+    pub quantity: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub total: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub unit_cost: Option<i64>,
 }
-impl<'a> ReceiptSpecs<'a> {
+impl ReceiptSpecs {
     pub fn new() -> Self {
         Self { description: None, quantity: None, total: None, unit_cost: None }
     }
 }
-impl<'a> Default for ReceiptSpecs<'a> {
+impl Default for ReceiptSpecs {
     fn default() -> Self {
         Self::new()
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct FlightSpecs<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct FlightSpecs {
     /// The time that the flight departed.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub departure_at: Option<stripe_types::Timestamp>,
     /// The name of the passenger.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub passenger_name: Option<&'a str>,
+    pub passenger_name: Option<String>,
     /// Whether the ticket is refundable.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub refundable: Option<bool>,
     /// The legs of the trip.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub segments: Option<&'a [FlightSegmentSpecs<'a>]>,
+    pub segments: Option<Vec<FlightSegmentSpecs>>,
     /// The travel agency that issued the ticket.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub travel_agency: Option<&'a str>,
+    pub travel_agency: Option<String>,
 }
-impl<'a> FlightSpecs<'a> {
+impl FlightSpecs {
     pub fn new() -> Self {
         Self {
             departure_at: None,
@@ -3146,7 +3151,7 @@ impl<'a> FlightSpecs<'a> {
         }
     }
 }
-impl<'a> Default for FlightSpecs<'a> {
+impl Default for FlightSpecs {
     fn default() -> Self {
         Self::new()
     }

--- a/generated/async-stripe-misc/src/apple_pay_domain/requests.rs
+++ b/generated/async-stripe-misc/src/apple_pay_domain/requests.rs
@@ -4,16 +4,16 @@ use stripe_client_core::{
 
 /// Delete an apple pay domain.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct DeleteApplePayDomain<'a> {
-    domain: &'a str,
+pub struct DeleteApplePayDomain {
+    domain: String,
 }
-impl<'a> DeleteApplePayDomain<'a> {
+impl DeleteApplePayDomain {
     /// Construct a new `DeleteApplePayDomain`.
-    pub fn new(domain: &'a str) -> Self {
-        Self { domain }
+    pub fn new(domain: impl Into<String>) -> Self {
+        Self { domain: domain.into() }
     }
 }
-impl DeleteApplePayDomain<'_> {
+impl DeleteApplePayDomain {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -31,28 +31,28 @@ impl DeleteApplePayDomain<'_> {
     }
 }
 
-impl StripeRequest for DeleteApplePayDomain<'_> {
+impl StripeRequest for DeleteApplePayDomain {
     type Output = stripe_misc::DeletedApplePayDomain;
 
     fn build(&self) -> RequestBuilder {
-        let domain = self.domain;
+        let domain = &self.domain;
         RequestBuilder::new(StripeMethod::Delete, format!("/apple_pay/domains/{domain}"))
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListApplePayDomainBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListApplePayDomainBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    domain_name: Option<&'a str>,
+    domain_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListApplePayDomainBuilder<'a> {
+impl ListApplePayDomainBuilder {
     fn new() -> Self {
         Self {
             domain_name: None,
@@ -65,50 +65,50 @@ impl<'a> ListApplePayDomainBuilder<'a> {
 }
 /// List apple pay domains.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListApplePayDomain<'a> {
-    inner: ListApplePayDomainBuilder<'a>,
+pub struct ListApplePayDomain {
+    inner: ListApplePayDomainBuilder,
 }
-impl<'a> ListApplePayDomain<'a> {
+impl ListApplePayDomain {
     /// Construct a new `ListApplePayDomain`.
     pub fn new() -> Self {
         Self { inner: ListApplePayDomainBuilder::new() }
     }
-    pub fn domain_name(mut self, domain_name: &'a str) -> Self {
-        self.inner.domain_name = Some(domain_name);
+    pub fn domain_name(mut self, domain_name: impl Into<String>) -> Self {
+        self.inner.domain_name = Some(domain_name.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl<'a> Default for ListApplePayDomain<'a> {
+impl Default for ListApplePayDomain {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListApplePayDomain<'_> {
+impl ListApplePayDomain {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -128,45 +128,45 @@ impl ListApplePayDomain<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_misc::ApplePayDomain>> {
-        stripe_client_core::ListPaginator::new_list("/apple_pay/domains", self.inner)
+        stripe_client_core::ListPaginator::new_list("/apple_pay/domains", &self.inner)
     }
 }
 
-impl StripeRequest for ListApplePayDomain<'_> {
+impl StripeRequest for ListApplePayDomain {
     type Output = stripe_types::List<stripe_misc::ApplePayDomain>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/apple_pay/domains").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveApplePayDomainBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveApplePayDomainBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveApplePayDomainBuilder<'a> {
+impl RetrieveApplePayDomainBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieve an apple pay domain.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveApplePayDomain<'a> {
-    inner: RetrieveApplePayDomainBuilder<'a>,
-    domain: &'a str,
+pub struct RetrieveApplePayDomain {
+    inner: RetrieveApplePayDomainBuilder,
+    domain: String,
 }
-impl<'a> RetrieveApplePayDomain<'a> {
+impl RetrieveApplePayDomain {
     /// Construct a new `RetrieveApplePayDomain`.
-    pub fn new(domain: &'a str) -> Self {
-        Self { domain, inner: RetrieveApplePayDomainBuilder::new() }
+    pub fn new(domain: impl Into<String>) -> Self {
+        Self { domain: domain.into(), inner: RetrieveApplePayDomainBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveApplePayDomain<'_> {
+impl RetrieveApplePayDomain {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -184,43 +184,43 @@ impl RetrieveApplePayDomain<'_> {
     }
 }
 
-impl StripeRequest for RetrieveApplePayDomain<'_> {
+impl StripeRequest for RetrieveApplePayDomain {
     type Output = stripe_misc::ApplePayDomain;
 
     fn build(&self) -> RequestBuilder {
-        let domain = self.domain;
+        let domain = &self.domain;
         RequestBuilder::new(StripeMethod::Get, format!("/apple_pay/domains/{domain}"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateApplePayDomainBuilder<'a> {
-    domain_name: &'a str,
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateApplePayDomainBuilder {
+    domain_name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> CreateApplePayDomainBuilder<'a> {
-    fn new(domain_name: &'a str) -> Self {
-        Self { domain_name, expand: None }
+impl CreateApplePayDomainBuilder {
+    fn new(domain_name: impl Into<String>) -> Self {
+        Self { domain_name: domain_name.into(), expand: None }
     }
 }
 /// Create an apple pay domain.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateApplePayDomain<'a> {
-    inner: CreateApplePayDomainBuilder<'a>,
+pub struct CreateApplePayDomain {
+    inner: CreateApplePayDomainBuilder,
 }
-impl<'a> CreateApplePayDomain<'a> {
+impl CreateApplePayDomain {
     /// Construct a new `CreateApplePayDomain`.
-    pub fn new(domain_name: &'a str) -> Self {
-        Self { inner: CreateApplePayDomainBuilder::new(domain_name) }
+    pub fn new(domain_name: impl Into<String>) -> Self {
+        Self { inner: CreateApplePayDomainBuilder::new(domain_name.into()) }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl CreateApplePayDomain<'_> {
+impl CreateApplePayDomain {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -238,7 +238,7 @@ impl CreateApplePayDomain<'_> {
     }
 }
 
-impl StripeRequest for CreateApplePayDomain<'_> {
+impl StripeRequest for CreateApplePayDomain {
     type Output = stripe_misc::ApplePayDomain;
 
     fn build(&self) -> RequestBuilder {

--- a/generated/async-stripe-misc/src/climate_order/requests.rs
+++ b/generated/async-stripe-misc/src/climate_order/requests.rs
@@ -2,18 +2,18 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListClimateOrderBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListClimateOrderBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListClimateOrderBuilder<'a> {
+impl ListClimateOrderBuilder {
     fn new() -> Self {
         Self { ending_before: None, expand: None, limit: None, starting_after: None }
     }
@@ -21,10 +21,10 @@ impl<'a> ListClimateOrderBuilder<'a> {
 /// Lists all Climate order objects. The orders are returned sorted by creation date, with the
 /// most recently created orders appearing first.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListClimateOrder<'a> {
-    inner: ListClimateOrderBuilder<'a>,
+pub struct ListClimateOrder {
+    inner: ListClimateOrderBuilder,
 }
-impl<'a> ListClimateOrder<'a> {
+impl ListClimateOrder {
     /// Construct a new `ListClimateOrder`.
     pub fn new() -> Self {
         Self { inner: ListClimateOrderBuilder::new() }
@@ -32,35 +32,35 @@ impl<'a> ListClimateOrder<'a> {
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl<'a> Default for ListClimateOrder<'a> {
+impl Default for ListClimateOrder {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListClimateOrder<'_> {
+impl ListClimateOrder {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -80,45 +80,45 @@ impl ListClimateOrder<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_misc::ClimateOrder>> {
-        stripe_client_core::ListPaginator::new_list("/climate/orders", self.inner)
+        stripe_client_core::ListPaginator::new_list("/climate/orders", &self.inner)
     }
 }
 
-impl StripeRequest for ListClimateOrder<'_> {
+impl StripeRequest for ListClimateOrder {
     type Output = stripe_types::List<stripe_misc::ClimateOrder>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/climate/orders").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveClimateOrderBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveClimateOrderBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveClimateOrderBuilder<'a> {
+impl RetrieveClimateOrderBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves the details of a Climate order object with the given ID.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveClimateOrder<'a> {
-    inner: RetrieveClimateOrderBuilder<'a>,
-    order: &'a stripe_misc::ClimateOrderId,
+pub struct RetrieveClimateOrder {
+    inner: RetrieveClimateOrderBuilder,
+    order: stripe_misc::ClimateOrderId,
 }
-impl<'a> RetrieveClimateOrder<'a> {
+impl RetrieveClimateOrder {
     /// Construct a new `RetrieveClimateOrder`.
-    pub fn new(order: &'a stripe_misc::ClimateOrderId) -> Self {
-        Self { order, inner: RetrieveClimateOrderBuilder::new() }
+    pub fn new(order: impl Into<stripe_misc::ClimateOrderId>) -> Self {
+        Self { order: order.into(), inner: RetrieveClimateOrderBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveClimateOrder<'_> {
+impl RetrieveClimateOrder {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -136,33 +136,33 @@ impl RetrieveClimateOrder<'_> {
     }
 }
 
-impl StripeRequest for RetrieveClimateOrder<'_> {
+impl StripeRequest for RetrieveClimateOrder {
     type Output = stripe_misc::ClimateOrder;
 
     fn build(&self) -> RequestBuilder {
-        let order = self.order;
+        let order = &self.order;
         RequestBuilder::new(StripeMethod::Get, format!("/climate/orders/{order}"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateClimateOrderBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateClimateOrderBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     amount: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    beneficiary: Option<BeneficiaryParams<'a>>,
+    beneficiary: Option<BeneficiaryParams>,
     #[serde(skip_serializing_if = "Option::is_none")]
     currency: Option<stripe_types::Currency>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metric_tons: Option<&'a str>,
-    product: &'a str,
+    metric_tons: Option<String>,
+    product: String,
 }
-impl<'a> CreateClimateOrderBuilder<'a> {
-    fn new(product: &'a str) -> Self {
+impl CreateClimateOrderBuilder {
+    fn new(product: impl Into<String>) -> Self {
         Self {
             amount: None,
             beneficiary: None,
@@ -170,59 +170,62 @@ impl<'a> CreateClimateOrderBuilder<'a> {
             expand: None,
             metadata: None,
             metric_tons: None,
-            product,
+            product: product.into(),
         }
     }
 }
 /// Creates a Climate order object for a given Climate product. The order will be processed immediately
 /// after creation and payment will be deducted your Stripe balance.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateClimateOrder<'a> {
-    inner: CreateClimateOrderBuilder<'a>,
+pub struct CreateClimateOrder {
+    inner: CreateClimateOrderBuilder,
 }
-impl<'a> CreateClimateOrder<'a> {
+impl CreateClimateOrder {
     /// Construct a new `CreateClimateOrder`.
-    pub fn new(product: &'a str) -> Self {
-        Self { inner: CreateClimateOrderBuilder::new(product) }
+    pub fn new(product: impl Into<String>) -> Self {
+        Self { inner: CreateClimateOrderBuilder::new(product.into()) }
     }
     /// Requested amount of carbon removal units. Either this or `metric_tons` must be specified.
-    pub fn amount(mut self, amount: i64) -> Self {
-        self.inner.amount = Some(amount);
+    pub fn amount(mut self, amount: impl Into<i64>) -> Self {
+        self.inner.amount = Some(amount.into());
         self
     }
     /// Publicly sharable reference for the end beneficiary of carbon removal.
     /// Assumed to be the Stripe account if not set.
-    pub fn beneficiary(mut self, beneficiary: BeneficiaryParams<'a>) -> Self {
-        self.inner.beneficiary = Some(beneficiary);
+    pub fn beneficiary(mut self, beneficiary: impl Into<BeneficiaryParams>) -> Self {
+        self.inner.beneficiary = Some(beneficiary.into());
         self
     }
     /// Request currency for the order as a three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     /// Must be a supported [settlement currency for your account](https://stripe.com/docs/currencies).
     /// If omitted, the account's default currency will be used.
-    pub fn currency(mut self, currency: stripe_types::Currency) -> Self {
-        self.inner.currency = Some(currency);
+    pub fn currency(mut self, currency: impl Into<stripe_types::Currency>) -> Self {
+        self.inner.currency = Some(currency.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// Requested number of tons for the order. Either this or `amount` must be specified.
-    pub fn metric_tons(mut self, metric_tons: &'a str) -> Self {
-        self.inner.metric_tons = Some(metric_tons);
+    pub fn metric_tons(mut self, metric_tons: impl Into<String>) -> Self {
+        self.inner.metric_tons = Some(metric_tons.into());
         self
     }
 }
-impl CreateClimateOrder<'_> {
+impl CreateClimateOrder {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -240,59 +243,62 @@ impl CreateClimateOrder<'_> {
     }
 }
 
-impl StripeRequest for CreateClimateOrder<'_> {
+impl StripeRequest for CreateClimateOrder {
     type Output = stripe_misc::ClimateOrder;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Post, "/climate/orders").form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdateClimateOrderBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdateClimateOrderBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    beneficiary: Option<BeneficiaryParams<'a>>,
+    beneficiary: Option<BeneficiaryParams>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
 }
-impl<'a> UpdateClimateOrderBuilder<'a> {
+impl UpdateClimateOrderBuilder {
     fn new() -> Self {
         Self { beneficiary: None, expand: None, metadata: None }
     }
 }
 /// Updates the specified order by setting the values of the parameters passed.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateClimateOrder<'a> {
-    inner: UpdateClimateOrderBuilder<'a>,
-    order: &'a stripe_misc::ClimateOrderId,
+pub struct UpdateClimateOrder {
+    inner: UpdateClimateOrderBuilder,
+    order: stripe_misc::ClimateOrderId,
 }
-impl<'a> UpdateClimateOrder<'a> {
+impl UpdateClimateOrder {
     /// Construct a new `UpdateClimateOrder`.
-    pub fn new(order: &'a stripe_misc::ClimateOrderId) -> Self {
-        Self { order, inner: UpdateClimateOrderBuilder::new() }
+    pub fn new(order: impl Into<stripe_misc::ClimateOrderId>) -> Self {
+        Self { order: order.into(), inner: UpdateClimateOrderBuilder::new() }
     }
     /// Publicly sharable reference for the end beneficiary of carbon removal.
     /// Assumed to be the Stripe account if not set.
-    pub fn beneficiary(mut self, beneficiary: BeneficiaryParams<'a>) -> Self {
-        self.inner.beneficiary = Some(beneficiary);
+    pub fn beneficiary(mut self, beneficiary: impl Into<BeneficiaryParams>) -> Self {
+        self.inner.beneficiary = Some(beneficiary.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
 }
-impl UpdateClimateOrder<'_> {
+impl UpdateClimateOrder {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -310,21 +316,21 @@ impl UpdateClimateOrder<'_> {
     }
 }
 
-impl StripeRequest for UpdateClimateOrder<'_> {
+impl StripeRequest for UpdateClimateOrder {
     type Output = stripe_misc::ClimateOrder;
 
     fn build(&self) -> RequestBuilder {
-        let order = self.order;
+        let order = &self.order;
         RequestBuilder::new(StripeMethod::Post, format!("/climate/orders/{order}"))
             .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CancelClimateOrderBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CancelClimateOrderBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> CancelClimateOrderBuilder<'a> {
+impl CancelClimateOrderBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
@@ -334,22 +340,22 @@ impl<'a> CancelClimateOrderBuilder<'a> {
 /// might cancel reservations if suppliers fail to deliver. If Frontier cancels the reservation, Stripe
 /// provides 90 days advance notice and refunds the `amount_total`.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CancelClimateOrder<'a> {
-    inner: CancelClimateOrderBuilder<'a>,
-    order: &'a stripe_misc::ClimateOrderId,
+pub struct CancelClimateOrder {
+    inner: CancelClimateOrderBuilder,
+    order: stripe_misc::ClimateOrderId,
 }
-impl<'a> CancelClimateOrder<'a> {
+impl CancelClimateOrder {
     /// Construct a new `CancelClimateOrder`.
-    pub fn new(order: &'a stripe_misc::ClimateOrderId) -> Self {
-        Self { order, inner: CancelClimateOrderBuilder::new() }
+    pub fn new(order: impl Into<stripe_misc::ClimateOrderId>) -> Self {
+        Self { order: order.into(), inner: CancelClimateOrderBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl CancelClimateOrder<'_> {
+impl CancelClimateOrder {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -367,23 +373,23 @@ impl CancelClimateOrder<'_> {
     }
 }
 
-impl StripeRequest for CancelClimateOrder<'_> {
+impl StripeRequest for CancelClimateOrder {
     type Output = stripe_misc::ClimateOrder;
 
     fn build(&self) -> RequestBuilder {
-        let order = self.order;
+        let order = &self.order;
         RequestBuilder::new(StripeMethod::Post, format!("/climate/orders/{order}/cancel"))
             .form(&self.inner)
     }
 }
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct BeneficiaryParams<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct BeneficiaryParams {
     /// Publicly displayable name for the end beneficiary of carbon removal.
-    pub public_name: &'a str,
+    pub public_name: String,
 }
-impl<'a> BeneficiaryParams<'a> {
-    pub fn new(public_name: &'a str) -> Self {
-        Self { public_name }
+impl BeneficiaryParams {
+    pub fn new(public_name: impl Into<String>) -> Self {
+        Self { public_name: public_name.into() }
     }
 }

--- a/generated/async-stripe-misc/src/climate_product/requests.rs
+++ b/generated/async-stripe-misc/src/climate_product/requests.rs
@@ -2,28 +2,28 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListClimateProductBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListClimateProductBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListClimateProductBuilder<'a> {
+impl ListClimateProductBuilder {
     fn new() -> Self {
         Self { ending_before: None, expand: None, limit: None, starting_after: None }
     }
 }
 /// Lists all available Climate product objects.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListClimateProduct<'a> {
-    inner: ListClimateProductBuilder<'a>,
+pub struct ListClimateProduct {
+    inner: ListClimateProductBuilder,
 }
-impl<'a> ListClimateProduct<'a> {
+impl ListClimateProduct {
     /// Construct a new `ListClimateProduct`.
     pub fn new() -> Self {
         Self { inner: ListClimateProductBuilder::new() }
@@ -31,35 +31,35 @@ impl<'a> ListClimateProduct<'a> {
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl<'a> Default for ListClimateProduct<'a> {
+impl Default for ListClimateProduct {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListClimateProduct<'_> {
+impl ListClimateProduct {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -79,45 +79,45 @@ impl ListClimateProduct<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_misc::ClimateProduct>> {
-        stripe_client_core::ListPaginator::new_list("/climate/products", self.inner)
+        stripe_client_core::ListPaginator::new_list("/climate/products", &self.inner)
     }
 }
 
-impl StripeRequest for ListClimateProduct<'_> {
+impl StripeRequest for ListClimateProduct {
     type Output = stripe_types::List<stripe_misc::ClimateProduct>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/climate/products").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveClimateProductBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveClimateProductBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveClimateProductBuilder<'a> {
+impl RetrieveClimateProductBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves the details of a Climate product with the given ID.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveClimateProduct<'a> {
-    inner: RetrieveClimateProductBuilder<'a>,
-    product: &'a stripe_misc::ClimateProductId,
+pub struct RetrieveClimateProduct {
+    inner: RetrieveClimateProductBuilder,
+    product: stripe_misc::ClimateProductId,
 }
-impl<'a> RetrieveClimateProduct<'a> {
+impl RetrieveClimateProduct {
     /// Construct a new `RetrieveClimateProduct`.
-    pub fn new(product: &'a stripe_misc::ClimateProductId) -> Self {
-        Self { product, inner: RetrieveClimateProductBuilder::new() }
+    pub fn new(product: impl Into<stripe_misc::ClimateProductId>) -> Self {
+        Self { product: product.into(), inner: RetrieveClimateProductBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveClimateProduct<'_> {
+impl RetrieveClimateProduct {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -135,11 +135,11 @@ impl RetrieveClimateProduct<'_> {
     }
 }
 
-impl StripeRequest for RetrieveClimateProduct<'_> {
+impl StripeRequest for RetrieveClimateProduct {
     type Output = stripe_misc::ClimateProduct;
 
     fn build(&self) -> RequestBuilder {
-        let product = self.product;
+        let product = &self.product;
         RequestBuilder::new(StripeMethod::Get, format!("/climate/products/{product}"))
             .query(&self.inner)
     }

--- a/generated/async-stripe-misc/src/climate_supplier/requests.rs
+++ b/generated/async-stripe-misc/src/climate_supplier/requests.rs
@@ -2,28 +2,28 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListClimateSupplierBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListClimateSupplierBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListClimateSupplierBuilder<'a> {
+impl ListClimateSupplierBuilder {
     fn new() -> Self {
         Self { ending_before: None, expand: None, limit: None, starting_after: None }
     }
 }
 /// Lists all available Climate supplier objects.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListClimateSupplier<'a> {
-    inner: ListClimateSupplierBuilder<'a>,
+pub struct ListClimateSupplier {
+    inner: ListClimateSupplierBuilder,
 }
-impl<'a> ListClimateSupplier<'a> {
+impl ListClimateSupplier {
     /// Construct a new `ListClimateSupplier`.
     pub fn new() -> Self {
         Self { inner: ListClimateSupplierBuilder::new() }
@@ -31,35 +31,35 @@ impl<'a> ListClimateSupplier<'a> {
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl<'a> Default for ListClimateSupplier<'a> {
+impl Default for ListClimateSupplier {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListClimateSupplier<'_> {
+impl ListClimateSupplier {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -79,45 +79,45 @@ impl ListClimateSupplier<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_misc::ClimateSupplier>> {
-        stripe_client_core::ListPaginator::new_list("/climate/suppliers", self.inner)
+        stripe_client_core::ListPaginator::new_list("/climate/suppliers", &self.inner)
     }
 }
 
-impl StripeRequest for ListClimateSupplier<'_> {
+impl StripeRequest for ListClimateSupplier {
     type Output = stripe_types::List<stripe_misc::ClimateSupplier>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/climate/suppliers").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveClimateSupplierBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveClimateSupplierBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveClimateSupplierBuilder<'a> {
+impl RetrieveClimateSupplierBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves a Climate supplier object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveClimateSupplier<'a> {
-    inner: RetrieveClimateSupplierBuilder<'a>,
-    supplier: &'a stripe_misc::ClimateSupplierId,
+pub struct RetrieveClimateSupplier {
+    inner: RetrieveClimateSupplierBuilder,
+    supplier: stripe_misc::ClimateSupplierId,
 }
-impl<'a> RetrieveClimateSupplier<'a> {
+impl RetrieveClimateSupplier {
     /// Construct a new `RetrieveClimateSupplier`.
-    pub fn new(supplier: &'a stripe_misc::ClimateSupplierId) -> Self {
-        Self { supplier, inner: RetrieveClimateSupplierBuilder::new() }
+    pub fn new(supplier: impl Into<stripe_misc::ClimateSupplierId>) -> Self {
+        Self { supplier: supplier.into(), inner: RetrieveClimateSupplierBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveClimateSupplier<'_> {
+impl RetrieveClimateSupplier {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -135,11 +135,11 @@ impl RetrieveClimateSupplier<'_> {
     }
 }
 
-impl StripeRequest for RetrieveClimateSupplier<'_> {
+impl StripeRequest for RetrieveClimateSupplier {
     type Output = stripe_misc::ClimateSupplier;
 
     fn build(&self) -> RequestBuilder {
-        let supplier = self.supplier;
+        let supplier = &self.supplier;
         RequestBuilder::new(StripeMethod::Get, format!("/climate/suppliers/{supplier}"))
             .query(&self.inner)
     }

--- a/generated/async-stripe-misc/src/entitlements_active_entitlement/requests.rs
+++ b/generated/async-stripe-misc/src/entitlements_active_entitlement/requests.rs
@@ -2,60 +2,66 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListEntitlementsActiveEntitlementBuilder<'a> {
-    customer: &'a str,
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListEntitlementsActiveEntitlementBuilder {
+    customer: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListEntitlementsActiveEntitlementBuilder<'a> {
-    fn new(customer: &'a str) -> Self {
-        Self { customer, ending_before: None, expand: None, limit: None, starting_after: None }
+impl ListEntitlementsActiveEntitlementBuilder {
+    fn new(customer: impl Into<String>) -> Self {
+        Self {
+            customer: customer.into(),
+            ending_before: None,
+            expand: None,
+            limit: None,
+            starting_after: None,
+        }
     }
 }
 /// Retrieve a list of active entitlements for a customer
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListEntitlementsActiveEntitlement<'a> {
-    inner: ListEntitlementsActiveEntitlementBuilder<'a>,
+pub struct ListEntitlementsActiveEntitlement {
+    inner: ListEntitlementsActiveEntitlementBuilder,
 }
-impl<'a> ListEntitlementsActiveEntitlement<'a> {
+impl ListEntitlementsActiveEntitlement {
     /// Construct a new `ListEntitlementsActiveEntitlement`.
-    pub fn new(customer: &'a str) -> Self {
-        Self { inner: ListEntitlementsActiveEntitlementBuilder::new(customer) }
+    pub fn new(customer: impl Into<String>) -> Self {
+        Self { inner: ListEntitlementsActiveEntitlementBuilder::new(customer.into()) }
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl ListEntitlementsActiveEntitlement<'_> {
+impl ListEntitlementsActiveEntitlement {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -77,11 +83,14 @@ impl ListEntitlementsActiveEntitlement<'_> {
     ) -> stripe_client_core::ListPaginator<
         stripe_types::List<stripe_misc::EntitlementsActiveEntitlement>,
     > {
-        stripe_client_core::ListPaginator::new_list("/entitlements/active_entitlements", self.inner)
+        stripe_client_core::ListPaginator::new_list(
+            "/entitlements/active_entitlements",
+            &self.inner,
+        )
     }
 }
 
-impl StripeRequest for ListEntitlementsActiveEntitlement<'_> {
+impl StripeRequest for ListEntitlementsActiveEntitlement {
     type Output = stripe_types::List<stripe_misc::EntitlementsActiveEntitlement>;
 
     fn build(&self) -> RequestBuilder {
@@ -89,34 +98,34 @@ impl StripeRequest for ListEntitlementsActiveEntitlement<'_> {
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveEntitlementsActiveEntitlementBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveEntitlementsActiveEntitlementBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveEntitlementsActiveEntitlementBuilder<'a> {
+impl RetrieveEntitlementsActiveEntitlementBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieve an active entitlement
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveEntitlementsActiveEntitlement<'a> {
-    inner: RetrieveEntitlementsActiveEntitlementBuilder<'a>,
-    id: &'a stripe_misc::EntitlementsActiveEntitlementId,
+pub struct RetrieveEntitlementsActiveEntitlement {
+    inner: RetrieveEntitlementsActiveEntitlementBuilder,
+    id: stripe_misc::EntitlementsActiveEntitlementId,
 }
-impl<'a> RetrieveEntitlementsActiveEntitlement<'a> {
+impl RetrieveEntitlementsActiveEntitlement {
     /// Construct a new `RetrieveEntitlementsActiveEntitlement`.
-    pub fn new(id: &'a stripe_misc::EntitlementsActiveEntitlementId) -> Self {
-        Self { id, inner: RetrieveEntitlementsActiveEntitlementBuilder::new() }
+    pub fn new(id: impl Into<stripe_misc::EntitlementsActiveEntitlementId>) -> Self {
+        Self { id: id.into(), inner: RetrieveEntitlementsActiveEntitlementBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveEntitlementsActiveEntitlement<'_> {
+impl RetrieveEntitlementsActiveEntitlement {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -134,11 +143,11 @@ impl RetrieveEntitlementsActiveEntitlement<'_> {
     }
 }
 
-impl StripeRequest for RetrieveEntitlementsActiveEntitlement<'_> {
+impl StripeRequest for RetrieveEntitlementsActiveEntitlement {
     type Output = stripe_misc::EntitlementsActiveEntitlement;
 
     fn build(&self) -> RequestBuilder {
-        let id = self.id;
+        let id = &self.id;
         RequestBuilder::new(StripeMethod::Get, format!("/entitlements/active_entitlements/{id}"))
             .query(&self.inner)
     }

--- a/generated/async-stripe-misc/src/entitlements_feature/requests.rs
+++ b/generated/async-stripe-misc/src/entitlements_feature/requests.rs
@@ -2,28 +2,28 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListEntitlementsFeatureBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListEntitlementsFeatureBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListEntitlementsFeatureBuilder<'a> {
+impl ListEntitlementsFeatureBuilder {
     fn new() -> Self {
         Self { ending_before: None, expand: None, limit: None, starting_after: None }
     }
 }
 /// Retrieve a list of features
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListEntitlementsFeature<'a> {
-    inner: ListEntitlementsFeatureBuilder<'a>,
+pub struct ListEntitlementsFeature {
+    inner: ListEntitlementsFeatureBuilder,
 }
-impl<'a> ListEntitlementsFeature<'a> {
+impl ListEntitlementsFeature {
     /// Construct a new `ListEntitlementsFeature`.
     pub fn new() -> Self {
         Self { inner: ListEntitlementsFeatureBuilder::new() }
@@ -31,35 +31,35 @@ impl<'a> ListEntitlementsFeature<'a> {
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl<'a> Default for ListEntitlementsFeature<'a> {
+impl Default for ListEntitlementsFeature {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListEntitlementsFeature<'_> {
+impl ListEntitlementsFeature {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -80,45 +80,45 @@ impl ListEntitlementsFeature<'_> {
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::EntitlementsFeature>>
     {
-        stripe_client_core::ListPaginator::new_list("/entitlements/features", self.inner)
+        stripe_client_core::ListPaginator::new_list("/entitlements/features", &self.inner)
     }
 }
 
-impl StripeRequest for ListEntitlementsFeature<'_> {
+impl StripeRequest for ListEntitlementsFeature {
     type Output = stripe_types::List<stripe_shared::EntitlementsFeature>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/entitlements/features").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveEntitlementsFeatureBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveEntitlementsFeatureBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveEntitlementsFeatureBuilder<'a> {
+impl RetrieveEntitlementsFeatureBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves a feature
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveEntitlementsFeature<'a> {
-    inner: RetrieveEntitlementsFeatureBuilder<'a>,
-    id: &'a stripe_shared::EntitlementsFeatureId,
+pub struct RetrieveEntitlementsFeature {
+    inner: RetrieveEntitlementsFeatureBuilder,
+    id: stripe_shared::EntitlementsFeatureId,
 }
-impl<'a> RetrieveEntitlementsFeature<'a> {
+impl RetrieveEntitlementsFeature {
     /// Construct a new `RetrieveEntitlementsFeature`.
-    pub fn new(id: &'a stripe_shared::EntitlementsFeatureId) -> Self {
-        Self { id, inner: RetrieveEntitlementsFeatureBuilder::new() }
+    pub fn new(id: impl Into<stripe_shared::EntitlementsFeatureId>) -> Self {
+        Self { id: id.into(), inner: RetrieveEntitlementsFeatureBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveEntitlementsFeature<'_> {
+impl RetrieveEntitlementsFeature {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -136,52 +136,55 @@ impl RetrieveEntitlementsFeature<'_> {
     }
 }
 
-impl StripeRequest for RetrieveEntitlementsFeature<'_> {
+impl StripeRequest for RetrieveEntitlementsFeature {
     type Output = stripe_shared::EntitlementsFeature;
 
     fn build(&self) -> RequestBuilder {
-        let id = self.id;
+        let id = &self.id;
         RequestBuilder::new(StripeMethod::Get, format!("/entitlements/features/{id}"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateEntitlementsFeatureBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateEntitlementsFeatureBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
-    lookup_key: &'a str,
+    expand: Option<Vec<String>>,
+    lookup_key: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
-    name: &'a str,
+    metadata: Option<std::collections::HashMap<String, String>>,
+    name: String,
 }
-impl<'a> CreateEntitlementsFeatureBuilder<'a> {
-    fn new(lookup_key: &'a str, name: &'a str) -> Self {
-        Self { expand: None, lookup_key, metadata: None, name }
+impl CreateEntitlementsFeatureBuilder {
+    fn new(lookup_key: impl Into<String>, name: impl Into<String>) -> Self {
+        Self { expand: None, lookup_key: lookup_key.into(), metadata: None, name: name.into() }
     }
 }
 /// Creates a feature
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateEntitlementsFeature<'a> {
-    inner: CreateEntitlementsFeatureBuilder<'a>,
+pub struct CreateEntitlementsFeature {
+    inner: CreateEntitlementsFeatureBuilder,
 }
-impl<'a> CreateEntitlementsFeature<'a> {
+impl CreateEntitlementsFeature {
     /// Construct a new `CreateEntitlementsFeature`.
-    pub fn new(lookup_key: &'a str, name: &'a str) -> Self {
-        Self { inner: CreateEntitlementsFeatureBuilder::new(lookup_key, name) }
+    pub fn new(lookup_key: impl Into<String>, name: impl Into<String>) -> Self {
+        Self { inner: CreateEntitlementsFeatureBuilder::new(lookup_key.into(), name.into()) }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of key-value pairs that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
 }
-impl CreateEntitlementsFeature<'_> {
+impl CreateEntitlementsFeature {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -199,63 +202,66 @@ impl CreateEntitlementsFeature<'_> {
     }
 }
 
-impl StripeRequest for CreateEntitlementsFeature<'_> {
+impl StripeRequest for CreateEntitlementsFeature {
     type Output = stripe_shared::EntitlementsFeature;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Post, "/entitlements/features").form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdateEntitlementsFeatureBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdateEntitlementsFeatureBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     active: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    name: Option<&'a str>,
+    name: Option<String>,
 }
-impl<'a> UpdateEntitlementsFeatureBuilder<'a> {
+impl UpdateEntitlementsFeatureBuilder {
     fn new() -> Self {
         Self { active: None, expand: None, metadata: None, name: None }
     }
 }
 /// Update a feature’s metadata or permanently deactivate it.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateEntitlementsFeature<'a> {
-    inner: UpdateEntitlementsFeatureBuilder<'a>,
-    id: &'a stripe_shared::EntitlementsFeatureId,
+pub struct UpdateEntitlementsFeature {
+    inner: UpdateEntitlementsFeatureBuilder,
+    id: stripe_shared::EntitlementsFeatureId,
 }
-impl<'a> UpdateEntitlementsFeature<'a> {
+impl UpdateEntitlementsFeature {
     /// Construct a new `UpdateEntitlementsFeature`.
-    pub fn new(id: &'a stripe_shared::EntitlementsFeatureId) -> Self {
-        Self { id, inner: UpdateEntitlementsFeatureBuilder::new() }
+    pub fn new(id: impl Into<stripe_shared::EntitlementsFeatureId>) -> Self {
+        Self { id: id.into(), inner: UpdateEntitlementsFeatureBuilder::new() }
     }
     /// Inactive features cannot be attached to new products and will not be returned from the features list endpoint.
-    pub fn active(mut self, active: bool) -> Self {
-        self.inner.active = Some(active);
+    pub fn active(mut self, active: impl Into<bool>) -> Self {
+        self.inner.active = Some(active.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of key-value pairs that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// The feature's name, for your own purpose, not meant to be displayable to the customer.
-    pub fn name(mut self, name: &'a str) -> Self {
-        self.inner.name = Some(name);
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.inner.name = Some(name.into());
         self
     }
 }
-impl UpdateEntitlementsFeature<'_> {
+impl UpdateEntitlementsFeature {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -273,11 +279,11 @@ impl UpdateEntitlementsFeature<'_> {
     }
 }
 
-impl StripeRequest for UpdateEntitlementsFeature<'_> {
+impl StripeRequest for UpdateEntitlementsFeature {
     type Output = stripe_shared::EntitlementsFeature;
 
     fn build(&self) -> RequestBuilder {
-        let id = self.id;
+        let id = &self.id;
         RequestBuilder::new(StripeMethod::Post, format!("/entitlements/features/{id}"))
             .form(&self.inner)
     }

--- a/generated/async-stripe-misc/src/ephemeral_key/requests.rs
+++ b/generated/async-stripe-misc/src/ephemeral_key/requests.rs
@@ -2,34 +2,34 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct DeleteEphemeralKeyBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct DeleteEphemeralKeyBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> DeleteEphemeralKeyBuilder<'a> {
+impl DeleteEphemeralKeyBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Invalidates a short-lived API key for a given resource.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct DeleteEphemeralKey<'a> {
-    inner: DeleteEphemeralKeyBuilder<'a>,
-    key: &'a stripe_misc::EphemeralKeyId,
+pub struct DeleteEphemeralKey {
+    inner: DeleteEphemeralKeyBuilder,
+    key: stripe_misc::EphemeralKeyId,
 }
-impl<'a> DeleteEphemeralKey<'a> {
+impl DeleteEphemeralKey {
     /// Construct a new `DeleteEphemeralKey`.
-    pub fn new(key: &'a stripe_misc::EphemeralKeyId) -> Self {
-        Self { key, inner: DeleteEphemeralKeyBuilder::new() }
+    pub fn new(key: impl Into<stripe_misc::EphemeralKeyId>) -> Self {
+        Self { key: key.into(), inner: DeleteEphemeralKeyBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl DeleteEphemeralKey<'_> {
+impl DeleteEphemeralKey {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -47,29 +47,29 @@ impl DeleteEphemeralKey<'_> {
     }
 }
 
-impl StripeRequest for DeleteEphemeralKey<'_> {
+impl StripeRequest for DeleteEphemeralKey {
     type Output = stripe_misc::EphemeralKey;
 
     fn build(&self) -> RequestBuilder {
-        let key = self.key;
+        let key = &self.key;
         RequestBuilder::new(StripeMethod::Delete, format!("/ephemeral_keys/{key}"))
             .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateEphemeralKeyBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateEphemeralKeyBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    customer: Option<&'a str>,
+    customer: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    issuing_card: Option<&'a str>,
+    issuing_card: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    nonce: Option<&'a str>,
+    nonce: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    verification_session: Option<&'a str>,
+    verification_session: Option<String>,
 }
-impl<'a> CreateEphemeralKeyBuilder<'a> {
+impl CreateEphemeralKeyBuilder {
     fn new() -> Self {
         Self {
             customer: None,
@@ -82,46 +82,46 @@ impl<'a> CreateEphemeralKeyBuilder<'a> {
 }
 /// Creates a short-lived API key for a given resource.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateEphemeralKey<'a> {
-    inner: CreateEphemeralKeyBuilder<'a>,
+pub struct CreateEphemeralKey {
+    inner: CreateEphemeralKeyBuilder,
 }
-impl<'a> CreateEphemeralKey<'a> {
+impl CreateEphemeralKey {
     /// Construct a new `CreateEphemeralKey`.
     pub fn new() -> Self {
         Self { inner: CreateEphemeralKeyBuilder::new() }
     }
     /// The ID of the Customer you'd like to modify using the resulting ephemeral key.
-    pub fn customer(mut self, customer: &'a str) -> Self {
-        self.inner.customer = Some(customer);
+    pub fn customer(mut self, customer: impl Into<String>) -> Self {
+        self.inner.customer = Some(customer.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// The ID of the Issuing Card you'd like to access using the resulting ephemeral key.
-    pub fn issuing_card(mut self, issuing_card: &'a str) -> Self {
-        self.inner.issuing_card = Some(issuing_card);
+    pub fn issuing_card(mut self, issuing_card: impl Into<String>) -> Self {
+        self.inner.issuing_card = Some(issuing_card.into());
         self
     }
     /// A single-use token, created by Stripe.js, used for creating ephemeral keys for Issuing Cards without exchanging sensitive information.
-    pub fn nonce(mut self, nonce: &'a str) -> Self {
-        self.inner.nonce = Some(nonce);
+    pub fn nonce(mut self, nonce: impl Into<String>) -> Self {
+        self.inner.nonce = Some(nonce.into());
         self
     }
     /// The ID of the Identity VerificationSession you'd like to access using the resulting ephemeral key
-    pub fn verification_session(mut self, verification_session: &'a str) -> Self {
-        self.inner.verification_session = Some(verification_session);
+    pub fn verification_session(mut self, verification_session: impl Into<String>) -> Self {
+        self.inner.verification_session = Some(verification_session.into());
         self
     }
 }
-impl<'a> Default for CreateEphemeralKey<'a> {
+impl Default for CreateEphemeralKey {
     fn default() -> Self {
         Self::new()
     }
 }
-impl CreateEphemeralKey<'_> {
+impl CreateEphemeralKey {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -139,7 +139,7 @@ impl CreateEphemeralKey<'_> {
     }
 }
 
-impl StripeRequest for CreateEphemeralKey<'_> {
+impl StripeRequest for CreateEphemeralKey {
     type Output = stripe_misc::EphemeralKey;
 
     fn build(&self) -> RequestBuilder {

--- a/generated/async-stripe-misc/src/exchange_rate/requests.rs
+++ b/generated/async-stripe-misc/src/exchange_rate/requests.rs
@@ -2,18 +2,18 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListExchangeRateBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListExchangeRateBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListExchangeRateBuilder<'a> {
+impl ListExchangeRateBuilder {
     fn new() -> Self {
         Self { ending_before: None, expand: None, limit: None, starting_after: None }
     }
@@ -21,10 +21,10 @@ impl<'a> ListExchangeRateBuilder<'a> {
 /// Returns a list of objects that contain the rates at which foreign currencies are converted to one another.
 /// Only shows the currencies for which Stripe supports.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListExchangeRate<'a> {
-    inner: ListExchangeRateBuilder<'a>,
+pub struct ListExchangeRate {
+    inner: ListExchangeRateBuilder,
 }
-impl<'a> ListExchangeRate<'a> {
+impl ListExchangeRate {
     /// Construct a new `ListExchangeRate`.
     pub fn new() -> Self {
         Self { inner: ListExchangeRateBuilder::new() }
@@ -32,35 +32,35 @@ impl<'a> ListExchangeRate<'a> {
     /// A cursor for use in pagination.
     /// `ending_before` is the currency that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with the exchange rate for currency X your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and total number of supported payout currencies, and the default is the max.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is the currency that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with the exchange rate for currency X, your subsequent call can include `starting_after=X` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl<'a> Default for ListExchangeRate<'a> {
+impl Default for ListExchangeRate {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListExchangeRate<'_> {
+impl ListExchangeRate {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -80,45 +80,45 @@ impl ListExchangeRate<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_misc::ExchangeRate>> {
-        stripe_client_core::ListPaginator::new_list("/exchange_rates", self.inner)
+        stripe_client_core::ListPaginator::new_list("/exchange_rates", &self.inner)
     }
 }
 
-impl StripeRequest for ListExchangeRate<'_> {
+impl StripeRequest for ListExchangeRate {
     type Output = stripe_types::List<stripe_misc::ExchangeRate>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/exchange_rates").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveExchangeRateBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveExchangeRateBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveExchangeRateBuilder<'a> {
+impl RetrieveExchangeRateBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves the exchange rates from the given currency to every supported currency.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveExchangeRate<'a> {
-    inner: RetrieveExchangeRateBuilder<'a>,
-    rate_id: &'a stripe_misc::ExchangeRateId,
+pub struct RetrieveExchangeRate {
+    inner: RetrieveExchangeRateBuilder,
+    rate_id: stripe_misc::ExchangeRateId,
 }
-impl<'a> RetrieveExchangeRate<'a> {
+impl RetrieveExchangeRate {
     /// Construct a new `RetrieveExchangeRate`.
-    pub fn new(rate_id: &'a stripe_misc::ExchangeRateId) -> Self {
-        Self { rate_id, inner: RetrieveExchangeRateBuilder::new() }
+    pub fn new(rate_id: impl Into<stripe_misc::ExchangeRateId>) -> Self {
+        Self { rate_id: rate_id.into(), inner: RetrieveExchangeRateBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveExchangeRate<'_> {
+impl RetrieveExchangeRate {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -136,11 +136,11 @@ impl RetrieveExchangeRate<'_> {
     }
 }
 
-impl StripeRequest for RetrieveExchangeRate<'_> {
+impl StripeRequest for RetrieveExchangeRate {
     type Output = stripe_misc::ExchangeRate;
 
     fn build(&self) -> RequestBuilder {
-        let rate_id = self.rate_id;
+        let rate_id = &self.rate_id;
         RequestBuilder::new(StripeMethod::Get, format!("/exchange_rates/{rate_id}"))
             .query(&self.inner)
     }

--- a/generated/async-stripe-misc/src/financial_connections_account/requests.rs
+++ b/generated/async-stripe-misc/src/financial_connections_account/requests.rs
@@ -2,22 +2,22 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListFinancialConnectionsAccountBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListFinancialConnectionsAccountBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    account_holder: Option<ListFinancialConnectionsAccountAccountHolder<'a>>,
+    account_holder: Option<ListFinancialConnectionsAccountAccountHolder>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    session: Option<&'a str>,
+    session: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListFinancialConnectionsAccountBuilder<'a> {
+impl ListFinancialConnectionsAccountBuilder {
     fn new() -> Self {
         Self {
             account_holder: None,
@@ -31,31 +31,31 @@ impl<'a> ListFinancialConnectionsAccountBuilder<'a> {
 }
 /// If present, only return accounts that belong to the specified account holder.
 /// `account_holder[customer]` and `account_holder[account]` are mutually exclusive.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ListFinancialConnectionsAccountAccountHolder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ListFinancialConnectionsAccountAccountHolder {
     /// The ID of the Stripe account whose accounts will be retrieved.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account: Option<&'a str>,
+    pub account: Option<String>,
     /// The ID of the Stripe customer whose accounts will be retrieved.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub customer: Option<&'a str>,
+    pub customer: Option<String>,
 }
-impl<'a> ListFinancialConnectionsAccountAccountHolder<'a> {
+impl ListFinancialConnectionsAccountAccountHolder {
     pub fn new() -> Self {
         Self { account: None, customer: None }
     }
 }
-impl<'a> Default for ListFinancialConnectionsAccountAccountHolder<'a> {
+impl Default for ListFinancialConnectionsAccountAccountHolder {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Returns a list of Financial Connections `Account` objects.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListFinancialConnectionsAccount<'a> {
-    inner: ListFinancialConnectionsAccountBuilder<'a>,
+pub struct ListFinancialConnectionsAccount {
+    inner: ListFinancialConnectionsAccountBuilder,
 }
-impl<'a> ListFinancialConnectionsAccount<'a> {
+impl ListFinancialConnectionsAccount {
     /// Construct a new `ListFinancialConnectionsAccount`.
     pub fn new() -> Self {
         Self { inner: ListFinancialConnectionsAccountBuilder::new() }
@@ -64,48 +64,48 @@ impl<'a> ListFinancialConnectionsAccount<'a> {
     /// `account_holder[customer]` and `account_holder[account]` are mutually exclusive.
     pub fn account_holder(
         mut self,
-        account_holder: ListFinancialConnectionsAccountAccountHolder<'a>,
+        account_holder: impl Into<ListFinancialConnectionsAccountAccountHolder>,
     ) -> Self {
-        self.inner.account_holder = Some(account_holder);
+        self.inner.account_holder = Some(account_holder.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// If present, only return accounts that were collected as part of the given session.
-    pub fn session(mut self, session: &'a str) -> Self {
-        self.inner.session = Some(session);
+    pub fn session(mut self, session: impl Into<String>) -> Self {
+        self.inner.session = Some(session.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl<'a> Default for ListFinancialConnectionsAccount<'a> {
+impl Default for ListFinancialConnectionsAccount {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListFinancialConnectionsAccount<'_> {
+impl ListFinancialConnectionsAccount {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -127,45 +127,45 @@ impl ListFinancialConnectionsAccount<'_> {
     ) -> stripe_client_core::ListPaginator<
         stripe_types::List<stripe_misc::FinancialConnectionsAccount>,
     > {
-        stripe_client_core::ListPaginator::new_list("/financial_connections/accounts", self.inner)
+        stripe_client_core::ListPaginator::new_list("/financial_connections/accounts", &self.inner)
     }
 }
 
-impl StripeRequest for ListFinancialConnectionsAccount<'_> {
+impl StripeRequest for ListFinancialConnectionsAccount {
     type Output = stripe_types::List<stripe_misc::FinancialConnectionsAccount>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/financial_connections/accounts").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveFinancialConnectionsAccountBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveFinancialConnectionsAccountBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveFinancialConnectionsAccountBuilder<'a> {
+impl RetrieveFinancialConnectionsAccountBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves the details of an Financial Connections `Account`.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveFinancialConnectionsAccount<'a> {
-    inner: RetrieveFinancialConnectionsAccountBuilder<'a>,
-    account: &'a stripe_misc::FinancialConnectionsAccountId,
+pub struct RetrieveFinancialConnectionsAccount {
+    inner: RetrieveFinancialConnectionsAccountBuilder,
+    account: stripe_misc::FinancialConnectionsAccountId,
 }
-impl<'a> RetrieveFinancialConnectionsAccount<'a> {
+impl RetrieveFinancialConnectionsAccount {
     /// Construct a new `RetrieveFinancialConnectionsAccount`.
-    pub fn new(account: &'a stripe_misc::FinancialConnectionsAccountId) -> Self {
-        Self { account, inner: RetrieveFinancialConnectionsAccountBuilder::new() }
+    pub fn new(account: impl Into<stripe_misc::FinancialConnectionsAccountId>) -> Self {
+        Self { account: account.into(), inner: RetrieveFinancialConnectionsAccountBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveFinancialConnectionsAccount<'_> {
+impl RetrieveFinancialConnectionsAccount {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -183,73 +183,82 @@ impl RetrieveFinancialConnectionsAccount<'_> {
     }
 }
 
-impl StripeRequest for RetrieveFinancialConnectionsAccount<'_> {
+impl StripeRequest for RetrieveFinancialConnectionsAccount {
     type Output = stripe_misc::FinancialConnectionsAccount;
 
     fn build(&self) -> RequestBuilder {
-        let account = self.account;
+        let account = &self.account;
         RequestBuilder::new(StripeMethod::Get, format!("/financial_connections/accounts/{account}"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListOwnersFinancialConnectionsAccountBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListOwnersFinancialConnectionsAccountBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
-    ownership: &'a str,
+    ownership: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListOwnersFinancialConnectionsAccountBuilder<'a> {
-    fn new(ownership: &'a str) -> Self {
-        Self { ending_before: None, expand: None, limit: None, ownership, starting_after: None }
+impl ListOwnersFinancialConnectionsAccountBuilder {
+    fn new(ownership: impl Into<String>) -> Self {
+        Self {
+            ending_before: None,
+            expand: None,
+            limit: None,
+            ownership: ownership.into(),
+            starting_after: None,
+        }
     }
 }
 /// Lists all owners for a given `Account`
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListOwnersFinancialConnectionsAccount<'a> {
-    inner: ListOwnersFinancialConnectionsAccountBuilder<'a>,
-    account: &'a stripe_misc::FinancialConnectionsAccountId,
+pub struct ListOwnersFinancialConnectionsAccount {
+    inner: ListOwnersFinancialConnectionsAccountBuilder,
+    account: stripe_misc::FinancialConnectionsAccountId,
 }
-impl<'a> ListOwnersFinancialConnectionsAccount<'a> {
+impl ListOwnersFinancialConnectionsAccount {
     /// Construct a new `ListOwnersFinancialConnectionsAccount`.
     pub fn new(
-        account: &'a stripe_misc::FinancialConnectionsAccountId,
-        ownership: &'a str,
+        account: impl Into<stripe_misc::FinancialConnectionsAccountId>,
+        ownership: impl Into<String>,
     ) -> Self {
-        Self { account, inner: ListOwnersFinancialConnectionsAccountBuilder::new(ownership) }
+        Self {
+            account: account.into(),
+            inner: ListOwnersFinancialConnectionsAccountBuilder::new(ownership.into()),
+        }
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl ListOwnersFinancialConnectionsAccount<'_> {
+impl ListOwnersFinancialConnectionsAccount {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -271,20 +280,20 @@ impl ListOwnersFinancialConnectionsAccount<'_> {
     ) -> stripe_client_core::ListPaginator<
         stripe_types::List<stripe_misc::FinancialConnectionsAccountOwner>,
     > {
-        let account = self.account;
+        let account = &self.account;
 
         stripe_client_core::ListPaginator::new_list(
             format!("/financial_connections/accounts/{account}/owners"),
-            self.inner,
+            &self.inner,
         )
     }
 }
 
-impl StripeRequest for ListOwnersFinancialConnectionsAccount<'_> {
+impl StripeRequest for ListOwnersFinancialConnectionsAccount {
     type Output = stripe_types::List<stripe_misc::FinancialConnectionsAccountOwner>;
 
     fn build(&self) -> RequestBuilder {
-        let account = self.account;
+        let account = &self.account;
         RequestBuilder::new(
             StripeMethod::Get,
             format!("/financial_connections/accounts/{account}/owners"),
@@ -292,12 +301,12 @@ impl StripeRequest for ListOwnersFinancialConnectionsAccount<'_> {
         .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct DisconnectFinancialConnectionsAccountBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct DisconnectFinancialConnectionsAccountBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> DisconnectFinancialConnectionsAccountBuilder<'a> {
+impl DisconnectFinancialConnectionsAccountBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
@@ -306,22 +315,22 @@ impl<'a> DisconnectFinancialConnectionsAccountBuilder<'a> {
 /// You will no longer be able to access data associated with the account (e.g.
 /// balances, transactions).
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct DisconnectFinancialConnectionsAccount<'a> {
-    inner: DisconnectFinancialConnectionsAccountBuilder<'a>,
-    account: &'a stripe_misc::FinancialConnectionsAccountId,
+pub struct DisconnectFinancialConnectionsAccount {
+    inner: DisconnectFinancialConnectionsAccountBuilder,
+    account: stripe_misc::FinancialConnectionsAccountId,
 }
-impl<'a> DisconnectFinancialConnectionsAccount<'a> {
+impl DisconnectFinancialConnectionsAccount {
     /// Construct a new `DisconnectFinancialConnectionsAccount`.
-    pub fn new(account: &'a stripe_misc::FinancialConnectionsAccountId) -> Self {
-        Self { account, inner: DisconnectFinancialConnectionsAccountBuilder::new() }
+    pub fn new(account: impl Into<stripe_misc::FinancialConnectionsAccountId>) -> Self {
+        Self { account: account.into(), inner: DisconnectFinancialConnectionsAccountBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl DisconnectFinancialConnectionsAccount<'_> {
+impl DisconnectFinancialConnectionsAccount {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -339,11 +348,11 @@ impl DisconnectFinancialConnectionsAccount<'_> {
     }
 }
 
-impl StripeRequest for DisconnectFinancialConnectionsAccount<'_> {
+impl StripeRequest for DisconnectFinancialConnectionsAccount {
     type Output = stripe_misc::FinancialConnectionsAccount;
 
     fn build(&self) -> RequestBuilder {
-        let account = self.account;
+        let account = &self.account;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/financial_connections/accounts/{account}/disconnect"),
@@ -351,15 +360,15 @@ impl StripeRequest for DisconnectFinancialConnectionsAccount<'_> {
         .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RefreshFinancialConnectionsAccountBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RefreshFinancialConnectionsAccountBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
-    features: &'a [RefreshFinancialConnectionsAccountFeatures],
+    expand: Option<Vec<String>>,
+    features: Vec<RefreshFinancialConnectionsAccountFeatures>,
 }
-impl<'a> RefreshFinancialConnectionsAccountBuilder<'a> {
-    fn new(features: &'a [RefreshFinancialConnectionsAccountFeatures]) -> Self {
-        Self { expand: None, features }
+impl RefreshFinancialConnectionsAccountBuilder {
+    fn new(features: impl Into<Vec<RefreshFinancialConnectionsAccountFeatures>>) -> Self {
+        Self { expand: None, features: features.into() }
     }
 }
 /// The list of account features that you would like to refresh.
@@ -423,25 +432,28 @@ impl<'de> serde::Deserialize<'de> for RefreshFinancialConnectionsAccountFeatures
 }
 /// Refreshes the data associated with a Financial Connections `Account`.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RefreshFinancialConnectionsAccount<'a> {
-    inner: RefreshFinancialConnectionsAccountBuilder<'a>,
-    account: &'a stripe_misc::FinancialConnectionsAccountId,
+pub struct RefreshFinancialConnectionsAccount {
+    inner: RefreshFinancialConnectionsAccountBuilder,
+    account: stripe_misc::FinancialConnectionsAccountId,
 }
-impl<'a> RefreshFinancialConnectionsAccount<'a> {
+impl RefreshFinancialConnectionsAccount {
     /// Construct a new `RefreshFinancialConnectionsAccount`.
     pub fn new(
-        account: &'a stripe_misc::FinancialConnectionsAccountId,
-        features: &'a [RefreshFinancialConnectionsAccountFeatures],
+        account: impl Into<stripe_misc::FinancialConnectionsAccountId>,
+        features: impl Into<Vec<RefreshFinancialConnectionsAccountFeatures>>,
     ) -> Self {
-        Self { account, inner: RefreshFinancialConnectionsAccountBuilder::new(features) }
+        Self {
+            account: account.into(),
+            inner: RefreshFinancialConnectionsAccountBuilder::new(features.into()),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RefreshFinancialConnectionsAccount<'_> {
+impl RefreshFinancialConnectionsAccount {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -459,11 +471,11 @@ impl RefreshFinancialConnectionsAccount<'_> {
     }
 }
 
-impl StripeRequest for RefreshFinancialConnectionsAccount<'_> {
+impl StripeRequest for RefreshFinancialConnectionsAccount {
     type Output = stripe_misc::FinancialConnectionsAccount;
 
     fn build(&self) -> RequestBuilder {
-        let account = self.account;
+        let account = &self.account;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/financial_connections/accounts/{account}/refresh"),
@@ -471,15 +483,15 @@ impl StripeRequest for RefreshFinancialConnectionsAccount<'_> {
         .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct SubscribeFinancialConnectionsAccountBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct SubscribeFinancialConnectionsAccountBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
-    features: &'a [SubscribeFinancialConnectionsAccountFeatures],
+    expand: Option<Vec<String>>,
+    features: Vec<SubscribeFinancialConnectionsAccountFeatures>,
 }
-impl<'a> SubscribeFinancialConnectionsAccountBuilder<'a> {
-    fn new(features: &'a [SubscribeFinancialConnectionsAccountFeatures]) -> Self {
-        Self { expand: None, features }
+impl SubscribeFinancialConnectionsAccountBuilder {
+    fn new(features: impl Into<Vec<SubscribeFinancialConnectionsAccountFeatures>>) -> Self {
+        Self { expand: None, features: features.into() }
     }
 }
 /// The list of account features to which you would like to subscribe.
@@ -539,25 +551,28 @@ impl<'de> serde::Deserialize<'de> for SubscribeFinancialConnectionsAccountFeatur
 }
 /// Subscribes to periodic refreshes of data associated with a Financial Connections `Account`.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct SubscribeFinancialConnectionsAccount<'a> {
-    inner: SubscribeFinancialConnectionsAccountBuilder<'a>,
-    account: &'a stripe_misc::FinancialConnectionsAccountId,
+pub struct SubscribeFinancialConnectionsAccount {
+    inner: SubscribeFinancialConnectionsAccountBuilder,
+    account: stripe_misc::FinancialConnectionsAccountId,
 }
-impl<'a> SubscribeFinancialConnectionsAccount<'a> {
+impl SubscribeFinancialConnectionsAccount {
     /// Construct a new `SubscribeFinancialConnectionsAccount`.
     pub fn new(
-        account: &'a stripe_misc::FinancialConnectionsAccountId,
-        features: &'a [SubscribeFinancialConnectionsAccountFeatures],
+        account: impl Into<stripe_misc::FinancialConnectionsAccountId>,
+        features: impl Into<Vec<SubscribeFinancialConnectionsAccountFeatures>>,
     ) -> Self {
-        Self { account, inner: SubscribeFinancialConnectionsAccountBuilder::new(features) }
+        Self {
+            account: account.into(),
+            inner: SubscribeFinancialConnectionsAccountBuilder::new(features.into()),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl SubscribeFinancialConnectionsAccount<'_> {
+impl SubscribeFinancialConnectionsAccount {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -575,11 +590,11 @@ impl SubscribeFinancialConnectionsAccount<'_> {
     }
 }
 
-impl StripeRequest for SubscribeFinancialConnectionsAccount<'_> {
+impl StripeRequest for SubscribeFinancialConnectionsAccount {
     type Output = stripe_misc::FinancialConnectionsAccount;
 
     fn build(&self) -> RequestBuilder {
-        let account = self.account;
+        let account = &self.account;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/financial_connections/accounts/{account}/subscribe"),
@@ -587,15 +602,15 @@ impl StripeRequest for SubscribeFinancialConnectionsAccount<'_> {
         .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UnsubscribeFinancialConnectionsAccountBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UnsubscribeFinancialConnectionsAccountBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
-    features: &'a [UnsubscribeFinancialConnectionsAccountFeatures],
+    expand: Option<Vec<String>>,
+    features: Vec<UnsubscribeFinancialConnectionsAccountFeatures>,
 }
-impl<'a> UnsubscribeFinancialConnectionsAccountBuilder<'a> {
-    fn new(features: &'a [UnsubscribeFinancialConnectionsAccountFeatures]) -> Self {
-        Self { expand: None, features }
+impl UnsubscribeFinancialConnectionsAccountBuilder {
+    fn new(features: impl Into<Vec<UnsubscribeFinancialConnectionsAccountFeatures>>) -> Self {
+        Self { expand: None, features: features.into() }
     }
 }
 /// The list of account features from which you would like to unsubscribe.
@@ -655,25 +670,28 @@ impl<'de> serde::Deserialize<'de> for UnsubscribeFinancialConnectionsAccountFeat
 }
 /// Unsubscribes from periodic refreshes of data associated with a Financial Connections `Account`.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UnsubscribeFinancialConnectionsAccount<'a> {
-    inner: UnsubscribeFinancialConnectionsAccountBuilder<'a>,
-    account: &'a stripe_misc::FinancialConnectionsAccountId,
+pub struct UnsubscribeFinancialConnectionsAccount {
+    inner: UnsubscribeFinancialConnectionsAccountBuilder,
+    account: stripe_misc::FinancialConnectionsAccountId,
 }
-impl<'a> UnsubscribeFinancialConnectionsAccount<'a> {
+impl UnsubscribeFinancialConnectionsAccount {
     /// Construct a new `UnsubscribeFinancialConnectionsAccount`.
     pub fn new(
-        account: &'a stripe_misc::FinancialConnectionsAccountId,
-        features: &'a [UnsubscribeFinancialConnectionsAccountFeatures],
+        account: impl Into<stripe_misc::FinancialConnectionsAccountId>,
+        features: impl Into<Vec<UnsubscribeFinancialConnectionsAccountFeatures>>,
     ) -> Self {
-        Self { account, inner: UnsubscribeFinancialConnectionsAccountBuilder::new(features) }
+        Self {
+            account: account.into(),
+            inner: UnsubscribeFinancialConnectionsAccountBuilder::new(features.into()),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl UnsubscribeFinancialConnectionsAccount<'_> {
+impl UnsubscribeFinancialConnectionsAccount {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -691,11 +709,11 @@ impl UnsubscribeFinancialConnectionsAccount<'_> {
     }
 }
 
-impl StripeRequest for UnsubscribeFinancialConnectionsAccount<'_> {
+impl StripeRequest for UnsubscribeFinancialConnectionsAccount {
     type Output = stripe_misc::FinancialConnectionsAccount;
 
     fn build(&self) -> RequestBuilder {
-        let account = self.account;
+        let account = &self.account;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/financial_connections/accounts/{account}/unsubscribe"),

--- a/generated/async-stripe-misc/src/financial_connections_session/requests.rs
+++ b/generated/async-stripe-misc/src/financial_connections_session/requests.rs
@@ -2,34 +2,34 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveFinancialConnectionsSessionBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveFinancialConnectionsSessionBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveFinancialConnectionsSessionBuilder<'a> {
+impl RetrieveFinancialConnectionsSessionBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves the details of a Financial Connections `Session`
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveFinancialConnectionsSession<'a> {
-    inner: RetrieveFinancialConnectionsSessionBuilder<'a>,
-    session: &'a stripe_misc::FinancialConnectionsSessionId,
+pub struct RetrieveFinancialConnectionsSession {
+    inner: RetrieveFinancialConnectionsSessionBuilder,
+    session: stripe_misc::FinancialConnectionsSessionId,
 }
-impl<'a> RetrieveFinancialConnectionsSession<'a> {
+impl RetrieveFinancialConnectionsSession {
     /// Construct a new `RetrieveFinancialConnectionsSession`.
-    pub fn new(session: &'a stripe_misc::FinancialConnectionsSessionId) -> Self {
-        Self { session, inner: RetrieveFinancialConnectionsSessionBuilder::new() }
+    pub fn new(session: impl Into<stripe_misc::FinancialConnectionsSessionId>) -> Self {
+        Self { session: session.into(), inner: RetrieveFinancialConnectionsSessionBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveFinancialConnectionsSession<'_> {
+impl RetrieveFinancialConnectionsSession {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -47,61 +47,61 @@ impl RetrieveFinancialConnectionsSession<'_> {
     }
 }
 
-impl StripeRequest for RetrieveFinancialConnectionsSession<'_> {
+impl StripeRequest for RetrieveFinancialConnectionsSession {
     type Output = stripe_misc::FinancialConnectionsSession;
 
     fn build(&self) -> RequestBuilder {
-        let session = self.session;
+        let session = &self.session;
         RequestBuilder::new(StripeMethod::Get, format!("/financial_connections/sessions/{session}"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateFinancialConnectionsSessionBuilder<'a> {
-    account_holder: CreateFinancialConnectionsSessionAccountHolder<'a>,
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateFinancialConnectionsSessionBuilder {
+    account_holder: CreateFinancialConnectionsSessionAccountHolder,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    filters: Option<CreateFinancialConnectionsSessionFilters<'a>>,
-    permissions: &'a [stripe_misc::FinancialConnectionsSessionPermissions],
+    filters: Option<CreateFinancialConnectionsSessionFilters>,
+    permissions: Vec<stripe_misc::FinancialConnectionsSessionPermissions>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    prefetch: Option<&'a [stripe_misc::FinancialConnectionsSessionPrefetch]>,
+    prefetch: Option<Vec<stripe_misc::FinancialConnectionsSessionPrefetch>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    return_url: Option<&'a str>,
+    return_url: Option<String>,
 }
-impl<'a> CreateFinancialConnectionsSessionBuilder<'a> {
+impl CreateFinancialConnectionsSessionBuilder {
     fn new(
-        account_holder: CreateFinancialConnectionsSessionAccountHolder<'a>,
-        permissions: &'a [stripe_misc::FinancialConnectionsSessionPermissions],
+        account_holder: impl Into<CreateFinancialConnectionsSessionAccountHolder>,
+        permissions: impl Into<Vec<stripe_misc::FinancialConnectionsSessionPermissions>>,
     ) -> Self {
         Self {
-            account_holder,
+            account_holder: account_holder.into(),
             expand: None,
             filters: None,
-            permissions,
+            permissions: permissions.into(),
             prefetch: None,
             return_url: None,
         }
     }
 }
 /// The account holder to link accounts for.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateFinancialConnectionsSessionAccountHolder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateFinancialConnectionsSessionAccountHolder {
     /// The ID of the Stripe account whose accounts will be retrieved.
     /// Should only be present if `type` is `account`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account: Option<&'a str>,
+    pub account: Option<String>,
     /// The ID of the Stripe customer whose accounts will be retrieved.
     /// Should only be present if `type` is `customer`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub customer: Option<&'a str>,
+    pub customer: Option<String>,
     /// Type of account holder to collect accounts for.
     #[serde(rename = "type")]
     pub type_: CreateFinancialConnectionsSessionAccountHolderType,
 }
-impl<'a> CreateFinancialConnectionsSessionAccountHolder<'a> {
-    pub fn new(type_: CreateFinancialConnectionsSessionAccountHolderType) -> Self {
-        Self { account: None, customer: None, type_ }
+impl CreateFinancialConnectionsSessionAccountHolder {
+    pub fn new(type_: impl Into<CreateFinancialConnectionsSessionAccountHolderType>) -> Self {
+        Self { account: None, customer: None, type_: type_.into() }
     }
 }
 /// Type of account holder to collect accounts for.
@@ -163,56 +163,61 @@ impl<'de> serde::Deserialize<'de> for CreateFinancialConnectionsSessionAccountHo
     }
 }
 /// Filters to restrict the kinds of accounts to collect.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateFinancialConnectionsSessionFilters<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateFinancialConnectionsSessionFilters {
     /// List of countries from which to collect accounts.
-    pub countries: &'a [&'a str],
+    pub countries: Vec<String>,
 }
-impl<'a> CreateFinancialConnectionsSessionFilters<'a> {
-    pub fn new(countries: &'a [&'a str]) -> Self {
-        Self { countries }
+impl CreateFinancialConnectionsSessionFilters {
+    pub fn new(countries: impl Into<Vec<String>>) -> Self {
+        Self { countries: countries.into() }
     }
 }
 /// To launch the Financial Connections authorization flow, create a `Session`.
 /// The session’s `client_secret` can be used to launch the flow using Stripe.js.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateFinancialConnectionsSession<'a> {
-    inner: CreateFinancialConnectionsSessionBuilder<'a>,
+pub struct CreateFinancialConnectionsSession {
+    inner: CreateFinancialConnectionsSessionBuilder,
 }
-impl<'a> CreateFinancialConnectionsSession<'a> {
+impl CreateFinancialConnectionsSession {
     /// Construct a new `CreateFinancialConnectionsSession`.
     pub fn new(
-        account_holder: CreateFinancialConnectionsSessionAccountHolder<'a>,
-        permissions: &'a [stripe_misc::FinancialConnectionsSessionPermissions],
+        account_holder: impl Into<CreateFinancialConnectionsSessionAccountHolder>,
+        permissions: impl Into<Vec<stripe_misc::FinancialConnectionsSessionPermissions>>,
     ) -> Self {
-        Self { inner: CreateFinancialConnectionsSessionBuilder::new(account_holder, permissions) }
+        Self {
+            inner: CreateFinancialConnectionsSessionBuilder::new(
+                account_holder.into(),
+                permissions.into(),
+            ),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Filters to restrict the kinds of accounts to collect.
-    pub fn filters(mut self, filters: CreateFinancialConnectionsSessionFilters<'a>) -> Self {
-        self.inner.filters = Some(filters);
+    pub fn filters(mut self, filters: impl Into<CreateFinancialConnectionsSessionFilters>) -> Self {
+        self.inner.filters = Some(filters.into());
         self
     }
     /// List of data features that you would like to retrieve upon account creation.
     pub fn prefetch(
         mut self,
-        prefetch: &'a [stripe_misc::FinancialConnectionsSessionPrefetch],
+        prefetch: impl Into<Vec<stripe_misc::FinancialConnectionsSessionPrefetch>>,
     ) -> Self {
-        self.inner.prefetch = Some(prefetch);
+        self.inner.prefetch = Some(prefetch.into());
         self
     }
     /// For webview integrations only.
     /// Upon completing OAuth login in the native browser, the user will be redirected to this URL to return to your app.
-    pub fn return_url(mut self, return_url: &'a str) -> Self {
-        self.inner.return_url = Some(return_url);
+    pub fn return_url(mut self, return_url: impl Into<String>) -> Self {
+        self.inner.return_url = Some(return_url.into());
         self
     }
 }
-impl CreateFinancialConnectionsSession<'_> {
+impl CreateFinancialConnectionsSession {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -230,7 +235,7 @@ impl CreateFinancialConnectionsSession<'_> {
     }
 }
 
-impl StripeRequest for CreateFinancialConnectionsSession<'_> {
+impl StripeRequest for CreateFinancialConnectionsSession {
     type Output = stripe_misc::FinancialConnectionsSession;
 
     fn build(&self) -> RequestBuilder {

--- a/generated/async-stripe-misc/src/financial_connections_transaction/requests.rs
+++ b/generated/async-stripe-misc/src/financial_connections_transaction/requests.rs
@@ -2,26 +2,26 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListFinancialConnectionsTransactionBuilder<'a> {
-    account: &'a str,
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListFinancialConnectionsTransactionBuilder {
+    account: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     transacted_at: Option<stripe_types::RangeQueryTs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    transaction_refresh: Option<ListFinancialConnectionsTransactionTransactionRefresh<'a>>,
+    transaction_refresh: Option<ListFinancialConnectionsTransactionTransactionRefresh>,
 }
-impl<'a> ListFinancialConnectionsTransactionBuilder<'a> {
-    fn new(account: &'a str) -> Self {
+impl ListFinancialConnectionsTransactionBuilder {
+    fn new(account: impl Into<String>) -> Self {
         Self {
-            account,
+            account: account.into(),
             ending_before: None,
             expand: None,
             limit: None,
@@ -33,68 +33,68 @@ impl<'a> ListFinancialConnectionsTransactionBuilder<'a> {
 }
 /// A filter on the list based on the object `transaction_refresh` field.
 /// The value can be a dictionary with the following options:.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ListFinancialConnectionsTransactionTransactionRefresh<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ListFinancialConnectionsTransactionTransactionRefresh {
     /// Return results where the transactions were created or updated by a refresh that took place after this refresh (non-inclusive).
-    pub after: &'a str,
+    pub after: String,
 }
-impl<'a> ListFinancialConnectionsTransactionTransactionRefresh<'a> {
-    pub fn new(after: &'a str) -> Self {
-        Self { after }
+impl ListFinancialConnectionsTransactionTransactionRefresh {
+    pub fn new(after: impl Into<String>) -> Self {
+        Self { after: after.into() }
     }
 }
 /// Returns a list of Financial Connections `Transaction` objects.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListFinancialConnectionsTransaction<'a> {
-    inner: ListFinancialConnectionsTransactionBuilder<'a>,
+pub struct ListFinancialConnectionsTransaction {
+    inner: ListFinancialConnectionsTransactionBuilder,
 }
-impl<'a> ListFinancialConnectionsTransaction<'a> {
+impl ListFinancialConnectionsTransaction {
     /// Construct a new `ListFinancialConnectionsTransaction`.
-    pub fn new(account: &'a str) -> Self {
-        Self { inner: ListFinancialConnectionsTransactionBuilder::new(account) }
+    pub fn new(account: impl Into<String>) -> Self {
+        Self { inner: ListFinancialConnectionsTransactionBuilder::new(account.into()) }
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
     /// A filter on the list based on the object `transacted_at` field.
     /// The value can be a string with an integer Unix timestamp, or it can be a dictionary with the following options:.
-    pub fn transacted_at(mut self, transacted_at: stripe_types::RangeQueryTs) -> Self {
-        self.inner.transacted_at = Some(transacted_at);
+    pub fn transacted_at(mut self, transacted_at: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.transacted_at = Some(transacted_at.into());
         self
     }
     /// A filter on the list based on the object `transaction_refresh` field.
     /// The value can be a dictionary with the following options:.
     pub fn transaction_refresh(
         mut self,
-        transaction_refresh: ListFinancialConnectionsTransactionTransactionRefresh<'a>,
+        transaction_refresh: impl Into<ListFinancialConnectionsTransactionTransactionRefresh>,
     ) -> Self {
-        self.inner.transaction_refresh = Some(transaction_refresh);
+        self.inner.transaction_refresh = Some(transaction_refresh.into());
         self
     }
 }
-impl ListFinancialConnectionsTransaction<'_> {
+impl ListFinancialConnectionsTransaction {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -118,12 +118,12 @@ impl ListFinancialConnectionsTransaction<'_> {
     > {
         stripe_client_core::ListPaginator::new_list(
             "/financial_connections/transactions",
-            self.inner,
+            &self.inner,
         )
     }
 }
 
-impl StripeRequest for ListFinancialConnectionsTransaction<'_> {
+impl StripeRequest for ListFinancialConnectionsTransaction {
     type Output = stripe_types::List<stripe_misc::FinancialConnectionsTransaction>;
 
     fn build(&self) -> RequestBuilder {
@@ -131,34 +131,37 @@ impl StripeRequest for ListFinancialConnectionsTransaction<'_> {
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveFinancialConnectionsTransactionBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveFinancialConnectionsTransactionBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveFinancialConnectionsTransactionBuilder<'a> {
+impl RetrieveFinancialConnectionsTransactionBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves the details of a Financial Connections `Transaction`
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveFinancialConnectionsTransaction<'a> {
-    inner: RetrieveFinancialConnectionsTransactionBuilder<'a>,
-    transaction: &'a stripe_misc::FinancialConnectionsTransactionId,
+pub struct RetrieveFinancialConnectionsTransaction {
+    inner: RetrieveFinancialConnectionsTransactionBuilder,
+    transaction: stripe_misc::FinancialConnectionsTransactionId,
 }
-impl<'a> RetrieveFinancialConnectionsTransaction<'a> {
+impl RetrieveFinancialConnectionsTransaction {
     /// Construct a new `RetrieveFinancialConnectionsTransaction`.
-    pub fn new(transaction: &'a stripe_misc::FinancialConnectionsTransactionId) -> Self {
-        Self { transaction, inner: RetrieveFinancialConnectionsTransactionBuilder::new() }
+    pub fn new(transaction: impl Into<stripe_misc::FinancialConnectionsTransactionId>) -> Self {
+        Self {
+            transaction: transaction.into(),
+            inner: RetrieveFinancialConnectionsTransactionBuilder::new(),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveFinancialConnectionsTransaction<'_> {
+impl RetrieveFinancialConnectionsTransaction {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -176,11 +179,11 @@ impl RetrieveFinancialConnectionsTransaction<'_> {
     }
 }
 
-impl StripeRequest for RetrieveFinancialConnectionsTransaction<'_> {
+impl StripeRequest for RetrieveFinancialConnectionsTransaction {
     type Output = stripe_misc::FinancialConnectionsTransaction;
 
     fn build(&self) -> RequestBuilder {
-        let transaction = self.transaction;
+        let transaction = &self.transaction;
         RequestBuilder::new(
             StripeMethod::Get,
             format!("/financial_connections/transactions/{transaction}"),

--- a/generated/async-stripe-misc/src/forwarding_request/requests.rs
+++ b/generated/async-stripe-misc/src/forwarding_request/requests.rs
@@ -2,20 +2,20 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListForwardingRequestBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListForwardingRequestBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     created: Option<ListForwardingRequestCreated>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListForwardingRequestBuilder<'a> {
+impl ListForwardingRequestBuilder {
     fn new() -> Self {
         Self { created: None, ending_before: None, expand: None, limit: None, starting_after: None }
     }
@@ -49,49 +49,49 @@ impl Default for ListForwardingRequestCreated {
 }
 /// Lists all ForwardingRequest objects.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListForwardingRequest<'a> {
-    inner: ListForwardingRequestBuilder<'a>,
+pub struct ListForwardingRequest {
+    inner: ListForwardingRequestBuilder,
 }
-impl<'a> ListForwardingRequest<'a> {
+impl ListForwardingRequest {
     /// Construct a new `ListForwardingRequest`.
     pub fn new() -> Self {
         Self { inner: ListForwardingRequestBuilder::new() }
     }
     /// Similar to other List endpoints, filters results based on created timestamp.
     /// You can pass gt, gte, lt, and lte timestamp values.
-    pub fn created(mut self, created: ListForwardingRequestCreated) -> Self {
-        self.inner.created = Some(created);
+    pub fn created(mut self, created: impl Into<ListForwardingRequestCreated>) -> Self {
+        self.inner.created = Some(created.into());
         self
     }
     /// A pagination cursor to fetch the previous page of the list.
     /// The value must be a ForwardingRequest ID.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A pagination cursor to fetch the next page of the list. The value must be a ForwardingRequest ID.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl<'a> Default for ListForwardingRequest<'a> {
+impl Default for ListForwardingRequest {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListForwardingRequest<'_> {
+impl ListForwardingRequest {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -111,45 +111,45 @@ impl ListForwardingRequest<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_misc::ForwardingRequest>> {
-        stripe_client_core::ListPaginator::new_list("/forwarding/requests", self.inner)
+        stripe_client_core::ListPaginator::new_list("/forwarding/requests", &self.inner)
     }
 }
 
-impl StripeRequest for ListForwardingRequest<'_> {
+impl StripeRequest for ListForwardingRequest {
     type Output = stripe_types::List<stripe_misc::ForwardingRequest>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/forwarding/requests").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveForwardingRequestBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveForwardingRequestBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveForwardingRequestBuilder<'a> {
+impl RetrieveForwardingRequestBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves a ForwardingRequest object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveForwardingRequest<'a> {
-    inner: RetrieveForwardingRequestBuilder<'a>,
-    id: &'a stripe_misc::ForwardingRequestId,
+pub struct RetrieveForwardingRequest {
+    inner: RetrieveForwardingRequestBuilder,
+    id: stripe_misc::ForwardingRequestId,
 }
-impl<'a> RetrieveForwardingRequest<'a> {
+impl RetrieveForwardingRequest {
     /// Construct a new `RetrieveForwardingRequest`.
-    pub fn new(id: &'a stripe_misc::ForwardingRequestId) -> Self {
-        Self { id, inner: RetrieveForwardingRequestBuilder::new() }
+    pub fn new(id: impl Into<stripe_misc::ForwardingRequestId>) -> Self {
+        Self { id: id.into(), inner: RetrieveForwardingRequestBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveForwardingRequest<'_> {
+impl RetrieveForwardingRequest {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -167,95 +167,107 @@ impl RetrieveForwardingRequest<'_> {
     }
 }
 
-impl StripeRequest for RetrieveForwardingRequest<'_> {
+impl StripeRequest for RetrieveForwardingRequest {
     type Output = stripe_misc::ForwardingRequest;
 
     fn build(&self) -> RequestBuilder {
-        let id = self.id;
+        let id = &self.id;
         RequestBuilder::new(StripeMethod::Get, format!("/forwarding/requests/{id}"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateForwardingRequestBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateForwardingRequestBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
-    payment_method: &'a str,
-    replacements: &'a [stripe_misc::ForwardingRequestReplacements],
+    expand: Option<Vec<String>>,
+    payment_method: String,
+    replacements: Vec<stripe_misc::ForwardingRequestReplacements>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    request: Option<CreateForwardingRequestRequest<'a>>,
-    url: &'a str,
+    request: Option<CreateForwardingRequestRequest>,
+    url: String,
 }
-impl<'a> CreateForwardingRequestBuilder<'a> {
+impl CreateForwardingRequestBuilder {
     fn new(
-        payment_method: &'a str,
-        replacements: &'a [stripe_misc::ForwardingRequestReplacements],
-        url: &'a str,
+        payment_method: impl Into<String>,
+        replacements: impl Into<Vec<stripe_misc::ForwardingRequestReplacements>>,
+        url: impl Into<String>,
     ) -> Self {
-        Self { expand: None, payment_method, replacements, request: None, url }
+        Self {
+            expand: None,
+            payment_method: payment_method.into(),
+            replacements: replacements.into(),
+            request: None,
+            url: url.into(),
+        }
     }
 }
 /// The request body and headers to be sent to the destination endpoint.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateForwardingRequestRequest<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateForwardingRequestRequest {
     /// The body payload to send to the destination endpoint.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub body: Option<&'a str>,
+    pub body: Option<String>,
     /// The headers to include in the forwarded request.
     /// Can be omitted if no additional headers (excluding Stripe-generated ones such as the Content-Type header) should be included.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub headers: Option<&'a [CreateForwardingRequestRequestHeaders<'a>]>,
+    pub headers: Option<Vec<CreateForwardingRequestRequestHeaders>>,
 }
-impl<'a> CreateForwardingRequestRequest<'a> {
+impl CreateForwardingRequestRequest {
     pub fn new() -> Self {
         Self { body: None, headers: None }
     }
 }
-impl<'a> Default for CreateForwardingRequestRequest<'a> {
+impl Default for CreateForwardingRequestRequest {
     fn default() -> Self {
         Self::new()
     }
 }
 /// The headers to include in the forwarded request.
 /// Can be omitted if no additional headers (excluding Stripe-generated ones such as the Content-Type header) should be included.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateForwardingRequestRequestHeaders<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateForwardingRequestRequestHeaders {
     /// The header name.
-    pub name: &'a str,
+    pub name: String,
     /// The header value.
-    pub value: &'a str,
+    pub value: String,
 }
-impl<'a> CreateForwardingRequestRequestHeaders<'a> {
-    pub fn new(name: &'a str, value: &'a str) -> Self {
-        Self { name, value }
+impl CreateForwardingRequestRequestHeaders {
+    pub fn new(name: impl Into<String>, value: impl Into<String>) -> Self {
+        Self { name: name.into(), value: value.into() }
     }
 }
 /// Creates a ForwardingRequest object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateForwardingRequest<'a> {
-    inner: CreateForwardingRequestBuilder<'a>,
+pub struct CreateForwardingRequest {
+    inner: CreateForwardingRequestBuilder,
 }
-impl<'a> CreateForwardingRequest<'a> {
+impl CreateForwardingRequest {
     /// Construct a new `CreateForwardingRequest`.
     pub fn new(
-        payment_method: &'a str,
-        replacements: &'a [stripe_misc::ForwardingRequestReplacements],
-        url: &'a str,
+        payment_method: impl Into<String>,
+        replacements: impl Into<Vec<stripe_misc::ForwardingRequestReplacements>>,
+        url: impl Into<String>,
     ) -> Self {
-        Self { inner: CreateForwardingRequestBuilder::new(payment_method, replacements, url) }
+        Self {
+            inner: CreateForwardingRequestBuilder::new(
+                payment_method.into(),
+                replacements.into(),
+                url.into(),
+            ),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// The request body and headers to be sent to the destination endpoint.
-    pub fn request(mut self, request: CreateForwardingRequestRequest<'a>) -> Self {
-        self.inner.request = Some(request);
+    pub fn request(mut self, request: impl Into<CreateForwardingRequestRequest>) -> Self {
+        self.inner.request = Some(request.into());
         self
     }
 }
-impl CreateForwardingRequest<'_> {
+impl CreateForwardingRequest {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -273,7 +285,7 @@ impl CreateForwardingRequest<'_> {
     }
 }
 
-impl StripeRequest for CreateForwardingRequest<'_> {
+impl StripeRequest for CreateForwardingRequest {
     type Output = stripe_misc::ForwardingRequest;
 
     fn build(&self) -> RequestBuilder {

--- a/generated/async-stripe-misc/src/identity_verification_report/requests.rs
+++ b/generated/async-stripe-misc/src/identity_verification_report/requests.rs
@@ -2,27 +2,27 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListIdentityVerificationReportBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListIdentityVerificationReportBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    client_reference_id: Option<&'a str>,
+    client_reference_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     created: Option<stripe_types::RangeQueryTs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
     #[serde(rename = "type")]
     #[serde(skip_serializing_if = "Option::is_none")]
     type_: Option<ListIdentityVerificationReportType>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    verification_session: Option<&'a str>,
+    verification_session: Option<String>,
 }
-impl<'a> ListIdentityVerificationReportBuilder<'a> {
+impl ListIdentityVerificationReportBuilder {
     fn new() -> Self {
         Self {
             client_reference_id: None,
@@ -94,68 +94,68 @@ impl<'de> serde::Deserialize<'de> for ListIdentityVerificationReportType {
 }
 /// List all verification reports.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListIdentityVerificationReport<'a> {
-    inner: ListIdentityVerificationReportBuilder<'a>,
+pub struct ListIdentityVerificationReport {
+    inner: ListIdentityVerificationReportBuilder,
 }
-impl<'a> ListIdentityVerificationReport<'a> {
+impl ListIdentityVerificationReport {
     /// Construct a new `ListIdentityVerificationReport`.
     pub fn new() -> Self {
         Self { inner: ListIdentityVerificationReportBuilder::new() }
     }
     /// A string to reference this user.
     /// This can be a customer ID, a session ID, or similar, and can be used to reconcile this verification with your internal systems.
-    pub fn client_reference_id(mut self, client_reference_id: &'a str) -> Self {
-        self.inner.client_reference_id = Some(client_reference_id);
+    pub fn client_reference_id(mut self, client_reference_id: impl Into<String>) -> Self {
+        self.inner.client_reference_id = Some(client_reference_id.into());
         self
     }
     /// Only return VerificationReports that were created during the given date interval.
-    pub fn created(mut self, created: stripe_types::RangeQueryTs) -> Self {
-        self.inner.created = Some(created);
+    pub fn created(mut self, created: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.created = Some(created.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
     /// Only return VerificationReports of this type
-    pub fn type_(mut self, type_: ListIdentityVerificationReportType) -> Self {
-        self.inner.type_ = Some(type_);
+    pub fn type_(mut self, type_: impl Into<ListIdentityVerificationReportType>) -> Self {
+        self.inner.type_ = Some(type_.into());
         self
     }
     /// Only return VerificationReports created by this VerificationSession ID.
     /// It is allowed to provide a VerificationIntent ID.
-    pub fn verification_session(mut self, verification_session: &'a str) -> Self {
-        self.inner.verification_session = Some(verification_session);
+    pub fn verification_session(mut self, verification_session: impl Into<String>) -> Self {
+        self.inner.verification_session = Some(verification_session.into());
         self
     }
 }
-impl<'a> Default for ListIdentityVerificationReport<'a> {
+impl Default for ListIdentityVerificationReport {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListIdentityVerificationReport<'_> {
+impl ListIdentityVerificationReport {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -177,45 +177,45 @@ impl ListIdentityVerificationReport<'_> {
     ) -> stripe_client_core::ListPaginator<
         stripe_types::List<stripe_misc::IdentityVerificationReport>,
     > {
-        stripe_client_core::ListPaginator::new_list("/identity/verification_reports", self.inner)
+        stripe_client_core::ListPaginator::new_list("/identity/verification_reports", &self.inner)
     }
 }
 
-impl StripeRequest for ListIdentityVerificationReport<'_> {
+impl StripeRequest for ListIdentityVerificationReport {
     type Output = stripe_types::List<stripe_misc::IdentityVerificationReport>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/identity/verification_reports").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveIdentityVerificationReportBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveIdentityVerificationReportBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveIdentityVerificationReportBuilder<'a> {
+impl RetrieveIdentityVerificationReportBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves an existing VerificationReport
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveIdentityVerificationReport<'a> {
-    inner: RetrieveIdentityVerificationReportBuilder<'a>,
-    report: &'a stripe_misc::IdentityVerificationReportId,
+pub struct RetrieveIdentityVerificationReport {
+    inner: RetrieveIdentityVerificationReportBuilder,
+    report: stripe_misc::IdentityVerificationReportId,
 }
-impl<'a> RetrieveIdentityVerificationReport<'a> {
+impl RetrieveIdentityVerificationReport {
     /// Construct a new `RetrieveIdentityVerificationReport`.
-    pub fn new(report: &'a stripe_misc::IdentityVerificationReportId) -> Self {
-        Self { report, inner: RetrieveIdentityVerificationReportBuilder::new() }
+    pub fn new(report: impl Into<stripe_misc::IdentityVerificationReportId>) -> Self {
+        Self { report: report.into(), inner: RetrieveIdentityVerificationReportBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveIdentityVerificationReport<'_> {
+impl RetrieveIdentityVerificationReport {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -233,11 +233,11 @@ impl RetrieveIdentityVerificationReport<'_> {
     }
 }
 
-impl StripeRequest for RetrieveIdentityVerificationReport<'_> {
+impl StripeRequest for RetrieveIdentityVerificationReport {
     type Output = stripe_misc::IdentityVerificationReport;
 
     fn build(&self) -> RequestBuilder {
-        let report = self.report;
+        let report = &self.report;
         RequestBuilder::new(StripeMethod::Get, format!("/identity/verification_reports/{report}"))
             .query(&self.inner)
     }

--- a/generated/async-stripe-misc/src/identity_verification_session/requests.rs
+++ b/generated/async-stripe-misc/src/identity_verification_session/requests.rs
@@ -2,24 +2,24 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListIdentityVerificationSessionBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListIdentityVerificationSessionBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    client_reference_id: Option<&'a str>,
+    client_reference_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     created: Option<stripe_types::RangeQueryTs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     status: Option<stripe_misc::IdentityVerificationSessionStatus>,
 }
-impl<'a> ListIdentityVerificationSessionBuilder<'a> {
+impl ListIdentityVerificationSessionBuilder {
     fn new() -> Self {
         Self {
             client_reference_id: None,
@@ -34,63 +34,66 @@ impl<'a> ListIdentityVerificationSessionBuilder<'a> {
 }
 /// Returns a list of VerificationSessions
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListIdentityVerificationSession<'a> {
-    inner: ListIdentityVerificationSessionBuilder<'a>,
+pub struct ListIdentityVerificationSession {
+    inner: ListIdentityVerificationSessionBuilder,
 }
-impl<'a> ListIdentityVerificationSession<'a> {
+impl ListIdentityVerificationSession {
     /// Construct a new `ListIdentityVerificationSession`.
     pub fn new() -> Self {
         Self { inner: ListIdentityVerificationSessionBuilder::new() }
     }
     /// A string to reference this user.
     /// This can be a customer ID, a session ID, or similar, and can be used to reconcile this verification with your internal systems.
-    pub fn client_reference_id(mut self, client_reference_id: &'a str) -> Self {
-        self.inner.client_reference_id = Some(client_reference_id);
+    pub fn client_reference_id(mut self, client_reference_id: impl Into<String>) -> Self {
+        self.inner.client_reference_id = Some(client_reference_id.into());
         self
     }
     /// Only return VerificationSessions that were created during the given date interval.
-    pub fn created(mut self, created: stripe_types::RangeQueryTs) -> Self {
-        self.inner.created = Some(created);
+    pub fn created(mut self, created: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.created = Some(created.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
     /// Only return VerificationSessions with this status.
     /// [Learn more about the lifecycle of sessions](https://stripe.com/docs/identity/how-sessions-work).
-    pub fn status(mut self, status: stripe_misc::IdentityVerificationSessionStatus) -> Self {
-        self.inner.status = Some(status);
+    pub fn status(
+        mut self,
+        status: impl Into<stripe_misc::IdentityVerificationSessionStatus>,
+    ) -> Self {
+        self.inner.status = Some(status.into());
         self
     }
 }
-impl<'a> Default for ListIdentityVerificationSession<'a> {
+impl Default for ListIdentityVerificationSession {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListIdentityVerificationSession<'_> {
+impl ListIdentityVerificationSession {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -112,23 +115,23 @@ impl ListIdentityVerificationSession<'_> {
     ) -> stripe_client_core::ListPaginator<
         stripe_types::List<stripe_misc::IdentityVerificationSession>,
     > {
-        stripe_client_core::ListPaginator::new_list("/identity/verification_sessions", self.inner)
+        stripe_client_core::ListPaginator::new_list("/identity/verification_sessions", &self.inner)
     }
 }
 
-impl StripeRequest for ListIdentityVerificationSession<'_> {
+impl StripeRequest for ListIdentityVerificationSession {
     type Output = stripe_types::List<stripe_misc::IdentityVerificationSession>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/identity/verification_sessions").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveIdentityVerificationSessionBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveIdentityVerificationSessionBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveIdentityVerificationSessionBuilder<'a> {
+impl RetrieveIdentityVerificationSessionBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
@@ -138,22 +141,22 @@ impl<'a> RetrieveIdentityVerificationSessionBuilder<'a> {
 /// When the session status is `requires_input`, you can use this method to retrieve a valid
 /// `client_secret` or `url` to allow re-submission.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveIdentityVerificationSession<'a> {
-    inner: RetrieveIdentityVerificationSessionBuilder<'a>,
-    session: &'a stripe_misc::IdentityVerificationSessionId,
+pub struct RetrieveIdentityVerificationSession {
+    inner: RetrieveIdentityVerificationSessionBuilder,
+    session: stripe_misc::IdentityVerificationSessionId,
 }
-impl<'a> RetrieveIdentityVerificationSession<'a> {
+impl RetrieveIdentityVerificationSession {
     /// Construct a new `RetrieveIdentityVerificationSession`.
-    pub fn new(session: &'a stripe_misc::IdentityVerificationSessionId) -> Self {
-        Self { session, inner: RetrieveIdentityVerificationSessionBuilder::new() }
+    pub fn new(session: impl Into<stripe_misc::IdentityVerificationSessionId>) -> Self {
+        Self { session: session.into(), inner: RetrieveIdentityVerificationSessionBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveIdentityVerificationSession<'_> {
+impl RetrieveIdentityVerificationSession {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -171,36 +174,36 @@ impl RetrieveIdentityVerificationSession<'_> {
     }
 }
 
-impl StripeRequest for RetrieveIdentityVerificationSession<'_> {
+impl StripeRequest for RetrieveIdentityVerificationSession {
     type Output = stripe_misc::IdentityVerificationSession;
 
     fn build(&self) -> RequestBuilder {
-        let session = self.session;
+        let session = &self.session;
         RequestBuilder::new(StripeMethod::Get, format!("/identity/verification_sessions/{session}"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateIdentityVerificationSessionBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateIdentityVerificationSessionBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    client_reference_id: Option<&'a str>,
+    client_reference_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    options: Option<CreateIdentityVerificationSessionOptions<'a>>,
+    options: Option<CreateIdentityVerificationSessionOptions>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    provided_details: Option<ProvidedDetailsParam<'a>>,
+    provided_details: Option<ProvidedDetailsParam>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    return_url: Option<&'a str>,
+    return_url: Option<String>,
     #[serde(rename = "type")]
     #[serde(skip_serializing_if = "Option::is_none")]
     type_: Option<CreateIdentityVerificationSessionType>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    verification_flow: Option<&'a str>,
+    verification_flow: Option<String>,
 }
-impl<'a> CreateIdentityVerificationSessionBuilder<'a> {
+impl CreateIdentityVerificationSessionBuilder {
     fn new() -> Self {
         Self {
             client_reference_id: None,
@@ -215,29 +218,29 @@ impl<'a> CreateIdentityVerificationSessionBuilder<'a> {
     }
 }
 /// A set of options for the session’s verification checks.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateIdentityVerificationSessionOptions<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateIdentityVerificationSessionOptions {
     /// Options that apply to the [document check](https://stripe.com/docs/identity/verification-checks?type=document).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub document: Option<CreateIdentityVerificationSessionOptionsDocument<'a>>,
+    pub document: Option<CreateIdentityVerificationSessionOptionsDocument>,
 }
-impl<'a> CreateIdentityVerificationSessionOptions<'a> {
+impl CreateIdentityVerificationSessionOptions {
     pub fn new() -> Self {
         Self { document: None }
     }
 }
-impl<'a> Default for CreateIdentityVerificationSessionOptions<'a> {
+impl Default for CreateIdentityVerificationSessionOptions {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Options that apply to the [document check](https://stripe.com/docs/identity/verification-checks?type=document).
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateIdentityVerificationSessionOptionsDocument<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateIdentityVerificationSessionOptionsDocument {
     /// Array of strings of allowed identity document types.
     /// If the provided identity document isn’t one of the allowed types, the verification check will fail with a document_type_not_allowed error code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub allowed_types: Option<&'a [CreateIdentityVerificationSessionOptionsDocumentAllowedTypes]>,
+    pub allowed_types: Option<Vec<CreateIdentityVerificationSessionOptionsDocumentAllowedTypes>>,
     /// Collect an ID number and perform an [ID number check](https://stripe.com/docs/identity/verification-checks?type=id-number) with the document’s extracted name and date of birth.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub require_id_number: Option<bool>,
@@ -249,7 +252,7 @@ pub struct CreateIdentityVerificationSessionOptionsDocument<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub require_matching_selfie: Option<bool>,
 }
-impl<'a> CreateIdentityVerificationSessionOptionsDocument<'a> {
+impl CreateIdentityVerificationSessionOptionsDocument {
     pub fn new() -> Self {
         Self {
             allowed_types: None,
@@ -259,7 +262,7 @@ impl<'a> CreateIdentityVerificationSessionOptionsDocument<'a> {
         }
     }
 }
-impl<'a> Default for CreateIdentityVerificationSessionOptionsDocument<'a> {
+impl Default for CreateIdentityVerificationSessionOptionsDocument {
     fn default() -> Self {
         Self::new()
     }
@@ -391,67 +394,70 @@ impl<'de> serde::Deserialize<'de> for CreateIdentityVerificationSessionType {
 ///
 /// Related guide: [Verify your users’ identity documents](https://stripe.com/docs/identity/verify-identity-documents).
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateIdentityVerificationSession<'a> {
-    inner: CreateIdentityVerificationSessionBuilder<'a>,
+pub struct CreateIdentityVerificationSession {
+    inner: CreateIdentityVerificationSessionBuilder,
 }
-impl<'a> CreateIdentityVerificationSession<'a> {
+impl CreateIdentityVerificationSession {
     /// Construct a new `CreateIdentityVerificationSession`.
     pub fn new() -> Self {
         Self { inner: CreateIdentityVerificationSessionBuilder::new() }
     }
     /// A string to reference this user.
     /// This can be a customer ID, a session ID, or similar, and can be used to reconcile this verification with your internal systems.
-    pub fn client_reference_id(mut self, client_reference_id: &'a str) -> Self {
-        self.inner.client_reference_id = Some(client_reference_id);
+    pub fn client_reference_id(mut self, client_reference_id: impl Into<String>) -> Self {
+        self.inner.client_reference_id = Some(client_reference_id.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// A set of options for the session’s verification checks.
-    pub fn options(mut self, options: CreateIdentityVerificationSessionOptions<'a>) -> Self {
-        self.inner.options = Some(options);
+    pub fn options(mut self, options: impl Into<CreateIdentityVerificationSessionOptions>) -> Self {
+        self.inner.options = Some(options.into());
         self
     }
     /// Details provided about the user being verified. These details may be shown to the user.
-    pub fn provided_details(mut self, provided_details: ProvidedDetailsParam<'a>) -> Self {
-        self.inner.provided_details = Some(provided_details);
+    pub fn provided_details(mut self, provided_details: impl Into<ProvidedDetailsParam>) -> Self {
+        self.inner.provided_details = Some(provided_details.into());
         self
     }
     /// The URL that the user will be redirected to upon completing the verification flow.
-    pub fn return_url(mut self, return_url: &'a str) -> Self {
-        self.inner.return_url = Some(return_url);
+    pub fn return_url(mut self, return_url: impl Into<String>) -> Self {
+        self.inner.return_url = Some(return_url.into());
         self
     }
     /// The type of [verification check](https://stripe.com/docs/identity/verification-checks) to be performed.
     /// You must provide a `type` if not passing `verification_flow`.
-    pub fn type_(mut self, type_: CreateIdentityVerificationSessionType) -> Self {
-        self.inner.type_ = Some(type_);
+    pub fn type_(mut self, type_: impl Into<CreateIdentityVerificationSessionType>) -> Self {
+        self.inner.type_ = Some(type_.into());
         self
     }
     /// The ID of a Verification Flow from the Dashboard.
     /// See <https://docs.stripe.com/identity/verification-flows>.
-    pub fn verification_flow(mut self, verification_flow: &'a str) -> Self {
-        self.inner.verification_flow = Some(verification_flow);
+    pub fn verification_flow(mut self, verification_flow: impl Into<String>) -> Self {
+        self.inner.verification_flow = Some(verification_flow.into());
         self
     }
 }
-impl<'a> Default for CreateIdentityVerificationSession<'a> {
+impl Default for CreateIdentityVerificationSession {
     fn default() -> Self {
         Self::new()
     }
 }
-impl CreateIdentityVerificationSession<'_> {
+impl CreateIdentityVerificationSession {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -469,56 +475,56 @@ impl CreateIdentityVerificationSession<'_> {
     }
 }
 
-impl StripeRequest for CreateIdentityVerificationSession<'_> {
+impl StripeRequest for CreateIdentityVerificationSession {
     type Output = stripe_misc::IdentityVerificationSession;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Post, "/identity/verification_sessions").form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdateIdentityVerificationSessionBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdateIdentityVerificationSessionBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    options: Option<UpdateIdentityVerificationSessionOptions<'a>>,
+    options: Option<UpdateIdentityVerificationSessionOptions>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    provided_details: Option<ProvidedDetailsParam<'a>>,
+    provided_details: Option<ProvidedDetailsParam>,
     #[serde(rename = "type")]
     #[serde(skip_serializing_if = "Option::is_none")]
     type_: Option<UpdateIdentityVerificationSessionType>,
 }
-impl<'a> UpdateIdentityVerificationSessionBuilder<'a> {
+impl UpdateIdentityVerificationSessionBuilder {
     fn new() -> Self {
         Self { expand: None, metadata: None, options: None, provided_details: None, type_: None }
     }
 }
 /// A set of options for the session’s verification checks.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateIdentityVerificationSessionOptions<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateIdentityVerificationSessionOptions {
     /// Options that apply to the [document check](https://stripe.com/docs/identity/verification-checks?type=document).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub document: Option<UpdateIdentityVerificationSessionOptionsDocument<'a>>,
+    pub document: Option<UpdateIdentityVerificationSessionOptionsDocument>,
 }
-impl<'a> UpdateIdentityVerificationSessionOptions<'a> {
+impl UpdateIdentityVerificationSessionOptions {
     pub fn new() -> Self {
         Self { document: None }
     }
 }
-impl<'a> Default for UpdateIdentityVerificationSessionOptions<'a> {
+impl Default for UpdateIdentityVerificationSessionOptions {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Options that apply to the [document check](https://stripe.com/docs/identity/verification-checks?type=document).
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateIdentityVerificationSessionOptionsDocument<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateIdentityVerificationSessionOptionsDocument {
     /// Array of strings of allowed identity document types.
     /// If the provided identity document isn’t one of the allowed types, the verification check will fail with a document_type_not_allowed error code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub allowed_types: Option<&'a [UpdateIdentityVerificationSessionOptionsDocumentAllowedTypes]>,
+    pub allowed_types: Option<Vec<UpdateIdentityVerificationSessionOptionsDocumentAllowedTypes>>,
     /// Collect an ID number and perform an [ID number check](https://stripe.com/docs/identity/verification-checks?type=id-number) with the document’s extracted name and date of birth.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub require_id_number: Option<bool>,
@@ -530,7 +536,7 @@ pub struct UpdateIdentityVerificationSessionOptionsDocument<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub require_matching_selfie: Option<bool>,
 }
-impl<'a> UpdateIdentityVerificationSessionOptionsDocument<'a> {
+impl UpdateIdentityVerificationSessionOptionsDocument {
     pub fn new() -> Self {
         Self {
             allowed_types: None,
@@ -540,7 +546,7 @@ impl<'a> UpdateIdentityVerificationSessionOptionsDocument<'a> {
         }
     }
 }
-impl<'a> Default for UpdateIdentityVerificationSessionOptionsDocument<'a> {
+impl Default for UpdateIdentityVerificationSessionOptionsDocument {
     fn default() -> Self {
         Self::new()
     }
@@ -668,45 +674,48 @@ impl<'de> serde::Deserialize<'de> for UpdateIdentityVerificationSessionType {
 /// When the session status is `requires_input`, you can use this method to update the
 /// verification check and options.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateIdentityVerificationSession<'a> {
-    inner: UpdateIdentityVerificationSessionBuilder<'a>,
-    session: &'a stripe_misc::IdentityVerificationSessionId,
+pub struct UpdateIdentityVerificationSession {
+    inner: UpdateIdentityVerificationSessionBuilder,
+    session: stripe_misc::IdentityVerificationSessionId,
 }
-impl<'a> UpdateIdentityVerificationSession<'a> {
+impl UpdateIdentityVerificationSession {
     /// Construct a new `UpdateIdentityVerificationSession`.
-    pub fn new(session: &'a stripe_misc::IdentityVerificationSessionId) -> Self {
-        Self { session, inner: UpdateIdentityVerificationSessionBuilder::new() }
+    pub fn new(session: impl Into<stripe_misc::IdentityVerificationSessionId>) -> Self {
+        Self { session: session.into(), inner: UpdateIdentityVerificationSessionBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// A set of options for the session’s verification checks.
-    pub fn options(mut self, options: UpdateIdentityVerificationSessionOptions<'a>) -> Self {
-        self.inner.options = Some(options);
+    pub fn options(mut self, options: impl Into<UpdateIdentityVerificationSessionOptions>) -> Self {
+        self.inner.options = Some(options.into());
         self
     }
     /// Details provided about the user being verified. These details may be shown to the user.
-    pub fn provided_details(mut self, provided_details: ProvidedDetailsParam<'a>) -> Self {
-        self.inner.provided_details = Some(provided_details);
+    pub fn provided_details(mut self, provided_details: impl Into<ProvidedDetailsParam>) -> Self {
+        self.inner.provided_details = Some(provided_details.into());
         self
     }
     /// The type of [verification check](https://stripe.com/docs/identity/verification-checks) to be performed.
-    pub fn type_(mut self, type_: UpdateIdentityVerificationSessionType) -> Self {
-        self.inner.type_ = Some(type_);
+    pub fn type_(mut self, type_: impl Into<UpdateIdentityVerificationSessionType>) -> Self {
+        self.inner.type_ = Some(type_.into());
         self
     }
 }
-impl UpdateIdentityVerificationSession<'_> {
+impl UpdateIdentityVerificationSession {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -724,11 +733,11 @@ impl UpdateIdentityVerificationSession<'_> {
     }
 }
 
-impl StripeRequest for UpdateIdentityVerificationSession<'_> {
+impl StripeRequest for UpdateIdentityVerificationSession {
     type Output = stripe_misc::IdentityVerificationSession;
 
     fn build(&self) -> RequestBuilder {
-        let session = self.session;
+        let session = &self.session;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/identity/verification_sessions/{session}"),
@@ -736,12 +745,12 @@ impl StripeRequest for UpdateIdentityVerificationSession<'_> {
         .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CancelIdentityVerificationSessionBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CancelIdentityVerificationSessionBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> CancelIdentityVerificationSessionBuilder<'a> {
+impl CancelIdentityVerificationSessionBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
@@ -752,22 +761,22 @@ impl<'a> CancelIdentityVerificationSessionBuilder<'a> {
 /// This cannot be undone.
 /// [Learn more](https://stripe.com/docs/identity/verification-sessions#cancel).
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CancelIdentityVerificationSession<'a> {
-    inner: CancelIdentityVerificationSessionBuilder<'a>,
-    session: &'a stripe_misc::IdentityVerificationSessionId,
+pub struct CancelIdentityVerificationSession {
+    inner: CancelIdentityVerificationSessionBuilder,
+    session: stripe_misc::IdentityVerificationSessionId,
 }
-impl<'a> CancelIdentityVerificationSession<'a> {
+impl CancelIdentityVerificationSession {
     /// Construct a new `CancelIdentityVerificationSession`.
-    pub fn new(session: &'a stripe_misc::IdentityVerificationSessionId) -> Self {
-        Self { session, inner: CancelIdentityVerificationSessionBuilder::new() }
+    pub fn new(session: impl Into<stripe_misc::IdentityVerificationSessionId>) -> Self {
+        Self { session: session.into(), inner: CancelIdentityVerificationSessionBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl CancelIdentityVerificationSession<'_> {
+impl CancelIdentityVerificationSession {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -785,11 +794,11 @@ impl CancelIdentityVerificationSession<'_> {
     }
 }
 
-impl StripeRequest for CancelIdentityVerificationSession<'_> {
+impl StripeRequest for CancelIdentityVerificationSession {
     type Output = stripe_misc::IdentityVerificationSession;
 
     fn build(&self) -> RequestBuilder {
-        let session = self.session;
+        let session = &self.session;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/identity/verification_sessions/{session}/cancel"),
@@ -797,12 +806,12 @@ impl StripeRequest for CancelIdentityVerificationSession<'_> {
         .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RedactIdentityVerificationSessionBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RedactIdentityVerificationSessionBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RedactIdentityVerificationSessionBuilder<'a> {
+impl RedactIdentityVerificationSessionBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
@@ -828,22 +837,22 @@ impl<'a> RedactIdentityVerificationSessionBuilder<'a> {
 ///
 /// [Learn more](https://stripe.com/docs/identity/verification-sessions#redact).
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RedactIdentityVerificationSession<'a> {
-    inner: RedactIdentityVerificationSessionBuilder<'a>,
-    session: &'a stripe_misc::IdentityVerificationSessionId,
+pub struct RedactIdentityVerificationSession {
+    inner: RedactIdentityVerificationSessionBuilder,
+    session: stripe_misc::IdentityVerificationSessionId,
 }
-impl<'a> RedactIdentityVerificationSession<'a> {
+impl RedactIdentityVerificationSession {
     /// Construct a new `RedactIdentityVerificationSession`.
-    pub fn new(session: &'a stripe_misc::IdentityVerificationSessionId) -> Self {
-        Self { session, inner: RedactIdentityVerificationSessionBuilder::new() }
+    pub fn new(session: impl Into<stripe_misc::IdentityVerificationSessionId>) -> Self {
+        Self { session: session.into(), inner: RedactIdentityVerificationSessionBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RedactIdentityVerificationSession<'_> {
+impl RedactIdentityVerificationSession {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -861,11 +870,11 @@ impl RedactIdentityVerificationSession<'_> {
     }
 }
 
-impl StripeRequest for RedactIdentityVerificationSession<'_> {
+impl StripeRequest for RedactIdentityVerificationSession {
     type Output = stripe_misc::IdentityVerificationSession;
 
     fn build(&self) -> RequestBuilder {
-        let session = self.session;
+        let session = &self.session;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/identity/verification_sessions/{session}/redact"),
@@ -874,21 +883,21 @@ impl StripeRequest for RedactIdentityVerificationSession<'_> {
     }
 }
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ProvidedDetailsParam<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ProvidedDetailsParam {
     /// Email of user being verified
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub email: Option<&'a str>,
+    pub email: Option<String>,
     /// Phone number of user being verified
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub phone: Option<&'a str>,
+    pub phone: Option<String>,
 }
-impl<'a> ProvidedDetailsParam<'a> {
+impl ProvidedDetailsParam {
     pub fn new() -> Self {
         Self { email: None, phone: None }
     }
 }
-impl<'a> Default for ProvidedDetailsParam<'a> {
+impl Default for ProvidedDetailsParam {
     fn default() -> Self {
         Self::new()
     }

--- a/generated/async-stripe-misc/src/reporting_report_run/requests.rs
+++ b/generated/async-stripe-misc/src/reporting_report_run/requests.rs
@@ -2,71 +2,71 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListReportingReportRunBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListReportingReportRunBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     created: Option<stripe_types::RangeQueryTs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListReportingReportRunBuilder<'a> {
+impl ListReportingReportRunBuilder {
     fn new() -> Self {
         Self { created: None, ending_before: None, expand: None, limit: None, starting_after: None }
     }
 }
 /// Returns a list of Report Runs, with the most recent appearing first.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListReportingReportRun<'a> {
-    inner: ListReportingReportRunBuilder<'a>,
+pub struct ListReportingReportRun {
+    inner: ListReportingReportRunBuilder,
 }
-impl<'a> ListReportingReportRun<'a> {
+impl ListReportingReportRun {
     /// Construct a new `ListReportingReportRun`.
     pub fn new() -> Self {
         Self { inner: ListReportingReportRunBuilder::new() }
     }
     /// Only return Report Runs that were created during the given date interval.
-    pub fn created(mut self, created: stripe_types::RangeQueryTs) -> Self {
-        self.inner.created = Some(created);
+    pub fn created(mut self, created: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.created = Some(created.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl<'a> Default for ListReportingReportRun<'a> {
+impl Default for ListReportingReportRun {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListReportingReportRun<'_> {
+impl ListReportingReportRun {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -87,45 +87,45 @@ impl ListReportingReportRun<'_> {
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_misc::ReportingReportRun>>
     {
-        stripe_client_core::ListPaginator::new_list("/reporting/report_runs", self.inner)
+        stripe_client_core::ListPaginator::new_list("/reporting/report_runs", &self.inner)
     }
 }
 
-impl StripeRequest for ListReportingReportRun<'_> {
+impl StripeRequest for ListReportingReportRun {
     type Output = stripe_types::List<stripe_misc::ReportingReportRun>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/reporting/report_runs").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveReportingReportRunBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveReportingReportRunBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveReportingReportRunBuilder<'a> {
+impl RetrieveReportingReportRunBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves the details of an existing Report Run.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveReportingReportRun<'a> {
-    inner: RetrieveReportingReportRunBuilder<'a>,
-    report_run: &'a stripe_misc::ReportingReportRunId,
+pub struct RetrieveReportingReportRun {
+    inner: RetrieveReportingReportRunBuilder,
+    report_run: stripe_misc::ReportingReportRunId,
 }
-impl<'a> RetrieveReportingReportRun<'a> {
+impl RetrieveReportingReportRun {
     /// Construct a new `RetrieveReportingReportRun`.
-    pub fn new(report_run: &'a stripe_misc::ReportingReportRunId) -> Self {
-        Self { report_run, inner: RetrieveReportingReportRunBuilder::new() }
+    pub fn new(report_run: impl Into<stripe_misc::ReportingReportRunId>) -> Self {
+        Self { report_run: report_run.into(), inner: RetrieveReportingReportRunBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveReportingReportRun<'_> {
+impl RetrieveReportingReportRun {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -143,39 +143,39 @@ impl RetrieveReportingReportRun<'_> {
     }
 }
 
-impl StripeRequest for RetrieveReportingReportRun<'_> {
+impl StripeRequest for RetrieveReportingReportRun {
     type Output = stripe_misc::ReportingReportRun;
 
     fn build(&self) -> RequestBuilder {
-        let report_run = self.report_run;
+        let report_run = &self.report_run;
         RequestBuilder::new(StripeMethod::Get, format!("/reporting/report_runs/{report_run}"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateReportingReportRunBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateReportingReportRunBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    parameters: Option<CreateReportingReportRunParameters<'a>>,
-    report_type: &'a str,
+    parameters: Option<CreateReportingReportRunParameters>,
+    report_type: String,
 }
-impl<'a> CreateReportingReportRunBuilder<'a> {
-    fn new(report_type: &'a str) -> Self {
-        Self { expand: None, parameters: None, report_type }
+impl CreateReportingReportRunBuilder {
+    fn new(report_type: impl Into<String>) -> Self {
+        Self { expand: None, parameters: None, report_type: report_type.into() }
     }
 }
 /// Parameters specifying how the report should be run.
 /// Different Report Types have different required and optional parameters, listed in the [API Access to Reports](https://stripe.com/docs/reporting/statements/api) documentation.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateReportingReportRunParameters<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateReportingReportRunParameters {
     /// The set of report columns to include in the report output.
     /// If omitted, the Report Type is run with its default column set.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub columns: Option<&'a [&'a str]>,
+    pub columns: Option<Vec<String>>,
     /// Connected account ID to filter for in the report run.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub connected_account: Option<&'a str>,
+    pub connected_account: Option<String>,
     /// Currency of objects to be included in the report run.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub currency: Option<stripe_types::Currency>,
@@ -187,7 +187,7 @@ pub struct CreateReportingReportRunParameters<'a> {
     pub interval_start: Option<stripe_types::Timestamp>,
     /// Payout ID by which to filter the report run.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub payout: Option<&'a str>,
+    pub payout: Option<String>,
     /// Category of balance transactions to be included in the report run.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reporting_category: Option<CreateReportingReportRunParametersReportingCategory>,
@@ -198,7 +198,7 @@ pub struct CreateReportingReportRunParameters<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timezone: Option<CreateReportingReportRunParametersTimezone>,
 }
-impl<'a> CreateReportingReportRunParameters<'a> {
+impl CreateReportingReportRunParameters {
     pub fn new() -> Self {
         Self {
             columns: None,
@@ -212,7 +212,7 @@ impl<'a> CreateReportingReportRunParameters<'a> {
         }
     }
 }
-impl<'a> Default for CreateReportingReportRunParameters<'a> {
+impl Default for CreateReportingReportRunParameters {
     fn default() -> Self {
         Self::new()
     }
@@ -2232,27 +2232,27 @@ impl<'de> serde::Deserialize<'de> for CreateReportingReportRunParametersTimezone
 /// Creates a new object and begin running the report.
 /// (Certain report types require a [live-mode API key](https://stripe.com/docs/keys#test-live-modes).).
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateReportingReportRun<'a> {
-    inner: CreateReportingReportRunBuilder<'a>,
+pub struct CreateReportingReportRun {
+    inner: CreateReportingReportRunBuilder,
 }
-impl<'a> CreateReportingReportRun<'a> {
+impl CreateReportingReportRun {
     /// Construct a new `CreateReportingReportRun`.
-    pub fn new(report_type: &'a str) -> Self {
-        Self { inner: CreateReportingReportRunBuilder::new(report_type) }
+    pub fn new(report_type: impl Into<String>) -> Self {
+        Self { inner: CreateReportingReportRunBuilder::new(report_type.into()) }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Parameters specifying how the report should be run.
     /// Different Report Types have different required and optional parameters, listed in the [API Access to Reports](https://stripe.com/docs/reporting/statements/api) documentation.
-    pub fn parameters(mut self, parameters: CreateReportingReportRunParameters<'a>) -> Self {
-        self.inner.parameters = Some(parameters);
+    pub fn parameters(mut self, parameters: impl Into<CreateReportingReportRunParameters>) -> Self {
+        self.inner.parameters = Some(parameters.into());
         self
     }
 }
-impl CreateReportingReportRun<'_> {
+impl CreateReportingReportRun {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -2270,7 +2270,7 @@ impl CreateReportingReportRun<'_> {
     }
 }
 
-impl StripeRequest for CreateReportingReportRun<'_> {
+impl StripeRequest for CreateReportingReportRun {
     type Output = stripe_misc::ReportingReportRun;
 
     fn build(&self) -> RequestBuilder {

--- a/generated/async-stripe-misc/src/reporting_report_type/requests.rs
+++ b/generated/async-stripe-misc/src/reporting_report_type/requests.rs
@@ -2,38 +2,38 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListReportingReportTypeBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListReportingReportTypeBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> ListReportingReportTypeBuilder<'a> {
+impl ListReportingReportTypeBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Returns a full list of Report Types.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListReportingReportType<'a> {
-    inner: ListReportingReportTypeBuilder<'a>,
+pub struct ListReportingReportType {
+    inner: ListReportingReportTypeBuilder,
 }
-impl<'a> ListReportingReportType<'a> {
+impl ListReportingReportType {
     /// Construct a new `ListReportingReportType`.
     pub fn new() -> Self {
         Self { inner: ListReportingReportTypeBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl<'a> Default for ListReportingReportType<'a> {
+impl Default for ListReportingReportType {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListReportingReportType<'_> {
+impl ListReportingReportType {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -54,23 +54,23 @@ impl ListReportingReportType<'_> {
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_misc::ReportingReportType>>
     {
-        stripe_client_core::ListPaginator::new_list("/reporting/report_types", self.inner)
+        stripe_client_core::ListPaginator::new_list("/reporting/report_types", &self.inner)
     }
 }
 
-impl StripeRequest for ListReportingReportType<'_> {
+impl StripeRequest for ListReportingReportType {
     type Output = stripe_types::List<stripe_misc::ReportingReportType>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/reporting/report_types").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveReportingReportTypeBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveReportingReportTypeBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveReportingReportTypeBuilder<'a> {
+impl RetrieveReportingReportTypeBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
@@ -78,22 +78,22 @@ impl<'a> RetrieveReportingReportTypeBuilder<'a> {
 /// Retrieves the details of a Report Type.
 /// (Certain report types require a [live-mode API key](https://stripe.com/docs/keys#test-live-modes).).
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveReportingReportType<'a> {
-    inner: RetrieveReportingReportTypeBuilder<'a>,
-    report_type: &'a stripe_misc::ReportingReportTypeId,
+pub struct RetrieveReportingReportType {
+    inner: RetrieveReportingReportTypeBuilder,
+    report_type: stripe_misc::ReportingReportTypeId,
 }
-impl<'a> RetrieveReportingReportType<'a> {
+impl RetrieveReportingReportType {
     /// Construct a new `RetrieveReportingReportType`.
-    pub fn new(report_type: &'a stripe_misc::ReportingReportTypeId) -> Self {
-        Self { report_type, inner: RetrieveReportingReportTypeBuilder::new() }
+    pub fn new(report_type: impl Into<stripe_misc::ReportingReportTypeId>) -> Self {
+        Self { report_type: report_type.into(), inner: RetrieveReportingReportTypeBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveReportingReportType<'_> {
+impl RetrieveReportingReportType {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -111,11 +111,11 @@ impl RetrieveReportingReportType<'_> {
     }
 }
 
-impl StripeRequest for RetrieveReportingReportType<'_> {
+impl StripeRequest for RetrieveReportingReportType {
     type Output = stripe_misc::ReportingReportType;
 
     fn build(&self) -> RequestBuilder {
-        let report_type = self.report_type;
+        let report_type = &self.report_type;
         RequestBuilder::new(StripeMethod::Get, format!("/reporting/report_types/{report_type}"))
             .query(&self.inner)
     }

--- a/generated/async-stripe-misc/src/scheduled_query_run/requests.rs
+++ b/generated/async-stripe-misc/src/scheduled_query_run/requests.rs
@@ -2,28 +2,28 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListScheduledQueryRunBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListScheduledQueryRunBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListScheduledQueryRunBuilder<'a> {
+impl ListScheduledQueryRunBuilder {
     fn new() -> Self {
         Self { ending_before: None, expand: None, limit: None, starting_after: None }
     }
 }
 /// Returns a list of scheduled query runs.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListScheduledQueryRun<'a> {
-    inner: ListScheduledQueryRunBuilder<'a>,
+pub struct ListScheduledQueryRun {
+    inner: ListScheduledQueryRunBuilder,
 }
-impl<'a> ListScheduledQueryRun<'a> {
+impl ListScheduledQueryRun {
     /// Construct a new `ListScheduledQueryRun`.
     pub fn new() -> Self {
         Self { inner: ListScheduledQueryRunBuilder::new() }
@@ -31,35 +31,35 @@ impl<'a> ListScheduledQueryRun<'a> {
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl<'a> Default for ListScheduledQueryRun<'a> {
+impl Default for ListScheduledQueryRun {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListScheduledQueryRun<'_> {
+impl ListScheduledQueryRun {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -79,45 +79,48 @@ impl ListScheduledQueryRun<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_misc::ScheduledQueryRun>> {
-        stripe_client_core::ListPaginator::new_list("/sigma/scheduled_query_runs", self.inner)
+        stripe_client_core::ListPaginator::new_list("/sigma/scheduled_query_runs", &self.inner)
     }
 }
 
-impl StripeRequest for ListScheduledQueryRun<'_> {
+impl StripeRequest for ListScheduledQueryRun {
     type Output = stripe_types::List<stripe_misc::ScheduledQueryRun>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/sigma/scheduled_query_runs").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveScheduledQueryRunBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveScheduledQueryRunBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveScheduledQueryRunBuilder<'a> {
+impl RetrieveScheduledQueryRunBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves the details of an scheduled query run.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveScheduledQueryRun<'a> {
-    inner: RetrieveScheduledQueryRunBuilder<'a>,
-    scheduled_query_run: &'a str,
+pub struct RetrieveScheduledQueryRun {
+    inner: RetrieveScheduledQueryRunBuilder,
+    scheduled_query_run: String,
 }
-impl<'a> RetrieveScheduledQueryRun<'a> {
+impl RetrieveScheduledQueryRun {
     /// Construct a new `RetrieveScheduledQueryRun`.
-    pub fn new(scheduled_query_run: &'a str) -> Self {
-        Self { scheduled_query_run, inner: RetrieveScheduledQueryRunBuilder::new() }
+    pub fn new(scheduled_query_run: impl Into<String>) -> Self {
+        Self {
+            scheduled_query_run: scheduled_query_run.into(),
+            inner: RetrieveScheduledQueryRunBuilder::new(),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveScheduledQueryRun<'_> {
+impl RetrieveScheduledQueryRun {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -135,11 +138,11 @@ impl RetrieveScheduledQueryRun<'_> {
     }
 }
 
-impl StripeRequest for RetrieveScheduledQueryRun<'_> {
+impl StripeRequest for RetrieveScheduledQueryRun {
     type Output = stripe_misc::ScheduledQueryRun;
 
     fn build(&self) -> RequestBuilder {
-        let scheduled_query_run = self.scheduled_query_run;
+        let scheduled_query_run = &self.scheduled_query_run;
         RequestBuilder::new(
             StripeMethod::Get,
             format!("/sigma/scheduled_query_runs/{scheduled_query_run}"),

--- a/generated/async-stripe-misc/src/tax_calculation/requests.rs
+++ b/generated/async-stripe-misc/src/tax_calculation/requests.rs
@@ -2,60 +2,60 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListLineItemsTaxCalculationBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListLineItemsTaxCalculationBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListLineItemsTaxCalculationBuilder<'a> {
+impl ListLineItemsTaxCalculationBuilder {
     fn new() -> Self {
         Self { ending_before: None, expand: None, limit: None, starting_after: None }
     }
 }
 /// Retrieves the line items of a persisted tax calculation as a collection.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListLineItemsTaxCalculation<'a> {
-    inner: ListLineItemsTaxCalculationBuilder<'a>,
-    calculation: &'a stripe_misc::TaxCalculationId,
+pub struct ListLineItemsTaxCalculation {
+    inner: ListLineItemsTaxCalculationBuilder,
+    calculation: stripe_misc::TaxCalculationId,
 }
-impl<'a> ListLineItemsTaxCalculation<'a> {
+impl ListLineItemsTaxCalculation {
     /// Construct a new `ListLineItemsTaxCalculation`.
-    pub fn new(calculation: &'a stripe_misc::TaxCalculationId) -> Self {
-        Self { calculation, inner: ListLineItemsTaxCalculationBuilder::new() }
+    pub fn new(calculation: impl Into<stripe_misc::TaxCalculationId>) -> Self {
+        Self { calculation: calculation.into(), inner: ListLineItemsTaxCalculationBuilder::new() }
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl ListLineItemsTaxCalculation<'_> {
+impl ListLineItemsTaxCalculation {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -76,20 +76,20 @@ impl ListLineItemsTaxCalculation<'_> {
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_misc::TaxCalculationLineItem>>
     {
-        let calculation = self.calculation;
+        let calculation = &self.calculation;
 
         stripe_client_core::ListPaginator::new_list(
             format!("/tax/calculations/{calculation}/line_items"),
-            self.inner,
+            &self.inner,
         )
     }
 }
 
-impl StripeRequest for ListLineItemsTaxCalculation<'_> {
+impl StripeRequest for ListLineItemsTaxCalculation {
     type Output = stripe_types::List<stripe_misc::TaxCalculationLineItem>;
 
     fn build(&self) -> RequestBuilder {
-        let calculation = self.calculation;
+        let calculation = &self.calculation;
         RequestBuilder::new(
             StripeMethod::Get,
             format!("/tax/calculations/{calculation}/line_items"),
@@ -97,34 +97,34 @@ impl StripeRequest for ListLineItemsTaxCalculation<'_> {
         .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateTaxCalculationBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateTaxCalculationBuilder {
     currency: stripe_types::Currency,
     #[serde(skip_serializing_if = "Option::is_none")]
-    customer: Option<&'a str>,
+    customer: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    customer_details: Option<CreateTaxCalculationCustomerDetails<'a>>,
+    customer_details: Option<CreateTaxCalculationCustomerDetails>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
-    line_items: &'a [CreateTaxCalculationLineItems<'a>],
+    expand: Option<Vec<String>>,
+    line_items: Vec<CreateTaxCalculationLineItems>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ship_from_details: Option<CreateTaxCalculationShipFromDetails<'a>>,
+    ship_from_details: Option<CreateTaxCalculationShipFromDetails>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    shipping_cost: Option<CreateTaxCalculationShippingCost<'a>>,
+    shipping_cost: Option<CreateTaxCalculationShippingCost>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tax_date: Option<stripe_types::Timestamp>,
 }
-impl<'a> CreateTaxCalculationBuilder<'a> {
+impl CreateTaxCalculationBuilder {
     fn new(
-        currency: stripe_types::Currency,
-        line_items: &'a [CreateTaxCalculationLineItems<'a>],
+        currency: impl Into<stripe_types::Currency>,
+        line_items: impl Into<Vec<CreateTaxCalculationLineItems>>,
     ) -> Self {
         Self {
-            currency,
+            currency: currency.into(),
             customer: None,
             customer_details: None,
             expand: None,
-            line_items,
+            line_items: line_items.into(),
             ship_from_details: None,
             shipping_cost: None,
             tax_date: None,
@@ -132,29 +132,29 @@ impl<'a> CreateTaxCalculationBuilder<'a> {
     }
 }
 /// Details about the customer, including address and tax IDs.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateTaxCalculationCustomerDetails<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateTaxCalculationCustomerDetails {
     /// The customer's postal address (for example, home or business location).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub address: Option<CreateTaxCalculationCustomerDetailsAddress<'a>>,
+    pub address: Option<CreateTaxCalculationCustomerDetailsAddress>,
     /// The type of customer address provided.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub address_source: Option<CreateTaxCalculationCustomerDetailsAddressSource>,
     /// The customer's IP address (IPv4 or IPv6).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ip_address: Option<&'a str>,
+    pub ip_address: Option<String>,
     /// The customer's tax IDs.
     /// Stripe Tax might consider a transaction with applicable tax IDs to be B2B, which might affect the tax calculation result.
     /// Stripe Tax doesn't validate tax IDs for correctness.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_ids: Option<&'a [CreateTaxCalculationCustomerDetailsTaxIds<'a>]>,
+    pub tax_ids: Option<Vec<CreateTaxCalculationCustomerDetailsTaxIds>>,
     /// Overrides the tax calculation result to allow you to not collect tax from your customer.
     /// Use this if you've manually checked your customer's tax exemptions.
     /// Prefer providing the customer's `tax_ids` where possible, which automatically determines whether `reverse_charge` applies.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub taxability_override: Option<CreateTaxCalculationCustomerDetailsTaxabilityOverride>,
 }
-impl<'a> CreateTaxCalculationCustomerDetails<'a> {
+impl CreateTaxCalculationCustomerDetails {
     pub fn new() -> Self {
         Self {
             address: None,
@@ -165,36 +165,43 @@ impl<'a> CreateTaxCalculationCustomerDetails<'a> {
         }
     }
 }
-impl<'a> Default for CreateTaxCalculationCustomerDetails<'a> {
+impl Default for CreateTaxCalculationCustomerDetails {
     fn default() -> Self {
         Self::new()
     }
 }
 /// The customer's postal address (for example, home or business location).
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateTaxCalculationCustomerDetailsAddress<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateTaxCalculationCustomerDetailsAddress {
     /// City, district, suburb, town, or village.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<&'a str>,
+    pub city: Option<String>,
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
-    pub country: &'a str,
+    pub country: String,
     /// Address line 1 (e.g., street, PO Box, or company name).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line1: Option<&'a str>,
+    pub line1: Option<String>,
     /// Address line 2 (e.g., apartment, suite, unit, or building).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line2: Option<&'a str>,
+    pub line2: Option<String>,
     /// ZIP or postal code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<&'a str>,
+    pub postal_code: Option<String>,
     /// State, county, province, or region.
     /// We recommend sending [ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-2) subdivision code value when possible.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
 }
-impl<'a> CreateTaxCalculationCustomerDetailsAddress<'a> {
-    pub fn new(country: &'a str) -> Self {
-        Self { city: None, country, line1: None, line2: None, postal_code: None, state: None }
+impl CreateTaxCalculationCustomerDetailsAddress {
+    pub fn new(country: impl Into<String>) -> Self {
+        Self {
+            city: None,
+            country: country.into(),
+            line1: None,
+            line2: None,
+            postal_code: None,
+            state: None,
+        }
     }
 }
 /// The type of customer address provided.
@@ -258,17 +265,20 @@ impl<'de> serde::Deserialize<'de> for CreateTaxCalculationCustomerDetailsAddress
 /// The customer's tax IDs.
 /// Stripe Tax might consider a transaction with applicable tax IDs to be B2B, which might affect the tax calculation result.
 /// Stripe Tax doesn't validate tax IDs for correctness.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateTaxCalculationCustomerDetailsTaxIds<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateTaxCalculationCustomerDetailsTaxIds {
     /// Type of the tax ID, one of `ad_nrt`, `ae_trn`, `ar_cuit`, `au_abn`, `au_arn`, `bg_uic`, `bh_vat`, `bo_tin`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `cn_tin`, `co_nit`, `cr_tin`, `do_rcn`, `ec_ruc`, `eg_tin`, `es_cif`, `eu_oss_vat`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `hu_tin`, `id_npwp`, `il_vat`, `in_gst`, `is_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `ke_pin`, `kr_brn`, `kz_bin`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `ng_tin`, `no_vat`, `no_voec`, `nz_gst`, `om_vat`, `pe_ruc`, `ph_tin`, `ro_tin`, `rs_pib`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `si_tin`, `sv_nit`, `th_vat`, `tr_tin`, `tw_vat`, `ua_vat`, `us_ein`, `uy_ruc`, `ve_rif`, `vn_tin`, or `za_vat`.
     #[serde(rename = "type")]
     pub type_: CreateTaxCalculationCustomerDetailsTaxIdsType,
     /// Value of the tax ID.
-    pub value: &'a str,
+    pub value: String,
 }
-impl<'a> CreateTaxCalculationCustomerDetailsTaxIds<'a> {
-    pub fn new(type_: CreateTaxCalculationCustomerDetailsTaxIdsType, value: &'a str) -> Self {
-        Self { type_, value }
+impl CreateTaxCalculationCustomerDetailsTaxIds {
+    pub fn new(
+        type_: impl Into<CreateTaxCalculationCustomerDetailsTaxIdsType>,
+        value: impl Into<String>,
+    ) -> Self {
+        Self { type_: type_.into(), value: value.into() }
     }
 }
 /// Type of the tax ID, one of `ad_nrt`, `ae_trn`, `ar_cuit`, `au_abn`, `au_arn`, `bg_uic`, `bh_vat`, `bo_tin`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `cn_tin`, `co_nit`, `cr_tin`, `do_rcn`, `ec_ruc`, `eg_tin`, `es_cif`, `eu_oss_vat`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `hu_tin`, `id_npwp`, `il_vat`, `in_gst`, `is_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `ke_pin`, `kr_brn`, `kz_bin`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `ng_tin`, `no_vat`, `no_voec`, `nz_gst`, `om_vat`, `pe_ruc`, `ph_tin`, `ro_tin`, `rs_pib`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `si_tin`, `sv_nit`, `th_vat`, `tr_tin`, `tw_vat`, `ua_vat`, `us_ein`, `uy_ruc`, `ve_rif`, `vn_tin`, or `za_vat`.
@@ -600,8 +610,8 @@ impl<'de> serde::Deserialize<'de> for CreateTaxCalculationCustomerDetailsTaxabil
     }
 }
 /// A list of items the customer is purchasing.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateTaxCalculationLineItems<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateTaxCalculationLineItems {
     /// A positive integer representing the line item's total price in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal) (e.g., 100 cents to charge $1.00 or 100 to charge ¥100, a zero-decimal currency).
     /// The minimum amount is $0.0 US or [equivalent in charge currency](https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts).
     /// The amount value supports up to twelve digits (e.g., a value of 999999999999 for a USD charge of $9,999,999,999.99).
@@ -610,7 +620,7 @@ pub struct CreateTaxCalculationLineItems<'a> {
     pub amount: i64,
     /// If provided, the product's `tax_code` will be used as the line item's `tax_code`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub product: Option<&'a str>,
+    pub product: Option<String>,
     /// The number of units of the item being purchased.
     /// Used to calculate the per-unit price from the total `amount` for the line.
     /// For example, if `amount=100` and `quantity=4`, the calculated unit price is 25.
@@ -619,7 +629,7 @@ pub struct CreateTaxCalculationLineItems<'a> {
     /// A custom identifier for this line item, which must be unique across the line items in the calculation.
     /// The reference helps identify each line item in exported [tax reports](https://stripe.com/docs/tax/reports).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub reference: Option<&'a str>,
+    pub reference: Option<String>,
     /// Specifies whether the `amount` includes taxes. Defaults to `exclusive`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tax_behavior: Option<CreateTaxCalculationLineItemsTaxBehavior>,
@@ -627,12 +637,12 @@ pub struct CreateTaxCalculationLineItems<'a> {
     /// If not provided, we will use the tax code from the provided `product` param.
     /// If neither `tax_code` nor `product` is provided, we will use the default tax code from your Tax Settings.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_code: Option<&'a str>,
+    pub tax_code: Option<String>,
 }
-impl<'a> CreateTaxCalculationLineItems<'a> {
-    pub fn new(amount: i64) -> Self {
+impl CreateTaxCalculationLineItems {
+    pub fn new(amount: impl Into<i64>) -> Self {
         Self {
-            amount,
+            amount: amount.into(),
             product: None,
             quantity: None,
             reference: None,
@@ -698,46 +708,53 @@ impl<'de> serde::Deserialize<'de> for CreateTaxCalculationLineItemsTaxBehavior {
     }
 }
 /// Details about the address from which the goods are being shipped.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateTaxCalculationShipFromDetails<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateTaxCalculationShipFromDetails {
     /// The address from which the goods are being shipped from.
-    pub address: CreateTaxCalculationShipFromDetailsAddress<'a>,
+    pub address: CreateTaxCalculationShipFromDetailsAddress,
 }
-impl<'a> CreateTaxCalculationShipFromDetails<'a> {
-    pub fn new(address: CreateTaxCalculationShipFromDetailsAddress<'a>) -> Self {
-        Self { address }
+impl CreateTaxCalculationShipFromDetails {
+    pub fn new(address: impl Into<CreateTaxCalculationShipFromDetailsAddress>) -> Self {
+        Self { address: address.into() }
     }
 }
 /// The address from which the goods are being shipped from.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateTaxCalculationShipFromDetailsAddress<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateTaxCalculationShipFromDetailsAddress {
     /// City, district, suburb, town, or village.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<&'a str>,
+    pub city: Option<String>,
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
-    pub country: &'a str,
+    pub country: String,
     /// Address line 1 (e.g., street, PO Box, or company name).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line1: Option<&'a str>,
+    pub line1: Option<String>,
     /// Address line 2 (e.g., apartment, suite, unit, or building).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line2: Option<&'a str>,
+    pub line2: Option<String>,
     /// ZIP or postal code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<&'a str>,
+    pub postal_code: Option<String>,
     /// State/province as an [ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-2) subdivision code, without country prefix.
     /// Example: "NY" or "TX".
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
 }
-impl<'a> CreateTaxCalculationShipFromDetailsAddress<'a> {
-    pub fn new(country: &'a str) -> Self {
-        Self { city: None, country, line1: None, line2: None, postal_code: None, state: None }
+impl CreateTaxCalculationShipFromDetailsAddress {
+    pub fn new(country: impl Into<String>) -> Self {
+        Self {
+            city: None,
+            country: country.into(),
+            line1: None,
+            line2: None,
+            postal_code: None,
+            state: None,
+        }
     }
 }
 /// Shipping cost details to be used for the calculation.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateTaxCalculationShippingCost<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateTaxCalculationShippingCost {
     /// A positive integer in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal) representing the shipping charge.
     /// If `tax_behavior=inclusive`, then this amount includes taxes.
     /// Otherwise, taxes are calculated on top of this amount.
@@ -746,7 +763,7 @@ pub struct CreateTaxCalculationShippingCost<'a> {
     /// If provided, the [shipping rate](https://stripe.com/docs/api/shipping_rates/object)'s `amount`, `tax_code` and `tax_behavior` are used.
     /// If you provide a shipping rate, then you cannot pass the `amount`, `tax_code`, or `tax_behavior` parameters.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub shipping_rate: Option<&'a str>,
+    pub shipping_rate: Option<String>,
     /// Specifies whether the `amount` includes taxes.
     /// If `tax_behavior=inclusive`, then the amount includes taxes.
     /// Defaults to `exclusive`.
@@ -755,14 +772,14 @@ pub struct CreateTaxCalculationShippingCost<'a> {
     /// The [tax code](https://stripe.com/docs/tax/tax-categories) used to calculate tax on shipping.
     /// If not provided, the default shipping tax code from your [Tax Settings](/settings/tax) is used.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_code: Option<&'a str>,
+    pub tax_code: Option<String>,
 }
-impl<'a> CreateTaxCalculationShippingCost<'a> {
+impl CreateTaxCalculationShippingCost {
     pub fn new() -> Self {
         Self { amount: None, shipping_rate: None, tax_behavior: None, tax_code: None }
     }
 }
-impl<'a> Default for CreateTaxCalculationShippingCost<'a> {
+impl Default for CreateTaxCalculationShippingCost {
     fn default() -> Self {
         Self::new()
     }
@@ -829,58 +846,61 @@ impl<'de> serde::Deserialize<'de> for CreateTaxCalculationShippingCostTaxBehavio
 }
 /// Calculates tax based on input and returns a Tax `Calculation` object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateTaxCalculation<'a> {
-    inner: CreateTaxCalculationBuilder<'a>,
+pub struct CreateTaxCalculation {
+    inner: CreateTaxCalculationBuilder,
 }
-impl<'a> CreateTaxCalculation<'a> {
+impl CreateTaxCalculation {
     /// Construct a new `CreateTaxCalculation`.
     pub fn new(
-        currency: stripe_types::Currency,
-        line_items: &'a [CreateTaxCalculationLineItems<'a>],
+        currency: impl Into<stripe_types::Currency>,
+        line_items: impl Into<Vec<CreateTaxCalculationLineItems>>,
     ) -> Self {
-        Self { inner: CreateTaxCalculationBuilder::new(currency, line_items) }
+        Self { inner: CreateTaxCalculationBuilder::new(currency.into(), line_items.into()) }
     }
     /// The ID of an existing customer to use for this calculation.
     /// If provided, the customer's address and tax IDs are copied to `customer_details`.
-    pub fn customer(mut self, customer: &'a str) -> Self {
-        self.inner.customer = Some(customer);
+    pub fn customer(mut self, customer: impl Into<String>) -> Self {
+        self.inner.customer = Some(customer.into());
         self
     }
     /// Details about the customer, including address and tax IDs.
     pub fn customer_details(
         mut self,
-        customer_details: CreateTaxCalculationCustomerDetails<'a>,
+        customer_details: impl Into<CreateTaxCalculationCustomerDetails>,
     ) -> Self {
-        self.inner.customer_details = Some(customer_details);
+        self.inner.customer_details = Some(customer_details.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Details about the address from which the goods are being shipped.
     pub fn ship_from_details(
         mut self,
-        ship_from_details: CreateTaxCalculationShipFromDetails<'a>,
+        ship_from_details: impl Into<CreateTaxCalculationShipFromDetails>,
     ) -> Self {
-        self.inner.ship_from_details = Some(ship_from_details);
+        self.inner.ship_from_details = Some(ship_from_details.into());
         self
     }
     /// Shipping cost details to be used for the calculation.
-    pub fn shipping_cost(mut self, shipping_cost: CreateTaxCalculationShippingCost<'a>) -> Self {
-        self.inner.shipping_cost = Some(shipping_cost);
+    pub fn shipping_cost(
+        mut self,
+        shipping_cost: impl Into<CreateTaxCalculationShippingCost>,
+    ) -> Self {
+        self.inner.shipping_cost = Some(shipping_cost.into());
         self
     }
     /// Timestamp of date at which the tax rules and rates in effect applies for the calculation.
     /// Measured in seconds since the Unix epoch.
     /// Can be up to 48 hours in the past, and up to 48 hours in the future.
-    pub fn tax_date(mut self, tax_date: stripe_types::Timestamp) -> Self {
-        self.inner.tax_date = Some(tax_date);
+    pub fn tax_date(mut self, tax_date: impl Into<stripe_types::Timestamp>) -> Self {
+        self.inner.tax_date = Some(tax_date.into());
         self
     }
 }
-impl CreateTaxCalculation<'_> {
+impl CreateTaxCalculation {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -898,7 +918,7 @@ impl CreateTaxCalculation<'_> {
     }
 }
 
-impl StripeRequest for CreateTaxCalculation<'_> {
+impl StripeRequest for CreateTaxCalculation {
     type Output = stripe_misc::TaxCalculation;
 
     fn build(&self) -> RequestBuilder {

--- a/generated/async-stripe-misc/src/tax_registration/requests.rs
+++ b/generated/async-stripe-misc/src/tax_registration/requests.rs
@@ -2,20 +2,20 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListTaxRegistrationBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListTaxRegistrationBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     status: Option<ListTaxRegistrationStatus>,
 }
-impl<'a> ListTaxRegistrationBuilder<'a> {
+impl ListTaxRegistrationBuilder {
     fn new() -> Self {
         Self { ending_before: None, expand: None, limit: None, starting_after: None, status: None }
     }
@@ -83,10 +83,10 @@ impl<'de> serde::Deserialize<'de> for ListTaxRegistrationStatus {
 }
 /// Returns a list of Tax `Registration` objects.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListTaxRegistration<'a> {
-    inner: ListTaxRegistrationBuilder<'a>,
+pub struct ListTaxRegistration {
+    inner: ListTaxRegistrationBuilder,
 }
-impl<'a> ListTaxRegistration<'a> {
+impl ListTaxRegistration {
     /// Construct a new `ListTaxRegistration`.
     pub fn new() -> Self {
         Self { inner: ListTaxRegistrationBuilder::new() }
@@ -94,40 +94,40 @@ impl<'a> ListTaxRegistration<'a> {
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
     /// The status of the Tax Registration.
-    pub fn status(mut self, status: ListTaxRegistrationStatus) -> Self {
-        self.inner.status = Some(status);
+    pub fn status(mut self, status: impl Into<ListTaxRegistrationStatus>) -> Self {
+        self.inner.status = Some(status.into());
         self
     }
 }
-impl<'a> Default for ListTaxRegistration<'a> {
+impl Default for ListTaxRegistration {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListTaxRegistration<'_> {
+impl ListTaxRegistration {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -147,45 +147,45 @@ impl ListTaxRegistration<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_misc::TaxRegistration>> {
-        stripe_client_core::ListPaginator::new_list("/tax/registrations", self.inner)
+        stripe_client_core::ListPaginator::new_list("/tax/registrations", &self.inner)
     }
 }
 
-impl StripeRequest for ListTaxRegistration<'_> {
+impl StripeRequest for ListTaxRegistration {
     type Output = stripe_types::List<stripe_misc::TaxRegistration>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/tax/registrations").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveTaxRegistrationBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveTaxRegistrationBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveTaxRegistrationBuilder<'a> {
+impl RetrieveTaxRegistrationBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Returns a Tax `Registration` object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveTaxRegistration<'a> {
-    inner: RetrieveTaxRegistrationBuilder<'a>,
-    id: &'a stripe_misc::TaxRegistrationId,
+pub struct RetrieveTaxRegistration {
+    inner: RetrieveTaxRegistrationBuilder,
+    id: stripe_misc::TaxRegistrationId,
 }
-impl<'a> RetrieveTaxRegistration<'a> {
+impl RetrieveTaxRegistration {
     /// Construct a new `RetrieveTaxRegistration`.
-    pub fn new(id: &'a stripe_misc::TaxRegistrationId) -> Self {
-        Self { id, inner: RetrieveTaxRegistrationBuilder::new() }
+    pub fn new(id: impl Into<stripe_misc::TaxRegistrationId>) -> Self {
+        Self { id: id.into(), inner: RetrieveTaxRegistrationBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveTaxRegistration<'_> {
+impl RetrieveTaxRegistration {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -203,32 +203,38 @@ impl RetrieveTaxRegistration<'_> {
     }
 }
 
-impl StripeRequest for RetrieveTaxRegistration<'_> {
+impl StripeRequest for RetrieveTaxRegistration {
     type Output = stripe_misc::TaxRegistration;
 
     fn build(&self) -> RequestBuilder {
-        let id = self.id;
+        let id = &self.id;
         RequestBuilder::new(StripeMethod::Get, format!("/tax/registrations/{id}"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateTaxRegistrationBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateTaxRegistrationBuilder {
     active_from: CreateTaxRegistrationActiveFrom,
-    country: &'a str,
-    country_options: CreateTaxRegistrationCountryOptions<'a>,
+    country: String,
+    country_options: CreateTaxRegistrationCountryOptions,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     expires_at: Option<stripe_types::Timestamp>,
 }
-impl<'a> CreateTaxRegistrationBuilder<'a> {
+impl CreateTaxRegistrationBuilder {
     fn new(
-        active_from: CreateTaxRegistrationActiveFrom,
-        country: &'a str,
-        country_options: CreateTaxRegistrationCountryOptions<'a>,
+        active_from: impl Into<CreateTaxRegistrationActiveFrom>,
+        country: impl Into<String>,
+        country_options: impl Into<CreateTaxRegistrationCountryOptions>,
     ) -> Self {
-        Self { active_from, country, country_options, expand: None, expires_at: None }
+        Self {
+            active_from: active_from.into(),
+            country: country.into(),
+            country_options: country_options.into(),
+            expand: None,
+            expires_at: None,
+        }
     }
 }
 /// Time at which the Tax Registration becomes active.
@@ -241,8 +247,8 @@ pub enum CreateTaxRegistrationActiveFrom {
     Timestamp(stripe_types::Timestamp),
 }
 /// Specific options for a registration in the specified `country`.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateTaxRegistrationCountryOptions<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateTaxRegistrationCountryOptions {
     /// Options for the registration in AE.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ae: Option<CreateTaxRegistrationCountryOptionsAe>,
@@ -260,7 +266,7 @@ pub struct CreateTaxRegistrationCountryOptions<'a> {
     pub bg: Option<CreateTaxRegistrationCountryOptionsBg>,
     /// Options for the registration in CA.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ca: Option<CreateTaxRegistrationCountryOptionsCa<'a>>,
+    pub ca: Option<CreateTaxRegistrationCountryOptionsCa>,
     /// Options for the registration in CH.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ch: Option<CreateTaxRegistrationCountryOptionsCh>,
@@ -383,7 +389,7 @@ pub struct CreateTaxRegistrationCountryOptions<'a> {
     pub tr: Option<CreateTaxRegistrationCountryOptionsTr>,
     /// Options for the registration in US.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub us: Option<CreateTaxRegistrationCountryOptionsUs<'a>>,
+    pub us: Option<CreateTaxRegistrationCountryOptionsUs>,
     /// Options for the registration in VN.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub vn: Option<CreateTaxRegistrationCountryOptionsVn>,
@@ -391,7 +397,7 @@ pub struct CreateTaxRegistrationCountryOptions<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub za: Option<CreateTaxRegistrationCountryOptionsZa>,
 }
-impl<'a> CreateTaxRegistrationCountryOptions<'a> {
+impl CreateTaxRegistrationCountryOptions {
     pub fn new() -> Self {
         Self {
             ae: None,
@@ -446,7 +452,7 @@ impl<'a> CreateTaxRegistrationCountryOptions<'a> {
         }
     }
 }
-impl<'a> Default for CreateTaxRegistrationCountryOptions<'a> {
+impl Default for CreateTaxRegistrationCountryOptions {
     fn default() -> Self {
         Self::new()
     }
@@ -459,8 +465,8 @@ pub struct CreateTaxRegistrationCountryOptionsAe {
     pub type_: CreateTaxRegistrationCountryOptionsAeType,
 }
 impl CreateTaxRegistrationCountryOptionsAe {
-    pub fn new(type_: CreateTaxRegistrationCountryOptionsAeType) -> Self {
-        Self { type_ }
+    pub fn new(type_: impl Into<CreateTaxRegistrationCountryOptionsAeType>) -> Self {
+        Self { type_: type_.into() }
     }
 }
 /// Type of registration to be created in `country`.
@@ -527,8 +533,8 @@ pub struct CreateTaxRegistrationCountryOptionsAt {
     pub type_: CreateTaxRegistrationCountryOptionsAtType,
 }
 impl CreateTaxRegistrationCountryOptionsAt {
-    pub fn new(type_: CreateTaxRegistrationCountryOptionsAtType) -> Self {
-        Self { standard: None, type_ }
+    pub fn new(type_: impl Into<CreateTaxRegistrationCountryOptionsAtType>) -> Self {
+        Self { standard: None, type_: type_.into() }
     }
 }
 /// Options for the standard registration.
@@ -539,9 +545,11 @@ pub struct CreateTaxRegistrationCountryOptionsAtStandard {
 }
 impl CreateTaxRegistrationCountryOptionsAtStandard {
     pub fn new(
-        place_of_supply_scheme: CreateTaxRegistrationCountryOptionsAtStandardPlaceOfSupplyScheme,
+        place_of_supply_scheme: impl Into<
+            CreateTaxRegistrationCountryOptionsAtStandardPlaceOfSupplyScheme,
+        >,
     ) -> Self {
-        Self { place_of_supply_scheme }
+        Self { place_of_supply_scheme: place_of_supply_scheme.into() }
     }
 }
 /// Place of supply scheme used in an EU standard registration.
@@ -670,8 +678,8 @@ pub struct CreateTaxRegistrationCountryOptionsAu {
     pub type_: CreateTaxRegistrationCountryOptionsAuType,
 }
 impl CreateTaxRegistrationCountryOptionsAu {
-    pub fn new(type_: CreateTaxRegistrationCountryOptionsAuType) -> Self {
-        Self { type_ }
+    pub fn new(type_: impl Into<CreateTaxRegistrationCountryOptionsAuType>) -> Self {
+        Self { type_: type_.into() }
     }
 }
 /// Type of registration to be created in `country`.
@@ -738,8 +746,8 @@ pub struct CreateTaxRegistrationCountryOptionsBe {
     pub type_: CreateTaxRegistrationCountryOptionsBeType,
 }
 impl CreateTaxRegistrationCountryOptionsBe {
-    pub fn new(type_: CreateTaxRegistrationCountryOptionsBeType) -> Self {
-        Self { standard: None, type_ }
+    pub fn new(type_: impl Into<CreateTaxRegistrationCountryOptionsBeType>) -> Self {
+        Self { standard: None, type_: type_.into() }
     }
 }
 /// Options for the standard registration.
@@ -750,9 +758,11 @@ pub struct CreateTaxRegistrationCountryOptionsBeStandard {
 }
 impl CreateTaxRegistrationCountryOptionsBeStandard {
     pub fn new(
-        place_of_supply_scheme: CreateTaxRegistrationCountryOptionsBeStandardPlaceOfSupplyScheme,
+        place_of_supply_scheme: impl Into<
+            CreateTaxRegistrationCountryOptionsBeStandardPlaceOfSupplyScheme,
+        >,
     ) -> Self {
-        Self { place_of_supply_scheme }
+        Self { place_of_supply_scheme: place_of_supply_scheme.into() }
     }
 }
 /// Place of supply scheme used in an EU standard registration.
@@ -884,8 +894,8 @@ pub struct CreateTaxRegistrationCountryOptionsBg {
     pub type_: CreateTaxRegistrationCountryOptionsBgType,
 }
 impl CreateTaxRegistrationCountryOptionsBg {
-    pub fn new(type_: CreateTaxRegistrationCountryOptionsBgType) -> Self {
-        Self { standard: None, type_ }
+    pub fn new(type_: impl Into<CreateTaxRegistrationCountryOptionsBgType>) -> Self {
+        Self { standard: None, type_: type_.into() }
     }
 }
 /// Options for the standard registration.
@@ -896,9 +906,11 @@ pub struct CreateTaxRegistrationCountryOptionsBgStandard {
 }
 impl CreateTaxRegistrationCountryOptionsBgStandard {
     pub fn new(
-        place_of_supply_scheme: CreateTaxRegistrationCountryOptionsBgStandardPlaceOfSupplyScheme,
+        place_of_supply_scheme: impl Into<
+            CreateTaxRegistrationCountryOptionsBgStandardPlaceOfSupplyScheme,
+        >,
     ) -> Self {
-        Self { place_of_supply_scheme }
+        Self { place_of_supply_scheme: place_of_supply_scheme.into() }
     }
 }
 /// Place of supply scheme used in an EU standard registration.
@@ -1020,29 +1032,29 @@ impl<'de> serde::Deserialize<'de> for CreateTaxRegistrationCountryOptionsBgType 
     }
 }
 /// Options for the registration in CA.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateTaxRegistrationCountryOptionsCa<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateTaxRegistrationCountryOptionsCa {
     /// Options for the provincial tax registration.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub province_standard: Option<CreateTaxRegistrationCountryOptionsCaProvinceStandard<'a>>,
+    pub province_standard: Option<CreateTaxRegistrationCountryOptionsCaProvinceStandard>,
     /// Type of registration to be created in Canada.
     #[serde(rename = "type")]
     pub type_: CreateTaxRegistrationCountryOptionsCaType,
 }
-impl<'a> CreateTaxRegistrationCountryOptionsCa<'a> {
-    pub fn new(type_: CreateTaxRegistrationCountryOptionsCaType) -> Self {
-        Self { province_standard: None, type_ }
+impl CreateTaxRegistrationCountryOptionsCa {
+    pub fn new(type_: impl Into<CreateTaxRegistrationCountryOptionsCaType>) -> Self {
+        Self { province_standard: None, type_: type_.into() }
     }
 }
 /// Options for the provincial tax registration.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateTaxRegistrationCountryOptionsCaProvinceStandard<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateTaxRegistrationCountryOptionsCaProvinceStandard {
     /// Two-letter CA province code ([ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-2)).
-    pub province: &'a str,
+    pub province: String,
 }
-impl<'a> CreateTaxRegistrationCountryOptionsCaProvinceStandard<'a> {
-    pub fn new(province: &'a str) -> Self {
-        Self { province }
+impl CreateTaxRegistrationCountryOptionsCaProvinceStandard {
+    pub fn new(province: impl Into<String>) -> Self {
+        Self { province: province.into() }
     }
 }
 /// Type of registration to be created in Canada.
@@ -1112,8 +1124,8 @@ pub struct CreateTaxRegistrationCountryOptionsCh {
     pub type_: CreateTaxRegistrationCountryOptionsChType,
 }
 impl CreateTaxRegistrationCountryOptionsCh {
-    pub fn new(type_: CreateTaxRegistrationCountryOptionsChType) -> Self {
-        Self { type_ }
+    pub fn new(type_: impl Into<CreateTaxRegistrationCountryOptionsChType>) -> Self {
+        Self { type_: type_.into() }
     }
 }
 /// Type of registration to be created in `country`.
@@ -1177,8 +1189,8 @@ pub struct CreateTaxRegistrationCountryOptionsCl {
     pub type_: CreateTaxRegistrationCountryOptionsClType,
 }
 impl CreateTaxRegistrationCountryOptionsCl {
-    pub fn new(type_: CreateTaxRegistrationCountryOptionsClType) -> Self {
-        Self { type_ }
+    pub fn new(type_: impl Into<CreateTaxRegistrationCountryOptionsClType>) -> Self {
+        Self { type_: type_.into() }
     }
 }
 /// Type of registration to be created in `country`.
@@ -1242,8 +1254,8 @@ pub struct CreateTaxRegistrationCountryOptionsCo {
     pub type_: CreateTaxRegistrationCountryOptionsCoType,
 }
 impl CreateTaxRegistrationCountryOptionsCo {
-    pub fn new(type_: CreateTaxRegistrationCountryOptionsCoType) -> Self {
-        Self { type_ }
+    pub fn new(type_: impl Into<CreateTaxRegistrationCountryOptionsCoType>) -> Self {
+        Self { type_: type_.into() }
     }
 }
 /// Type of registration to be created in `country`.
@@ -1310,8 +1322,8 @@ pub struct CreateTaxRegistrationCountryOptionsCy {
     pub type_: CreateTaxRegistrationCountryOptionsCyType,
 }
 impl CreateTaxRegistrationCountryOptionsCy {
-    pub fn new(type_: CreateTaxRegistrationCountryOptionsCyType) -> Self {
-        Self { standard: None, type_ }
+    pub fn new(type_: impl Into<CreateTaxRegistrationCountryOptionsCyType>) -> Self {
+        Self { standard: None, type_: type_.into() }
     }
 }
 /// Options for the standard registration.
@@ -1322,9 +1334,11 @@ pub struct CreateTaxRegistrationCountryOptionsCyStandard {
 }
 impl CreateTaxRegistrationCountryOptionsCyStandard {
     pub fn new(
-        place_of_supply_scheme: CreateTaxRegistrationCountryOptionsCyStandardPlaceOfSupplyScheme,
+        place_of_supply_scheme: impl Into<
+            CreateTaxRegistrationCountryOptionsCyStandardPlaceOfSupplyScheme,
+        >,
     ) -> Self {
-        Self { place_of_supply_scheme }
+        Self { place_of_supply_scheme: place_of_supply_scheme.into() }
     }
 }
 /// Place of supply scheme used in an EU standard registration.
@@ -1456,8 +1470,8 @@ pub struct CreateTaxRegistrationCountryOptionsCz {
     pub type_: CreateTaxRegistrationCountryOptionsCzType,
 }
 impl CreateTaxRegistrationCountryOptionsCz {
-    pub fn new(type_: CreateTaxRegistrationCountryOptionsCzType) -> Self {
-        Self { standard: None, type_ }
+    pub fn new(type_: impl Into<CreateTaxRegistrationCountryOptionsCzType>) -> Self {
+        Self { standard: None, type_: type_.into() }
     }
 }
 /// Options for the standard registration.
@@ -1468,9 +1482,11 @@ pub struct CreateTaxRegistrationCountryOptionsCzStandard {
 }
 impl CreateTaxRegistrationCountryOptionsCzStandard {
     pub fn new(
-        place_of_supply_scheme: CreateTaxRegistrationCountryOptionsCzStandardPlaceOfSupplyScheme,
+        place_of_supply_scheme: impl Into<
+            CreateTaxRegistrationCountryOptionsCzStandardPlaceOfSupplyScheme,
+        >,
     ) -> Self {
-        Self { place_of_supply_scheme }
+        Self { place_of_supply_scheme: place_of_supply_scheme.into() }
     }
 }
 /// Place of supply scheme used in an EU standard registration.
@@ -1602,8 +1618,8 @@ pub struct CreateTaxRegistrationCountryOptionsDe {
     pub type_: CreateTaxRegistrationCountryOptionsDeType,
 }
 impl CreateTaxRegistrationCountryOptionsDe {
-    pub fn new(type_: CreateTaxRegistrationCountryOptionsDeType) -> Self {
-        Self { standard: None, type_ }
+    pub fn new(type_: impl Into<CreateTaxRegistrationCountryOptionsDeType>) -> Self {
+        Self { standard: None, type_: type_.into() }
     }
 }
 /// Options for the standard registration.
@@ -1614,9 +1630,11 @@ pub struct CreateTaxRegistrationCountryOptionsDeStandard {
 }
 impl CreateTaxRegistrationCountryOptionsDeStandard {
     pub fn new(
-        place_of_supply_scheme: CreateTaxRegistrationCountryOptionsDeStandardPlaceOfSupplyScheme,
+        place_of_supply_scheme: impl Into<
+            CreateTaxRegistrationCountryOptionsDeStandardPlaceOfSupplyScheme,
+        >,
     ) -> Self {
-        Self { place_of_supply_scheme }
+        Self { place_of_supply_scheme: place_of_supply_scheme.into() }
     }
 }
 /// Place of supply scheme used in an EU standard registration.
@@ -1748,8 +1766,8 @@ pub struct CreateTaxRegistrationCountryOptionsDk {
     pub type_: CreateTaxRegistrationCountryOptionsDkType,
 }
 impl CreateTaxRegistrationCountryOptionsDk {
-    pub fn new(type_: CreateTaxRegistrationCountryOptionsDkType) -> Self {
-        Self { standard: None, type_ }
+    pub fn new(type_: impl Into<CreateTaxRegistrationCountryOptionsDkType>) -> Self {
+        Self { standard: None, type_: type_.into() }
     }
 }
 /// Options for the standard registration.
@@ -1760,9 +1778,11 @@ pub struct CreateTaxRegistrationCountryOptionsDkStandard {
 }
 impl CreateTaxRegistrationCountryOptionsDkStandard {
     pub fn new(
-        place_of_supply_scheme: CreateTaxRegistrationCountryOptionsDkStandardPlaceOfSupplyScheme,
+        place_of_supply_scheme: impl Into<
+            CreateTaxRegistrationCountryOptionsDkStandardPlaceOfSupplyScheme,
+        >,
     ) -> Self {
-        Self { place_of_supply_scheme }
+        Self { place_of_supply_scheme: place_of_supply_scheme.into() }
     }
 }
 /// Place of supply scheme used in an EU standard registration.
@@ -1894,8 +1914,8 @@ pub struct CreateTaxRegistrationCountryOptionsEe {
     pub type_: CreateTaxRegistrationCountryOptionsEeType,
 }
 impl CreateTaxRegistrationCountryOptionsEe {
-    pub fn new(type_: CreateTaxRegistrationCountryOptionsEeType) -> Self {
-        Self { standard: None, type_ }
+    pub fn new(type_: impl Into<CreateTaxRegistrationCountryOptionsEeType>) -> Self {
+        Self { standard: None, type_: type_.into() }
     }
 }
 /// Options for the standard registration.
@@ -1906,9 +1926,11 @@ pub struct CreateTaxRegistrationCountryOptionsEeStandard {
 }
 impl CreateTaxRegistrationCountryOptionsEeStandard {
     pub fn new(
-        place_of_supply_scheme: CreateTaxRegistrationCountryOptionsEeStandardPlaceOfSupplyScheme,
+        place_of_supply_scheme: impl Into<
+            CreateTaxRegistrationCountryOptionsEeStandardPlaceOfSupplyScheme,
+        >,
     ) -> Self {
-        Self { place_of_supply_scheme }
+        Self { place_of_supply_scheme: place_of_supply_scheme.into() }
     }
 }
 /// Place of supply scheme used in an EU standard registration.
@@ -2040,8 +2062,8 @@ pub struct CreateTaxRegistrationCountryOptionsEs {
     pub type_: CreateTaxRegistrationCountryOptionsEsType,
 }
 impl CreateTaxRegistrationCountryOptionsEs {
-    pub fn new(type_: CreateTaxRegistrationCountryOptionsEsType) -> Self {
-        Self { standard: None, type_ }
+    pub fn new(type_: impl Into<CreateTaxRegistrationCountryOptionsEsType>) -> Self {
+        Self { standard: None, type_: type_.into() }
     }
 }
 /// Options for the standard registration.
@@ -2052,9 +2074,11 @@ pub struct CreateTaxRegistrationCountryOptionsEsStandard {
 }
 impl CreateTaxRegistrationCountryOptionsEsStandard {
     pub fn new(
-        place_of_supply_scheme: CreateTaxRegistrationCountryOptionsEsStandardPlaceOfSupplyScheme,
+        place_of_supply_scheme: impl Into<
+            CreateTaxRegistrationCountryOptionsEsStandardPlaceOfSupplyScheme,
+        >,
     ) -> Self {
-        Self { place_of_supply_scheme }
+        Self { place_of_supply_scheme: place_of_supply_scheme.into() }
     }
 }
 /// Place of supply scheme used in an EU standard registration.
@@ -2186,8 +2210,8 @@ pub struct CreateTaxRegistrationCountryOptionsFi {
     pub type_: CreateTaxRegistrationCountryOptionsFiType,
 }
 impl CreateTaxRegistrationCountryOptionsFi {
-    pub fn new(type_: CreateTaxRegistrationCountryOptionsFiType) -> Self {
-        Self { standard: None, type_ }
+    pub fn new(type_: impl Into<CreateTaxRegistrationCountryOptionsFiType>) -> Self {
+        Self { standard: None, type_: type_.into() }
     }
 }
 /// Options for the standard registration.
@@ -2198,9 +2222,11 @@ pub struct CreateTaxRegistrationCountryOptionsFiStandard {
 }
 impl CreateTaxRegistrationCountryOptionsFiStandard {
     pub fn new(
-        place_of_supply_scheme: CreateTaxRegistrationCountryOptionsFiStandardPlaceOfSupplyScheme,
+        place_of_supply_scheme: impl Into<
+            CreateTaxRegistrationCountryOptionsFiStandardPlaceOfSupplyScheme,
+        >,
     ) -> Self {
-        Self { place_of_supply_scheme }
+        Self { place_of_supply_scheme: place_of_supply_scheme.into() }
     }
 }
 /// Place of supply scheme used in an EU standard registration.
@@ -2332,8 +2358,8 @@ pub struct CreateTaxRegistrationCountryOptionsFr {
     pub type_: CreateTaxRegistrationCountryOptionsFrType,
 }
 impl CreateTaxRegistrationCountryOptionsFr {
-    pub fn new(type_: CreateTaxRegistrationCountryOptionsFrType) -> Self {
-        Self { standard: None, type_ }
+    pub fn new(type_: impl Into<CreateTaxRegistrationCountryOptionsFrType>) -> Self {
+        Self { standard: None, type_: type_.into() }
     }
 }
 /// Options for the standard registration.
@@ -2344,9 +2370,11 @@ pub struct CreateTaxRegistrationCountryOptionsFrStandard {
 }
 impl CreateTaxRegistrationCountryOptionsFrStandard {
     pub fn new(
-        place_of_supply_scheme: CreateTaxRegistrationCountryOptionsFrStandardPlaceOfSupplyScheme,
+        place_of_supply_scheme: impl Into<
+            CreateTaxRegistrationCountryOptionsFrStandardPlaceOfSupplyScheme,
+        >,
     ) -> Self {
-        Self { place_of_supply_scheme }
+        Self { place_of_supply_scheme: place_of_supply_scheme.into() }
     }
 }
 /// Place of supply scheme used in an EU standard registration.
@@ -2475,8 +2503,8 @@ pub struct CreateTaxRegistrationCountryOptionsGb {
     pub type_: CreateTaxRegistrationCountryOptionsGbType,
 }
 impl CreateTaxRegistrationCountryOptionsGb {
-    pub fn new(type_: CreateTaxRegistrationCountryOptionsGbType) -> Self {
-        Self { type_ }
+    pub fn new(type_: impl Into<CreateTaxRegistrationCountryOptionsGbType>) -> Self {
+        Self { type_: type_.into() }
     }
 }
 /// Type of registration to be created in `country`.
@@ -2543,8 +2571,8 @@ pub struct CreateTaxRegistrationCountryOptionsGr {
     pub type_: CreateTaxRegistrationCountryOptionsGrType,
 }
 impl CreateTaxRegistrationCountryOptionsGr {
-    pub fn new(type_: CreateTaxRegistrationCountryOptionsGrType) -> Self {
-        Self { standard: None, type_ }
+    pub fn new(type_: impl Into<CreateTaxRegistrationCountryOptionsGrType>) -> Self {
+        Self { standard: None, type_: type_.into() }
     }
 }
 /// Options for the standard registration.
@@ -2555,9 +2583,11 @@ pub struct CreateTaxRegistrationCountryOptionsGrStandard {
 }
 impl CreateTaxRegistrationCountryOptionsGrStandard {
     pub fn new(
-        place_of_supply_scheme: CreateTaxRegistrationCountryOptionsGrStandardPlaceOfSupplyScheme,
+        place_of_supply_scheme: impl Into<
+            CreateTaxRegistrationCountryOptionsGrStandardPlaceOfSupplyScheme,
+        >,
     ) -> Self {
-        Self { place_of_supply_scheme }
+        Self { place_of_supply_scheme: place_of_supply_scheme.into() }
     }
 }
 /// Place of supply scheme used in an EU standard registration.
@@ -2689,8 +2719,8 @@ pub struct CreateTaxRegistrationCountryOptionsHr {
     pub type_: CreateTaxRegistrationCountryOptionsHrType,
 }
 impl CreateTaxRegistrationCountryOptionsHr {
-    pub fn new(type_: CreateTaxRegistrationCountryOptionsHrType) -> Self {
-        Self { standard: None, type_ }
+    pub fn new(type_: impl Into<CreateTaxRegistrationCountryOptionsHrType>) -> Self {
+        Self { standard: None, type_: type_.into() }
     }
 }
 /// Options for the standard registration.
@@ -2701,9 +2731,11 @@ pub struct CreateTaxRegistrationCountryOptionsHrStandard {
 }
 impl CreateTaxRegistrationCountryOptionsHrStandard {
     pub fn new(
-        place_of_supply_scheme: CreateTaxRegistrationCountryOptionsHrStandardPlaceOfSupplyScheme,
+        place_of_supply_scheme: impl Into<
+            CreateTaxRegistrationCountryOptionsHrStandardPlaceOfSupplyScheme,
+        >,
     ) -> Self {
-        Self { place_of_supply_scheme }
+        Self { place_of_supply_scheme: place_of_supply_scheme.into() }
     }
 }
 /// Place of supply scheme used in an EU standard registration.
@@ -2835,8 +2867,8 @@ pub struct CreateTaxRegistrationCountryOptionsHu {
     pub type_: CreateTaxRegistrationCountryOptionsHuType,
 }
 impl CreateTaxRegistrationCountryOptionsHu {
-    pub fn new(type_: CreateTaxRegistrationCountryOptionsHuType) -> Self {
-        Self { standard: None, type_ }
+    pub fn new(type_: impl Into<CreateTaxRegistrationCountryOptionsHuType>) -> Self {
+        Self { standard: None, type_: type_.into() }
     }
 }
 /// Options for the standard registration.
@@ -2847,9 +2879,11 @@ pub struct CreateTaxRegistrationCountryOptionsHuStandard {
 }
 impl CreateTaxRegistrationCountryOptionsHuStandard {
     pub fn new(
-        place_of_supply_scheme: CreateTaxRegistrationCountryOptionsHuStandardPlaceOfSupplyScheme,
+        place_of_supply_scheme: impl Into<
+            CreateTaxRegistrationCountryOptionsHuStandardPlaceOfSupplyScheme,
+        >,
     ) -> Self {
-        Self { place_of_supply_scheme }
+        Self { place_of_supply_scheme: place_of_supply_scheme.into() }
     }
 }
 /// Place of supply scheme used in an EU standard registration.
@@ -2978,8 +3012,8 @@ pub struct CreateTaxRegistrationCountryOptionsId {
     pub type_: CreateTaxRegistrationCountryOptionsIdType,
 }
 impl CreateTaxRegistrationCountryOptionsId {
-    pub fn new(type_: CreateTaxRegistrationCountryOptionsIdType) -> Self {
-        Self { type_ }
+    pub fn new(type_: impl Into<CreateTaxRegistrationCountryOptionsIdType>) -> Self {
+        Self { type_: type_.into() }
     }
 }
 /// Type of registration to be created in `country`.
@@ -3046,8 +3080,8 @@ pub struct CreateTaxRegistrationCountryOptionsIe {
     pub type_: CreateTaxRegistrationCountryOptionsIeType,
 }
 impl CreateTaxRegistrationCountryOptionsIe {
-    pub fn new(type_: CreateTaxRegistrationCountryOptionsIeType) -> Self {
-        Self { standard: None, type_ }
+    pub fn new(type_: impl Into<CreateTaxRegistrationCountryOptionsIeType>) -> Self {
+        Self { standard: None, type_: type_.into() }
     }
 }
 /// Options for the standard registration.
@@ -3058,9 +3092,11 @@ pub struct CreateTaxRegistrationCountryOptionsIeStandard {
 }
 impl CreateTaxRegistrationCountryOptionsIeStandard {
     pub fn new(
-        place_of_supply_scheme: CreateTaxRegistrationCountryOptionsIeStandardPlaceOfSupplyScheme,
+        place_of_supply_scheme: impl Into<
+            CreateTaxRegistrationCountryOptionsIeStandardPlaceOfSupplyScheme,
+        >,
     ) -> Self {
-        Self { place_of_supply_scheme }
+        Self { place_of_supply_scheme: place_of_supply_scheme.into() }
     }
 }
 /// Place of supply scheme used in an EU standard registration.
@@ -3189,8 +3225,8 @@ pub struct CreateTaxRegistrationCountryOptionsIs {
     pub type_: CreateTaxRegistrationCountryOptionsIsType,
 }
 impl CreateTaxRegistrationCountryOptionsIs {
-    pub fn new(type_: CreateTaxRegistrationCountryOptionsIsType) -> Self {
-        Self { type_ }
+    pub fn new(type_: impl Into<CreateTaxRegistrationCountryOptionsIsType>) -> Self {
+        Self { type_: type_.into() }
     }
 }
 /// Type of registration to be created in `country`.
@@ -3257,8 +3293,8 @@ pub struct CreateTaxRegistrationCountryOptionsIt {
     pub type_: CreateTaxRegistrationCountryOptionsItType,
 }
 impl CreateTaxRegistrationCountryOptionsIt {
-    pub fn new(type_: CreateTaxRegistrationCountryOptionsItType) -> Self {
-        Self { standard: None, type_ }
+    pub fn new(type_: impl Into<CreateTaxRegistrationCountryOptionsItType>) -> Self {
+        Self { standard: None, type_: type_.into() }
     }
 }
 /// Options for the standard registration.
@@ -3269,9 +3305,11 @@ pub struct CreateTaxRegistrationCountryOptionsItStandard {
 }
 impl CreateTaxRegistrationCountryOptionsItStandard {
     pub fn new(
-        place_of_supply_scheme: CreateTaxRegistrationCountryOptionsItStandardPlaceOfSupplyScheme,
+        place_of_supply_scheme: impl Into<
+            CreateTaxRegistrationCountryOptionsItStandardPlaceOfSupplyScheme,
+        >,
     ) -> Self {
-        Self { place_of_supply_scheme }
+        Self { place_of_supply_scheme: place_of_supply_scheme.into() }
     }
 }
 /// Place of supply scheme used in an EU standard registration.
@@ -3400,8 +3438,8 @@ pub struct CreateTaxRegistrationCountryOptionsJp {
     pub type_: CreateTaxRegistrationCountryOptionsJpType,
 }
 impl CreateTaxRegistrationCountryOptionsJp {
-    pub fn new(type_: CreateTaxRegistrationCountryOptionsJpType) -> Self {
-        Self { type_ }
+    pub fn new(type_: impl Into<CreateTaxRegistrationCountryOptionsJpType>) -> Self {
+        Self { type_: type_.into() }
     }
 }
 /// Type of registration to be created in `country`.
@@ -3465,8 +3503,8 @@ pub struct CreateTaxRegistrationCountryOptionsKr {
     pub type_: CreateTaxRegistrationCountryOptionsKrType,
 }
 impl CreateTaxRegistrationCountryOptionsKr {
-    pub fn new(type_: CreateTaxRegistrationCountryOptionsKrType) -> Self {
-        Self { type_ }
+    pub fn new(type_: impl Into<CreateTaxRegistrationCountryOptionsKrType>) -> Self {
+        Self { type_: type_.into() }
     }
 }
 /// Type of registration to be created in `country`.
@@ -3533,8 +3571,8 @@ pub struct CreateTaxRegistrationCountryOptionsLt {
     pub type_: CreateTaxRegistrationCountryOptionsLtType,
 }
 impl CreateTaxRegistrationCountryOptionsLt {
-    pub fn new(type_: CreateTaxRegistrationCountryOptionsLtType) -> Self {
-        Self { standard: None, type_ }
+    pub fn new(type_: impl Into<CreateTaxRegistrationCountryOptionsLtType>) -> Self {
+        Self { standard: None, type_: type_.into() }
     }
 }
 /// Options for the standard registration.
@@ -3545,9 +3583,11 @@ pub struct CreateTaxRegistrationCountryOptionsLtStandard {
 }
 impl CreateTaxRegistrationCountryOptionsLtStandard {
     pub fn new(
-        place_of_supply_scheme: CreateTaxRegistrationCountryOptionsLtStandardPlaceOfSupplyScheme,
+        place_of_supply_scheme: impl Into<
+            CreateTaxRegistrationCountryOptionsLtStandardPlaceOfSupplyScheme,
+        >,
     ) -> Self {
-        Self { place_of_supply_scheme }
+        Self { place_of_supply_scheme: place_of_supply_scheme.into() }
     }
 }
 /// Place of supply scheme used in an EU standard registration.
@@ -3679,8 +3719,8 @@ pub struct CreateTaxRegistrationCountryOptionsLu {
     pub type_: CreateTaxRegistrationCountryOptionsLuType,
 }
 impl CreateTaxRegistrationCountryOptionsLu {
-    pub fn new(type_: CreateTaxRegistrationCountryOptionsLuType) -> Self {
-        Self { standard: None, type_ }
+    pub fn new(type_: impl Into<CreateTaxRegistrationCountryOptionsLuType>) -> Self {
+        Self { standard: None, type_: type_.into() }
     }
 }
 /// Options for the standard registration.
@@ -3691,9 +3731,11 @@ pub struct CreateTaxRegistrationCountryOptionsLuStandard {
 }
 impl CreateTaxRegistrationCountryOptionsLuStandard {
     pub fn new(
-        place_of_supply_scheme: CreateTaxRegistrationCountryOptionsLuStandardPlaceOfSupplyScheme,
+        place_of_supply_scheme: impl Into<
+            CreateTaxRegistrationCountryOptionsLuStandardPlaceOfSupplyScheme,
+        >,
     ) -> Self {
-        Self { place_of_supply_scheme }
+        Self { place_of_supply_scheme: place_of_supply_scheme.into() }
     }
 }
 /// Place of supply scheme used in an EU standard registration.
@@ -3825,8 +3867,8 @@ pub struct CreateTaxRegistrationCountryOptionsLv {
     pub type_: CreateTaxRegistrationCountryOptionsLvType,
 }
 impl CreateTaxRegistrationCountryOptionsLv {
-    pub fn new(type_: CreateTaxRegistrationCountryOptionsLvType) -> Self {
-        Self { standard: None, type_ }
+    pub fn new(type_: impl Into<CreateTaxRegistrationCountryOptionsLvType>) -> Self {
+        Self { standard: None, type_: type_.into() }
     }
 }
 /// Options for the standard registration.
@@ -3837,9 +3879,11 @@ pub struct CreateTaxRegistrationCountryOptionsLvStandard {
 }
 impl CreateTaxRegistrationCountryOptionsLvStandard {
     pub fn new(
-        place_of_supply_scheme: CreateTaxRegistrationCountryOptionsLvStandardPlaceOfSupplyScheme,
+        place_of_supply_scheme: impl Into<
+            CreateTaxRegistrationCountryOptionsLvStandardPlaceOfSupplyScheme,
+        >,
     ) -> Self {
-        Self { place_of_supply_scheme }
+        Self { place_of_supply_scheme: place_of_supply_scheme.into() }
     }
 }
 /// Place of supply scheme used in an EU standard registration.
@@ -3971,8 +4015,8 @@ pub struct CreateTaxRegistrationCountryOptionsMt {
     pub type_: CreateTaxRegistrationCountryOptionsMtType,
 }
 impl CreateTaxRegistrationCountryOptionsMt {
-    pub fn new(type_: CreateTaxRegistrationCountryOptionsMtType) -> Self {
-        Self { standard: None, type_ }
+    pub fn new(type_: impl Into<CreateTaxRegistrationCountryOptionsMtType>) -> Self {
+        Self { standard: None, type_: type_.into() }
     }
 }
 /// Options for the standard registration.
@@ -3983,9 +4027,11 @@ pub struct CreateTaxRegistrationCountryOptionsMtStandard {
 }
 impl CreateTaxRegistrationCountryOptionsMtStandard {
     pub fn new(
-        place_of_supply_scheme: CreateTaxRegistrationCountryOptionsMtStandardPlaceOfSupplyScheme,
+        place_of_supply_scheme: impl Into<
+            CreateTaxRegistrationCountryOptionsMtStandardPlaceOfSupplyScheme,
+        >,
     ) -> Self {
-        Self { place_of_supply_scheme }
+        Self { place_of_supply_scheme: place_of_supply_scheme.into() }
     }
 }
 /// Place of supply scheme used in an EU standard registration.
@@ -4114,8 +4160,8 @@ pub struct CreateTaxRegistrationCountryOptionsMx {
     pub type_: CreateTaxRegistrationCountryOptionsMxType,
 }
 impl CreateTaxRegistrationCountryOptionsMx {
-    pub fn new(type_: CreateTaxRegistrationCountryOptionsMxType) -> Self {
-        Self { type_ }
+    pub fn new(type_: impl Into<CreateTaxRegistrationCountryOptionsMxType>) -> Self {
+        Self { type_: type_.into() }
     }
 }
 /// Type of registration to be created in `country`.
@@ -4179,8 +4225,8 @@ pub struct CreateTaxRegistrationCountryOptionsMy {
     pub type_: CreateTaxRegistrationCountryOptionsMyType,
 }
 impl CreateTaxRegistrationCountryOptionsMy {
-    pub fn new(type_: CreateTaxRegistrationCountryOptionsMyType) -> Self {
-        Self { type_ }
+    pub fn new(type_: impl Into<CreateTaxRegistrationCountryOptionsMyType>) -> Self {
+        Self { type_: type_.into() }
     }
 }
 /// Type of registration to be created in `country`.
@@ -4247,8 +4293,8 @@ pub struct CreateTaxRegistrationCountryOptionsNl {
     pub type_: CreateTaxRegistrationCountryOptionsNlType,
 }
 impl CreateTaxRegistrationCountryOptionsNl {
-    pub fn new(type_: CreateTaxRegistrationCountryOptionsNlType) -> Self {
-        Self { standard: None, type_ }
+    pub fn new(type_: impl Into<CreateTaxRegistrationCountryOptionsNlType>) -> Self {
+        Self { standard: None, type_: type_.into() }
     }
 }
 /// Options for the standard registration.
@@ -4259,9 +4305,11 @@ pub struct CreateTaxRegistrationCountryOptionsNlStandard {
 }
 impl CreateTaxRegistrationCountryOptionsNlStandard {
     pub fn new(
-        place_of_supply_scheme: CreateTaxRegistrationCountryOptionsNlStandardPlaceOfSupplyScheme,
+        place_of_supply_scheme: impl Into<
+            CreateTaxRegistrationCountryOptionsNlStandardPlaceOfSupplyScheme,
+        >,
     ) -> Self {
-        Self { place_of_supply_scheme }
+        Self { place_of_supply_scheme: place_of_supply_scheme.into() }
     }
 }
 /// Place of supply scheme used in an EU standard registration.
@@ -4390,8 +4438,8 @@ pub struct CreateTaxRegistrationCountryOptionsNo {
     pub type_: CreateTaxRegistrationCountryOptionsNoType,
 }
 impl CreateTaxRegistrationCountryOptionsNo {
-    pub fn new(type_: CreateTaxRegistrationCountryOptionsNoType) -> Self {
-        Self { type_ }
+    pub fn new(type_: impl Into<CreateTaxRegistrationCountryOptionsNoType>) -> Self {
+        Self { type_: type_.into() }
     }
 }
 /// Type of registration to be created in `country`.
@@ -4455,8 +4503,8 @@ pub struct CreateTaxRegistrationCountryOptionsNz {
     pub type_: CreateTaxRegistrationCountryOptionsNzType,
 }
 impl CreateTaxRegistrationCountryOptionsNz {
-    pub fn new(type_: CreateTaxRegistrationCountryOptionsNzType) -> Self {
-        Self { type_ }
+    pub fn new(type_: impl Into<CreateTaxRegistrationCountryOptionsNzType>) -> Self {
+        Self { type_: type_.into() }
     }
 }
 /// Type of registration to be created in `country`.
@@ -4523,8 +4571,8 @@ pub struct CreateTaxRegistrationCountryOptionsPl {
     pub type_: CreateTaxRegistrationCountryOptionsPlType,
 }
 impl CreateTaxRegistrationCountryOptionsPl {
-    pub fn new(type_: CreateTaxRegistrationCountryOptionsPlType) -> Self {
-        Self { standard: None, type_ }
+    pub fn new(type_: impl Into<CreateTaxRegistrationCountryOptionsPlType>) -> Self {
+        Self { standard: None, type_: type_.into() }
     }
 }
 /// Options for the standard registration.
@@ -4535,9 +4583,11 @@ pub struct CreateTaxRegistrationCountryOptionsPlStandard {
 }
 impl CreateTaxRegistrationCountryOptionsPlStandard {
     pub fn new(
-        place_of_supply_scheme: CreateTaxRegistrationCountryOptionsPlStandardPlaceOfSupplyScheme,
+        place_of_supply_scheme: impl Into<
+            CreateTaxRegistrationCountryOptionsPlStandardPlaceOfSupplyScheme,
+        >,
     ) -> Self {
-        Self { place_of_supply_scheme }
+        Self { place_of_supply_scheme: place_of_supply_scheme.into() }
     }
 }
 /// Place of supply scheme used in an EU standard registration.
@@ -4669,8 +4719,8 @@ pub struct CreateTaxRegistrationCountryOptionsPt {
     pub type_: CreateTaxRegistrationCountryOptionsPtType,
 }
 impl CreateTaxRegistrationCountryOptionsPt {
-    pub fn new(type_: CreateTaxRegistrationCountryOptionsPtType) -> Self {
-        Self { standard: None, type_ }
+    pub fn new(type_: impl Into<CreateTaxRegistrationCountryOptionsPtType>) -> Self {
+        Self { standard: None, type_: type_.into() }
     }
 }
 /// Options for the standard registration.
@@ -4681,9 +4731,11 @@ pub struct CreateTaxRegistrationCountryOptionsPtStandard {
 }
 impl CreateTaxRegistrationCountryOptionsPtStandard {
     pub fn new(
-        place_of_supply_scheme: CreateTaxRegistrationCountryOptionsPtStandardPlaceOfSupplyScheme,
+        place_of_supply_scheme: impl Into<
+            CreateTaxRegistrationCountryOptionsPtStandardPlaceOfSupplyScheme,
+        >,
     ) -> Self {
-        Self { place_of_supply_scheme }
+        Self { place_of_supply_scheme: place_of_supply_scheme.into() }
     }
 }
 /// Place of supply scheme used in an EU standard registration.
@@ -4815,8 +4867,8 @@ pub struct CreateTaxRegistrationCountryOptionsRo {
     pub type_: CreateTaxRegistrationCountryOptionsRoType,
 }
 impl CreateTaxRegistrationCountryOptionsRo {
-    pub fn new(type_: CreateTaxRegistrationCountryOptionsRoType) -> Self {
-        Self { standard: None, type_ }
+    pub fn new(type_: impl Into<CreateTaxRegistrationCountryOptionsRoType>) -> Self {
+        Self { standard: None, type_: type_.into() }
     }
 }
 /// Options for the standard registration.
@@ -4827,9 +4879,11 @@ pub struct CreateTaxRegistrationCountryOptionsRoStandard {
 }
 impl CreateTaxRegistrationCountryOptionsRoStandard {
     pub fn new(
-        place_of_supply_scheme: CreateTaxRegistrationCountryOptionsRoStandardPlaceOfSupplyScheme,
+        place_of_supply_scheme: impl Into<
+            CreateTaxRegistrationCountryOptionsRoStandardPlaceOfSupplyScheme,
+        >,
     ) -> Self {
-        Self { place_of_supply_scheme }
+        Self { place_of_supply_scheme: place_of_supply_scheme.into() }
     }
 }
 /// Place of supply scheme used in an EU standard registration.
@@ -4958,8 +5012,8 @@ pub struct CreateTaxRegistrationCountryOptionsSa {
     pub type_: CreateTaxRegistrationCountryOptionsSaType,
 }
 impl CreateTaxRegistrationCountryOptionsSa {
-    pub fn new(type_: CreateTaxRegistrationCountryOptionsSaType) -> Self {
-        Self { type_ }
+    pub fn new(type_: impl Into<CreateTaxRegistrationCountryOptionsSaType>) -> Self {
+        Self { type_: type_.into() }
     }
 }
 /// Type of registration to be created in `country`.
@@ -5026,8 +5080,8 @@ pub struct CreateTaxRegistrationCountryOptionsSe {
     pub type_: CreateTaxRegistrationCountryOptionsSeType,
 }
 impl CreateTaxRegistrationCountryOptionsSe {
-    pub fn new(type_: CreateTaxRegistrationCountryOptionsSeType) -> Self {
-        Self { standard: None, type_ }
+    pub fn new(type_: impl Into<CreateTaxRegistrationCountryOptionsSeType>) -> Self {
+        Self { standard: None, type_: type_.into() }
     }
 }
 /// Options for the standard registration.
@@ -5038,9 +5092,11 @@ pub struct CreateTaxRegistrationCountryOptionsSeStandard {
 }
 impl CreateTaxRegistrationCountryOptionsSeStandard {
     pub fn new(
-        place_of_supply_scheme: CreateTaxRegistrationCountryOptionsSeStandardPlaceOfSupplyScheme,
+        place_of_supply_scheme: impl Into<
+            CreateTaxRegistrationCountryOptionsSeStandardPlaceOfSupplyScheme,
+        >,
     ) -> Self {
-        Self { place_of_supply_scheme }
+        Self { place_of_supply_scheme: place_of_supply_scheme.into() }
     }
 }
 /// Place of supply scheme used in an EU standard registration.
@@ -5169,8 +5225,8 @@ pub struct CreateTaxRegistrationCountryOptionsSg {
     pub type_: CreateTaxRegistrationCountryOptionsSgType,
 }
 impl CreateTaxRegistrationCountryOptionsSg {
-    pub fn new(type_: CreateTaxRegistrationCountryOptionsSgType) -> Self {
-        Self { type_ }
+    pub fn new(type_: impl Into<CreateTaxRegistrationCountryOptionsSgType>) -> Self {
+        Self { type_: type_.into() }
     }
 }
 /// Type of registration to be created in `country`.
@@ -5237,8 +5293,8 @@ pub struct CreateTaxRegistrationCountryOptionsSi {
     pub type_: CreateTaxRegistrationCountryOptionsSiType,
 }
 impl CreateTaxRegistrationCountryOptionsSi {
-    pub fn new(type_: CreateTaxRegistrationCountryOptionsSiType) -> Self {
-        Self { standard: None, type_ }
+    pub fn new(type_: impl Into<CreateTaxRegistrationCountryOptionsSiType>) -> Self {
+        Self { standard: None, type_: type_.into() }
     }
 }
 /// Options for the standard registration.
@@ -5249,9 +5305,11 @@ pub struct CreateTaxRegistrationCountryOptionsSiStandard {
 }
 impl CreateTaxRegistrationCountryOptionsSiStandard {
     pub fn new(
-        place_of_supply_scheme: CreateTaxRegistrationCountryOptionsSiStandardPlaceOfSupplyScheme,
+        place_of_supply_scheme: impl Into<
+            CreateTaxRegistrationCountryOptionsSiStandardPlaceOfSupplyScheme,
+        >,
     ) -> Self {
-        Self { place_of_supply_scheme }
+        Self { place_of_supply_scheme: place_of_supply_scheme.into() }
     }
 }
 /// Place of supply scheme used in an EU standard registration.
@@ -5383,8 +5441,8 @@ pub struct CreateTaxRegistrationCountryOptionsSk {
     pub type_: CreateTaxRegistrationCountryOptionsSkType,
 }
 impl CreateTaxRegistrationCountryOptionsSk {
-    pub fn new(type_: CreateTaxRegistrationCountryOptionsSkType) -> Self {
-        Self { standard: None, type_ }
+    pub fn new(type_: impl Into<CreateTaxRegistrationCountryOptionsSkType>) -> Self {
+        Self { standard: None, type_: type_.into() }
     }
 }
 /// Options for the standard registration.
@@ -5395,9 +5453,11 @@ pub struct CreateTaxRegistrationCountryOptionsSkStandard {
 }
 impl CreateTaxRegistrationCountryOptionsSkStandard {
     pub fn new(
-        place_of_supply_scheme: CreateTaxRegistrationCountryOptionsSkStandardPlaceOfSupplyScheme,
+        place_of_supply_scheme: impl Into<
+            CreateTaxRegistrationCountryOptionsSkStandardPlaceOfSupplyScheme,
+        >,
     ) -> Self {
-        Self { place_of_supply_scheme }
+        Self { place_of_supply_scheme: place_of_supply_scheme.into() }
     }
 }
 /// Place of supply scheme used in an EU standard registration.
@@ -5526,8 +5586,8 @@ pub struct CreateTaxRegistrationCountryOptionsTh {
     pub type_: CreateTaxRegistrationCountryOptionsThType,
 }
 impl CreateTaxRegistrationCountryOptionsTh {
-    pub fn new(type_: CreateTaxRegistrationCountryOptionsThType) -> Self {
-        Self { type_ }
+    pub fn new(type_: impl Into<CreateTaxRegistrationCountryOptionsThType>) -> Self {
+        Self { type_: type_.into() }
     }
 }
 /// Type of registration to be created in `country`.
@@ -5591,8 +5651,8 @@ pub struct CreateTaxRegistrationCountryOptionsTr {
     pub type_: CreateTaxRegistrationCountryOptionsTrType,
 }
 impl CreateTaxRegistrationCountryOptionsTr {
-    pub fn new(type_: CreateTaxRegistrationCountryOptionsTrType) -> Self {
-        Self { type_ }
+    pub fn new(type_: impl Into<CreateTaxRegistrationCountryOptionsTrType>) -> Self {
+        Self { type_: type_.into() }
     }
 }
 /// Type of registration to be created in `country`.
@@ -5649,47 +5709,55 @@ impl<'de> serde::Deserialize<'de> for CreateTaxRegistrationCountryOptionsTrType 
     }
 }
 /// Options for the registration in US.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateTaxRegistrationCountryOptionsUs<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateTaxRegistrationCountryOptionsUs {
     /// Options for the local amusement tax registration.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub local_amusement_tax: Option<CreateTaxRegistrationCountryOptionsUsLocalAmusementTax<'a>>,
+    pub local_amusement_tax: Option<CreateTaxRegistrationCountryOptionsUsLocalAmusementTax>,
     /// Options for the local lease tax registration.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub local_lease_tax: Option<CreateTaxRegistrationCountryOptionsUsLocalLeaseTax<'a>>,
+    pub local_lease_tax: Option<CreateTaxRegistrationCountryOptionsUsLocalLeaseTax>,
     /// Two-letter US state code ([ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-2)).
-    pub state: &'a str,
+    pub state: String,
     /// Type of registration to be created in the US.
     #[serde(rename = "type")]
     pub type_: CreateTaxRegistrationCountryOptionsUsType,
 }
-impl<'a> CreateTaxRegistrationCountryOptionsUs<'a> {
-    pub fn new(state: &'a str, type_: CreateTaxRegistrationCountryOptionsUsType) -> Self {
-        Self { local_amusement_tax: None, local_lease_tax: None, state, type_ }
+impl CreateTaxRegistrationCountryOptionsUs {
+    pub fn new(
+        state: impl Into<String>,
+        type_: impl Into<CreateTaxRegistrationCountryOptionsUsType>,
+    ) -> Self {
+        Self {
+            local_amusement_tax: None,
+            local_lease_tax: None,
+            state: state.into(),
+            type_: type_.into(),
+        }
     }
 }
 /// Options for the local amusement tax registration.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateTaxRegistrationCountryOptionsUsLocalAmusementTax<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateTaxRegistrationCountryOptionsUsLocalAmusementTax {
     /// A [FIPS code](https://www.census.gov/library/reference/code-lists/ansi.html) representing the local jurisdiction.
     /// Supported FIPS codes are: `14000` (Chicago), `06613` (Bloomington), `21696` (East Dundee), `24582` (Evanston), and `68081` (Schiller Park).
-    pub jurisdiction: &'a str,
+    pub jurisdiction: String,
 }
-impl<'a> CreateTaxRegistrationCountryOptionsUsLocalAmusementTax<'a> {
-    pub fn new(jurisdiction: &'a str) -> Self {
-        Self { jurisdiction }
+impl CreateTaxRegistrationCountryOptionsUsLocalAmusementTax {
+    pub fn new(jurisdiction: impl Into<String>) -> Self {
+        Self { jurisdiction: jurisdiction.into() }
     }
 }
 /// Options for the local lease tax registration.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateTaxRegistrationCountryOptionsUsLocalLeaseTax<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateTaxRegistrationCountryOptionsUsLocalLeaseTax {
     /// A [FIPS code](https://www.census.gov/library/reference/code-lists/ansi.html) representing the local jurisdiction.
     /// Supported FIPS codes are: `14000` (Chicago).
-    pub jurisdiction: &'a str,
+    pub jurisdiction: String,
 }
-impl<'a> CreateTaxRegistrationCountryOptionsUsLocalLeaseTax<'a> {
-    pub fn new(jurisdiction: &'a str) -> Self {
-        Self { jurisdiction }
+impl CreateTaxRegistrationCountryOptionsUsLocalLeaseTax {
+    pub fn new(jurisdiction: impl Into<String>) -> Self {
+        Self { jurisdiction: jurisdiction.into() }
     }
 }
 /// Type of registration to be created in the US.
@@ -5762,8 +5830,8 @@ pub struct CreateTaxRegistrationCountryOptionsVn {
     pub type_: CreateTaxRegistrationCountryOptionsVnType,
 }
 impl CreateTaxRegistrationCountryOptionsVn {
-    pub fn new(type_: CreateTaxRegistrationCountryOptionsVnType) -> Self {
-        Self { type_ }
+    pub fn new(type_: impl Into<CreateTaxRegistrationCountryOptionsVnType>) -> Self {
+        Self { type_: type_.into() }
     }
 }
 /// Type of registration to be created in `country`.
@@ -5827,8 +5895,8 @@ pub struct CreateTaxRegistrationCountryOptionsZa {
     pub type_: CreateTaxRegistrationCountryOptionsZaType,
 }
 impl CreateTaxRegistrationCountryOptionsZa {
-    pub fn new(type_: CreateTaxRegistrationCountryOptionsZaType) -> Self {
-        Self { type_ }
+    pub fn new(type_: impl Into<CreateTaxRegistrationCountryOptionsZaType>) -> Self {
+        Self { type_: type_.into() }
     }
 }
 /// Type of registration to be created in `country`.
@@ -5886,32 +5954,38 @@ impl<'de> serde::Deserialize<'de> for CreateTaxRegistrationCountryOptionsZaType 
 }
 /// Creates a new Tax `Registration` object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateTaxRegistration<'a> {
-    inner: CreateTaxRegistrationBuilder<'a>,
+pub struct CreateTaxRegistration {
+    inner: CreateTaxRegistrationBuilder,
 }
-impl<'a> CreateTaxRegistration<'a> {
+impl CreateTaxRegistration {
     /// Construct a new `CreateTaxRegistration`.
     pub fn new(
-        active_from: CreateTaxRegistrationActiveFrom,
-        country: &'a str,
-        country_options: CreateTaxRegistrationCountryOptions<'a>,
+        active_from: impl Into<CreateTaxRegistrationActiveFrom>,
+        country: impl Into<String>,
+        country_options: impl Into<CreateTaxRegistrationCountryOptions>,
     ) -> Self {
-        Self { inner: CreateTaxRegistrationBuilder::new(active_from, country, country_options) }
+        Self {
+            inner: CreateTaxRegistrationBuilder::new(
+                active_from.into(),
+                country.into(),
+                country_options.into(),
+            ),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// If set, the Tax Registration stops being active at this time.
     /// If not set, the Tax Registration will be active indefinitely.
     /// Timestamp measured in seconds since the Unix epoch.
-    pub fn expires_at(mut self, expires_at: stripe_types::Timestamp) -> Self {
-        self.inner.expires_at = Some(expires_at);
+    pub fn expires_at(mut self, expires_at: impl Into<stripe_types::Timestamp>) -> Self {
+        self.inner.expires_at = Some(expires_at.into());
         self
     }
 }
-impl CreateTaxRegistration<'_> {
+impl CreateTaxRegistration {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -5929,23 +6003,23 @@ impl CreateTaxRegistration<'_> {
     }
 }
 
-impl StripeRequest for CreateTaxRegistration<'_> {
+impl StripeRequest for CreateTaxRegistration {
     type Output = stripe_misc::TaxRegistration;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Post, "/tax/registrations").form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdateTaxRegistrationBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdateTaxRegistrationBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     active_from: Option<UpdateTaxRegistrationActiveFrom>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     expires_at: Option<UpdateTaxRegistrationExpiresAt>,
 }
-impl<'a> UpdateTaxRegistrationBuilder<'a> {
+impl UpdateTaxRegistrationBuilder {
     fn new() -> Self {
         Self { active_from: None, expand: None, expires_at: None }
     }
@@ -5974,35 +6048,35 @@ pub enum UpdateTaxRegistrationExpiresAt {
 /// A registration cannot be deleted after it has been created.
 /// If you wish to end a registration you may do so by setting `expires_at`.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateTaxRegistration<'a> {
-    inner: UpdateTaxRegistrationBuilder<'a>,
-    id: &'a stripe_misc::TaxRegistrationId,
+pub struct UpdateTaxRegistration {
+    inner: UpdateTaxRegistrationBuilder,
+    id: stripe_misc::TaxRegistrationId,
 }
-impl<'a> UpdateTaxRegistration<'a> {
+impl UpdateTaxRegistration {
     /// Construct a new `UpdateTaxRegistration`.
-    pub fn new(id: &'a stripe_misc::TaxRegistrationId) -> Self {
-        Self { id, inner: UpdateTaxRegistrationBuilder::new() }
+    pub fn new(id: impl Into<stripe_misc::TaxRegistrationId>) -> Self {
+        Self { id: id.into(), inner: UpdateTaxRegistrationBuilder::new() }
     }
     /// Time at which the registration becomes active.
     /// It can be either `now` to indicate the current time, or a timestamp measured in seconds since the Unix epoch.
-    pub fn active_from(mut self, active_from: UpdateTaxRegistrationActiveFrom) -> Self {
-        self.inner.active_from = Some(active_from);
+    pub fn active_from(mut self, active_from: impl Into<UpdateTaxRegistrationActiveFrom>) -> Self {
+        self.inner.active_from = Some(active_from.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// If set, the registration stops being active at this time.
     /// If not set, the registration will be active indefinitely.
     /// It can be either `now` to indicate the current time, or a timestamp measured in seconds since the Unix epoch.
-    pub fn expires_at(mut self, expires_at: UpdateTaxRegistrationExpiresAt) -> Self {
-        self.inner.expires_at = Some(expires_at);
+    pub fn expires_at(mut self, expires_at: impl Into<UpdateTaxRegistrationExpiresAt>) -> Self {
+        self.inner.expires_at = Some(expires_at.into());
         self
     }
 }
-impl UpdateTaxRegistration<'_> {
+impl UpdateTaxRegistration {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -6020,11 +6094,11 @@ impl UpdateTaxRegistration<'_> {
     }
 }
 
-impl StripeRequest for UpdateTaxRegistration<'_> {
+impl StripeRequest for UpdateTaxRegistration {
     type Output = stripe_misc::TaxRegistration;
 
     fn build(&self) -> RequestBuilder {
-        let id = self.id;
+        let id = &self.id;
         RequestBuilder::new(StripeMethod::Post, format!("/tax/registrations/{id}"))
             .form(&self.inner)
     }

--- a/generated/async-stripe-misc/src/tax_settings/requests.rs
+++ b/generated/async-stripe-misc/src/tax_settings/requests.rs
@@ -2,38 +2,38 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveForMyAccountTaxSettingsBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveForMyAccountTaxSettingsBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveForMyAccountTaxSettingsBuilder<'a> {
+impl RetrieveForMyAccountTaxSettingsBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves Tax `Settings` for a merchant.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveForMyAccountTaxSettings<'a> {
-    inner: RetrieveForMyAccountTaxSettingsBuilder<'a>,
+pub struct RetrieveForMyAccountTaxSettings {
+    inner: RetrieveForMyAccountTaxSettingsBuilder,
 }
-impl<'a> RetrieveForMyAccountTaxSettings<'a> {
+impl RetrieveForMyAccountTaxSettings {
     /// Construct a new `RetrieveForMyAccountTaxSettings`.
     pub fn new() -> Self {
         Self { inner: RetrieveForMyAccountTaxSettingsBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl<'a> Default for RetrieveForMyAccountTaxSettings<'a> {
+impl Default for RetrieveForMyAccountTaxSettings {
     fn default() -> Self {
         Self::new()
     }
 }
-impl RetrieveForMyAccountTaxSettings<'_> {
+impl RetrieveForMyAccountTaxSettings {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -51,30 +51,30 @@ impl RetrieveForMyAccountTaxSettings<'_> {
     }
 }
 
-impl StripeRequest for RetrieveForMyAccountTaxSettings<'_> {
+impl StripeRequest for RetrieveForMyAccountTaxSettings {
     type Output = stripe_misc::TaxSettings;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/tax/settings").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdateTaxSettingsBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdateTaxSettingsBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    defaults: Option<UpdateTaxSettingsDefaults<'a>>,
+    defaults: Option<UpdateTaxSettingsDefaults>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    head_office: Option<UpdateTaxSettingsHeadOffice<'a>>,
+    head_office: Option<UpdateTaxSettingsHeadOffice>,
 }
-impl<'a> UpdateTaxSettingsBuilder<'a> {
+impl UpdateTaxSettingsBuilder {
     fn new() -> Self {
         Self { defaults: None, expand: None, head_office: None }
     }
 }
 /// Default configuration to be used on Stripe Tax calculations.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateTaxSettingsDefaults<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateTaxSettingsDefaults {
     /// Specifies the default [tax behavior](https://stripe.com/docs/tax/products-prices-tax-categories-tax-behavior#tax-behavior) to be used when the item's price has unspecified tax behavior.
     /// One of inclusive, exclusive, or inferred_by_currency.
     /// Once specified, it cannot be changed back to null.
@@ -82,14 +82,14 @@ pub struct UpdateTaxSettingsDefaults<'a> {
     pub tax_behavior: Option<UpdateTaxSettingsDefaultsTaxBehavior>,
     /// A [tax code](https://stripe.com/docs/tax/tax-categories) ID.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_code: Option<&'a str>,
+    pub tax_code: Option<String>,
 }
-impl<'a> UpdateTaxSettingsDefaults<'a> {
+impl UpdateTaxSettingsDefaults {
     pub fn new() -> Self {
         Self { tax_behavior: None, tax_code: None }
     }
 }
-impl<'a> Default for UpdateTaxSettingsDefaults<'a> {
+impl Default for UpdateTaxSettingsDefaults {
     fn default() -> Self {
         Self::new()
     }
@@ -156,45 +156,45 @@ impl<'de> serde::Deserialize<'de> for UpdateTaxSettingsDefaultsTaxBehavior {
     }
 }
 /// The place where your business is located.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateTaxSettingsHeadOffice<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateTaxSettingsHeadOffice {
     /// The location of the business for tax purposes.
-    pub address: UpdateTaxSettingsHeadOfficeAddress<'a>,
+    pub address: UpdateTaxSettingsHeadOfficeAddress,
 }
-impl<'a> UpdateTaxSettingsHeadOffice<'a> {
-    pub fn new(address: UpdateTaxSettingsHeadOfficeAddress<'a>) -> Self {
-        Self { address }
+impl UpdateTaxSettingsHeadOffice {
+    pub fn new(address: impl Into<UpdateTaxSettingsHeadOfficeAddress>) -> Self {
+        Self { address: address.into() }
     }
 }
 /// The location of the business for tax purposes.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateTaxSettingsHeadOfficeAddress<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateTaxSettingsHeadOfficeAddress {
     /// City, district, suburb, town, or village.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<&'a str>,
+    pub city: Option<String>,
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub country: Option<&'a str>,
+    pub country: Option<String>,
     /// Address line 1 (e.g., street, PO Box, or company name).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line1: Option<&'a str>,
+    pub line1: Option<String>,
     /// Address line 2 (e.g., apartment, suite, unit, or building).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line2: Option<&'a str>,
+    pub line2: Option<String>,
     /// ZIP or postal code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<&'a str>,
+    pub postal_code: Option<String>,
     /// State/province as an [ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-2) subdivision code, without country prefix.
     /// Example: "NY" or "TX".
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
 }
-impl<'a> UpdateTaxSettingsHeadOfficeAddress<'a> {
+impl UpdateTaxSettingsHeadOfficeAddress {
     pub fn new() -> Self {
         Self { city: None, country: None, line1: None, line2: None, postal_code: None, state: None }
     }
 }
-impl<'a> Default for UpdateTaxSettingsHeadOfficeAddress<'a> {
+impl Default for UpdateTaxSettingsHeadOfficeAddress {
     fn default() -> Self {
         Self::new()
     }
@@ -202,36 +202,36 @@ impl<'a> Default for UpdateTaxSettingsHeadOfficeAddress<'a> {
 /// Updates Tax `Settings` parameters used in tax calculations.
 /// All parameters are editable but none can be removed once set.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateTaxSettings<'a> {
-    inner: UpdateTaxSettingsBuilder<'a>,
+pub struct UpdateTaxSettings {
+    inner: UpdateTaxSettingsBuilder,
 }
-impl<'a> UpdateTaxSettings<'a> {
+impl UpdateTaxSettings {
     /// Construct a new `UpdateTaxSettings`.
     pub fn new() -> Self {
         Self { inner: UpdateTaxSettingsBuilder::new() }
     }
     /// Default configuration to be used on Stripe Tax calculations.
-    pub fn defaults(mut self, defaults: UpdateTaxSettingsDefaults<'a>) -> Self {
-        self.inner.defaults = Some(defaults);
+    pub fn defaults(mut self, defaults: impl Into<UpdateTaxSettingsDefaults>) -> Self {
+        self.inner.defaults = Some(defaults.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// The place where your business is located.
-    pub fn head_office(mut self, head_office: UpdateTaxSettingsHeadOffice<'a>) -> Self {
-        self.inner.head_office = Some(head_office);
+    pub fn head_office(mut self, head_office: impl Into<UpdateTaxSettingsHeadOffice>) -> Self {
+        self.inner.head_office = Some(head_office.into());
         self
     }
 }
-impl<'a> Default for UpdateTaxSettings<'a> {
+impl Default for UpdateTaxSettings {
     fn default() -> Self {
         Self::new()
     }
 }
-impl UpdateTaxSettings<'_> {
+impl UpdateTaxSettings {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -249,7 +249,7 @@ impl UpdateTaxSettings<'_> {
     }
 }
 
-impl StripeRequest for UpdateTaxSettings<'_> {
+impl StripeRequest for UpdateTaxSettings {
     type Output = stripe_misc::TaxSettings;
 
     fn build(&self) -> RequestBuilder {

--- a/generated/async-stripe-misc/src/tax_transaction/requests.rs
+++ b/generated/async-stripe-misc/src/tax_transaction/requests.rs
@@ -2,34 +2,34 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveTaxTransactionBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveTaxTransactionBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveTaxTransactionBuilder<'a> {
+impl RetrieveTaxTransactionBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves a Tax `Transaction` object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveTaxTransaction<'a> {
-    inner: RetrieveTaxTransactionBuilder<'a>,
-    transaction: &'a stripe_misc::TaxTransactionId,
+pub struct RetrieveTaxTransaction {
+    inner: RetrieveTaxTransactionBuilder,
+    transaction: stripe_misc::TaxTransactionId,
 }
-impl<'a> RetrieveTaxTransaction<'a> {
+impl RetrieveTaxTransaction {
     /// Construct a new `RetrieveTaxTransaction`.
-    pub fn new(transaction: &'a stripe_misc::TaxTransactionId) -> Self {
-        Self { transaction, inner: RetrieveTaxTransactionBuilder::new() }
+    pub fn new(transaction: impl Into<stripe_misc::TaxTransactionId>) -> Self {
+        Self { transaction: transaction.into(), inner: RetrieveTaxTransactionBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveTaxTransaction<'_> {
+impl RetrieveTaxTransaction {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -47,69 +47,69 @@ impl RetrieveTaxTransaction<'_> {
     }
 }
 
-impl StripeRequest for RetrieveTaxTransaction<'_> {
+impl StripeRequest for RetrieveTaxTransaction {
     type Output = stripe_misc::TaxTransaction;
 
     fn build(&self) -> RequestBuilder {
-        let transaction = self.transaction;
+        let transaction = &self.transaction;
         RequestBuilder::new(StripeMethod::Get, format!("/tax/transactions/{transaction}"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListLineItemsTaxTransactionBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListLineItemsTaxTransactionBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListLineItemsTaxTransactionBuilder<'a> {
+impl ListLineItemsTaxTransactionBuilder {
     fn new() -> Self {
         Self { ending_before: None, expand: None, limit: None, starting_after: None }
     }
 }
 /// Retrieves the line items of a committed standalone transaction as a collection.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListLineItemsTaxTransaction<'a> {
-    inner: ListLineItemsTaxTransactionBuilder<'a>,
-    transaction: &'a stripe_misc::TaxTransactionId,
+pub struct ListLineItemsTaxTransaction {
+    inner: ListLineItemsTaxTransactionBuilder,
+    transaction: stripe_misc::TaxTransactionId,
 }
-impl<'a> ListLineItemsTaxTransaction<'a> {
+impl ListLineItemsTaxTransaction {
     /// Construct a new `ListLineItemsTaxTransaction`.
-    pub fn new(transaction: &'a stripe_misc::TaxTransactionId) -> Self {
-        Self { transaction, inner: ListLineItemsTaxTransactionBuilder::new() }
+    pub fn new(transaction: impl Into<stripe_misc::TaxTransactionId>) -> Self {
+        Self { transaction: transaction.into(), inner: ListLineItemsTaxTransactionBuilder::new() }
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl ListLineItemsTaxTransaction<'_> {
+impl ListLineItemsTaxTransaction {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -130,20 +130,20 @@ impl ListLineItemsTaxTransaction<'_> {
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_misc::TaxTransactionLineItem>>
     {
-        let transaction = self.transaction;
+        let transaction = &self.transaction;
 
         stripe_client_core::ListPaginator::new_list(
             format!("/tax/transactions/{transaction}/line_items"),
-            self.inner,
+            &self.inner,
         )
     }
 }
 
-impl StripeRequest for ListLineItemsTaxTransaction<'_> {
+impl StripeRequest for ListLineItemsTaxTransaction {
     type Output = stripe_types::List<stripe_misc::TaxTransactionLineItem>;
 
     fn build(&self) -> RequestBuilder {
-        let transaction = self.transaction;
+        let transaction = &self.transaction;
         RequestBuilder::new(
             StripeMethod::Get,
             format!("/tax/transactions/{transaction}/line_items"),
@@ -151,45 +151,58 @@ impl StripeRequest for ListLineItemsTaxTransaction<'_> {
         .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateFromCalculationTaxTransactionBuilder<'a> {
-    calculation: &'a str,
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateFromCalculationTaxTransactionBuilder {
+    calculation: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
-    reference: &'a str,
+    metadata: Option<std::collections::HashMap<String, String>>,
+    reference: String,
 }
-impl<'a> CreateFromCalculationTaxTransactionBuilder<'a> {
-    fn new(calculation: &'a str, reference: &'a str) -> Self {
-        Self { calculation, expand: None, metadata: None, reference }
+impl CreateFromCalculationTaxTransactionBuilder {
+    fn new(calculation: impl Into<String>, reference: impl Into<String>) -> Self {
+        Self {
+            calculation: calculation.into(),
+            expand: None,
+            metadata: None,
+            reference: reference.into(),
+        }
     }
 }
 /// Creates a Tax `Transaction` from a calculation.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateFromCalculationTaxTransaction<'a> {
-    inner: CreateFromCalculationTaxTransactionBuilder<'a>,
+pub struct CreateFromCalculationTaxTransaction {
+    inner: CreateFromCalculationTaxTransactionBuilder,
 }
-impl<'a> CreateFromCalculationTaxTransaction<'a> {
+impl CreateFromCalculationTaxTransaction {
     /// Construct a new `CreateFromCalculationTaxTransaction`.
-    pub fn new(calculation: &'a str, reference: &'a str) -> Self {
-        Self { inner: CreateFromCalculationTaxTransactionBuilder::new(calculation, reference) }
+    pub fn new(calculation: impl Into<String>, reference: impl Into<String>) -> Self {
+        Self {
+            inner: CreateFromCalculationTaxTransactionBuilder::new(
+                calculation.into(),
+                reference.into(),
+            ),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
 }
-impl CreateFromCalculationTaxTransaction<'_> {
+impl CreateFromCalculationTaxTransaction {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -207,7 +220,7 @@ impl CreateFromCalculationTaxTransaction<'_> {
     }
 }
 
-impl StripeRequest for CreateFromCalculationTaxTransaction<'_> {
+impl StripeRequest for CreateFromCalculationTaxTransaction {
     type Output = stripe_misc::TaxTransaction;
 
     fn build(&self) -> RequestBuilder {
@@ -215,43 +228,43 @@ impl StripeRequest for CreateFromCalculationTaxTransaction<'_> {
             .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateReversalTaxTransactionBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateReversalTaxTransactionBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     flat_amount: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    line_items: Option<&'a [CreateReversalTaxTransactionLineItems<'a>]>,
+    line_items: Option<Vec<CreateReversalTaxTransactionLineItems>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     mode: CreateReversalTaxTransactionMode,
-    original_transaction: &'a str,
-    reference: &'a str,
+    original_transaction: String,
+    reference: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     shipping_cost: Option<CreateReversalTaxTransactionShippingCost>,
 }
-impl<'a> CreateReversalTaxTransactionBuilder<'a> {
+impl CreateReversalTaxTransactionBuilder {
     fn new(
-        mode: CreateReversalTaxTransactionMode,
-        original_transaction: &'a str,
-        reference: &'a str,
+        mode: impl Into<CreateReversalTaxTransactionMode>,
+        original_transaction: impl Into<String>,
+        reference: impl Into<String>,
     ) -> Self {
         Self {
             expand: None,
             flat_amount: None,
             line_items: None,
             metadata: None,
-            mode,
-            original_transaction,
-            reference,
+            mode: mode.into(),
+            original_transaction: original_transaction.into(),
+            reference: reference.into(),
             shipping_cost: None,
         }
     }
 }
 /// The line item amounts to reverse.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateReversalTaxTransactionLineItems<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateReversalTaxTransactionLineItems {
     /// The amount to reverse, in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal) in negative.
     pub amount: i64,
     /// The amount of tax to reverse, in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal) in negative.
@@ -259,24 +272,31 @@ pub struct CreateReversalTaxTransactionLineItems<'a> {
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// The `id` of the line item to reverse in the original transaction.
-    pub original_line_item: &'a str,
+    pub original_line_item: String,
     /// The quantity reversed.
     /// Appears in [tax exports](https://stripe.com/docs/tax/reports), but does not affect the amount of tax reversed.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub quantity: Option<u64>,
     /// A custom identifier for this line item in the reversal transaction, such as 'L1-refund'.
-    pub reference: &'a str,
+    pub reference: String,
 }
-impl<'a> CreateReversalTaxTransactionLineItems<'a> {
+impl CreateReversalTaxTransactionLineItems {
     pub fn new(
-        amount: i64,
-        amount_tax: i64,
-        original_line_item: &'a str,
-        reference: &'a str,
+        amount: impl Into<i64>,
+        amount_tax: impl Into<i64>,
+        original_line_item: impl Into<String>,
+        reference: impl Into<String>,
     ) -> Self {
-        Self { amount, amount_tax, metadata: None, original_line_item, quantity: None, reference }
+        Self {
+            amount: amount.into(),
+            amount_tax: amount_tax.into(),
+            metadata: None,
+            original_line_item: original_line_item.into(),
+            quantity: None,
+            reference: reference.into(),
+        }
     }
 }
 /// If `partial`, the provided line item or shipping cost amounts are reversed.
@@ -345,63 +365,70 @@ pub struct CreateReversalTaxTransactionShippingCost {
     pub amount_tax: i64,
 }
 impl CreateReversalTaxTransactionShippingCost {
-    pub fn new(amount: i64, amount_tax: i64) -> Self {
-        Self { amount, amount_tax }
+    pub fn new(amount: impl Into<i64>, amount_tax: impl Into<i64>) -> Self {
+        Self { amount: amount.into(), amount_tax: amount_tax.into() }
     }
 }
 /// Partially or fully reverses a previously created `Transaction`.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateReversalTaxTransaction<'a> {
-    inner: CreateReversalTaxTransactionBuilder<'a>,
+pub struct CreateReversalTaxTransaction {
+    inner: CreateReversalTaxTransactionBuilder,
 }
-impl<'a> CreateReversalTaxTransaction<'a> {
+impl CreateReversalTaxTransaction {
     /// Construct a new `CreateReversalTaxTransaction`.
     pub fn new(
-        mode: CreateReversalTaxTransactionMode,
-        original_transaction: &'a str,
-        reference: &'a str,
+        mode: impl Into<CreateReversalTaxTransactionMode>,
+        original_transaction: impl Into<String>,
+        reference: impl Into<String>,
     ) -> Self {
         Self {
-            inner: CreateReversalTaxTransactionBuilder::new(mode, original_transaction, reference),
+            inner: CreateReversalTaxTransactionBuilder::new(
+                mode.into(),
+                original_transaction.into(),
+                reference.into(),
+            ),
         }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A flat amount to reverse across the entire transaction, in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal) in negative.
     /// This value represents the total amount to refund from the transaction, including taxes.
-    pub fn flat_amount(mut self, flat_amount: i64) -> Self {
-        self.inner.flat_amount = Some(flat_amount);
+    pub fn flat_amount(mut self, flat_amount: impl Into<i64>) -> Self {
+        self.inner.flat_amount = Some(flat_amount.into());
         self
     }
     /// The line item amounts to reverse.
     pub fn line_items(
         mut self,
-        line_items: &'a [CreateReversalTaxTransactionLineItems<'a>],
+        line_items: impl Into<Vec<CreateReversalTaxTransactionLineItems>>,
     ) -> Self {
-        self.inner.line_items = Some(line_items);
+        self.inner.line_items = Some(line_items.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// The shipping cost to reverse.
     pub fn shipping_cost(
         mut self,
-        shipping_cost: CreateReversalTaxTransactionShippingCost,
+        shipping_cost: impl Into<CreateReversalTaxTransactionShippingCost>,
     ) -> Self {
-        self.inner.shipping_cost = Some(shipping_cost);
+        self.inner.shipping_cost = Some(shipping_cost.into());
         self
     }
 }
-impl CreateReversalTaxTransaction<'_> {
+impl CreateReversalTaxTransaction {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -419,7 +446,7 @@ impl CreateReversalTaxTransaction<'_> {
     }
 }
 
-impl StripeRequest for CreateReversalTaxTransaction<'_> {
+impl StripeRequest for CreateReversalTaxTransaction {
     type Output = stripe_misc::TaxTransaction;
 
     fn build(&self) -> RequestBuilder {

--- a/generated/async-stripe-misc/src/webhook_endpoint/requests.rs
+++ b/generated/async-stripe-misc/src/webhook_endpoint/requests.rs
@@ -4,16 +4,16 @@ use stripe_client_core::{
 
 /// You can also delete webhook endpoints via the [webhook endpoint management](https://dashboard.stripe.com/account/webhooks) page of the Stripe dashboard.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct DeleteWebhookEndpoint<'a> {
-    webhook_endpoint: &'a stripe_misc::WebhookEndpointId,
+pub struct DeleteWebhookEndpoint {
+    webhook_endpoint: stripe_misc::WebhookEndpointId,
 }
-impl<'a> DeleteWebhookEndpoint<'a> {
+impl DeleteWebhookEndpoint {
     /// Construct a new `DeleteWebhookEndpoint`.
-    pub fn new(webhook_endpoint: &'a stripe_misc::WebhookEndpointId) -> Self {
-        Self { webhook_endpoint }
+    pub fn new(webhook_endpoint: impl Into<stripe_misc::WebhookEndpointId>) -> Self {
+        Self { webhook_endpoint: webhook_endpoint.into() }
     }
 }
-impl DeleteWebhookEndpoint<'_> {
+impl DeleteWebhookEndpoint {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -31,36 +31,36 @@ impl DeleteWebhookEndpoint<'_> {
     }
 }
 
-impl StripeRequest for DeleteWebhookEndpoint<'_> {
+impl StripeRequest for DeleteWebhookEndpoint {
     type Output = stripe_misc::DeletedWebhookEndpoint;
 
     fn build(&self) -> RequestBuilder {
-        let webhook_endpoint = self.webhook_endpoint;
+        let webhook_endpoint = &self.webhook_endpoint;
         RequestBuilder::new(StripeMethod::Delete, format!("/webhook_endpoints/{webhook_endpoint}"))
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListWebhookEndpointBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListWebhookEndpointBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListWebhookEndpointBuilder<'a> {
+impl ListWebhookEndpointBuilder {
     fn new() -> Self {
         Self { ending_before: None, expand: None, limit: None, starting_after: None }
     }
 }
 /// Returns a list of your webhook endpoints.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListWebhookEndpoint<'a> {
-    inner: ListWebhookEndpointBuilder<'a>,
+pub struct ListWebhookEndpoint {
+    inner: ListWebhookEndpointBuilder,
 }
-impl<'a> ListWebhookEndpoint<'a> {
+impl ListWebhookEndpoint {
     /// Construct a new `ListWebhookEndpoint`.
     pub fn new() -> Self {
         Self { inner: ListWebhookEndpointBuilder::new() }
@@ -68,35 +68,35 @@ impl<'a> ListWebhookEndpoint<'a> {
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl<'a> Default for ListWebhookEndpoint<'a> {
+impl Default for ListWebhookEndpoint {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListWebhookEndpoint<'_> {
+impl ListWebhookEndpoint {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -116,45 +116,48 @@ impl ListWebhookEndpoint<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_misc::WebhookEndpoint>> {
-        stripe_client_core::ListPaginator::new_list("/webhook_endpoints", self.inner)
+        stripe_client_core::ListPaginator::new_list("/webhook_endpoints", &self.inner)
     }
 }
 
-impl StripeRequest for ListWebhookEndpoint<'_> {
+impl StripeRequest for ListWebhookEndpoint {
     type Output = stripe_types::List<stripe_misc::WebhookEndpoint>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/webhook_endpoints").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveWebhookEndpointBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveWebhookEndpointBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveWebhookEndpointBuilder<'a> {
+impl RetrieveWebhookEndpointBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves the webhook endpoint with the given ID.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveWebhookEndpoint<'a> {
-    inner: RetrieveWebhookEndpointBuilder<'a>,
-    webhook_endpoint: &'a stripe_misc::WebhookEndpointId,
+pub struct RetrieveWebhookEndpoint {
+    inner: RetrieveWebhookEndpointBuilder,
+    webhook_endpoint: stripe_misc::WebhookEndpointId,
 }
-impl<'a> RetrieveWebhookEndpoint<'a> {
+impl RetrieveWebhookEndpoint {
     /// Construct a new `RetrieveWebhookEndpoint`.
-    pub fn new(webhook_endpoint: &'a stripe_misc::WebhookEndpointId) -> Self {
-        Self { webhook_endpoint, inner: RetrieveWebhookEndpointBuilder::new() }
+    pub fn new(webhook_endpoint: impl Into<stripe_misc::WebhookEndpointId>) -> Self {
+        Self {
+            webhook_endpoint: webhook_endpoint.into(),
+            inner: RetrieveWebhookEndpointBuilder::new(),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveWebhookEndpoint<'_> {
+impl RetrieveWebhookEndpoint {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -172,40 +175,43 @@ impl RetrieveWebhookEndpoint<'_> {
     }
 }
 
-impl StripeRequest for RetrieveWebhookEndpoint<'_> {
+impl StripeRequest for RetrieveWebhookEndpoint {
     type Output = stripe_misc::WebhookEndpoint;
 
     fn build(&self) -> RequestBuilder {
-        let webhook_endpoint = self.webhook_endpoint;
+        let webhook_endpoint = &self.webhook_endpoint;
         RequestBuilder::new(StripeMethod::Get, format!("/webhook_endpoints/{webhook_endpoint}"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateWebhookEndpointBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateWebhookEndpointBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     api_version: Option<stripe_shared::ApiVersion>,
     #[serde(skip_serializing_if = "Option::is_none")]
     connect: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<&'a str>,
-    enabled_events: &'a [CreateWebhookEndpointEnabledEvents],
+    description: Option<String>,
+    enabled_events: Vec<CreateWebhookEndpointEnabledEvents>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
-    url: &'a str,
+    metadata: Option<std::collections::HashMap<String, String>>,
+    url: String,
 }
-impl<'a> CreateWebhookEndpointBuilder<'a> {
-    fn new(enabled_events: &'a [CreateWebhookEndpointEnabledEvents], url: &'a str) -> Self {
+impl CreateWebhookEndpointBuilder {
+    fn new(
+        enabled_events: impl Into<Vec<CreateWebhookEndpointEnabledEvents>>,
+        url: impl Into<String>,
+    ) -> Self {
         Self {
             api_version: None,
             connect: None,
             description: None,
-            enabled_events,
+            enabled_events: enabled_events.into(),
             expand: None,
             metadata: None,
-            url,
+            url: url.into(),
         }
     }
 }
@@ -1003,45 +1009,51 @@ impl<'de> serde::Deserialize<'de> for CreateWebhookEndpointEnabledEvents {
 /// If set to true, then a Connect webhook endpoint that notifies the specified `url` about events from all connected accounts is created; otherwise an account webhook endpoint that notifies the specified `url` only about events from your account is created.
 /// You can also create webhook endpoints in the [webhooks settings](https://dashboard.stripe.com/account/webhooks) section of the Dashboard.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateWebhookEndpoint<'a> {
-    inner: CreateWebhookEndpointBuilder<'a>,
+pub struct CreateWebhookEndpoint {
+    inner: CreateWebhookEndpointBuilder,
 }
-impl<'a> CreateWebhookEndpoint<'a> {
+impl CreateWebhookEndpoint {
     /// Construct a new `CreateWebhookEndpoint`.
-    pub fn new(enabled_events: &'a [CreateWebhookEndpointEnabledEvents], url: &'a str) -> Self {
-        Self { inner: CreateWebhookEndpointBuilder::new(enabled_events, url) }
+    pub fn new(
+        enabled_events: impl Into<Vec<CreateWebhookEndpointEnabledEvents>>,
+        url: impl Into<String>,
+    ) -> Self {
+        Self { inner: CreateWebhookEndpointBuilder::new(enabled_events.into(), url.into()) }
     }
     /// Events sent to this endpoint will be generated with this Stripe Version instead of your account's default Stripe Version.
-    pub fn api_version(mut self, api_version: stripe_shared::ApiVersion) -> Self {
-        self.inner.api_version = Some(api_version);
+    pub fn api_version(mut self, api_version: impl Into<stripe_shared::ApiVersion>) -> Self {
+        self.inner.api_version = Some(api_version.into());
         self
     }
     /// Whether this endpoint should receive events from connected accounts (`true`), or from your account (`false`).
     /// Defaults to `false`.
-    pub fn connect(mut self, connect: bool) -> Self {
-        self.inner.connect = Some(connect);
+    pub fn connect(mut self, connect: impl Into<bool>) -> Self {
+        self.inner.connect = Some(connect.into());
         self
     }
     /// An optional description of what the webhook is used for.
-    pub fn description(mut self, description: &'a str) -> Self {
-        self.inner.description = Some(description);
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.inner.description = Some(description.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
 }
-impl CreateWebhookEndpoint<'_> {
+impl CreateWebhookEndpoint {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -1059,29 +1071,29 @@ impl CreateWebhookEndpoint<'_> {
     }
 }
 
-impl StripeRequest for CreateWebhookEndpoint<'_> {
+impl StripeRequest for CreateWebhookEndpoint {
     type Output = stripe_misc::WebhookEndpoint;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Post, "/webhook_endpoints").form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdateWebhookEndpointBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdateWebhookEndpointBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<&'a str>,
+    description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     disabled: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    enabled_events: Option<&'a [UpdateWebhookEndpointEnabledEvents]>,
+    enabled_events: Option<Vec<UpdateWebhookEndpointEnabledEvents>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    url: Option<&'a str>,
+    url: Option<String>,
 }
-impl<'a> UpdateWebhookEndpointBuilder<'a> {
+impl UpdateWebhookEndpointBuilder {
     fn new() -> Self {
         Self {
             description: None,
@@ -1885,54 +1897,60 @@ impl<'de> serde::Deserialize<'de> for UpdateWebhookEndpointEnabledEvents {
 /// Updates the webhook endpoint.
 /// You may edit the `url`, the list of `enabled_events`, and the status of your endpoint.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateWebhookEndpoint<'a> {
-    inner: UpdateWebhookEndpointBuilder<'a>,
-    webhook_endpoint: &'a stripe_misc::WebhookEndpointId,
+pub struct UpdateWebhookEndpoint {
+    inner: UpdateWebhookEndpointBuilder,
+    webhook_endpoint: stripe_misc::WebhookEndpointId,
 }
-impl<'a> UpdateWebhookEndpoint<'a> {
+impl UpdateWebhookEndpoint {
     /// Construct a new `UpdateWebhookEndpoint`.
-    pub fn new(webhook_endpoint: &'a stripe_misc::WebhookEndpointId) -> Self {
-        Self { webhook_endpoint, inner: UpdateWebhookEndpointBuilder::new() }
+    pub fn new(webhook_endpoint: impl Into<stripe_misc::WebhookEndpointId>) -> Self {
+        Self {
+            webhook_endpoint: webhook_endpoint.into(),
+            inner: UpdateWebhookEndpointBuilder::new(),
+        }
     }
     /// An optional description of what the webhook is used for.
-    pub fn description(mut self, description: &'a str) -> Self {
-        self.inner.description = Some(description);
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.inner.description = Some(description.into());
         self
     }
     /// Disable the webhook endpoint if set to true.
-    pub fn disabled(mut self, disabled: bool) -> Self {
-        self.inner.disabled = Some(disabled);
+    pub fn disabled(mut self, disabled: impl Into<bool>) -> Self {
+        self.inner.disabled = Some(disabled.into());
         self
     }
     /// The list of events to enable for this endpoint.
     /// You may specify `['*']` to enable all events, except those that require explicit selection.
     pub fn enabled_events(
         mut self,
-        enabled_events: &'a [UpdateWebhookEndpointEnabledEvents],
+        enabled_events: impl Into<Vec<UpdateWebhookEndpointEnabledEvents>>,
     ) -> Self {
-        self.inner.enabled_events = Some(enabled_events);
+        self.inner.enabled_events = Some(enabled_events.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// The URL of the webhook endpoint.
-    pub fn url(mut self, url: &'a str) -> Self {
-        self.inner.url = Some(url);
+    pub fn url(mut self, url: impl Into<String>) -> Self {
+        self.inner.url = Some(url.into());
         self
     }
 }
-impl UpdateWebhookEndpoint<'_> {
+impl UpdateWebhookEndpoint {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -1950,11 +1968,11 @@ impl UpdateWebhookEndpoint<'_> {
     }
 }
 
-impl StripeRequest for UpdateWebhookEndpoint<'_> {
+impl StripeRequest for UpdateWebhookEndpoint {
     type Output = stripe_misc::WebhookEndpoint;
 
     fn build(&self) -> RequestBuilder {
-        let webhook_endpoint = self.webhook_endpoint;
+        let webhook_endpoint = &self.webhook_endpoint;
         RequestBuilder::new(StripeMethod::Post, format!("/webhook_endpoints/{webhook_endpoint}"))
             .form(&self.inner)
     }

--- a/generated/async-stripe-payment/src/bank_account/requests.rs
+++ b/generated/async-stripe-payment/src/bank_account/requests.rs
@@ -4,17 +4,17 @@ use stripe_client_core::{
 
 /// Delete a specified external account for a given account.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct DeleteAccountBankAccount<'a> {
-    account: &'a stripe_shared::AccountId,
-    id: &'a str,
+pub struct DeleteAccountBankAccount {
+    account: stripe_shared::AccountId,
+    id: String,
 }
-impl<'a> DeleteAccountBankAccount<'a> {
+impl DeleteAccountBankAccount {
     /// Construct a new `DeleteAccountBankAccount`.
-    pub fn new(account: &'a stripe_shared::AccountId, id: &'a str) -> Self {
-        Self { account, id }
+    pub fn new(account: impl Into<stripe_shared::AccountId>, id: impl Into<String>) -> Self {
+        Self { account: account.into(), id: id.into() }
     }
 }
-impl DeleteAccountBankAccount<'_> {
+impl DeleteAccountBankAccount {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -32,47 +32,51 @@ impl DeleteAccountBankAccount<'_> {
     }
 }
 
-impl StripeRequest for DeleteAccountBankAccount<'_> {
+impl StripeRequest for DeleteAccountBankAccount {
     type Output = stripe_shared::DeletedExternalAccount;
 
     fn build(&self) -> RequestBuilder {
-        let account = self.account;
-        let id = self.id;
+        let account = &self.account;
+        let id = &self.id;
         RequestBuilder::new(
             StripeMethod::Delete,
             format!("/accounts/{account}/external_accounts/{id}"),
         )
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct DeleteCustomerBankAccountBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct DeleteCustomerBankAccountBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> DeleteCustomerBankAccountBuilder<'a> {
+impl DeleteCustomerBankAccountBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Delete a specified source for a given customer.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct DeleteCustomerBankAccount<'a> {
-    inner: DeleteCustomerBankAccountBuilder<'a>,
-    customer: &'a stripe_shared::CustomerId,
-    id: &'a str,
+pub struct DeleteCustomerBankAccount {
+    inner: DeleteCustomerBankAccountBuilder,
+    customer: stripe_shared::CustomerId,
+    id: String,
 }
-impl<'a> DeleteCustomerBankAccount<'a> {
+impl DeleteCustomerBankAccount {
     /// Construct a new `DeleteCustomerBankAccount`.
-    pub fn new(customer: &'a stripe_shared::CustomerId, id: &'a str) -> Self {
-        Self { customer, id, inner: DeleteCustomerBankAccountBuilder::new() }
+    pub fn new(customer: impl Into<stripe_shared::CustomerId>, id: impl Into<String>) -> Self {
+        Self {
+            customer: customer.into(),
+            id: id.into(),
+            inner: DeleteCustomerBankAccountBuilder::new(),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl DeleteCustomerBankAccount<'_> {
+impl DeleteCustomerBankAccount {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -90,12 +94,12 @@ impl DeleteCustomerBankAccount<'_> {
     }
 }
 
-impl StripeRequest for DeleteCustomerBankAccount<'_> {
+impl StripeRequest for DeleteCustomerBankAccount {
     type Output = DeleteCustomerBankAccountReturned;
 
     fn build(&self) -> RequestBuilder {
-        let customer = self.customer;
-        let id = self.id;
+        let customer = &self.customer;
+        let id = &self.id;
         RequestBuilder::new(StripeMethod::Delete, format!("/customers/{customer}/sources/{id}"))
             .form(&self.inner)
     }
@@ -182,42 +186,42 @@ const _: () = {
     }
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdateAccountBankAccountBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdateAccountBankAccountBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    account_holder_name: Option<&'a str>,
+    account_holder_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     account_holder_type: Option<UpdateAccountBankAccountAccountHolderType>,
     #[serde(skip_serializing_if = "Option::is_none")]
     account_type: Option<UpdateAccountBankAccountAccountType>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    address_city: Option<&'a str>,
+    address_city: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    address_country: Option<&'a str>,
+    address_country: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    address_line1: Option<&'a str>,
+    address_line1: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    address_line2: Option<&'a str>,
+    address_line2: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    address_state: Option<&'a str>,
+    address_state: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    address_zip: Option<&'a str>,
+    address_zip: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     default_for_currency: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    documents: Option<UpdateAccountBankAccountDocuments<'a>>,
+    documents: Option<UpdateAccountBankAccountDocuments>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    exp_month: Option<&'a str>,
+    exp_month: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    exp_year: Option<&'a str>,
+    exp_year: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    name: Option<&'a str>,
+    name: Option<String>,
 }
-impl<'a> UpdateAccountBankAccountBuilder<'a> {
+impl UpdateAccountBankAccountBuilder {
     fn new() -> Self {
         Self {
             account_holder_name: None,
@@ -360,38 +364,38 @@ impl<'de> serde::Deserialize<'de> for UpdateAccountBankAccountAccountType {
     }
 }
 /// Documents that may be submitted to satisfy various informational requests.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateAccountBankAccountDocuments<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateAccountBankAccountDocuments {
     /// One or more documents that support the [Bank account ownership verification](https://support.stripe.com/questions/bank-account-ownership-verification) requirement.
     /// Must be a document associated with the bank account that displays the last 4 digits of the account number, either a statement or a voided check.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bank_account_ownership_verification:
-        Option<UpdateAccountBankAccountDocumentsBankAccountOwnershipVerification<'a>>,
+        Option<UpdateAccountBankAccountDocumentsBankAccountOwnershipVerification>,
 }
-impl<'a> UpdateAccountBankAccountDocuments<'a> {
+impl UpdateAccountBankAccountDocuments {
     pub fn new() -> Self {
         Self { bank_account_ownership_verification: None }
     }
 }
-impl<'a> Default for UpdateAccountBankAccountDocuments<'a> {
+impl Default for UpdateAccountBankAccountDocuments {
     fn default() -> Self {
         Self::new()
     }
 }
 /// One or more documents that support the [Bank account ownership verification](https://support.stripe.com/questions/bank-account-ownership-verification) requirement.
 /// Must be a document associated with the bank account that displays the last 4 digits of the account number, either a statement or a voided check.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateAccountBankAccountDocumentsBankAccountOwnershipVerification<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateAccountBankAccountDocumentsBankAccountOwnershipVerification {
     /// One or more document ids returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `account_requirement`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub files: Option<&'a [&'a str]>,
+    pub files: Option<Vec<String>>,
 }
-impl<'a> UpdateAccountBankAccountDocumentsBankAccountOwnershipVerification<'a> {
+impl UpdateAccountBankAccountDocumentsBankAccountOwnershipVerification {
     pub fn new() -> Self {
         Self { files: None }
     }
 }
-impl<'a> Default for UpdateAccountBankAccountDocumentsBankAccountOwnershipVerification<'a> {
+impl Default for UpdateAccountBankAccountDocumentsBankAccountOwnershipVerification {
     fn default() -> Self {
         Self::new()
     }
@@ -405,106 +409,116 @@ impl<'a> Default for UpdateAccountBankAccountDocumentsBankAccountOwnershipVerifi
 /// You can re-enable a disabled bank account by performing an update call without providing any
 /// arguments or changes.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateAccountBankAccount<'a> {
-    inner: UpdateAccountBankAccountBuilder<'a>,
-    account: &'a stripe_shared::AccountId,
-    id: &'a str,
+pub struct UpdateAccountBankAccount {
+    inner: UpdateAccountBankAccountBuilder,
+    account: stripe_shared::AccountId,
+    id: String,
 }
-impl<'a> UpdateAccountBankAccount<'a> {
+impl UpdateAccountBankAccount {
     /// Construct a new `UpdateAccountBankAccount`.
-    pub fn new(account: &'a stripe_shared::AccountId, id: &'a str) -> Self {
-        Self { account, id, inner: UpdateAccountBankAccountBuilder::new() }
+    pub fn new(account: impl Into<stripe_shared::AccountId>, id: impl Into<String>) -> Self {
+        Self {
+            account: account.into(),
+            id: id.into(),
+            inner: UpdateAccountBankAccountBuilder::new(),
+        }
     }
     /// The name of the person or business that owns the bank account.
-    pub fn account_holder_name(mut self, account_holder_name: &'a str) -> Self {
-        self.inner.account_holder_name = Some(account_holder_name);
+    pub fn account_holder_name(mut self, account_holder_name: impl Into<String>) -> Self {
+        self.inner.account_holder_name = Some(account_holder_name.into());
         self
     }
     /// The type of entity that holds the account. This can be either `individual` or `company`.
     pub fn account_holder_type(
         mut self,
-        account_holder_type: UpdateAccountBankAccountAccountHolderType,
+        account_holder_type: impl Into<UpdateAccountBankAccountAccountHolderType>,
     ) -> Self {
-        self.inner.account_holder_type = Some(account_holder_type);
+        self.inner.account_holder_type = Some(account_holder_type.into());
         self
     }
     /// The bank account type.
     /// This can only be `checking` or `savings` in most countries.
     /// In Japan, this can only be `futsu` or `toza`.
-    pub fn account_type(mut self, account_type: UpdateAccountBankAccountAccountType) -> Self {
-        self.inner.account_type = Some(account_type);
+    pub fn account_type(
+        mut self,
+        account_type: impl Into<UpdateAccountBankAccountAccountType>,
+    ) -> Self {
+        self.inner.account_type = Some(account_type.into());
         self
     }
     /// City/District/Suburb/Town/Village.
-    pub fn address_city(mut self, address_city: &'a str) -> Self {
-        self.inner.address_city = Some(address_city);
+    pub fn address_city(mut self, address_city: impl Into<String>) -> Self {
+        self.inner.address_city = Some(address_city.into());
         self
     }
     /// Billing address country, if provided when creating card.
-    pub fn address_country(mut self, address_country: &'a str) -> Self {
-        self.inner.address_country = Some(address_country);
+    pub fn address_country(mut self, address_country: impl Into<String>) -> Self {
+        self.inner.address_country = Some(address_country.into());
         self
     }
     /// Address line 1 (Street address/PO Box/Company name).
-    pub fn address_line1(mut self, address_line1: &'a str) -> Self {
-        self.inner.address_line1 = Some(address_line1);
+    pub fn address_line1(mut self, address_line1: impl Into<String>) -> Self {
+        self.inner.address_line1 = Some(address_line1.into());
         self
     }
     /// Address line 2 (Apartment/Suite/Unit/Building).
-    pub fn address_line2(mut self, address_line2: &'a str) -> Self {
-        self.inner.address_line2 = Some(address_line2);
+    pub fn address_line2(mut self, address_line2: impl Into<String>) -> Self {
+        self.inner.address_line2 = Some(address_line2.into());
         self
     }
     /// State/County/Province/Region.
-    pub fn address_state(mut self, address_state: &'a str) -> Self {
-        self.inner.address_state = Some(address_state);
+    pub fn address_state(mut self, address_state: impl Into<String>) -> Self {
+        self.inner.address_state = Some(address_state.into());
         self
     }
     /// ZIP or postal code.
-    pub fn address_zip(mut self, address_zip: &'a str) -> Self {
-        self.inner.address_zip = Some(address_zip);
+    pub fn address_zip(mut self, address_zip: impl Into<String>) -> Self {
+        self.inner.address_zip = Some(address_zip.into());
         self
     }
     /// When set to true, this becomes the default external account for its currency.
-    pub fn default_for_currency(mut self, default_for_currency: bool) -> Self {
-        self.inner.default_for_currency = Some(default_for_currency);
+    pub fn default_for_currency(mut self, default_for_currency: impl Into<bool>) -> Self {
+        self.inner.default_for_currency = Some(default_for_currency.into());
         self
     }
     /// Documents that may be submitted to satisfy various informational requests.
-    pub fn documents(mut self, documents: UpdateAccountBankAccountDocuments<'a>) -> Self {
-        self.inner.documents = Some(documents);
+    pub fn documents(mut self, documents: impl Into<UpdateAccountBankAccountDocuments>) -> Self {
+        self.inner.documents = Some(documents.into());
         self
     }
     /// Two digit number representing the card’s expiration month.
-    pub fn exp_month(mut self, exp_month: &'a str) -> Self {
-        self.inner.exp_month = Some(exp_month);
+    pub fn exp_month(mut self, exp_month: impl Into<String>) -> Self {
+        self.inner.exp_month = Some(exp_month.into());
         self
     }
     /// Four digit number representing the card’s expiration year.
-    pub fn exp_year(mut self, exp_year: &'a str) -> Self {
-        self.inner.exp_year = Some(exp_year);
+    pub fn exp_year(mut self, exp_year: impl Into<String>) -> Self {
+        self.inner.exp_year = Some(exp_year.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// Cardholder name.
-    pub fn name(mut self, name: &'a str) -> Self {
-        self.inner.name = Some(name);
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.inner.name = Some(name.into());
         self
     }
 }
-impl UpdateAccountBankAccount<'_> {
+impl UpdateAccountBankAccount {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -522,12 +536,12 @@ impl UpdateAccountBankAccount<'_> {
     }
 }
 
-impl StripeRequest for UpdateAccountBankAccount<'_> {
+impl StripeRequest for UpdateAccountBankAccount {
     type Output = stripe_shared::ExternalAccount;
 
     fn build(&self) -> RequestBuilder {
-        let account = self.account;
-        let id = self.id;
+        let account = &self.account;
+        let id = &self.id;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/accounts/{account}/external_accounts/{id}"),
@@ -535,38 +549,38 @@ impl StripeRequest for UpdateAccountBankAccount<'_> {
         .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdateCustomerBankAccountBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdateCustomerBankAccountBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    account_holder_name: Option<&'a str>,
+    account_holder_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     account_holder_type: Option<UpdateCustomerBankAccountAccountHolderType>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    address_city: Option<&'a str>,
+    address_city: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    address_country: Option<&'a str>,
+    address_country: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    address_line1: Option<&'a str>,
+    address_line1: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    address_line2: Option<&'a str>,
+    address_line2: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    address_state: Option<&'a str>,
+    address_state: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    address_zip: Option<&'a str>,
+    address_zip: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    exp_month: Option<&'a str>,
+    exp_month: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    exp_year: Option<&'a str>,
+    exp_year: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    name: Option<&'a str>,
+    name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    owner: Option<UpdateCustomerBankAccountOwner<'a>>,
+    owner: Option<UpdateCustomerBankAccountOwner>,
 }
-impl<'a> UpdateCustomerBankAccountBuilder<'a> {
+impl UpdateCustomerBankAccountBuilder {
     fn new() -> Self {
         Self {
             account_holder_name: None,
@@ -642,152 +656,159 @@ impl<'de> serde::Deserialize<'de> for UpdateCustomerBankAccountAccountHolderType
         })
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateCustomerBankAccountOwner<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateCustomerBankAccountOwner {
     /// Owner's address.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub address: Option<UpdateCustomerBankAccountOwnerAddress<'a>>,
+    pub address: Option<UpdateCustomerBankAccountOwnerAddress>,
     /// Owner's email address.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub email: Option<&'a str>,
+    pub email: Option<String>,
     /// Owner's full name.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<&'a str>,
+    pub name: Option<String>,
     /// Owner's phone number.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub phone: Option<&'a str>,
+    pub phone: Option<String>,
 }
-impl<'a> UpdateCustomerBankAccountOwner<'a> {
+impl UpdateCustomerBankAccountOwner {
     pub fn new() -> Self {
         Self { address: None, email: None, name: None, phone: None }
     }
 }
-impl<'a> Default for UpdateCustomerBankAccountOwner<'a> {
+impl Default for UpdateCustomerBankAccountOwner {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Owner's address.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateCustomerBankAccountOwnerAddress<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateCustomerBankAccountOwnerAddress {
     /// City, district, suburb, town, or village.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<&'a str>,
+    pub city: Option<String>,
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub country: Option<&'a str>,
+    pub country: Option<String>,
     /// Address line 1 (e.g., street, PO Box, or company name).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line1: Option<&'a str>,
+    pub line1: Option<String>,
     /// Address line 2 (e.g., apartment, suite, unit, or building).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line2: Option<&'a str>,
+    pub line2: Option<String>,
     /// ZIP or postal code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<&'a str>,
+    pub postal_code: Option<String>,
     /// State, county, province, or region.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
 }
-impl<'a> UpdateCustomerBankAccountOwnerAddress<'a> {
+impl UpdateCustomerBankAccountOwnerAddress {
     pub fn new() -> Self {
         Self { city: None, country: None, line1: None, line2: None, postal_code: None, state: None }
     }
 }
-impl<'a> Default for UpdateCustomerBankAccountOwnerAddress<'a> {
+impl Default for UpdateCustomerBankAccountOwnerAddress {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Update a specified source for a given customer.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateCustomerBankAccount<'a> {
-    inner: UpdateCustomerBankAccountBuilder<'a>,
-    customer: &'a stripe_shared::CustomerId,
-    id: &'a str,
+pub struct UpdateCustomerBankAccount {
+    inner: UpdateCustomerBankAccountBuilder,
+    customer: stripe_shared::CustomerId,
+    id: String,
 }
-impl<'a> UpdateCustomerBankAccount<'a> {
+impl UpdateCustomerBankAccount {
     /// Construct a new `UpdateCustomerBankAccount`.
-    pub fn new(customer: &'a stripe_shared::CustomerId, id: &'a str) -> Self {
-        Self { customer, id, inner: UpdateCustomerBankAccountBuilder::new() }
+    pub fn new(customer: impl Into<stripe_shared::CustomerId>, id: impl Into<String>) -> Self {
+        Self {
+            customer: customer.into(),
+            id: id.into(),
+            inner: UpdateCustomerBankAccountBuilder::new(),
+        }
     }
     /// The name of the person or business that owns the bank account.
-    pub fn account_holder_name(mut self, account_holder_name: &'a str) -> Self {
-        self.inner.account_holder_name = Some(account_holder_name);
+    pub fn account_holder_name(mut self, account_holder_name: impl Into<String>) -> Self {
+        self.inner.account_holder_name = Some(account_holder_name.into());
         self
     }
     /// The type of entity that holds the account. This can be either `individual` or `company`.
     pub fn account_holder_type(
         mut self,
-        account_holder_type: UpdateCustomerBankAccountAccountHolderType,
+        account_holder_type: impl Into<UpdateCustomerBankAccountAccountHolderType>,
     ) -> Self {
-        self.inner.account_holder_type = Some(account_holder_type);
+        self.inner.account_holder_type = Some(account_holder_type.into());
         self
     }
     /// City/District/Suburb/Town/Village.
-    pub fn address_city(mut self, address_city: &'a str) -> Self {
-        self.inner.address_city = Some(address_city);
+    pub fn address_city(mut self, address_city: impl Into<String>) -> Self {
+        self.inner.address_city = Some(address_city.into());
         self
     }
     /// Billing address country, if provided when creating card.
-    pub fn address_country(mut self, address_country: &'a str) -> Self {
-        self.inner.address_country = Some(address_country);
+    pub fn address_country(mut self, address_country: impl Into<String>) -> Self {
+        self.inner.address_country = Some(address_country.into());
         self
     }
     /// Address line 1 (Street address/PO Box/Company name).
-    pub fn address_line1(mut self, address_line1: &'a str) -> Self {
-        self.inner.address_line1 = Some(address_line1);
+    pub fn address_line1(mut self, address_line1: impl Into<String>) -> Self {
+        self.inner.address_line1 = Some(address_line1.into());
         self
     }
     /// Address line 2 (Apartment/Suite/Unit/Building).
-    pub fn address_line2(mut self, address_line2: &'a str) -> Self {
-        self.inner.address_line2 = Some(address_line2);
+    pub fn address_line2(mut self, address_line2: impl Into<String>) -> Self {
+        self.inner.address_line2 = Some(address_line2.into());
         self
     }
     /// State/County/Province/Region.
-    pub fn address_state(mut self, address_state: &'a str) -> Self {
-        self.inner.address_state = Some(address_state);
+    pub fn address_state(mut self, address_state: impl Into<String>) -> Self {
+        self.inner.address_state = Some(address_state.into());
         self
     }
     /// ZIP or postal code.
-    pub fn address_zip(mut self, address_zip: &'a str) -> Self {
-        self.inner.address_zip = Some(address_zip);
+    pub fn address_zip(mut self, address_zip: impl Into<String>) -> Self {
+        self.inner.address_zip = Some(address_zip.into());
         self
     }
     /// Two digit number representing the card’s expiration month.
-    pub fn exp_month(mut self, exp_month: &'a str) -> Self {
-        self.inner.exp_month = Some(exp_month);
+    pub fn exp_month(mut self, exp_month: impl Into<String>) -> Self {
+        self.inner.exp_month = Some(exp_month.into());
         self
     }
     /// Four digit number representing the card’s expiration year.
-    pub fn exp_year(mut self, exp_year: &'a str) -> Self {
-        self.inner.exp_year = Some(exp_year);
+    pub fn exp_year(mut self, exp_year: impl Into<String>) -> Self {
+        self.inner.exp_year = Some(exp_year.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// Cardholder name.
-    pub fn name(mut self, name: &'a str) -> Self {
-        self.inner.name = Some(name);
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.inner.name = Some(name.into());
         self
     }
-    pub fn owner(mut self, owner: UpdateCustomerBankAccountOwner<'a>) -> Self {
-        self.inner.owner = Some(owner);
+    pub fn owner(mut self, owner: impl Into<UpdateCustomerBankAccountOwner>) -> Self {
+        self.inner.owner = Some(owner.into());
         self
     }
 }
-impl UpdateCustomerBankAccount<'_> {
+impl UpdateCustomerBankAccount {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -805,12 +826,12 @@ impl UpdateCustomerBankAccount<'_> {
     }
 }
 
-impl StripeRequest for UpdateCustomerBankAccount<'_> {
+impl StripeRequest for UpdateCustomerBankAccount {
     type Output = UpdateCustomerBankAccountReturned;
 
     fn build(&self) -> RequestBuilder {
-        let customer = self.customer;
-        let id = self.id;
+        let customer = &self.customer;
+        let id = &self.id;
         RequestBuilder::new(StripeMethod::Post, format!("/customers/{customer}/sources/{id}"))
             .form(&self.inner)
     }
@@ -914,42 +935,42 @@ const _: () = {
     }
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct VerifyBankAccountBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct VerifyBankAccountBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    amounts: Option<&'a [i64]>,
+    amounts: Option<Vec<i64>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> VerifyBankAccountBuilder<'a> {
+impl VerifyBankAccountBuilder {
     fn new() -> Self {
         Self { amounts: None, expand: None }
     }
 }
 /// Verify a specified bank account for a given customer.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct VerifyBankAccount<'a> {
-    inner: VerifyBankAccountBuilder<'a>,
-    customer: &'a stripe_shared::CustomerId,
-    id: &'a str,
+pub struct VerifyBankAccount {
+    inner: VerifyBankAccountBuilder,
+    customer: stripe_shared::CustomerId,
+    id: String,
 }
-impl<'a> VerifyBankAccount<'a> {
+impl VerifyBankAccount {
     /// Construct a new `VerifyBankAccount`.
-    pub fn new(customer: &'a stripe_shared::CustomerId, id: &'a str) -> Self {
-        Self { customer, id, inner: VerifyBankAccountBuilder::new() }
+    pub fn new(customer: impl Into<stripe_shared::CustomerId>, id: impl Into<String>) -> Self {
+        Self { customer: customer.into(), id: id.into(), inner: VerifyBankAccountBuilder::new() }
     }
     /// Two positive integers, in *cents*, equal to the values of the microdeposits sent to the bank account.
-    pub fn amounts(mut self, amounts: &'a [i64]) -> Self {
-        self.inner.amounts = Some(amounts);
+    pub fn amounts(mut self, amounts: impl Into<Vec<i64>>) -> Self {
+        self.inner.amounts = Some(amounts.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl VerifyBankAccount<'_> {
+impl VerifyBankAccount {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -967,12 +988,12 @@ impl VerifyBankAccount<'_> {
     }
 }
 
-impl StripeRequest for VerifyBankAccount<'_> {
+impl StripeRequest for VerifyBankAccount {
     type Output = stripe_shared::BankAccount;
 
     fn build(&self) -> RequestBuilder {
-        let customer = self.customer;
-        let id = self.id;
+        let customer = &self.customer;
+        let id = &self.id;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/customers/{customer}/sources/{id}/verify"),

--- a/generated/async-stripe-payment/src/card/requests.rs
+++ b/generated/async-stripe-payment/src/card/requests.rs
@@ -4,17 +4,17 @@ use stripe_client_core::{
 
 /// Delete a specified external account for a given account.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct DeleteAccountCard<'a> {
-    account: &'a stripe_shared::AccountId,
-    id: &'a str,
+pub struct DeleteAccountCard {
+    account: stripe_shared::AccountId,
+    id: String,
 }
-impl<'a> DeleteAccountCard<'a> {
+impl DeleteAccountCard {
     /// Construct a new `DeleteAccountCard`.
-    pub fn new(account: &'a stripe_shared::AccountId, id: &'a str) -> Self {
-        Self { account, id }
+    pub fn new(account: impl Into<stripe_shared::AccountId>, id: impl Into<String>) -> Self {
+        Self { account: account.into(), id: id.into() }
     }
 }
-impl DeleteAccountCard<'_> {
+impl DeleteAccountCard {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -32,47 +32,47 @@ impl DeleteAccountCard<'_> {
     }
 }
 
-impl StripeRequest for DeleteAccountCard<'_> {
+impl StripeRequest for DeleteAccountCard {
     type Output = stripe_shared::DeletedExternalAccount;
 
     fn build(&self) -> RequestBuilder {
-        let account = self.account;
-        let id = self.id;
+        let account = &self.account;
+        let id = &self.id;
         RequestBuilder::new(
             StripeMethod::Delete,
             format!("/accounts/{account}/external_accounts/{id}"),
         )
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct DeleteCustomerCardBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct DeleteCustomerCardBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> DeleteCustomerCardBuilder<'a> {
+impl DeleteCustomerCardBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Delete a specified source for a given customer.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct DeleteCustomerCard<'a> {
-    inner: DeleteCustomerCardBuilder<'a>,
-    customer: &'a stripe_shared::CustomerId,
-    id: &'a str,
+pub struct DeleteCustomerCard {
+    inner: DeleteCustomerCardBuilder,
+    customer: stripe_shared::CustomerId,
+    id: String,
 }
-impl<'a> DeleteCustomerCard<'a> {
+impl DeleteCustomerCard {
     /// Construct a new `DeleteCustomerCard`.
-    pub fn new(customer: &'a stripe_shared::CustomerId, id: &'a str) -> Self {
-        Self { customer, id, inner: DeleteCustomerCardBuilder::new() }
+    pub fn new(customer: impl Into<stripe_shared::CustomerId>, id: impl Into<String>) -> Self {
+        Self { customer: customer.into(), id: id.into(), inner: DeleteCustomerCardBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl DeleteCustomerCard<'_> {
+impl DeleteCustomerCard {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -90,12 +90,12 @@ impl DeleteCustomerCard<'_> {
     }
 }
 
-impl StripeRequest for DeleteCustomerCard<'_> {
+impl StripeRequest for DeleteCustomerCard {
     type Output = DeleteCustomerCardReturned;
 
     fn build(&self) -> RequestBuilder {
-        let customer = self.customer;
-        let id = self.id;
+        let customer = &self.customer;
+        let id = &self.id;
         RequestBuilder::new(StripeMethod::Delete, format!("/customers/{customer}/sources/{id}"))
             .form(&self.inner)
     }
@@ -182,42 +182,42 @@ const _: () = {
     }
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdateAccountCardBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdateAccountCardBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    account_holder_name: Option<&'a str>,
+    account_holder_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     account_holder_type: Option<UpdateAccountCardAccountHolderType>,
     #[serde(skip_serializing_if = "Option::is_none")]
     account_type: Option<UpdateAccountCardAccountType>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    address_city: Option<&'a str>,
+    address_city: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    address_country: Option<&'a str>,
+    address_country: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    address_line1: Option<&'a str>,
+    address_line1: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    address_line2: Option<&'a str>,
+    address_line2: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    address_state: Option<&'a str>,
+    address_state: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    address_zip: Option<&'a str>,
+    address_zip: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     default_for_currency: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    documents: Option<UpdateAccountCardDocuments<'a>>,
+    documents: Option<UpdateAccountCardDocuments>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    exp_month: Option<&'a str>,
+    exp_month: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    exp_year: Option<&'a str>,
+    exp_year: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    name: Option<&'a str>,
+    name: Option<String>,
 }
-impl<'a> UpdateAccountCardBuilder<'a> {
+impl UpdateAccountCardBuilder {
     fn new() -> Self {
         Self {
             account_holder_name: None,
@@ -359,38 +359,38 @@ impl<'de> serde::Deserialize<'de> for UpdateAccountCardAccountType {
     }
 }
 /// Documents that may be submitted to satisfy various informational requests.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateAccountCardDocuments<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateAccountCardDocuments {
     /// One or more documents that support the [Bank account ownership verification](https://support.stripe.com/questions/bank-account-ownership-verification) requirement.
     /// Must be a document associated with the bank account that displays the last 4 digits of the account number, either a statement or a voided check.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bank_account_ownership_verification:
-        Option<UpdateAccountCardDocumentsBankAccountOwnershipVerification<'a>>,
+        Option<UpdateAccountCardDocumentsBankAccountOwnershipVerification>,
 }
-impl<'a> UpdateAccountCardDocuments<'a> {
+impl UpdateAccountCardDocuments {
     pub fn new() -> Self {
         Self { bank_account_ownership_verification: None }
     }
 }
-impl<'a> Default for UpdateAccountCardDocuments<'a> {
+impl Default for UpdateAccountCardDocuments {
     fn default() -> Self {
         Self::new()
     }
 }
 /// One or more documents that support the [Bank account ownership verification](https://support.stripe.com/questions/bank-account-ownership-verification) requirement.
 /// Must be a document associated with the bank account that displays the last 4 digits of the account number, either a statement or a voided check.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateAccountCardDocumentsBankAccountOwnershipVerification<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateAccountCardDocumentsBankAccountOwnershipVerification {
     /// One or more document ids returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `account_requirement`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub files: Option<&'a [&'a str]>,
+    pub files: Option<Vec<String>>,
 }
-impl<'a> UpdateAccountCardDocumentsBankAccountOwnershipVerification<'a> {
+impl UpdateAccountCardDocumentsBankAccountOwnershipVerification {
     pub fn new() -> Self {
         Self { files: None }
     }
 }
-impl<'a> Default for UpdateAccountCardDocumentsBankAccountOwnershipVerification<'a> {
+impl Default for UpdateAccountCardDocumentsBankAccountOwnershipVerification {
     fn default() -> Self {
         Self::new()
     }
@@ -404,106 +404,109 @@ impl<'a> Default for UpdateAccountCardDocumentsBankAccountOwnershipVerification<
 /// You can re-enable a disabled bank account by performing an update call without providing any
 /// arguments or changes.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateAccountCard<'a> {
-    inner: UpdateAccountCardBuilder<'a>,
-    account: &'a stripe_shared::AccountId,
-    id: &'a str,
+pub struct UpdateAccountCard {
+    inner: UpdateAccountCardBuilder,
+    account: stripe_shared::AccountId,
+    id: String,
 }
-impl<'a> UpdateAccountCard<'a> {
+impl UpdateAccountCard {
     /// Construct a new `UpdateAccountCard`.
-    pub fn new(account: &'a stripe_shared::AccountId, id: &'a str) -> Self {
-        Self { account, id, inner: UpdateAccountCardBuilder::new() }
+    pub fn new(account: impl Into<stripe_shared::AccountId>, id: impl Into<String>) -> Self {
+        Self { account: account.into(), id: id.into(), inner: UpdateAccountCardBuilder::new() }
     }
     /// The name of the person or business that owns the bank account.
-    pub fn account_holder_name(mut self, account_holder_name: &'a str) -> Self {
-        self.inner.account_holder_name = Some(account_holder_name);
+    pub fn account_holder_name(mut self, account_holder_name: impl Into<String>) -> Self {
+        self.inner.account_holder_name = Some(account_holder_name.into());
         self
     }
     /// The type of entity that holds the account. This can be either `individual` or `company`.
     pub fn account_holder_type(
         mut self,
-        account_holder_type: UpdateAccountCardAccountHolderType,
+        account_holder_type: impl Into<UpdateAccountCardAccountHolderType>,
     ) -> Self {
-        self.inner.account_holder_type = Some(account_holder_type);
+        self.inner.account_holder_type = Some(account_holder_type.into());
         self
     }
     /// The bank account type.
     /// This can only be `checking` or `savings` in most countries.
     /// In Japan, this can only be `futsu` or `toza`.
-    pub fn account_type(mut self, account_type: UpdateAccountCardAccountType) -> Self {
-        self.inner.account_type = Some(account_type);
+    pub fn account_type(mut self, account_type: impl Into<UpdateAccountCardAccountType>) -> Self {
+        self.inner.account_type = Some(account_type.into());
         self
     }
     /// City/District/Suburb/Town/Village.
-    pub fn address_city(mut self, address_city: &'a str) -> Self {
-        self.inner.address_city = Some(address_city);
+    pub fn address_city(mut self, address_city: impl Into<String>) -> Self {
+        self.inner.address_city = Some(address_city.into());
         self
     }
     /// Billing address country, if provided when creating card.
-    pub fn address_country(mut self, address_country: &'a str) -> Self {
-        self.inner.address_country = Some(address_country);
+    pub fn address_country(mut self, address_country: impl Into<String>) -> Self {
+        self.inner.address_country = Some(address_country.into());
         self
     }
     /// Address line 1 (Street address/PO Box/Company name).
-    pub fn address_line1(mut self, address_line1: &'a str) -> Self {
-        self.inner.address_line1 = Some(address_line1);
+    pub fn address_line1(mut self, address_line1: impl Into<String>) -> Self {
+        self.inner.address_line1 = Some(address_line1.into());
         self
     }
     /// Address line 2 (Apartment/Suite/Unit/Building).
-    pub fn address_line2(mut self, address_line2: &'a str) -> Self {
-        self.inner.address_line2 = Some(address_line2);
+    pub fn address_line2(mut self, address_line2: impl Into<String>) -> Self {
+        self.inner.address_line2 = Some(address_line2.into());
         self
     }
     /// State/County/Province/Region.
-    pub fn address_state(mut self, address_state: &'a str) -> Self {
-        self.inner.address_state = Some(address_state);
+    pub fn address_state(mut self, address_state: impl Into<String>) -> Self {
+        self.inner.address_state = Some(address_state.into());
         self
     }
     /// ZIP or postal code.
-    pub fn address_zip(mut self, address_zip: &'a str) -> Self {
-        self.inner.address_zip = Some(address_zip);
+    pub fn address_zip(mut self, address_zip: impl Into<String>) -> Self {
+        self.inner.address_zip = Some(address_zip.into());
         self
     }
     /// When set to true, this becomes the default external account for its currency.
-    pub fn default_for_currency(mut self, default_for_currency: bool) -> Self {
-        self.inner.default_for_currency = Some(default_for_currency);
+    pub fn default_for_currency(mut self, default_for_currency: impl Into<bool>) -> Self {
+        self.inner.default_for_currency = Some(default_for_currency.into());
         self
     }
     /// Documents that may be submitted to satisfy various informational requests.
-    pub fn documents(mut self, documents: UpdateAccountCardDocuments<'a>) -> Self {
-        self.inner.documents = Some(documents);
+    pub fn documents(mut self, documents: impl Into<UpdateAccountCardDocuments>) -> Self {
+        self.inner.documents = Some(documents.into());
         self
     }
     /// Two digit number representing the card’s expiration month.
-    pub fn exp_month(mut self, exp_month: &'a str) -> Self {
-        self.inner.exp_month = Some(exp_month);
+    pub fn exp_month(mut self, exp_month: impl Into<String>) -> Self {
+        self.inner.exp_month = Some(exp_month.into());
         self
     }
     /// Four digit number representing the card’s expiration year.
-    pub fn exp_year(mut self, exp_year: &'a str) -> Self {
-        self.inner.exp_year = Some(exp_year);
+    pub fn exp_year(mut self, exp_year: impl Into<String>) -> Self {
+        self.inner.exp_year = Some(exp_year.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// Cardholder name.
-    pub fn name(mut self, name: &'a str) -> Self {
-        self.inner.name = Some(name);
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.inner.name = Some(name.into());
         self
     }
 }
-impl UpdateAccountCard<'_> {
+impl UpdateAccountCard {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -521,12 +524,12 @@ impl UpdateAccountCard<'_> {
     }
 }
 
-impl StripeRequest for UpdateAccountCard<'_> {
+impl StripeRequest for UpdateAccountCard {
     type Output = stripe_shared::ExternalAccount;
 
     fn build(&self) -> RequestBuilder {
-        let account = self.account;
-        let id = self.id;
+        let account = &self.account;
+        let id = &self.id;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/accounts/{account}/external_accounts/{id}"),
@@ -534,38 +537,38 @@ impl StripeRequest for UpdateAccountCard<'_> {
         .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdateCustomerCardBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdateCustomerCardBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    account_holder_name: Option<&'a str>,
+    account_holder_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     account_holder_type: Option<UpdateCustomerCardAccountHolderType>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    address_city: Option<&'a str>,
+    address_city: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    address_country: Option<&'a str>,
+    address_country: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    address_line1: Option<&'a str>,
+    address_line1: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    address_line2: Option<&'a str>,
+    address_line2: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    address_state: Option<&'a str>,
+    address_state: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    address_zip: Option<&'a str>,
+    address_zip: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    exp_month: Option<&'a str>,
+    exp_month: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    exp_year: Option<&'a str>,
+    exp_year: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    name: Option<&'a str>,
+    name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    owner: Option<UpdateCustomerCardOwner<'a>>,
+    owner: Option<UpdateCustomerCardOwner>,
 }
-impl<'a> UpdateCustomerCardBuilder<'a> {
+impl UpdateCustomerCardBuilder {
     fn new() -> Self {
         Self {
             account_holder_name: None,
@@ -641,152 +644,155 @@ impl<'de> serde::Deserialize<'de> for UpdateCustomerCardAccountHolderType {
         })
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateCustomerCardOwner<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateCustomerCardOwner {
     /// Owner's address.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub address: Option<UpdateCustomerCardOwnerAddress<'a>>,
+    pub address: Option<UpdateCustomerCardOwnerAddress>,
     /// Owner's email address.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub email: Option<&'a str>,
+    pub email: Option<String>,
     /// Owner's full name.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<&'a str>,
+    pub name: Option<String>,
     /// Owner's phone number.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub phone: Option<&'a str>,
+    pub phone: Option<String>,
 }
-impl<'a> UpdateCustomerCardOwner<'a> {
+impl UpdateCustomerCardOwner {
     pub fn new() -> Self {
         Self { address: None, email: None, name: None, phone: None }
     }
 }
-impl<'a> Default for UpdateCustomerCardOwner<'a> {
+impl Default for UpdateCustomerCardOwner {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Owner's address.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateCustomerCardOwnerAddress<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateCustomerCardOwnerAddress {
     /// City, district, suburb, town, or village.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<&'a str>,
+    pub city: Option<String>,
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub country: Option<&'a str>,
+    pub country: Option<String>,
     /// Address line 1 (e.g., street, PO Box, or company name).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line1: Option<&'a str>,
+    pub line1: Option<String>,
     /// Address line 2 (e.g., apartment, suite, unit, or building).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line2: Option<&'a str>,
+    pub line2: Option<String>,
     /// ZIP or postal code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<&'a str>,
+    pub postal_code: Option<String>,
     /// State, county, province, or region.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
 }
-impl<'a> UpdateCustomerCardOwnerAddress<'a> {
+impl UpdateCustomerCardOwnerAddress {
     pub fn new() -> Self {
         Self { city: None, country: None, line1: None, line2: None, postal_code: None, state: None }
     }
 }
-impl<'a> Default for UpdateCustomerCardOwnerAddress<'a> {
+impl Default for UpdateCustomerCardOwnerAddress {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Update a specified source for a given customer.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateCustomerCard<'a> {
-    inner: UpdateCustomerCardBuilder<'a>,
-    customer: &'a stripe_shared::CustomerId,
-    id: &'a str,
+pub struct UpdateCustomerCard {
+    inner: UpdateCustomerCardBuilder,
+    customer: stripe_shared::CustomerId,
+    id: String,
 }
-impl<'a> UpdateCustomerCard<'a> {
+impl UpdateCustomerCard {
     /// Construct a new `UpdateCustomerCard`.
-    pub fn new(customer: &'a stripe_shared::CustomerId, id: &'a str) -> Self {
-        Self { customer, id, inner: UpdateCustomerCardBuilder::new() }
+    pub fn new(customer: impl Into<stripe_shared::CustomerId>, id: impl Into<String>) -> Self {
+        Self { customer: customer.into(), id: id.into(), inner: UpdateCustomerCardBuilder::new() }
     }
     /// The name of the person or business that owns the bank account.
-    pub fn account_holder_name(mut self, account_holder_name: &'a str) -> Self {
-        self.inner.account_holder_name = Some(account_holder_name);
+    pub fn account_holder_name(mut self, account_holder_name: impl Into<String>) -> Self {
+        self.inner.account_holder_name = Some(account_holder_name.into());
         self
     }
     /// The type of entity that holds the account. This can be either `individual` or `company`.
     pub fn account_holder_type(
         mut self,
-        account_holder_type: UpdateCustomerCardAccountHolderType,
+        account_holder_type: impl Into<UpdateCustomerCardAccountHolderType>,
     ) -> Self {
-        self.inner.account_holder_type = Some(account_holder_type);
+        self.inner.account_holder_type = Some(account_holder_type.into());
         self
     }
     /// City/District/Suburb/Town/Village.
-    pub fn address_city(mut self, address_city: &'a str) -> Self {
-        self.inner.address_city = Some(address_city);
+    pub fn address_city(mut self, address_city: impl Into<String>) -> Self {
+        self.inner.address_city = Some(address_city.into());
         self
     }
     /// Billing address country, if provided when creating card.
-    pub fn address_country(mut self, address_country: &'a str) -> Self {
-        self.inner.address_country = Some(address_country);
+    pub fn address_country(mut self, address_country: impl Into<String>) -> Self {
+        self.inner.address_country = Some(address_country.into());
         self
     }
     /// Address line 1 (Street address/PO Box/Company name).
-    pub fn address_line1(mut self, address_line1: &'a str) -> Self {
-        self.inner.address_line1 = Some(address_line1);
+    pub fn address_line1(mut self, address_line1: impl Into<String>) -> Self {
+        self.inner.address_line1 = Some(address_line1.into());
         self
     }
     /// Address line 2 (Apartment/Suite/Unit/Building).
-    pub fn address_line2(mut self, address_line2: &'a str) -> Self {
-        self.inner.address_line2 = Some(address_line2);
+    pub fn address_line2(mut self, address_line2: impl Into<String>) -> Self {
+        self.inner.address_line2 = Some(address_line2.into());
         self
     }
     /// State/County/Province/Region.
-    pub fn address_state(mut self, address_state: &'a str) -> Self {
-        self.inner.address_state = Some(address_state);
+    pub fn address_state(mut self, address_state: impl Into<String>) -> Self {
+        self.inner.address_state = Some(address_state.into());
         self
     }
     /// ZIP or postal code.
-    pub fn address_zip(mut self, address_zip: &'a str) -> Self {
-        self.inner.address_zip = Some(address_zip);
+    pub fn address_zip(mut self, address_zip: impl Into<String>) -> Self {
+        self.inner.address_zip = Some(address_zip.into());
         self
     }
     /// Two digit number representing the card’s expiration month.
-    pub fn exp_month(mut self, exp_month: &'a str) -> Self {
-        self.inner.exp_month = Some(exp_month);
+    pub fn exp_month(mut self, exp_month: impl Into<String>) -> Self {
+        self.inner.exp_month = Some(exp_month.into());
         self
     }
     /// Four digit number representing the card’s expiration year.
-    pub fn exp_year(mut self, exp_year: &'a str) -> Self {
-        self.inner.exp_year = Some(exp_year);
+    pub fn exp_year(mut self, exp_year: impl Into<String>) -> Self {
+        self.inner.exp_year = Some(exp_year.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// Cardholder name.
-    pub fn name(mut self, name: &'a str) -> Self {
-        self.inner.name = Some(name);
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.inner.name = Some(name.into());
         self
     }
-    pub fn owner(mut self, owner: UpdateCustomerCardOwner<'a>) -> Self {
-        self.inner.owner = Some(owner);
+    pub fn owner(mut self, owner: impl Into<UpdateCustomerCardOwner>) -> Self {
+        self.inner.owner = Some(owner.into());
         self
     }
 }
-impl UpdateCustomerCard<'_> {
+impl UpdateCustomerCard {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -804,12 +810,12 @@ impl UpdateCustomerCard<'_> {
     }
 }
 
-impl StripeRequest for UpdateCustomerCard<'_> {
+impl StripeRequest for UpdateCustomerCard {
     type Output = UpdateCustomerCardReturned;
 
     fn build(&self) -> RequestBuilder {
-        let customer = self.customer;
-        let id = self.id;
+        let customer = &self.customer;
+        let id = &self.id;
         RequestBuilder::new(StripeMethod::Post, format!("/customers/{customer}/sources/{id}"))
             .form(&self.inner)
     }

--- a/generated/async-stripe-payment/src/confirmation_token/requests.rs
+++ b/generated/async-stripe-payment/src/confirmation_token/requests.rs
@@ -2,34 +2,37 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveConfirmationTokenBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveConfirmationTokenBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveConfirmationTokenBuilder<'a> {
+impl RetrieveConfirmationTokenBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves an existing ConfirmationToken object
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveConfirmationToken<'a> {
-    inner: RetrieveConfirmationTokenBuilder<'a>,
-    confirmation_token: &'a stripe_payment::ConfirmationTokenId,
+pub struct RetrieveConfirmationToken {
+    inner: RetrieveConfirmationTokenBuilder,
+    confirmation_token: stripe_payment::ConfirmationTokenId,
 }
-impl<'a> RetrieveConfirmationToken<'a> {
+impl RetrieveConfirmationToken {
     /// Construct a new `RetrieveConfirmationToken`.
-    pub fn new(confirmation_token: &'a stripe_payment::ConfirmationTokenId) -> Self {
-        Self { confirmation_token, inner: RetrieveConfirmationTokenBuilder::new() }
+    pub fn new(confirmation_token: impl Into<stripe_payment::ConfirmationTokenId>) -> Self {
+        Self {
+            confirmation_token: confirmation_token.into(),
+            inner: RetrieveConfirmationTokenBuilder::new(),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveConfirmationToken<'_> {
+impl RetrieveConfirmationToken {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -47,31 +50,31 @@ impl RetrieveConfirmationToken<'_> {
     }
 }
 
-impl StripeRequest for RetrieveConfirmationToken<'_> {
+impl StripeRequest for RetrieveConfirmationToken {
     type Output = stripe_payment::ConfirmationToken;
 
     fn build(&self) -> RequestBuilder {
-        let confirmation_token = self.confirmation_token;
+        let confirmation_token = &self.confirmation_token;
         RequestBuilder::new(StripeMethod::Get, format!("/confirmation_tokens/{confirmation_token}"))
             .query(&self.inner)
     }
 }
 #[derive(Clone, Debug, serde::Serialize)]
-struct CreateConfirmationTokenBuilder<'a> {
+struct CreateConfirmationTokenBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_method: Option<&'a str>,
+    payment_method: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_method_data: Option<CreateConfirmationTokenPaymentMethodData<'a>>,
+    payment_method_data: Option<CreateConfirmationTokenPaymentMethodData>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    return_url: Option<&'a str>,
+    return_url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     setup_future_usage: Option<stripe_payment::ConfirmationTokenSetupFutureUsage>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    shipping: Option<CreateConfirmationTokenShipping<'a>>,
+    shipping: Option<CreateConfirmationTokenShipping>,
 }
-impl<'a> CreateConfirmationTokenBuilder<'a> {
+impl CreateConfirmationTokenBuilder {
     fn new() -> Self {
         Self {
             expand: None,
@@ -85,10 +88,10 @@ impl<'a> CreateConfirmationTokenBuilder<'a> {
 }
 /// If provided, this hash will be used to create a PaymentMethod.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateConfirmationTokenPaymentMethodData<'a> {
+pub struct CreateConfirmationTokenPaymentMethodData {
     /// If this is an `acss_debit` PaymentMethod, this hash contains details about the ACSS Debit payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub acss_debit: Option<CreateConfirmationTokenPaymentMethodDataAcssDebit<'a>>,
+    pub acss_debit: Option<CreateConfirmationTokenPaymentMethodDataAcssDebit>,
     /// If this is an `affirm` PaymentMethod, this hash contains details about the Affirm payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
@@ -112,24 +115,24 @@ pub struct CreateConfirmationTokenPaymentMethodData<'a> {
     pub amazon_pay: Option<miniserde::json::Value>,
     /// If this is an `au_becs_debit` PaymentMethod, this hash contains details about the bank account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub au_becs_debit: Option<CreateConfirmationTokenPaymentMethodDataAuBecsDebit<'a>>,
+    pub au_becs_debit: Option<CreateConfirmationTokenPaymentMethodDataAuBecsDebit>,
     /// If this is a `bacs_debit` PaymentMethod, this hash contains details about the Bacs Direct Debit bank account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub bacs_debit: Option<CreateConfirmationTokenPaymentMethodDataBacsDebit<'a>>,
+    pub bacs_debit: Option<CreateConfirmationTokenPaymentMethodDataBacsDebit>,
     /// If this is a `bancontact` PaymentMethod, this hash contains details about the Bancontact payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
     pub bancontact: Option<miniserde::json::Value>,
     /// Billing information associated with the PaymentMethod that may be used or required by particular types of payment methods.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub billing_details: Option<CreateConfirmationTokenPaymentMethodDataBillingDetails<'a>>,
+    pub billing_details: Option<CreateConfirmationTokenPaymentMethodDataBillingDetails>,
     /// If this is a `blik` PaymentMethod, this hash contains details about the BLIK payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
     pub blik: Option<miniserde::json::Value>,
     /// If this is a `boleto` PaymentMethod, this hash contains details about the Boleto payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub boleto: Option<CreateConfirmationTokenPaymentMethodDataBoleto<'a>>,
+    pub boleto: Option<CreateConfirmationTokenPaymentMethodDataBoleto>,
     /// If this is a `cashapp` PaymentMethod, this hash contains details about the Cash App Pay payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
@@ -175,7 +178,7 @@ pub struct CreateConfirmationTokenPaymentMethodData<'a> {
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// If this is a `mobilepay` PaymentMethod, this hash contains details about the MobilePay payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
@@ -206,14 +209,14 @@ pub struct CreateConfirmationTokenPaymentMethodData<'a> {
     /// Options to configure Radar.
     /// See [Radar Session](https://stripe.com/docs/radar/radar-session) for more information.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub radar_options: Option<CreateConfirmationTokenPaymentMethodDataRadarOptions<'a>>,
+    pub radar_options: Option<CreateConfirmationTokenPaymentMethodDataRadarOptions>,
     /// If this is a `Revolut Pay` PaymentMethod, this hash contains details about the Revolut Pay payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
     pub revolut_pay: Option<miniserde::json::Value>,
     /// If this is a `sepa_debit` PaymentMethod, this hash contains details about the SEPA debit bank account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub sepa_debit: Option<CreateConfirmationTokenPaymentMethodDataSepaDebit<'a>>,
+    pub sepa_debit: Option<CreateConfirmationTokenPaymentMethodDataSepaDebit>,
     /// If this is a `sofort` PaymentMethod, this hash contains details about the SOFORT payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sofort: Option<CreateConfirmationTokenPaymentMethodDataSofort>,
@@ -228,7 +231,7 @@ pub struct CreateConfirmationTokenPaymentMethodData<'a> {
     pub type_: CreateConfirmationTokenPaymentMethodDataType,
     /// If this is an `us_bank_account` PaymentMethod, this hash contains details about the US bank account payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub us_bank_account: Option<CreateConfirmationTokenPaymentMethodDataUsBankAccount<'a>>,
+    pub us_bank_account: Option<CreateConfirmationTokenPaymentMethodDataUsBankAccount>,
     /// If this is an `wechat_pay` PaymentMethod, this hash contains details about the wechat_pay payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
@@ -238,8 +241,8 @@ pub struct CreateConfirmationTokenPaymentMethodData<'a> {
     #[serde(with = "stripe_types::with_serde_json_opt")]
     pub zip: Option<miniserde::json::Value>,
 }
-impl<'a> CreateConfirmationTokenPaymentMethodData<'a> {
-    pub fn new(type_: CreateConfirmationTokenPaymentMethodDataType) -> Self {
+impl CreateConfirmationTokenPaymentMethodData {
+    pub fn new(type_: impl Into<CreateConfirmationTokenPaymentMethodDataType>) -> Self {
         Self {
             acss_debit: None,
             affirm: None,
@@ -277,7 +280,7 @@ impl<'a> CreateConfirmationTokenPaymentMethodData<'a> {
             sepa_debit: None,
             sofort: None,
             swish: None,
-            type_,
+            type_: type_.into(),
             us_bank_account: None,
             wechat_pay: None,
             zip: None,
@@ -285,22 +288,26 @@ impl<'a> CreateConfirmationTokenPaymentMethodData<'a> {
     }
 }
 /// If this is an `acss_debit` PaymentMethod, this hash contains details about the ACSS Debit payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateConfirmationTokenPaymentMethodDataAcssDebit<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateConfirmationTokenPaymentMethodDataAcssDebit {
     /// Customer's bank account number.
-    pub account_number: &'a str,
+    pub account_number: String,
     /// Institution number of the customer's bank.
-    pub institution_number: &'a str,
+    pub institution_number: String,
     /// Transit number of the customer's bank.
-    pub transit_number: &'a str,
+    pub transit_number: String,
 }
-impl<'a> CreateConfirmationTokenPaymentMethodDataAcssDebit<'a> {
+impl CreateConfirmationTokenPaymentMethodDataAcssDebit {
     pub fn new(
-        account_number: &'a str,
-        institution_number: &'a str,
-        transit_number: &'a str,
+        account_number: impl Into<String>,
+        institution_number: impl Into<String>,
+        transit_number: impl Into<String>,
     ) -> Self {
-        Self { account_number, institution_number, transit_number }
+        Self {
+            account_number: account_number.into(),
+            institution_number: institution_number.into(),
+            transit_number: transit_number.into(),
+        }
     }
 }
 /// This field indicates whether this payment method can be shown again to its customer in a checkout flow.
@@ -367,105 +374,105 @@ impl<'de> serde::Deserialize<'de> for CreateConfirmationTokenPaymentMethodDataAl
     }
 }
 /// If this is an `au_becs_debit` PaymentMethod, this hash contains details about the bank account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateConfirmationTokenPaymentMethodDataAuBecsDebit<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateConfirmationTokenPaymentMethodDataAuBecsDebit {
     /// The account number for the bank account.
-    pub account_number: &'a str,
+    pub account_number: String,
     /// Bank-State-Branch number of the bank account.
-    pub bsb_number: &'a str,
+    pub bsb_number: String,
 }
-impl<'a> CreateConfirmationTokenPaymentMethodDataAuBecsDebit<'a> {
-    pub fn new(account_number: &'a str, bsb_number: &'a str) -> Self {
-        Self { account_number, bsb_number }
+impl CreateConfirmationTokenPaymentMethodDataAuBecsDebit {
+    pub fn new(account_number: impl Into<String>, bsb_number: impl Into<String>) -> Self {
+        Self { account_number: account_number.into(), bsb_number: bsb_number.into() }
     }
 }
 /// If this is a `bacs_debit` PaymentMethod, this hash contains details about the Bacs Direct Debit bank account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateConfirmationTokenPaymentMethodDataBacsDebit<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateConfirmationTokenPaymentMethodDataBacsDebit {
     /// Account number of the bank account that the funds will be debited from.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account_number: Option<&'a str>,
+    pub account_number: Option<String>,
     /// Sort code of the bank account. (e.g., `10-20-30`)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub sort_code: Option<&'a str>,
+    pub sort_code: Option<String>,
 }
-impl<'a> CreateConfirmationTokenPaymentMethodDataBacsDebit<'a> {
+impl CreateConfirmationTokenPaymentMethodDataBacsDebit {
     pub fn new() -> Self {
         Self { account_number: None, sort_code: None }
     }
 }
-impl<'a> Default for CreateConfirmationTokenPaymentMethodDataBacsDebit<'a> {
+impl Default for CreateConfirmationTokenPaymentMethodDataBacsDebit {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Billing information associated with the PaymentMethod that may be used or required by particular types of payment methods.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateConfirmationTokenPaymentMethodDataBillingDetails<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateConfirmationTokenPaymentMethodDataBillingDetails {
     /// Billing address.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub address: Option<CreateConfirmationTokenPaymentMethodDataBillingDetailsAddress<'a>>,
+    pub address: Option<CreateConfirmationTokenPaymentMethodDataBillingDetailsAddress>,
     /// Email address.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub email: Option<&'a str>,
+    pub email: Option<String>,
     /// Full name.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<&'a str>,
+    pub name: Option<String>,
     /// Billing phone number (including extension).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub phone: Option<&'a str>,
+    pub phone: Option<String>,
 }
-impl<'a> CreateConfirmationTokenPaymentMethodDataBillingDetails<'a> {
+impl CreateConfirmationTokenPaymentMethodDataBillingDetails {
     pub fn new() -> Self {
         Self { address: None, email: None, name: None, phone: None }
     }
 }
-impl<'a> Default for CreateConfirmationTokenPaymentMethodDataBillingDetails<'a> {
+impl Default for CreateConfirmationTokenPaymentMethodDataBillingDetails {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Billing address.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateConfirmationTokenPaymentMethodDataBillingDetailsAddress<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateConfirmationTokenPaymentMethodDataBillingDetailsAddress {
     /// City, district, suburb, town, or village.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<&'a str>,
+    pub city: Option<String>,
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub country: Option<&'a str>,
+    pub country: Option<String>,
     /// Address line 1 (e.g., street, PO Box, or company name).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line1: Option<&'a str>,
+    pub line1: Option<String>,
     /// Address line 2 (e.g., apartment, suite, unit, or building).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line2: Option<&'a str>,
+    pub line2: Option<String>,
     /// ZIP or postal code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<&'a str>,
+    pub postal_code: Option<String>,
     /// State, county, province, or region.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
 }
-impl<'a> CreateConfirmationTokenPaymentMethodDataBillingDetailsAddress<'a> {
+impl CreateConfirmationTokenPaymentMethodDataBillingDetailsAddress {
     pub fn new() -> Self {
         Self { city: None, country: None, line1: None, line2: None, postal_code: None, state: None }
     }
 }
-impl<'a> Default for CreateConfirmationTokenPaymentMethodDataBillingDetailsAddress<'a> {
+impl Default for CreateConfirmationTokenPaymentMethodDataBillingDetailsAddress {
     fn default() -> Self {
         Self::new()
     }
 }
 /// If this is a `boleto` PaymentMethod, this hash contains details about the Boleto payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateConfirmationTokenPaymentMethodDataBoleto<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateConfirmationTokenPaymentMethodDataBoleto {
     /// The tax ID of the customer (CPF for individual consumers or CNPJ for businesses consumers)
-    pub tax_id: &'a str,
+    pub tax_id: String,
 }
-impl<'a> CreateConfirmationTokenPaymentMethodDataBoleto<'a> {
-    pub fn new(tax_id: &'a str) -> Self {
-        Self { tax_id }
+impl CreateConfirmationTokenPaymentMethodDataBoleto {
+    pub fn new(tax_id: impl Into<String>) -> Self {
+        Self { tax_id: tax_id.into() }
     }
 }
 /// If this is an `eps` PaymentMethod, this hash contains details about the EPS payment method.
@@ -631,8 +638,8 @@ pub struct CreateConfirmationTokenPaymentMethodDataFpx {
     pub bank: CreateConfirmationTokenPaymentMethodDataFpxBank,
 }
 impl CreateConfirmationTokenPaymentMethodDataFpx {
-    pub fn new(bank: CreateConfirmationTokenPaymentMethodDataFpxBank) -> Self {
-        Self { account_holder_type: None, bank }
+    pub fn new(bank: impl Into<CreateConfirmationTokenPaymentMethodDataFpxBank>) -> Self {
+        Self { account_holder_type: None, bank: bank.into() }
     }
 }
 /// Account holder type for FPX transaction
@@ -956,8 +963,8 @@ pub struct CreateConfirmationTokenPaymentMethodDataKlarnaDob {
     pub year: i64,
 }
 impl CreateConfirmationTokenPaymentMethodDataKlarnaDob {
-    pub fn new(day: i64, month: i64, year: i64) -> Self {
-        Self { day, month, year }
+    pub fn new(day: impl Into<i64>, month: impl Into<i64>, year: impl Into<i64>) -> Self {
+        Self { day: day.into(), month: month.into(), year: year.into() }
     }
 }
 /// If this is a `p24` PaymentMethod, this hash contains details about the P24 payment method.
@@ -1109,31 +1116,31 @@ impl<'de> serde::Deserialize<'de> for CreateConfirmationTokenPaymentMethodDataP2
 }
 /// Options to configure Radar.
 /// See [Radar Session](https://stripe.com/docs/radar/radar-session) for more information.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateConfirmationTokenPaymentMethodDataRadarOptions<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateConfirmationTokenPaymentMethodDataRadarOptions {
     /// A [Radar Session](https://stripe.com/docs/radar/radar-session) is a snapshot of the browser metadata and device details that help Radar make more accurate predictions on your payments.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub session: Option<&'a str>,
+    pub session: Option<String>,
 }
-impl<'a> CreateConfirmationTokenPaymentMethodDataRadarOptions<'a> {
+impl CreateConfirmationTokenPaymentMethodDataRadarOptions {
     pub fn new() -> Self {
         Self { session: None }
     }
 }
-impl<'a> Default for CreateConfirmationTokenPaymentMethodDataRadarOptions<'a> {
+impl Default for CreateConfirmationTokenPaymentMethodDataRadarOptions {
     fn default() -> Self {
         Self::new()
     }
 }
 /// If this is a `sepa_debit` PaymentMethod, this hash contains details about the SEPA debit bank account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateConfirmationTokenPaymentMethodDataSepaDebit<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateConfirmationTokenPaymentMethodDataSepaDebit {
     /// IBAN of the bank account.
-    pub iban: &'a str,
+    pub iban: String,
 }
-impl<'a> CreateConfirmationTokenPaymentMethodDataSepaDebit<'a> {
-    pub fn new(iban: &'a str) -> Self {
-        Self { iban }
+impl CreateConfirmationTokenPaymentMethodDataSepaDebit {
+    pub fn new(iban: impl Into<String>) -> Self {
+        Self { iban: iban.into() }
     }
 }
 /// If this is a `sofort` PaymentMethod, this hash contains details about the SOFORT payment method.
@@ -1143,8 +1150,8 @@ pub struct CreateConfirmationTokenPaymentMethodDataSofort {
     pub country: CreateConfirmationTokenPaymentMethodDataSofortCountry,
 }
 impl CreateConfirmationTokenPaymentMethodDataSofort {
-    pub fn new(country: CreateConfirmationTokenPaymentMethodDataSofortCountry) -> Self {
-        Self { country }
+    pub fn new(country: impl Into<CreateConfirmationTokenPaymentMethodDataSofortCountry>) -> Self {
+        Self { country: country.into() }
     }
 }
 /// Two-letter ISO code representing the country the bank account is located in.
@@ -1374,26 +1381,26 @@ impl<'de> serde::Deserialize<'de> for CreateConfirmationTokenPaymentMethodDataTy
     }
 }
 /// If this is an `us_bank_account` PaymentMethod, this hash contains details about the US bank account payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateConfirmationTokenPaymentMethodDataUsBankAccount<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateConfirmationTokenPaymentMethodDataUsBankAccount {
     /// Account holder type: individual or company.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub account_holder_type:
         Option<CreateConfirmationTokenPaymentMethodDataUsBankAccountAccountHolderType>,
     /// Account number of the bank account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account_number: Option<&'a str>,
+    pub account_number: Option<String>,
     /// Account type: checkings or savings. Defaults to checking if omitted.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub account_type: Option<CreateConfirmationTokenPaymentMethodDataUsBankAccountAccountType>,
     /// The ID of a Financial Connections Account to use as a payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub financial_connections_account: Option<&'a str>,
+    pub financial_connections_account: Option<String>,
     /// Routing number of the bank account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub routing_number: Option<&'a str>,
+    pub routing_number: Option<String>,
 }
-impl<'a> CreateConfirmationTokenPaymentMethodDataUsBankAccount<'a> {
+impl CreateConfirmationTokenPaymentMethodDataUsBankAccount {
     pub fn new() -> Self {
         Self {
             account_holder_type: None,
@@ -1404,7 +1411,7 @@ impl<'a> CreateConfirmationTokenPaymentMethodDataUsBankAccount<'a> {
         }
     }
 }
-impl<'a> Default for CreateConfirmationTokenPaymentMethodDataUsBankAccount<'a> {
+impl Default for CreateConfirmationTokenPaymentMethodDataUsBankAccount {
     fn default() -> Self {
         Self::new()
     }
@@ -1522,84 +1529,87 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// Shipping information for this ConfirmationToken.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateConfirmationTokenShipping<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateConfirmationTokenShipping {
     /// Shipping address
-    pub address: CreateConfirmationTokenShippingAddress<'a>,
+    pub address: CreateConfirmationTokenShippingAddress,
     /// Recipient name.
-    pub name: &'a str,
+    pub name: String,
     /// Recipient phone (including extension)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub phone: Option<&'a str>,
+    pub phone: Option<String>,
 }
-impl<'a> CreateConfirmationTokenShipping<'a> {
-    pub fn new(address: CreateConfirmationTokenShippingAddress<'a>, name: &'a str) -> Self {
-        Self { address, name, phone: None }
+impl CreateConfirmationTokenShipping {
+    pub fn new(
+        address: impl Into<CreateConfirmationTokenShippingAddress>,
+        name: impl Into<String>,
+    ) -> Self {
+        Self { address: address.into(), name: name.into(), phone: None }
     }
 }
 /// Shipping address
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateConfirmationTokenShippingAddress<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateConfirmationTokenShippingAddress {
     /// City, district, suburb, town, or village.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<&'a str>,
+    pub city: Option<String>,
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub country: Option<&'a str>,
+    pub country: Option<String>,
     /// Address line 1 (e.g., street, PO Box, or company name).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line1: Option<&'a str>,
+    pub line1: Option<String>,
     /// Address line 2 (e.g., apartment, suite, unit, or building).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line2: Option<&'a str>,
+    pub line2: Option<String>,
     /// ZIP or postal code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<&'a str>,
+    pub postal_code: Option<String>,
     /// State, county, province, or region.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
 }
-impl<'a> CreateConfirmationTokenShippingAddress<'a> {
+impl CreateConfirmationTokenShippingAddress {
     pub fn new() -> Self {
         Self { city: None, country: None, line1: None, line2: None, postal_code: None, state: None }
     }
 }
-impl<'a> Default for CreateConfirmationTokenShippingAddress<'a> {
+impl Default for CreateConfirmationTokenShippingAddress {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Creates a test mode Confirmation Token server side for your integration tests.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateConfirmationToken<'a> {
-    inner: CreateConfirmationTokenBuilder<'a>,
+pub struct CreateConfirmationToken {
+    inner: CreateConfirmationTokenBuilder,
 }
-impl<'a> CreateConfirmationToken<'a> {
+impl CreateConfirmationToken {
     /// Construct a new `CreateConfirmationToken`.
     pub fn new() -> Self {
         Self { inner: CreateConfirmationTokenBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// ID of an existing PaymentMethod.
-    pub fn payment_method(mut self, payment_method: &'a str) -> Self {
-        self.inner.payment_method = Some(payment_method);
+    pub fn payment_method(mut self, payment_method: impl Into<String>) -> Self {
+        self.inner.payment_method = Some(payment_method.into());
         self
     }
     /// If provided, this hash will be used to create a PaymentMethod.
     pub fn payment_method_data(
         mut self,
-        payment_method_data: CreateConfirmationTokenPaymentMethodData<'a>,
+        payment_method_data: impl Into<CreateConfirmationTokenPaymentMethodData>,
     ) -> Self {
-        self.inner.payment_method_data = Some(payment_method_data);
+        self.inner.payment_method_data = Some(payment_method_data.into());
         self
     }
     /// Return URL used to confirm the Intent.
-    pub fn return_url(mut self, return_url: &'a str) -> Self {
-        self.inner.return_url = Some(return_url);
+    pub fn return_url(mut self, return_url: impl Into<String>) -> Self {
+        self.inner.return_url = Some(return_url.into());
         self
     }
     /// Indicates that you intend to make future payments with this ConfirmationToken's payment method.
@@ -1607,23 +1617,23 @@ impl<'a> CreateConfirmationToken<'a> {
     /// The presence of this property will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete.
     pub fn setup_future_usage(
         mut self,
-        setup_future_usage: stripe_payment::ConfirmationTokenSetupFutureUsage,
+        setup_future_usage: impl Into<stripe_payment::ConfirmationTokenSetupFutureUsage>,
     ) -> Self {
-        self.inner.setup_future_usage = Some(setup_future_usage);
+        self.inner.setup_future_usage = Some(setup_future_usage.into());
         self
     }
     /// Shipping information for this ConfirmationToken.
-    pub fn shipping(mut self, shipping: CreateConfirmationTokenShipping<'a>) -> Self {
-        self.inner.shipping = Some(shipping);
+    pub fn shipping(mut self, shipping: impl Into<CreateConfirmationTokenShipping>) -> Self {
+        self.inner.shipping = Some(shipping.into());
         self
     }
 }
-impl<'a> Default for CreateConfirmationToken<'a> {
+impl Default for CreateConfirmationToken {
     fn default() -> Self {
         Self::new()
     }
 }
-impl CreateConfirmationToken<'_> {
+impl CreateConfirmationToken {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -1641,7 +1651,7 @@ impl CreateConfirmationToken<'_> {
     }
 }
 
-impl StripeRequest for CreateConfirmationToken<'_> {
+impl StripeRequest for CreateConfirmationToken {
     type Output = stripe_payment::ConfirmationToken;
 
     fn build(&self) -> RequestBuilder {

--- a/generated/async-stripe-payment/src/payment_link/requests.rs
+++ b/generated/async-stripe-payment/src/payment_link/requests.rs
@@ -2,71 +2,71 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListPaymentLinkBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListPaymentLinkBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     active: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListPaymentLinkBuilder<'a> {
+impl ListPaymentLinkBuilder {
     fn new() -> Self {
         Self { active: None, ending_before: None, expand: None, limit: None, starting_after: None }
     }
 }
 /// Returns a list of your payment links.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListPaymentLink<'a> {
-    inner: ListPaymentLinkBuilder<'a>,
+pub struct ListPaymentLink {
+    inner: ListPaymentLinkBuilder,
 }
-impl<'a> ListPaymentLink<'a> {
+impl ListPaymentLink {
     /// Construct a new `ListPaymentLink`.
     pub fn new() -> Self {
         Self { inner: ListPaymentLinkBuilder::new() }
     }
     /// Only return payment links that are active or inactive (e.g., pass `false` to list all inactive payment links).
-    pub fn active(mut self, active: bool) -> Self {
-        self.inner.active = Some(active);
+    pub fn active(mut self, active: impl Into<bool>) -> Self {
+        self.inner.active = Some(active.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl<'a> Default for ListPaymentLink<'a> {
+impl Default for ListPaymentLink {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListPaymentLink<'_> {
+impl ListPaymentLink {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -86,45 +86,45 @@ impl ListPaymentLink<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::PaymentLink>> {
-        stripe_client_core::ListPaginator::new_list("/payment_links", self.inner)
+        stripe_client_core::ListPaginator::new_list("/payment_links", &self.inner)
     }
 }
 
-impl StripeRequest for ListPaymentLink<'_> {
+impl StripeRequest for ListPaymentLink {
     type Output = stripe_types::List<stripe_shared::PaymentLink>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/payment_links").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrievePaymentLinkBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrievePaymentLinkBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrievePaymentLinkBuilder<'a> {
+impl RetrievePaymentLinkBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieve a payment link.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrievePaymentLink<'a> {
-    inner: RetrievePaymentLinkBuilder<'a>,
-    payment_link: &'a stripe_shared::PaymentLinkId,
+pub struct RetrievePaymentLink {
+    inner: RetrievePaymentLinkBuilder,
+    payment_link: stripe_shared::PaymentLinkId,
 }
-impl<'a> RetrievePaymentLink<'a> {
+impl RetrievePaymentLink {
     /// Construct a new `RetrievePaymentLink`.
-    pub fn new(payment_link: &'a stripe_shared::PaymentLinkId) -> Self {
-        Self { payment_link, inner: RetrievePaymentLinkBuilder::new() }
+    pub fn new(payment_link: impl Into<stripe_shared::PaymentLinkId>) -> Self {
+        Self { payment_link: payment_link.into(), inner: RetrievePaymentLinkBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrievePaymentLink<'_> {
+impl RetrievePaymentLink {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -142,27 +142,27 @@ impl RetrievePaymentLink<'_> {
     }
 }
 
-impl StripeRequest for RetrievePaymentLink<'_> {
+impl StripeRequest for RetrievePaymentLink {
     type Output = stripe_shared::PaymentLink;
 
     fn build(&self) -> RequestBuilder {
-        let payment_link = self.payment_link;
+        let payment_link = &self.payment_link;
         RequestBuilder::new(StripeMethod::Get, format!("/payment_links/{payment_link}"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListLineItemsPaymentLinkBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListLineItemsPaymentLinkBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListLineItemsPaymentLinkBuilder<'a> {
+impl ListLineItemsPaymentLinkBuilder {
     fn new() -> Self {
         Self { ending_before: None, expand: None, limit: None, starting_after: None }
     }
@@ -170,42 +170,42 @@ impl<'a> ListLineItemsPaymentLinkBuilder<'a> {
 /// When retrieving a payment link, there is an includable **line_items** property containing the first handful of those items.
 /// There is also a URL where you can retrieve the full (paginated) list of line items.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListLineItemsPaymentLink<'a> {
-    inner: ListLineItemsPaymentLinkBuilder<'a>,
-    payment_link: &'a stripe_shared::PaymentLinkId,
+pub struct ListLineItemsPaymentLink {
+    inner: ListLineItemsPaymentLinkBuilder,
+    payment_link: stripe_shared::PaymentLinkId,
 }
-impl<'a> ListLineItemsPaymentLink<'a> {
+impl ListLineItemsPaymentLink {
     /// Construct a new `ListLineItemsPaymentLink`.
-    pub fn new(payment_link: &'a stripe_shared::PaymentLinkId) -> Self {
-        Self { payment_link, inner: ListLineItemsPaymentLinkBuilder::new() }
+    pub fn new(payment_link: impl Into<stripe_shared::PaymentLinkId>) -> Self {
+        Self { payment_link: payment_link.into(), inner: ListLineItemsPaymentLinkBuilder::new() }
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl ListLineItemsPaymentLink<'_> {
+impl ListLineItemsPaymentLink {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -226,28 +226,28 @@ impl ListLineItemsPaymentLink<'_> {
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::CheckoutSessionItem>>
     {
-        let payment_link = self.payment_link;
+        let payment_link = &self.payment_link;
 
         stripe_client_core::ListPaginator::new_list(
             format!("/payment_links/{payment_link}/line_items"),
-            self.inner,
+            &self.inner,
         )
     }
 }
 
-impl StripeRequest for ListLineItemsPaymentLink<'_> {
+impl StripeRequest for ListLineItemsPaymentLink {
     type Output = stripe_types::List<stripe_shared::CheckoutSessionItem>;
 
     fn build(&self) -> RequestBuilder {
-        let payment_link = self.payment_link;
+        let payment_link = &self.payment_link;
         RequestBuilder::new(StripeMethod::Get, format!("/payment_links/{payment_link}/line_items"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreatePaymentLinkBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreatePaymentLinkBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    after_completion: Option<CreatePaymentLinkAfterCompletion<'a>>,
+    after_completion: Option<CreatePaymentLinkAfterCompletion>,
     #[serde(skip_serializing_if = "Option::is_none")]
     allow_promotion_codes: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -255,7 +255,7 @@ struct CreatePaymentLinkBuilder<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     application_fee_percent: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    automatic_tax: Option<CreatePaymentLinkAutomaticTax<'a>>,
+    automatic_tax: Option<CreatePaymentLinkAutomaticTax>,
     #[serde(skip_serializing_if = "Option::is_none")]
     billing_address_collection: Option<stripe_shared::PaymentLinkBillingAddressCollection>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -263,47 +263,47 @@ struct CreatePaymentLinkBuilder<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     currency: Option<stripe_types::Currency>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    custom_fields: Option<&'a [CreatePaymentLinkCustomFields<'a>]>,
+    custom_fields: Option<Vec<CreatePaymentLinkCustomFields>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    custom_text: Option<CustomTextParam<'a>>,
+    custom_text: Option<CustomTextParam>,
     #[serde(skip_serializing_if = "Option::is_none")]
     customer_creation: Option<CreatePaymentLinkCustomerCreation>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    inactive_message: Option<&'a str>,
+    inactive_message: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    invoice_creation: Option<CreatePaymentLinkInvoiceCreation<'a>>,
-    line_items: &'a [CreatePaymentLinkLineItems<'a>],
+    invoice_creation: Option<CreatePaymentLinkInvoiceCreation>,
+    line_items: Vec<CreatePaymentLinkLineItems>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    on_behalf_of: Option<&'a str>,
+    on_behalf_of: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_intent_data: Option<CreatePaymentLinkPaymentIntentData<'a>>,
+    payment_intent_data: Option<CreatePaymentLinkPaymentIntentData>,
     #[serde(skip_serializing_if = "Option::is_none")]
     payment_method_collection: Option<CreatePaymentLinkPaymentMethodCollection>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_method_types: Option<&'a [stripe_shared::PaymentLinkPaymentMethodTypes]>,
+    payment_method_types: Option<Vec<stripe_shared::PaymentLinkPaymentMethodTypes>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     phone_number_collection: Option<CreatePaymentLinkPhoneNumberCollection>,
     #[serde(skip_serializing_if = "Option::is_none")]
     restrictions: Option<RestrictionsParams>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    shipping_address_collection: Option<CreatePaymentLinkShippingAddressCollection<'a>>,
+    shipping_address_collection: Option<CreatePaymentLinkShippingAddressCollection>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    shipping_options: Option<&'a [CreatePaymentLinkShippingOptions<'a>]>,
+    shipping_options: Option<Vec<CreatePaymentLinkShippingOptions>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     submit_type: Option<stripe_shared::PaymentLinkSubmitType>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    subscription_data: Option<CreatePaymentLinkSubscriptionData<'a>>,
+    subscription_data: Option<CreatePaymentLinkSubscriptionData>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tax_id_collection: Option<CreatePaymentLinkTaxIdCollection>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    transfer_data: Option<CreatePaymentLinkTransferData<'a>>,
+    transfer_data: Option<CreatePaymentLinkTransferData>,
 }
-impl<'a> CreatePaymentLinkBuilder<'a> {
-    fn new(line_items: &'a [CreatePaymentLinkLineItems<'a>]) -> Self {
+impl CreatePaymentLinkBuilder {
+    fn new(line_items: impl Into<Vec<CreatePaymentLinkLineItems>>) -> Self {
         Self {
             after_completion: None,
             allow_promotion_codes: None,
@@ -319,7 +319,7 @@ impl<'a> CreatePaymentLinkBuilder<'a> {
             expand: None,
             inactive_message: None,
             invoice_creation: None,
-            line_items,
+            line_items: line_items.into(),
             metadata: None,
             on_behalf_of: None,
             payment_intent_data: None,
@@ -337,21 +337,21 @@ impl<'a> CreatePaymentLinkBuilder<'a> {
     }
 }
 /// Behavior after the purchase is complete.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentLinkAfterCompletion<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentLinkAfterCompletion {
     /// Configuration when `type=hosted_confirmation`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub hosted_confirmation: Option<AfterCompletionConfirmationPageParams<'a>>,
+    pub hosted_confirmation: Option<AfterCompletionConfirmationPageParams>,
     /// Configuration when `type=redirect`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub redirect: Option<AfterCompletionRedirectParams<'a>>,
+    pub redirect: Option<AfterCompletionRedirectParams>,
     /// The specified behavior after the purchase is complete. Either `redirect` or `hosted_confirmation`.
     #[serde(rename = "type")]
     pub type_: CreatePaymentLinkAfterCompletionType,
 }
-impl<'a> CreatePaymentLinkAfterCompletion<'a> {
-    pub fn new(type_: CreatePaymentLinkAfterCompletionType) -> Self {
-        Self { hosted_confirmation: None, redirect: None, type_ }
+impl CreatePaymentLinkAfterCompletion {
+    pub fn new(type_: impl Into<CreatePaymentLinkAfterCompletionType>) -> Self {
+        Self { hosted_confirmation: None, redirect: None, type_: type_.into() }
     }
 }
 /// The specified behavior after the purchase is complete. Either `redirect` or `hosted_confirmation`.
@@ -411,36 +411,36 @@ impl<'de> serde::Deserialize<'de> for CreatePaymentLinkAfterCompletionType {
     }
 }
 /// Configuration for automatic tax collection.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentLinkAutomaticTax<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentLinkAutomaticTax {
     /// If `true`, tax will be calculated automatically using the customer's location.
     pub enabled: bool,
     /// The account that's liable for tax.
     /// If set, the business address and tax registrations required to perform the tax calculation are loaded from this account.
     /// The tax transaction is returned in the report of the connected account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub liability: Option<CreatePaymentLinkAutomaticTaxLiability<'a>>,
+    pub liability: Option<CreatePaymentLinkAutomaticTaxLiability>,
 }
-impl<'a> CreatePaymentLinkAutomaticTax<'a> {
-    pub fn new(enabled: bool) -> Self {
-        Self { enabled, liability: None }
+impl CreatePaymentLinkAutomaticTax {
+    pub fn new(enabled: impl Into<bool>) -> Self {
+        Self { enabled: enabled.into(), liability: None }
     }
 }
 /// The account that's liable for tax.
 /// If set, the business address and tax registrations required to perform the tax calculation are loaded from this account.
 /// The tax transaction is returned in the report of the connected account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentLinkAutomaticTaxLiability<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentLinkAutomaticTaxLiability {
     /// The connected account being referenced when `type` is `account`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account: Option<&'a str>,
+    pub account: Option<String>,
     /// Type of the account referenced in the request.
     #[serde(rename = "type")]
     pub type_: CreatePaymentLinkAutomaticTaxLiabilityType,
 }
-impl<'a> CreatePaymentLinkAutomaticTaxLiability<'a> {
-    pub fn new(type_: CreatePaymentLinkAutomaticTaxLiabilityType) -> Self {
-        Self { account: None, type_ }
+impl CreatePaymentLinkAutomaticTaxLiability {
+    pub fn new(type_: impl Into<CreatePaymentLinkAutomaticTaxLiabilityType>) -> Self {
+        Self { account: None, type_: type_.into() }
     }
 }
 /// Type of the account referenced in the request.
@@ -540,9 +540,9 @@ pub struct CreatePaymentLinkConsentCollectionPaymentMethodReuseAgreement {
 }
 impl CreatePaymentLinkConsentCollectionPaymentMethodReuseAgreement {
     pub fn new(
-        position: CreatePaymentLinkConsentCollectionPaymentMethodReuseAgreementPosition,
+        position: impl Into<CreatePaymentLinkConsentCollectionPaymentMethodReuseAgreementPosition>,
     ) -> Self {
-        Self { position }
+        Self { position: position.into() }
     }
 }
 /// Determines the position and visibility of the payment method reuse agreement in the UI.
@@ -726,16 +726,16 @@ impl<'de> serde::Deserialize<'de> for CreatePaymentLinkConsentCollectionTermsOfS
 }
 /// Collect additional information from your customer using custom fields.
 /// Up to 3 fields are supported.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentLinkCustomFields<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentLinkCustomFields {
     /// Configuration for `type=dropdown` fields.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub dropdown: Option<CustomFieldDropdownParam<'a>>,
+    pub dropdown: Option<CustomFieldDropdownParam>,
     /// String of your choice that your integration can use to reconcile this field.
     /// Must be unique to this field, alphanumeric, and up to 200 characters.
-    pub key: &'a str,
+    pub key: String,
     /// The label for the field, displayed to the customer.
-    pub label: CreatePaymentLinkCustomFieldsLabel<'a>,
+    pub label: CreatePaymentLinkCustomFieldsLabel,
     /// Configuration for `type=numeric` fields.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub numeric: Option<CreatePaymentLinkCustomFieldsNumeric>,
@@ -750,27 +750,38 @@ pub struct CreatePaymentLinkCustomFields<'a> {
     #[serde(rename = "type")]
     pub type_: CreatePaymentLinkCustomFieldsType,
 }
-impl<'a> CreatePaymentLinkCustomFields<'a> {
+impl CreatePaymentLinkCustomFields {
     pub fn new(
-        key: &'a str,
-        label: CreatePaymentLinkCustomFieldsLabel<'a>,
-        type_: CreatePaymentLinkCustomFieldsType,
+        key: impl Into<String>,
+        label: impl Into<CreatePaymentLinkCustomFieldsLabel>,
+        type_: impl Into<CreatePaymentLinkCustomFieldsType>,
     ) -> Self {
-        Self { dropdown: None, key, label, numeric: None, optional: None, text: None, type_ }
+        Self {
+            dropdown: None,
+            key: key.into(),
+            label: label.into(),
+            numeric: None,
+            optional: None,
+            text: None,
+            type_: type_.into(),
+        }
     }
 }
 /// The label for the field, displayed to the customer.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentLinkCustomFieldsLabel<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentLinkCustomFieldsLabel {
     /// Custom text for the label, displayed to the customer. Up to 50 characters.
-    pub custom: &'a str,
+    pub custom: String,
     /// The type of the label.
     #[serde(rename = "type")]
     pub type_: CreatePaymentLinkCustomFieldsLabelType,
 }
-impl<'a> CreatePaymentLinkCustomFieldsLabel<'a> {
-    pub fn new(custom: &'a str, type_: CreatePaymentLinkCustomFieldsLabelType) -> Self {
-        Self { custom, type_ }
+impl CreatePaymentLinkCustomFieldsLabel {
+    pub fn new(
+        custom: impl Into<String>,
+        type_: impl Into<CreatePaymentLinkCustomFieldsLabelType>,
+    ) -> Self {
+        Self { custom: custom.into(), type_: type_.into() }
     }
 }
 /// The type of the label.
@@ -982,49 +993,49 @@ impl<'de> serde::Deserialize<'de> for CreatePaymentLinkCustomerCreation {
     }
 }
 /// Generate a post-purchase Invoice for one-time payments.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentLinkInvoiceCreation<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentLinkInvoiceCreation {
     /// Whether the feature is enabled
     pub enabled: bool,
     /// Invoice PDF configuration.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub invoice_data: Option<CreatePaymentLinkInvoiceCreationInvoiceData<'a>>,
+    pub invoice_data: Option<CreatePaymentLinkInvoiceCreationInvoiceData>,
 }
-impl<'a> CreatePaymentLinkInvoiceCreation<'a> {
-    pub fn new(enabled: bool) -> Self {
-        Self { enabled, invoice_data: None }
+impl CreatePaymentLinkInvoiceCreation {
+    pub fn new(enabled: impl Into<bool>) -> Self {
+        Self { enabled: enabled.into(), invoice_data: None }
     }
 }
 /// Invoice PDF configuration.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentLinkInvoiceCreationInvoiceData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentLinkInvoiceCreationInvoiceData {
     /// The account tax IDs associated with the invoice.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account_tax_ids: Option<&'a [&'a str]>,
+    pub account_tax_ids: Option<Vec<String>>,
     /// Default custom fields to be displayed on invoices for this customer.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub custom_fields: Option<&'a [CustomFieldParams<'a>]>,
+    pub custom_fields: Option<Vec<CustomFieldParams>>,
     /// An arbitrary string attached to the object. Often useful for displaying to users.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<&'a str>,
+    pub description: Option<String>,
     /// Default footer to be displayed on invoices for this customer.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub footer: Option<&'a str>,
+    pub footer: Option<String>,
     /// The connected account that issues the invoice.
     /// The invoice is presented with the branding and support information of the specified account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub issuer: Option<CreatePaymentLinkInvoiceCreationInvoiceDataIssuer<'a>>,
+    pub issuer: Option<CreatePaymentLinkInvoiceCreationInvoiceDataIssuer>,
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// Default options for invoice PDF rendering for this customer.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rendering_options: Option<CreatePaymentLinkInvoiceCreationInvoiceDataRenderingOptions>,
 }
-impl<'a> CreatePaymentLinkInvoiceCreationInvoiceData<'a> {
+impl CreatePaymentLinkInvoiceCreationInvoiceData {
     pub fn new() -> Self {
         Self {
             account_tax_ids: None,
@@ -1037,25 +1048,25 @@ impl<'a> CreatePaymentLinkInvoiceCreationInvoiceData<'a> {
         }
     }
 }
-impl<'a> Default for CreatePaymentLinkInvoiceCreationInvoiceData<'a> {
+impl Default for CreatePaymentLinkInvoiceCreationInvoiceData {
     fn default() -> Self {
         Self::new()
     }
 }
 /// The connected account that issues the invoice.
 /// The invoice is presented with the branding and support information of the specified account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentLinkInvoiceCreationInvoiceDataIssuer<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentLinkInvoiceCreationInvoiceDataIssuer {
     /// The connected account being referenced when `type` is `account`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account: Option<&'a str>,
+    pub account: Option<String>,
     /// Type of the account referenced in the request.
     #[serde(rename = "type")]
     pub type_: CreatePaymentLinkInvoiceCreationInvoiceDataIssuerType,
 }
-impl<'a> CreatePaymentLinkInvoiceCreationInvoiceDataIssuer<'a> {
-    pub fn new(type_: CreatePaymentLinkInvoiceCreationInvoiceDataIssuerType) -> Self {
-        Self { account: None, type_ }
+impl CreatePaymentLinkInvoiceCreationInvoiceDataIssuer {
+    pub fn new(type_: impl Into<CreatePaymentLinkInvoiceCreationInvoiceDataIssuerType>) -> Self {
+        Self { account: None, type_: type_.into() }
     }
 }
 /// Type of the account referenced in the request.
@@ -1207,35 +1218,35 @@ impl<'de> serde::Deserialize<'de>
 /// The line items representing what is being sold.
 /// Each line item represents an item being sold.
 /// Up to 20 line items are supported.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentLinkLineItems<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentLinkLineItems {
     /// When set, provides configuration for this item’s quantity to be adjusted by the customer during checkout.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub adjustable_quantity: Option<AdjustableQuantityParams>,
     /// The ID of the [Price](https://stripe.com/docs/api/prices) or [Plan](https://stripe.com/docs/api/plans) object.
-    pub price: &'a str,
+    pub price: String,
     /// The quantity of the line item being purchased.
     pub quantity: u64,
 }
-impl<'a> CreatePaymentLinkLineItems<'a> {
-    pub fn new(price: &'a str, quantity: u64) -> Self {
-        Self { adjustable_quantity: None, price, quantity }
+impl CreatePaymentLinkLineItems {
+    pub fn new(price: impl Into<String>, quantity: impl Into<u64>) -> Self {
+        Self { adjustable_quantity: None, price: price.into(), quantity: quantity.into() }
     }
 }
 /// A subset of parameters to be passed to PaymentIntent creation for Checkout Sessions in `payment` mode.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentLinkPaymentIntentData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentLinkPaymentIntentData {
     /// Controls when the funds will be captured from the customer's account.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub capture_method: Option<CreatePaymentLinkPaymentIntentDataCaptureMethod>,
     /// An arbitrary string attached to the object. Often useful for displaying to users.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<&'a str>,
+    pub description: Option<String>,
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that will declaratively set metadata on [Payment Intents](https://stripe.com/docs/api/payment_intents) generated from this payment link.
     /// Unlike object-level metadata, this field is declarative.
     /// Updates will clear prior values.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// Indicates that you intend to [make future payments](https://stripe.com/docs/payments/payment-intents#future-usage) with the payment method collected by this Checkout Session.
     ///
     /// When setting this to `on_session`, Checkout will show a notice to the customer that their payment details will be saved.
@@ -1253,18 +1264,18 @@ pub struct CreatePaymentLinkPaymentIntentData<'a> {
     /// Extra information about the payment.
     /// This will appear on your customer's statement when this payment succeeds in creating a charge.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub statement_descriptor: Option<&'a str>,
+    pub statement_descriptor: Option<String>,
     /// Provides information about the charge that customers see on their statements.
     /// Concatenated with the prefix (shortened descriptor) or statement descriptor that's set on the account to form the complete statement descriptor.
     /// Maximum 22 characters for the concatenated descriptor.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub statement_descriptor_suffix: Option<&'a str>,
+    pub statement_descriptor_suffix: Option<String>,
     /// A string that identifies the resulting payment as part of a group.
     /// See the PaymentIntents [use case for connected accounts](https://stripe.com/docs/connect/separate-charges-and-transfers) for details.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub transfer_group: Option<&'a str>,
+    pub transfer_group: Option<String>,
 }
-impl<'a> CreatePaymentLinkPaymentIntentData<'a> {
+impl CreatePaymentLinkPaymentIntentData {
     pub fn new() -> Self {
         Self {
             capture_method: None,
@@ -1277,7 +1288,7 @@ impl<'a> CreatePaymentLinkPaymentIntentData<'a> {
         }
     }
 }
-impl<'a> Default for CreatePaymentLinkPaymentIntentData<'a> {
+impl Default for CreatePaymentLinkPaymentIntentData {
     fn default() -> Self {
         Self::new()
     }
@@ -1482,23 +1493,23 @@ pub struct CreatePaymentLinkPhoneNumberCollection {
     pub enabled: bool,
 }
 impl CreatePaymentLinkPhoneNumberCollection {
-    pub fn new(enabled: bool) -> Self {
-        Self { enabled }
+    pub fn new(enabled: impl Into<bool>) -> Self {
+        Self { enabled: enabled.into() }
     }
 }
 /// Configuration for collecting the customer's shipping address.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentLinkShippingAddressCollection<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentLinkShippingAddressCollection {
     /// An array of two-letter ISO country codes representing which countries Checkout should provide as options for.
     /// shipping locations.
     /// Unsupported country codes: `AS, CX, CC, CU, HM, IR, KP, MH, FM, NF, MP, PW, SD, SY, UM, VI`.
-    pub allowed_countries: &'a [CreatePaymentLinkShippingAddressCollectionAllowedCountries],
+    pub allowed_countries: Vec<CreatePaymentLinkShippingAddressCollectionAllowedCountries>,
 }
-impl<'a> CreatePaymentLinkShippingAddressCollection<'a> {
+impl CreatePaymentLinkShippingAddressCollection {
     pub fn new(
-        allowed_countries: &'a [CreatePaymentLinkShippingAddressCollectionAllowedCountries],
+        allowed_countries: impl Into<Vec<CreatePaymentLinkShippingAddressCollectionAllowedCountries>>,
     ) -> Self {
-        Self { allowed_countries }
+        Self { allowed_countries: allowed_countries.into() }
     }
 }
 /// An array of two-letter ISO country codes representing which countries Checkout should provide as options for.
@@ -2267,38 +2278,38 @@ impl<'de> serde::Deserialize<'de> for CreatePaymentLinkShippingAddressCollection
     }
 }
 /// The shipping rate options to apply to [checkout sessions](https://stripe.com/docs/api/checkout/sessions) created by this payment link.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentLinkShippingOptions<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentLinkShippingOptions {
     /// The ID of the Shipping Rate to use for this shipping option.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub shipping_rate: Option<&'a str>,
+    pub shipping_rate: Option<String>,
 }
-impl<'a> CreatePaymentLinkShippingOptions<'a> {
+impl CreatePaymentLinkShippingOptions {
     pub fn new() -> Self {
         Self { shipping_rate: None }
     }
 }
-impl<'a> Default for CreatePaymentLinkShippingOptions<'a> {
+impl Default for CreatePaymentLinkShippingOptions {
     fn default() -> Self {
         Self::new()
     }
 }
 /// When creating a subscription, the specified configuration data will be used.
 /// There must be at least one line item with a recurring price to use `subscription_data`.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentLinkSubscriptionData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentLinkSubscriptionData {
     /// The subscription's description, meant to be displayable to the customer.
     /// Use this field to optionally store an explanation of the subscription for rendering in Stripe surfaces and certain local payment methods UIs.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<&'a str>,
+    pub description: Option<String>,
     /// All invoices will be billed using the specified settings.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub invoice_settings: Option<CreatePaymentLinkSubscriptionDataInvoiceSettings<'a>>,
+    pub invoice_settings: Option<CreatePaymentLinkSubscriptionDataInvoiceSettings>,
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that will declaratively set metadata on [Subscriptions](https://stripe.com/docs/api/subscriptions) generated from this payment link.
     /// Unlike object-level metadata, this field is declarative.
     /// Updates will clear prior values.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// Integer representing the number of trial period days before the customer is charged for the first time.
     /// Has to be at least 1.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -2307,7 +2318,7 @@ pub struct CreatePaymentLinkSubscriptionData<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub trial_settings: Option<CreatePaymentLinkSubscriptionDataTrialSettings>,
 }
-impl<'a> CreatePaymentLinkSubscriptionData<'a> {
+impl CreatePaymentLinkSubscriptionData {
     pub fn new() -> Self {
         Self {
             description: None,
@@ -2318,43 +2329,45 @@ impl<'a> CreatePaymentLinkSubscriptionData<'a> {
         }
     }
 }
-impl<'a> Default for CreatePaymentLinkSubscriptionData<'a> {
+impl Default for CreatePaymentLinkSubscriptionData {
     fn default() -> Self {
         Self::new()
     }
 }
 /// All invoices will be billed using the specified settings.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentLinkSubscriptionDataInvoiceSettings<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentLinkSubscriptionDataInvoiceSettings {
     /// The connected account that issues the invoice.
     /// The invoice is presented with the branding and support information of the specified account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub issuer: Option<CreatePaymentLinkSubscriptionDataInvoiceSettingsIssuer<'a>>,
+    pub issuer: Option<CreatePaymentLinkSubscriptionDataInvoiceSettingsIssuer>,
 }
-impl<'a> CreatePaymentLinkSubscriptionDataInvoiceSettings<'a> {
+impl CreatePaymentLinkSubscriptionDataInvoiceSettings {
     pub fn new() -> Self {
         Self { issuer: None }
     }
 }
-impl<'a> Default for CreatePaymentLinkSubscriptionDataInvoiceSettings<'a> {
+impl Default for CreatePaymentLinkSubscriptionDataInvoiceSettings {
     fn default() -> Self {
         Self::new()
     }
 }
 /// The connected account that issues the invoice.
 /// The invoice is presented with the branding and support information of the specified account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentLinkSubscriptionDataInvoiceSettingsIssuer<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentLinkSubscriptionDataInvoiceSettingsIssuer {
     /// The connected account being referenced when `type` is `account`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account: Option<&'a str>,
+    pub account: Option<String>,
     /// Type of the account referenced in the request.
     #[serde(rename = "type")]
     pub type_: CreatePaymentLinkSubscriptionDataInvoiceSettingsIssuerType,
 }
-impl<'a> CreatePaymentLinkSubscriptionDataInvoiceSettingsIssuer<'a> {
-    pub fn new(type_: CreatePaymentLinkSubscriptionDataInvoiceSettingsIssuerType) -> Self {
-        Self { account: None, type_ }
+impl CreatePaymentLinkSubscriptionDataInvoiceSettingsIssuer {
+    pub fn new(
+        type_: impl Into<CreatePaymentLinkSubscriptionDataInvoiceSettingsIssuerType>,
+    ) -> Self {
+        Self { account: None, type_: type_.into() }
     }
 }
 /// Type of the account referenced in the request.
@@ -2422,8 +2435,10 @@ pub struct CreatePaymentLinkSubscriptionDataTrialSettings {
     pub end_behavior: CreatePaymentLinkSubscriptionDataTrialSettingsEndBehavior,
 }
 impl CreatePaymentLinkSubscriptionDataTrialSettings {
-    pub fn new(end_behavior: CreatePaymentLinkSubscriptionDataTrialSettingsEndBehavior) -> Self {
-        Self { end_behavior }
+    pub fn new(
+        end_behavior: impl Into<CreatePaymentLinkSubscriptionDataTrialSettingsEndBehavior>,
+    ) -> Self {
+        Self { end_behavior: end_behavior.into() }
     }
 }
 /// Defines how the subscription should behave when the user's free trial ends.
@@ -2435,9 +2450,11 @@ pub struct CreatePaymentLinkSubscriptionDataTrialSettingsEndBehavior {
 }
 impl CreatePaymentLinkSubscriptionDataTrialSettingsEndBehavior {
     pub fn new(
-        missing_payment_method: CreatePaymentLinkSubscriptionDataTrialSettingsEndBehaviorMissingPaymentMethod,
+        missing_payment_method: impl Into<
+            CreatePaymentLinkSubscriptionDataTrialSettingsEndBehaviorMissingPaymentMethod,
+        >,
     ) -> Self {
-        Self { missing_payment_method }
+        Self { missing_payment_method: missing_payment_method.into() }
     }
 }
 /// Indicates how the subscription should change when the trial ends if the user did not provide a payment method.
@@ -2514,13 +2531,13 @@ pub struct CreatePaymentLinkTaxIdCollection {
     pub enabled: bool,
 }
 impl CreatePaymentLinkTaxIdCollection {
-    pub fn new(enabled: bool) -> Self {
-        Self { enabled }
+    pub fn new(enabled: impl Into<bool>) -> Self {
+        Self { enabled: enabled.into() }
     }
 }
 /// The account (if any) the payments will be attributed to for tax reporting, and where funds from each payment will be transferred to.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentLinkTransferData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentLinkTransferData {
     /// The amount that will be transferred automatically when a charge succeeds.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub amount: Option<i64>,
@@ -2528,111 +2545,117 @@ pub struct CreatePaymentLinkTransferData<'a> {
     /// account for tax reporting, and the funds from charges will be transferred
     /// to the destination account. The ID of the resulting transfer will be
     /// returned on the successful charge's `transfer` field.
-    pub destination: &'a str,
+    pub destination: String,
 }
-impl<'a> CreatePaymentLinkTransferData<'a> {
-    pub fn new(destination: &'a str) -> Self {
-        Self { amount: None, destination }
+impl CreatePaymentLinkTransferData {
+    pub fn new(destination: impl Into<String>) -> Self {
+        Self { amount: None, destination: destination.into() }
     }
 }
 /// Creates a payment link.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentLink<'a> {
-    inner: CreatePaymentLinkBuilder<'a>,
+pub struct CreatePaymentLink {
+    inner: CreatePaymentLinkBuilder,
 }
-impl<'a> CreatePaymentLink<'a> {
+impl CreatePaymentLink {
     /// Construct a new `CreatePaymentLink`.
-    pub fn new(line_items: &'a [CreatePaymentLinkLineItems<'a>]) -> Self {
-        Self { inner: CreatePaymentLinkBuilder::new(line_items) }
+    pub fn new(line_items: impl Into<Vec<CreatePaymentLinkLineItems>>) -> Self {
+        Self { inner: CreatePaymentLinkBuilder::new(line_items.into()) }
     }
     /// Behavior after the purchase is complete.
     pub fn after_completion(
         mut self,
-        after_completion: CreatePaymentLinkAfterCompletion<'a>,
+        after_completion: impl Into<CreatePaymentLinkAfterCompletion>,
     ) -> Self {
-        self.inner.after_completion = Some(after_completion);
+        self.inner.after_completion = Some(after_completion.into());
         self
     }
     /// Enables user redeemable promotion codes.
-    pub fn allow_promotion_codes(mut self, allow_promotion_codes: bool) -> Self {
-        self.inner.allow_promotion_codes = Some(allow_promotion_codes);
+    pub fn allow_promotion_codes(mut self, allow_promotion_codes: impl Into<bool>) -> Self {
+        self.inner.allow_promotion_codes = Some(allow_promotion_codes.into());
         self
     }
     /// The amount of the application fee (if any) that will be requested to be applied to the payment and transferred to the application owner's Stripe account.
     /// Can only be applied when there are no line items with recurring prices.
-    pub fn application_fee_amount(mut self, application_fee_amount: i64) -> Self {
-        self.inner.application_fee_amount = Some(application_fee_amount);
+    pub fn application_fee_amount(mut self, application_fee_amount: impl Into<i64>) -> Self {
+        self.inner.application_fee_amount = Some(application_fee_amount.into());
         self
     }
     /// A non-negative decimal between 0 and 100, with at most two decimal places.
     /// This represents the percentage of the subscription invoice total that will be transferred to the application owner's Stripe account.
     /// There must be at least 1 line item with a recurring price to use this field.
-    pub fn application_fee_percent(mut self, application_fee_percent: f64) -> Self {
-        self.inner.application_fee_percent = Some(application_fee_percent);
+    pub fn application_fee_percent(mut self, application_fee_percent: impl Into<f64>) -> Self {
+        self.inner.application_fee_percent = Some(application_fee_percent.into());
         self
     }
     /// Configuration for automatic tax collection.
-    pub fn automatic_tax(mut self, automatic_tax: CreatePaymentLinkAutomaticTax<'a>) -> Self {
-        self.inner.automatic_tax = Some(automatic_tax);
+    pub fn automatic_tax(
+        mut self,
+        automatic_tax: impl Into<CreatePaymentLinkAutomaticTax>,
+    ) -> Self {
+        self.inner.automatic_tax = Some(automatic_tax.into());
         self
     }
     /// Configuration for collecting the customer's billing address. Defaults to `auto`.
     pub fn billing_address_collection(
         mut self,
-        billing_address_collection: stripe_shared::PaymentLinkBillingAddressCollection,
+        billing_address_collection: impl Into<stripe_shared::PaymentLinkBillingAddressCollection>,
     ) -> Self {
-        self.inner.billing_address_collection = Some(billing_address_collection);
+        self.inner.billing_address_collection = Some(billing_address_collection.into());
         self
     }
     /// Configure fields to gather active consent from customers.
     pub fn consent_collection(
         mut self,
-        consent_collection: CreatePaymentLinkConsentCollection,
+        consent_collection: impl Into<CreatePaymentLinkConsentCollection>,
     ) -> Self {
-        self.inner.consent_collection = Some(consent_collection);
+        self.inner.consent_collection = Some(consent_collection.into());
         self
     }
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     /// Must be a [supported currency](https://stripe.com/docs/currencies) and supported by each line item's price.
-    pub fn currency(mut self, currency: stripe_types::Currency) -> Self {
-        self.inner.currency = Some(currency);
+    pub fn currency(mut self, currency: impl Into<stripe_types::Currency>) -> Self {
+        self.inner.currency = Some(currency.into());
         self
     }
     /// Collect additional information from your customer using custom fields.
     /// Up to 3 fields are supported.
-    pub fn custom_fields(mut self, custom_fields: &'a [CreatePaymentLinkCustomFields<'a>]) -> Self {
-        self.inner.custom_fields = Some(custom_fields);
+    pub fn custom_fields(
+        mut self,
+        custom_fields: impl Into<Vec<CreatePaymentLinkCustomFields>>,
+    ) -> Self {
+        self.inner.custom_fields = Some(custom_fields.into());
         self
     }
     /// Display additional text for your customers using custom text.
-    pub fn custom_text(mut self, custom_text: CustomTextParam<'a>) -> Self {
-        self.inner.custom_text = Some(custom_text);
+    pub fn custom_text(mut self, custom_text: impl Into<CustomTextParam>) -> Self {
+        self.inner.custom_text = Some(custom_text.into());
         self
     }
     /// Configures whether [checkout sessions](https://stripe.com/docs/api/checkout/sessions) created by this payment link create a [Customer](https://stripe.com/docs/api/customers).
     pub fn customer_creation(
         mut self,
-        customer_creation: CreatePaymentLinkCustomerCreation,
+        customer_creation: impl Into<CreatePaymentLinkCustomerCreation>,
     ) -> Self {
-        self.inner.customer_creation = Some(customer_creation);
+        self.inner.customer_creation = Some(customer_creation.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// The custom message to be displayed to a customer when a payment link is no longer active.
-    pub fn inactive_message(mut self, inactive_message: &'a str) -> Self {
-        self.inner.inactive_message = Some(inactive_message);
+    pub fn inactive_message(mut self, inactive_message: impl Into<String>) -> Self {
+        self.inner.inactive_message = Some(inactive_message.into());
         self
     }
     /// Generate a post-purchase Invoice for one-time payments.
     pub fn invoice_creation(
         mut self,
-        invoice_creation: CreatePaymentLinkInvoiceCreation<'a>,
+        invoice_creation: impl Into<CreatePaymentLinkInvoiceCreation>,
     ) -> Self {
-        self.inner.invoice_creation = Some(invoice_creation);
+        self.inner.invoice_creation = Some(invoice_creation.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
@@ -2640,21 +2663,24 @@ impl<'a> CreatePaymentLink<'a> {
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
     /// Metadata associated with this Payment Link will automatically be copied to [checkout sessions](https://stripe.com/docs/api/checkout/sessions) created by this payment link.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// The account on behalf of which to charge.
-    pub fn on_behalf_of(mut self, on_behalf_of: &'a str) -> Self {
-        self.inner.on_behalf_of = Some(on_behalf_of);
+    pub fn on_behalf_of(mut self, on_behalf_of: impl Into<String>) -> Self {
+        self.inner.on_behalf_of = Some(on_behalf_of.into());
         self
     }
     /// A subset of parameters to be passed to PaymentIntent creation for Checkout Sessions in `payment` mode.
     pub fn payment_intent_data(
         mut self,
-        payment_intent_data: CreatePaymentLinkPaymentIntentData<'a>,
+        payment_intent_data: impl Into<CreatePaymentLinkPaymentIntentData>,
     ) -> Self {
-        self.inner.payment_intent_data = Some(payment_intent_data);
+        self.inner.payment_intent_data = Some(payment_intent_data.into());
         self
     }
     /// Specify whether Checkout should collect a payment method.
@@ -2665,18 +2691,18 @@ impl<'a> CreatePaymentLink<'a> {
     /// If you'd like information on how to collect a payment method outside of Checkout, read the guide on [configuring subscriptions with a free trial](https://stripe.com/docs/payments/checkout/free-trials).
     pub fn payment_method_collection(
         mut self,
-        payment_method_collection: CreatePaymentLinkPaymentMethodCollection,
+        payment_method_collection: impl Into<CreatePaymentLinkPaymentMethodCollection>,
     ) -> Self {
-        self.inner.payment_method_collection = Some(payment_method_collection);
+        self.inner.payment_method_collection = Some(payment_method_collection.into());
         self
     }
     /// The list of payment method types that customers can use.
     /// If no value is passed, Stripe will dynamically show relevant payment methods from your [payment method settings](https://dashboard.stripe.com/settings/payment_methods) (20+ payment methods [supported](https://stripe.com/docs/payments/payment-methods/integration-options#payment-method-product-support)).
     pub fn payment_method_types(
         mut self,
-        payment_method_types: &'a [stripe_shared::PaymentLinkPaymentMethodTypes],
+        payment_method_types: impl Into<Vec<stripe_shared::PaymentLinkPaymentMethodTypes>>,
     ) -> Self {
-        self.inner.payment_method_types = Some(payment_method_types);
+        self.inner.payment_method_types = Some(payment_method_types.into());
         self
     }
     /// Controls phone number collection settings during checkout.
@@ -2684,62 +2710,68 @@ impl<'a> CreatePaymentLink<'a> {
     /// We recommend that you review your privacy policy and check with your legal contacts.
     pub fn phone_number_collection(
         mut self,
-        phone_number_collection: CreatePaymentLinkPhoneNumberCollection,
+        phone_number_collection: impl Into<CreatePaymentLinkPhoneNumberCollection>,
     ) -> Self {
-        self.inner.phone_number_collection = Some(phone_number_collection);
+        self.inner.phone_number_collection = Some(phone_number_collection.into());
         self
     }
     /// Settings that restrict the usage of a payment link.
-    pub fn restrictions(mut self, restrictions: RestrictionsParams) -> Self {
-        self.inner.restrictions = Some(restrictions);
+    pub fn restrictions(mut self, restrictions: impl Into<RestrictionsParams>) -> Self {
+        self.inner.restrictions = Some(restrictions.into());
         self
     }
     /// Configuration for collecting the customer's shipping address.
     pub fn shipping_address_collection(
         mut self,
-        shipping_address_collection: CreatePaymentLinkShippingAddressCollection<'a>,
+        shipping_address_collection: impl Into<CreatePaymentLinkShippingAddressCollection>,
     ) -> Self {
-        self.inner.shipping_address_collection = Some(shipping_address_collection);
+        self.inner.shipping_address_collection = Some(shipping_address_collection.into());
         self
     }
     /// The shipping rate options to apply to [checkout sessions](https://stripe.com/docs/api/checkout/sessions) created by this payment link.
     pub fn shipping_options(
         mut self,
-        shipping_options: &'a [CreatePaymentLinkShippingOptions<'a>],
+        shipping_options: impl Into<Vec<CreatePaymentLinkShippingOptions>>,
     ) -> Self {
-        self.inner.shipping_options = Some(shipping_options);
+        self.inner.shipping_options = Some(shipping_options.into());
         self
     }
     /// Describes the type of transaction being performed in order to customize relevant text on the page, such as the submit button.
     /// Changing this value will also affect the hostname in the [url](https://stripe.com/docs/api/payment_links/payment_links/object#url) property (example: `donate.stripe.com`).
-    pub fn submit_type(mut self, submit_type: stripe_shared::PaymentLinkSubmitType) -> Self {
-        self.inner.submit_type = Some(submit_type);
+    pub fn submit_type(
+        mut self,
+        submit_type: impl Into<stripe_shared::PaymentLinkSubmitType>,
+    ) -> Self {
+        self.inner.submit_type = Some(submit_type.into());
         self
     }
     /// When creating a subscription, the specified configuration data will be used.
     /// There must be at least one line item with a recurring price to use `subscription_data`.
     pub fn subscription_data(
         mut self,
-        subscription_data: CreatePaymentLinkSubscriptionData<'a>,
+        subscription_data: impl Into<CreatePaymentLinkSubscriptionData>,
     ) -> Self {
-        self.inner.subscription_data = Some(subscription_data);
+        self.inner.subscription_data = Some(subscription_data.into());
         self
     }
     /// Controls tax ID collection during checkout.
     pub fn tax_id_collection(
         mut self,
-        tax_id_collection: CreatePaymentLinkTaxIdCollection,
+        tax_id_collection: impl Into<CreatePaymentLinkTaxIdCollection>,
     ) -> Self {
-        self.inner.tax_id_collection = Some(tax_id_collection);
+        self.inner.tax_id_collection = Some(tax_id_collection.into());
         self
     }
     /// The account (if any) the payments will be attributed to for tax reporting, and where funds from each payment will be transferred to.
-    pub fn transfer_data(mut self, transfer_data: CreatePaymentLinkTransferData<'a>) -> Self {
-        self.inner.transfer_data = Some(transfer_data);
+    pub fn transfer_data(
+        mut self,
+        transfer_data: impl Into<CreatePaymentLinkTransferData>,
+    ) -> Self {
+        self.inner.transfer_data = Some(transfer_data.into());
         self
     }
 }
-impl CreatePaymentLink<'_> {
+impl CreatePaymentLink {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -2757,55 +2789,55 @@ impl CreatePaymentLink<'_> {
     }
 }
 
-impl StripeRequest for CreatePaymentLink<'_> {
+impl StripeRequest for CreatePaymentLink {
     type Output = stripe_shared::PaymentLink;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Post, "/payment_links").form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdatePaymentLinkBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdatePaymentLinkBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     active: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    after_completion: Option<UpdatePaymentLinkAfterCompletion<'a>>,
+    after_completion: Option<UpdatePaymentLinkAfterCompletion>,
     #[serde(skip_serializing_if = "Option::is_none")]
     allow_promotion_codes: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    automatic_tax: Option<UpdatePaymentLinkAutomaticTax<'a>>,
+    automatic_tax: Option<UpdatePaymentLinkAutomaticTax>,
     #[serde(skip_serializing_if = "Option::is_none")]
     billing_address_collection: Option<stripe_shared::PaymentLinkBillingAddressCollection>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    custom_fields: Option<&'a [UpdatePaymentLinkCustomFields<'a>]>,
+    custom_fields: Option<Vec<UpdatePaymentLinkCustomFields>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    custom_text: Option<CustomTextParam<'a>>,
+    custom_text: Option<CustomTextParam>,
     #[serde(skip_serializing_if = "Option::is_none")]
     customer_creation: Option<UpdatePaymentLinkCustomerCreation>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    inactive_message: Option<&'a str>,
+    inactive_message: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    invoice_creation: Option<UpdatePaymentLinkInvoiceCreation<'a>>,
+    invoice_creation: Option<UpdatePaymentLinkInvoiceCreation>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    line_items: Option<&'a [UpdatePaymentLinkLineItems<'a>]>,
+    line_items: Option<Vec<UpdatePaymentLinkLineItems>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_intent_data: Option<UpdatePaymentLinkPaymentIntentData<'a>>,
+    payment_intent_data: Option<UpdatePaymentLinkPaymentIntentData>,
     #[serde(skip_serializing_if = "Option::is_none")]
     payment_method_collection: Option<UpdatePaymentLinkPaymentMethodCollection>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_method_types: Option<&'a [stripe_shared::PaymentLinkPaymentMethodTypes]>,
+    payment_method_types: Option<Vec<stripe_shared::PaymentLinkPaymentMethodTypes>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     restrictions: Option<RestrictionsParams>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    shipping_address_collection: Option<UpdatePaymentLinkShippingAddressCollection<'a>>,
+    shipping_address_collection: Option<UpdatePaymentLinkShippingAddressCollection>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    subscription_data: Option<UpdatePaymentLinkSubscriptionData<'a>>,
+    subscription_data: Option<UpdatePaymentLinkSubscriptionData>,
 }
-impl<'a> UpdatePaymentLinkBuilder<'a> {
+impl UpdatePaymentLinkBuilder {
     fn new() -> Self {
         Self {
             active: None,
@@ -2831,21 +2863,21 @@ impl<'a> UpdatePaymentLinkBuilder<'a> {
     }
 }
 /// Behavior after the purchase is complete.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentLinkAfterCompletion<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdatePaymentLinkAfterCompletion {
     /// Configuration when `type=hosted_confirmation`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub hosted_confirmation: Option<AfterCompletionConfirmationPageParams<'a>>,
+    pub hosted_confirmation: Option<AfterCompletionConfirmationPageParams>,
     /// Configuration when `type=redirect`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub redirect: Option<AfterCompletionRedirectParams<'a>>,
+    pub redirect: Option<AfterCompletionRedirectParams>,
     /// The specified behavior after the purchase is complete. Either `redirect` or `hosted_confirmation`.
     #[serde(rename = "type")]
     pub type_: UpdatePaymentLinkAfterCompletionType,
 }
-impl<'a> UpdatePaymentLinkAfterCompletion<'a> {
-    pub fn new(type_: UpdatePaymentLinkAfterCompletionType) -> Self {
-        Self { hosted_confirmation: None, redirect: None, type_ }
+impl UpdatePaymentLinkAfterCompletion {
+    pub fn new(type_: impl Into<UpdatePaymentLinkAfterCompletionType>) -> Self {
+        Self { hosted_confirmation: None, redirect: None, type_: type_.into() }
     }
 }
 /// The specified behavior after the purchase is complete. Either `redirect` or `hosted_confirmation`.
@@ -2905,36 +2937,36 @@ impl<'de> serde::Deserialize<'de> for UpdatePaymentLinkAfterCompletionType {
     }
 }
 /// Configuration for automatic tax collection.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentLinkAutomaticTax<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdatePaymentLinkAutomaticTax {
     /// If `true`, tax will be calculated automatically using the customer's location.
     pub enabled: bool,
     /// The account that's liable for tax.
     /// If set, the business address and tax registrations required to perform the tax calculation are loaded from this account.
     /// The tax transaction is returned in the report of the connected account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub liability: Option<UpdatePaymentLinkAutomaticTaxLiability<'a>>,
+    pub liability: Option<UpdatePaymentLinkAutomaticTaxLiability>,
 }
-impl<'a> UpdatePaymentLinkAutomaticTax<'a> {
-    pub fn new(enabled: bool) -> Self {
-        Self { enabled, liability: None }
+impl UpdatePaymentLinkAutomaticTax {
+    pub fn new(enabled: impl Into<bool>) -> Self {
+        Self { enabled: enabled.into(), liability: None }
     }
 }
 /// The account that's liable for tax.
 /// If set, the business address and tax registrations required to perform the tax calculation are loaded from this account.
 /// The tax transaction is returned in the report of the connected account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentLinkAutomaticTaxLiability<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdatePaymentLinkAutomaticTaxLiability {
     /// The connected account being referenced when `type` is `account`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account: Option<&'a str>,
+    pub account: Option<String>,
     /// Type of the account referenced in the request.
     #[serde(rename = "type")]
     pub type_: UpdatePaymentLinkAutomaticTaxLiabilityType,
 }
-impl<'a> UpdatePaymentLinkAutomaticTaxLiability<'a> {
-    pub fn new(type_: UpdatePaymentLinkAutomaticTaxLiabilityType) -> Self {
-        Self { account: None, type_ }
+impl UpdatePaymentLinkAutomaticTaxLiability {
+    pub fn new(type_: impl Into<UpdatePaymentLinkAutomaticTaxLiabilityType>) -> Self {
+        Self { account: None, type_: type_.into() }
     }
 }
 /// Type of the account referenced in the request.
@@ -2995,16 +3027,16 @@ impl<'de> serde::Deserialize<'de> for UpdatePaymentLinkAutomaticTaxLiabilityType
 }
 /// Collect additional information from your customer using custom fields.
 /// Up to 3 fields are supported.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentLinkCustomFields<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdatePaymentLinkCustomFields {
     /// Configuration for `type=dropdown` fields.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub dropdown: Option<CustomFieldDropdownParam<'a>>,
+    pub dropdown: Option<CustomFieldDropdownParam>,
     /// String of your choice that your integration can use to reconcile this field.
     /// Must be unique to this field, alphanumeric, and up to 200 characters.
-    pub key: &'a str,
+    pub key: String,
     /// The label for the field, displayed to the customer.
-    pub label: UpdatePaymentLinkCustomFieldsLabel<'a>,
+    pub label: UpdatePaymentLinkCustomFieldsLabel,
     /// Configuration for `type=numeric` fields.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub numeric: Option<UpdatePaymentLinkCustomFieldsNumeric>,
@@ -3019,27 +3051,38 @@ pub struct UpdatePaymentLinkCustomFields<'a> {
     #[serde(rename = "type")]
     pub type_: UpdatePaymentLinkCustomFieldsType,
 }
-impl<'a> UpdatePaymentLinkCustomFields<'a> {
+impl UpdatePaymentLinkCustomFields {
     pub fn new(
-        key: &'a str,
-        label: UpdatePaymentLinkCustomFieldsLabel<'a>,
-        type_: UpdatePaymentLinkCustomFieldsType,
+        key: impl Into<String>,
+        label: impl Into<UpdatePaymentLinkCustomFieldsLabel>,
+        type_: impl Into<UpdatePaymentLinkCustomFieldsType>,
     ) -> Self {
-        Self { dropdown: None, key, label, numeric: None, optional: None, text: None, type_ }
+        Self {
+            dropdown: None,
+            key: key.into(),
+            label: label.into(),
+            numeric: None,
+            optional: None,
+            text: None,
+            type_: type_.into(),
+        }
     }
 }
 /// The label for the field, displayed to the customer.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentLinkCustomFieldsLabel<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdatePaymentLinkCustomFieldsLabel {
     /// Custom text for the label, displayed to the customer. Up to 50 characters.
-    pub custom: &'a str,
+    pub custom: String,
     /// The type of the label.
     #[serde(rename = "type")]
     pub type_: UpdatePaymentLinkCustomFieldsLabelType,
 }
-impl<'a> UpdatePaymentLinkCustomFieldsLabel<'a> {
-    pub fn new(custom: &'a str, type_: UpdatePaymentLinkCustomFieldsLabelType) -> Self {
-        Self { custom, type_ }
+impl UpdatePaymentLinkCustomFieldsLabel {
+    pub fn new(
+        custom: impl Into<String>,
+        type_: impl Into<UpdatePaymentLinkCustomFieldsLabelType>,
+    ) -> Self {
+        Self { custom: custom.into(), type_: type_.into() }
     }
 }
 /// The type of the label.
@@ -3251,49 +3294,49 @@ impl<'de> serde::Deserialize<'de> for UpdatePaymentLinkCustomerCreation {
     }
 }
 /// Generate a post-purchase Invoice for one-time payments.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentLinkInvoiceCreation<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdatePaymentLinkInvoiceCreation {
     /// Whether the feature is enabled
     pub enabled: bool,
     /// Invoice PDF configuration.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub invoice_data: Option<UpdatePaymentLinkInvoiceCreationInvoiceData<'a>>,
+    pub invoice_data: Option<UpdatePaymentLinkInvoiceCreationInvoiceData>,
 }
-impl<'a> UpdatePaymentLinkInvoiceCreation<'a> {
-    pub fn new(enabled: bool) -> Self {
-        Self { enabled, invoice_data: None }
+impl UpdatePaymentLinkInvoiceCreation {
+    pub fn new(enabled: impl Into<bool>) -> Self {
+        Self { enabled: enabled.into(), invoice_data: None }
     }
 }
 /// Invoice PDF configuration.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentLinkInvoiceCreationInvoiceData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdatePaymentLinkInvoiceCreationInvoiceData {
     /// The account tax IDs associated with the invoice.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account_tax_ids: Option<&'a [&'a str]>,
+    pub account_tax_ids: Option<Vec<String>>,
     /// Default custom fields to be displayed on invoices for this customer.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub custom_fields: Option<&'a [CustomFieldParams<'a>]>,
+    pub custom_fields: Option<Vec<CustomFieldParams>>,
     /// An arbitrary string attached to the object. Often useful for displaying to users.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<&'a str>,
+    pub description: Option<String>,
     /// Default footer to be displayed on invoices for this customer.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub footer: Option<&'a str>,
+    pub footer: Option<String>,
     /// The connected account that issues the invoice.
     /// The invoice is presented with the branding and support information of the specified account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub issuer: Option<UpdatePaymentLinkInvoiceCreationInvoiceDataIssuer<'a>>,
+    pub issuer: Option<UpdatePaymentLinkInvoiceCreationInvoiceDataIssuer>,
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// Default options for invoice PDF rendering for this customer.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rendering_options: Option<UpdatePaymentLinkInvoiceCreationInvoiceDataRenderingOptions>,
 }
-impl<'a> UpdatePaymentLinkInvoiceCreationInvoiceData<'a> {
+impl UpdatePaymentLinkInvoiceCreationInvoiceData {
     pub fn new() -> Self {
         Self {
             account_tax_ids: None,
@@ -3306,25 +3349,25 @@ impl<'a> UpdatePaymentLinkInvoiceCreationInvoiceData<'a> {
         }
     }
 }
-impl<'a> Default for UpdatePaymentLinkInvoiceCreationInvoiceData<'a> {
+impl Default for UpdatePaymentLinkInvoiceCreationInvoiceData {
     fn default() -> Self {
         Self::new()
     }
 }
 /// The connected account that issues the invoice.
 /// The invoice is presented with the branding and support information of the specified account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentLinkInvoiceCreationInvoiceDataIssuer<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdatePaymentLinkInvoiceCreationInvoiceDataIssuer {
     /// The connected account being referenced when `type` is `account`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account: Option<&'a str>,
+    pub account: Option<String>,
     /// Type of the account referenced in the request.
     #[serde(rename = "type")]
     pub type_: UpdatePaymentLinkInvoiceCreationInvoiceDataIssuerType,
 }
-impl<'a> UpdatePaymentLinkInvoiceCreationInvoiceDataIssuer<'a> {
-    pub fn new(type_: UpdatePaymentLinkInvoiceCreationInvoiceDataIssuerType) -> Self {
-        Self { account: None, type_ }
+impl UpdatePaymentLinkInvoiceCreationInvoiceDataIssuer {
+    pub fn new(type_: impl Into<UpdatePaymentLinkInvoiceCreationInvoiceDataIssuerType>) -> Self {
+        Self { account: None, type_: type_.into() }
     }
 }
 /// Type of the account referenced in the request.
@@ -3476,48 +3519,48 @@ impl<'de> serde::Deserialize<'de>
 /// The line items representing what is being sold.
 /// Each line item represents an item being sold.
 /// Up to 20 line items are supported.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentLinkLineItems<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdatePaymentLinkLineItems {
     /// When set, provides configuration for this item’s quantity to be adjusted by the customer during checkout.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub adjustable_quantity: Option<AdjustableQuantityParams>,
     /// The ID of an existing line item on the payment link.
-    pub id: &'a str,
+    pub id: String,
     /// The quantity of the line item being purchased.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub quantity: Option<u64>,
 }
-impl<'a> UpdatePaymentLinkLineItems<'a> {
-    pub fn new(id: &'a str) -> Self {
-        Self { adjustable_quantity: None, id, quantity: None }
+impl UpdatePaymentLinkLineItems {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self { adjustable_quantity: None, id: id.into(), quantity: None }
     }
 }
 /// A subset of parameters to be passed to PaymentIntent creation for Checkout Sessions in `payment` mode.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentLinkPaymentIntentData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdatePaymentLinkPaymentIntentData {
     /// An arbitrary string attached to the object. Often useful for displaying to users.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<&'a str>,
+    pub description: Option<String>,
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that will declaratively set metadata on [Payment Intents](https://stripe.com/docs/api/payment_intents) generated from this payment link.
     /// Unlike object-level metadata, this field is declarative.
     /// Updates will clear prior values.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// Extra information about the payment.
     /// This will appear on your customer's statement when this payment succeeds in creating a charge.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub statement_descriptor: Option<&'a str>,
+    pub statement_descriptor: Option<String>,
     /// Provides information about the charge that customers see on their statements.
     /// Concatenated with the prefix (shortened descriptor) or statement descriptor that's set on the account to form the complete statement descriptor.
     /// Maximum 22 characters for the concatenated descriptor.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub statement_descriptor_suffix: Option<&'a str>,
+    pub statement_descriptor_suffix: Option<String>,
     /// A string that identifies the resulting payment as part of a group.
     /// See the PaymentIntents [use case for connected accounts](https://stripe.com/docs/connect/separate-charges-and-transfers) for details.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub transfer_group: Option<&'a str>,
+    pub transfer_group: Option<String>,
 }
-impl<'a> UpdatePaymentLinkPaymentIntentData<'a> {
+impl UpdatePaymentLinkPaymentIntentData {
     pub fn new() -> Self {
         Self {
             description: None,
@@ -3528,7 +3571,7 @@ impl<'a> UpdatePaymentLinkPaymentIntentData<'a> {
         }
     }
 }
-impl<'a> Default for UpdatePaymentLinkPaymentIntentData<'a> {
+impl Default for UpdatePaymentLinkPaymentIntentData {
     fn default() -> Self {
         Self::new()
     }
@@ -3595,18 +3638,18 @@ impl<'de> serde::Deserialize<'de> for UpdatePaymentLinkPaymentMethodCollection {
     }
 }
 /// Configuration for collecting the customer's shipping address.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentLinkShippingAddressCollection<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdatePaymentLinkShippingAddressCollection {
     /// An array of two-letter ISO country codes representing which countries Checkout should provide as options for.
     /// shipping locations.
     /// Unsupported country codes: `AS, CX, CC, CU, HM, IR, KP, MH, FM, NF, MP, PW, SD, SY, UM, VI`.
-    pub allowed_countries: &'a [UpdatePaymentLinkShippingAddressCollectionAllowedCountries],
+    pub allowed_countries: Vec<UpdatePaymentLinkShippingAddressCollectionAllowedCountries>,
 }
-impl<'a> UpdatePaymentLinkShippingAddressCollection<'a> {
+impl UpdatePaymentLinkShippingAddressCollection {
     pub fn new(
-        allowed_countries: &'a [UpdatePaymentLinkShippingAddressCollectionAllowedCountries],
+        allowed_countries: impl Into<Vec<UpdatePaymentLinkShippingAddressCollectionAllowedCountries>>,
     ) -> Self {
-        Self { allowed_countries }
+        Self { allowed_countries: allowed_countries.into() }
     }
 }
 /// An array of two-letter ISO country codes representing which countries Checkout should provide as options for.
@@ -4376,62 +4419,64 @@ impl<'de> serde::Deserialize<'de> for UpdatePaymentLinkShippingAddressCollection
 }
 /// When creating a subscription, the specified configuration data will be used.
 /// There must be at least one line item with a recurring price to use `subscription_data`.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentLinkSubscriptionData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdatePaymentLinkSubscriptionData {
     /// All invoices will be billed using the specified settings.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub invoice_settings: Option<UpdatePaymentLinkSubscriptionDataInvoiceSettings<'a>>,
+    pub invoice_settings: Option<UpdatePaymentLinkSubscriptionDataInvoiceSettings>,
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that will declaratively set metadata on [Subscriptions](https://stripe.com/docs/api/subscriptions) generated from this payment link.
     /// Unlike object-level metadata, this field is declarative.
     /// Updates will clear prior values.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// Settings related to subscription trials.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub trial_settings: Option<UpdatePaymentLinkSubscriptionDataTrialSettings>,
 }
-impl<'a> UpdatePaymentLinkSubscriptionData<'a> {
+impl UpdatePaymentLinkSubscriptionData {
     pub fn new() -> Self {
         Self { invoice_settings: None, metadata: None, trial_settings: None }
     }
 }
-impl<'a> Default for UpdatePaymentLinkSubscriptionData<'a> {
+impl Default for UpdatePaymentLinkSubscriptionData {
     fn default() -> Self {
         Self::new()
     }
 }
 /// All invoices will be billed using the specified settings.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentLinkSubscriptionDataInvoiceSettings<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdatePaymentLinkSubscriptionDataInvoiceSettings {
     /// The connected account that issues the invoice.
     /// The invoice is presented with the branding and support information of the specified account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub issuer: Option<UpdatePaymentLinkSubscriptionDataInvoiceSettingsIssuer<'a>>,
+    pub issuer: Option<UpdatePaymentLinkSubscriptionDataInvoiceSettingsIssuer>,
 }
-impl<'a> UpdatePaymentLinkSubscriptionDataInvoiceSettings<'a> {
+impl UpdatePaymentLinkSubscriptionDataInvoiceSettings {
     pub fn new() -> Self {
         Self { issuer: None }
     }
 }
-impl<'a> Default for UpdatePaymentLinkSubscriptionDataInvoiceSettings<'a> {
+impl Default for UpdatePaymentLinkSubscriptionDataInvoiceSettings {
     fn default() -> Self {
         Self::new()
     }
 }
 /// The connected account that issues the invoice.
 /// The invoice is presented with the branding and support information of the specified account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentLinkSubscriptionDataInvoiceSettingsIssuer<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdatePaymentLinkSubscriptionDataInvoiceSettingsIssuer {
     /// The connected account being referenced when `type` is `account`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account: Option<&'a str>,
+    pub account: Option<String>,
     /// Type of the account referenced in the request.
     #[serde(rename = "type")]
     pub type_: UpdatePaymentLinkSubscriptionDataInvoiceSettingsIssuerType,
 }
-impl<'a> UpdatePaymentLinkSubscriptionDataInvoiceSettingsIssuer<'a> {
-    pub fn new(type_: UpdatePaymentLinkSubscriptionDataInvoiceSettingsIssuerType) -> Self {
-        Self { account: None, type_ }
+impl UpdatePaymentLinkSubscriptionDataInvoiceSettingsIssuer {
+    pub fn new(
+        type_: impl Into<UpdatePaymentLinkSubscriptionDataInvoiceSettingsIssuerType>,
+    ) -> Self {
+        Self { account: None, type_: type_.into() }
     }
 }
 /// Type of the account referenced in the request.
@@ -4499,8 +4544,10 @@ pub struct UpdatePaymentLinkSubscriptionDataTrialSettings {
     pub end_behavior: UpdatePaymentLinkSubscriptionDataTrialSettingsEndBehavior,
 }
 impl UpdatePaymentLinkSubscriptionDataTrialSettings {
-    pub fn new(end_behavior: UpdatePaymentLinkSubscriptionDataTrialSettingsEndBehavior) -> Self {
-        Self { end_behavior }
+    pub fn new(
+        end_behavior: impl Into<UpdatePaymentLinkSubscriptionDataTrialSettingsEndBehavior>,
+    ) -> Self {
+        Self { end_behavior: end_behavior.into() }
     }
 }
 /// Defines how the subscription should behave when the user's free trial ends.
@@ -4512,9 +4559,11 @@ pub struct UpdatePaymentLinkSubscriptionDataTrialSettingsEndBehavior {
 }
 impl UpdatePaymentLinkSubscriptionDataTrialSettingsEndBehavior {
     pub fn new(
-        missing_payment_method: UpdatePaymentLinkSubscriptionDataTrialSettingsEndBehaviorMissingPaymentMethod,
+        missing_payment_method: impl Into<
+            UpdatePaymentLinkSubscriptionDataTrialSettingsEndBehaviorMissingPaymentMethod,
+        >,
     ) -> Self {
-        Self { missing_payment_method }
+        Self { missing_payment_method: missing_payment_method.into() }
     }
 }
 /// Indicates how the subscription should change when the trial ends if the user did not provide a payment method.
@@ -4586,89 +4635,95 @@ impl<'de> serde::Deserialize<'de>
 }
 /// Updates a payment link.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentLink<'a> {
-    inner: UpdatePaymentLinkBuilder<'a>,
-    payment_link: &'a stripe_shared::PaymentLinkId,
+pub struct UpdatePaymentLink {
+    inner: UpdatePaymentLinkBuilder,
+    payment_link: stripe_shared::PaymentLinkId,
 }
-impl<'a> UpdatePaymentLink<'a> {
+impl UpdatePaymentLink {
     /// Construct a new `UpdatePaymentLink`.
-    pub fn new(payment_link: &'a stripe_shared::PaymentLinkId) -> Self {
-        Self { payment_link, inner: UpdatePaymentLinkBuilder::new() }
+    pub fn new(payment_link: impl Into<stripe_shared::PaymentLinkId>) -> Self {
+        Self { payment_link: payment_link.into(), inner: UpdatePaymentLinkBuilder::new() }
     }
     /// Whether the payment link's `url` is active.
     /// If `false`, customers visiting the URL will be shown a page saying that the link has been deactivated.
-    pub fn active(mut self, active: bool) -> Self {
-        self.inner.active = Some(active);
+    pub fn active(mut self, active: impl Into<bool>) -> Self {
+        self.inner.active = Some(active.into());
         self
     }
     /// Behavior after the purchase is complete.
     pub fn after_completion(
         mut self,
-        after_completion: UpdatePaymentLinkAfterCompletion<'a>,
+        after_completion: impl Into<UpdatePaymentLinkAfterCompletion>,
     ) -> Self {
-        self.inner.after_completion = Some(after_completion);
+        self.inner.after_completion = Some(after_completion.into());
         self
     }
     /// Enables user redeemable promotion codes.
-    pub fn allow_promotion_codes(mut self, allow_promotion_codes: bool) -> Self {
-        self.inner.allow_promotion_codes = Some(allow_promotion_codes);
+    pub fn allow_promotion_codes(mut self, allow_promotion_codes: impl Into<bool>) -> Self {
+        self.inner.allow_promotion_codes = Some(allow_promotion_codes.into());
         self
     }
     /// Configuration for automatic tax collection.
-    pub fn automatic_tax(mut self, automatic_tax: UpdatePaymentLinkAutomaticTax<'a>) -> Self {
-        self.inner.automatic_tax = Some(automatic_tax);
+    pub fn automatic_tax(
+        mut self,
+        automatic_tax: impl Into<UpdatePaymentLinkAutomaticTax>,
+    ) -> Self {
+        self.inner.automatic_tax = Some(automatic_tax.into());
         self
     }
     /// Configuration for collecting the customer's billing address. Defaults to `auto`.
     pub fn billing_address_collection(
         mut self,
-        billing_address_collection: stripe_shared::PaymentLinkBillingAddressCollection,
+        billing_address_collection: impl Into<stripe_shared::PaymentLinkBillingAddressCollection>,
     ) -> Self {
-        self.inner.billing_address_collection = Some(billing_address_collection);
+        self.inner.billing_address_collection = Some(billing_address_collection.into());
         self
     }
     /// Collect additional information from your customer using custom fields.
     /// Up to 3 fields are supported.
-    pub fn custom_fields(mut self, custom_fields: &'a [UpdatePaymentLinkCustomFields<'a>]) -> Self {
-        self.inner.custom_fields = Some(custom_fields);
+    pub fn custom_fields(
+        mut self,
+        custom_fields: impl Into<Vec<UpdatePaymentLinkCustomFields>>,
+    ) -> Self {
+        self.inner.custom_fields = Some(custom_fields.into());
         self
     }
     /// Display additional text for your customers using custom text.
-    pub fn custom_text(mut self, custom_text: CustomTextParam<'a>) -> Self {
-        self.inner.custom_text = Some(custom_text);
+    pub fn custom_text(mut self, custom_text: impl Into<CustomTextParam>) -> Self {
+        self.inner.custom_text = Some(custom_text.into());
         self
     }
     /// Configures whether [checkout sessions](https://stripe.com/docs/api/checkout/sessions) created by this payment link create a [Customer](https://stripe.com/docs/api/customers).
     pub fn customer_creation(
         mut self,
-        customer_creation: UpdatePaymentLinkCustomerCreation,
+        customer_creation: impl Into<UpdatePaymentLinkCustomerCreation>,
     ) -> Self {
-        self.inner.customer_creation = Some(customer_creation);
+        self.inner.customer_creation = Some(customer_creation.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// The custom message to be displayed to a customer when a payment link is no longer active.
-    pub fn inactive_message(mut self, inactive_message: &'a str) -> Self {
-        self.inner.inactive_message = Some(inactive_message);
+    pub fn inactive_message(mut self, inactive_message: impl Into<String>) -> Self {
+        self.inner.inactive_message = Some(inactive_message.into());
         self
     }
     /// Generate a post-purchase Invoice for one-time payments.
     pub fn invoice_creation(
         mut self,
-        invoice_creation: UpdatePaymentLinkInvoiceCreation<'a>,
+        invoice_creation: impl Into<UpdatePaymentLinkInvoiceCreation>,
     ) -> Self {
-        self.inner.invoice_creation = Some(invoice_creation);
+        self.inner.invoice_creation = Some(invoice_creation.into());
         self
     }
     /// The line items representing what is being sold.
     /// Each line item represents an item being sold.
     /// Up to 20 line items are supported.
-    pub fn line_items(mut self, line_items: &'a [UpdatePaymentLinkLineItems<'a>]) -> Self {
-        self.inner.line_items = Some(line_items);
+    pub fn line_items(mut self, line_items: impl Into<Vec<UpdatePaymentLinkLineItems>>) -> Self {
+        self.inner.line_items = Some(line_items.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
@@ -4676,16 +4731,19 @@ impl<'a> UpdatePaymentLink<'a> {
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
     /// Metadata associated with this Payment Link will automatically be copied to [checkout sessions](https://stripe.com/docs/api/checkout/sessions) created by this payment link.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// A subset of parameters to be passed to PaymentIntent creation for Checkout Sessions in `payment` mode.
     pub fn payment_intent_data(
         mut self,
-        payment_intent_data: UpdatePaymentLinkPaymentIntentData<'a>,
+        payment_intent_data: impl Into<UpdatePaymentLinkPaymentIntentData>,
     ) -> Self {
-        self.inner.payment_intent_data = Some(payment_intent_data);
+        self.inner.payment_intent_data = Some(payment_intent_data.into());
         self
     }
     /// Specify whether Checkout should collect a payment method.
@@ -4696,44 +4754,44 @@ impl<'a> UpdatePaymentLink<'a> {
     /// If you'd like information on how to collect a payment method outside of Checkout, read the guide on [configuring subscriptions with a free trial](https://stripe.com/docs/payments/checkout/free-trials).
     pub fn payment_method_collection(
         mut self,
-        payment_method_collection: UpdatePaymentLinkPaymentMethodCollection,
+        payment_method_collection: impl Into<UpdatePaymentLinkPaymentMethodCollection>,
     ) -> Self {
-        self.inner.payment_method_collection = Some(payment_method_collection);
+        self.inner.payment_method_collection = Some(payment_method_collection.into());
         self
     }
     /// The list of payment method types that customers can use.
     /// Pass an empty string to enable dynamic payment methods that use your [payment method settings](https://dashboard.stripe.com/settings/payment_methods).
     pub fn payment_method_types(
         mut self,
-        payment_method_types: &'a [stripe_shared::PaymentLinkPaymentMethodTypes],
+        payment_method_types: impl Into<Vec<stripe_shared::PaymentLinkPaymentMethodTypes>>,
     ) -> Self {
-        self.inner.payment_method_types = Some(payment_method_types);
+        self.inner.payment_method_types = Some(payment_method_types.into());
         self
     }
     /// Settings that restrict the usage of a payment link.
-    pub fn restrictions(mut self, restrictions: RestrictionsParams) -> Self {
-        self.inner.restrictions = Some(restrictions);
+    pub fn restrictions(mut self, restrictions: impl Into<RestrictionsParams>) -> Self {
+        self.inner.restrictions = Some(restrictions.into());
         self
     }
     /// Configuration for collecting the customer's shipping address.
     pub fn shipping_address_collection(
         mut self,
-        shipping_address_collection: UpdatePaymentLinkShippingAddressCollection<'a>,
+        shipping_address_collection: impl Into<UpdatePaymentLinkShippingAddressCollection>,
     ) -> Self {
-        self.inner.shipping_address_collection = Some(shipping_address_collection);
+        self.inner.shipping_address_collection = Some(shipping_address_collection.into());
         self
     }
     /// When creating a subscription, the specified configuration data will be used.
     /// There must be at least one line item with a recurring price to use `subscription_data`.
     pub fn subscription_data(
         mut self,
-        subscription_data: UpdatePaymentLinkSubscriptionData<'a>,
+        subscription_data: impl Into<UpdatePaymentLinkSubscriptionData>,
     ) -> Self {
-        self.inner.subscription_data = Some(subscription_data);
+        self.inner.subscription_data = Some(subscription_data.into());
         self
     }
 }
-impl UpdatePaymentLink<'_> {
+impl UpdatePaymentLink {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -4751,76 +4809,76 @@ impl UpdatePaymentLink<'_> {
     }
 }
 
-impl StripeRequest for UpdatePaymentLink<'_> {
+impl StripeRequest for UpdatePaymentLink {
     type Output = stripe_shared::PaymentLink;
 
     fn build(&self) -> RequestBuilder {
-        let payment_link = self.payment_link;
+        let payment_link = &self.payment_link;
         RequestBuilder::new(StripeMethod::Post, format!("/payment_links/{payment_link}"))
             .form(&self.inner)
     }
 }
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct AfterCompletionConfirmationPageParams<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct AfterCompletionConfirmationPageParams {
     /// A custom message to display to the customer after the purchase is complete.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub custom_message: Option<&'a str>,
+    pub custom_message: Option<String>,
 }
-impl<'a> AfterCompletionConfirmationPageParams<'a> {
+impl AfterCompletionConfirmationPageParams {
     pub fn new() -> Self {
         Self { custom_message: None }
     }
 }
-impl<'a> Default for AfterCompletionConfirmationPageParams<'a> {
+impl Default for AfterCompletionConfirmationPageParams {
     fn default() -> Self {
         Self::new()
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct AfterCompletionRedirectParams<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct AfterCompletionRedirectParams {
     /// The URL the customer will be redirected to after the purchase is complete.
     /// You can embed `{CHECKOUT_SESSION_ID}` into the URL to have the `id` of the completed [checkout session](https://stripe.com/docs/api/checkout/sessions/object#checkout_session_object-id) included.
-    pub url: &'a str,
+    pub url: String,
 }
-impl<'a> AfterCompletionRedirectParams<'a> {
-    pub fn new(url: &'a str) -> Self {
-        Self { url }
+impl AfterCompletionRedirectParams {
+    pub fn new(url: impl Into<String>) -> Self {
+        Self { url: url.into() }
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CustomFieldOptionParam<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CustomFieldOptionParam {
     /// The label for the option, displayed to the customer. Up to 100 characters.
-    pub label: &'a str,
+    pub label: String,
     /// The value for this option, not displayed to the customer, used by your integration to reconcile the option selected by the customer.
     /// Must be unique to this option, alphanumeric, and up to 100 characters.
-    pub value: &'a str,
+    pub value: String,
 }
-impl<'a> CustomFieldOptionParam<'a> {
-    pub fn new(label: &'a str, value: &'a str) -> Self {
-        Self { label, value }
+impl CustomFieldOptionParam {
+    pub fn new(label: impl Into<String>, value: impl Into<String>) -> Self {
+        Self { label: label.into(), value: value.into() }
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CustomTextPositionParam<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CustomTextPositionParam {
     /// Text may be up to 1200 characters in length.
-    pub message: &'a str,
+    pub message: String,
 }
-impl<'a> CustomTextPositionParam<'a> {
-    pub fn new(message: &'a str) -> Self {
-        Self { message }
+impl CustomTextPositionParam {
+    pub fn new(message: impl Into<String>) -> Self {
+        Self { message: message.into() }
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CustomFieldParams<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CustomFieldParams {
     /// The name of the custom field. This may be up to 40 characters.
-    pub name: &'a str,
+    pub name: String,
     /// The value of the custom field. This may be up to 140 characters.
-    pub value: &'a str,
+    pub value: String,
 }
-impl<'a> CustomFieldParams<'a> {
-    pub fn new(name: &'a str, value: &'a str) -> Self {
-        Self { name, value }
+impl CustomFieldParams {
+    pub fn new(name: impl Into<String>, value: impl Into<String>) -> Self {
+        Self { name: name.into(), value: value.into() }
     }
 }
 #[derive(Copy, Clone, Debug, serde::Serialize)]
@@ -4839,8 +4897,8 @@ pub struct AdjustableQuantityParams {
     pub minimum: Option<i64>,
 }
 impl AdjustableQuantityParams {
-    pub fn new(enabled: bool) -> Self {
-        Self { enabled, maximum: None, minimum: None }
+    pub fn new(enabled: impl Into<bool>) -> Self {
+        Self { enabled: enabled.into(), maximum: None, minimum: None }
     }
 }
 #[derive(Copy, Clone, Debug, serde::Serialize)]
@@ -4849,36 +4907,36 @@ pub struct CompletedSessionsParams {
     pub limit: i64,
 }
 impl CompletedSessionsParams {
-    pub fn new(limit: i64) -> Self {
-        Self { limit }
+    pub fn new(limit: impl Into<i64>) -> Self {
+        Self { limit: limit.into() }
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CustomFieldDropdownParam<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CustomFieldDropdownParam {
     /// The options available for the customer to select. Up to 200 options allowed.
-    pub options: &'a [CustomFieldOptionParam<'a>],
+    pub options: Vec<CustomFieldOptionParam>,
 }
-impl<'a> CustomFieldDropdownParam<'a> {
-    pub fn new(options: &'a [CustomFieldOptionParam<'a>]) -> Self {
-        Self { options }
+impl CustomFieldDropdownParam {
+    pub fn new(options: impl Into<Vec<CustomFieldOptionParam>>) -> Self {
+        Self { options: options.into() }
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CustomTextParam<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CustomTextParam {
     /// Custom text that should be displayed after the payment confirmation button.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub after_submit: Option<CustomTextPositionParam<'a>>,
+    pub after_submit: Option<CustomTextPositionParam>,
     /// Custom text that should be displayed alongside shipping address collection.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub shipping_address: Option<CustomTextPositionParam<'a>>,
+    pub shipping_address: Option<CustomTextPositionParam>,
     /// Custom text that should be displayed alongside the payment confirmation button.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub submit: Option<CustomTextPositionParam<'a>>,
+    pub submit: Option<CustomTextPositionParam>,
     /// Custom text that should be displayed in place of the default terms of service agreement text.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub terms_of_service_acceptance: Option<CustomTextPositionParam<'a>>,
+    pub terms_of_service_acceptance: Option<CustomTextPositionParam>,
 }
-impl<'a> CustomTextParam<'a> {
+impl CustomTextParam {
     pub fn new() -> Self {
         Self {
             after_submit: None,
@@ -4888,7 +4946,7 @@ impl<'a> CustomTextParam<'a> {
         }
     }
 }
-impl<'a> Default for CustomTextParam<'a> {
+impl Default for CustomTextParam {
     fn default() -> Self {
         Self::new()
     }
@@ -4899,7 +4957,7 @@ pub struct RestrictionsParams {
     pub completed_sessions: CompletedSessionsParams,
 }
 impl RestrictionsParams {
-    pub fn new(completed_sessions: CompletedSessionsParams) -> Self {
-        Self { completed_sessions }
+    pub fn new(completed_sessions: impl Into<CompletedSessionsParams>) -> Self {
+        Self { completed_sessions: completed_sessions.into() }
     }
 }

--- a/generated/async-stripe-payment/src/payment_method/requests.rs
+++ b/generated/async-stripe-payment/src/payment_method/requests.rs
@@ -2,23 +2,23 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListPaymentMethodBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListPaymentMethodBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    customer: Option<&'a str>,
+    customer: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
     #[serde(rename = "type")]
     #[serde(skip_serializing_if = "Option::is_none")]
     type_: Option<ListPaymentMethodType>,
 }
-impl<'a> ListPaymentMethodBuilder<'a> {
+impl ListPaymentMethodBuilder {
     fn new() -> Self {
         Self {
             customer: None,
@@ -192,58 +192,58 @@ impl<'de> serde::Deserialize<'de> for ListPaymentMethodType {
 /// Returns a list of PaymentMethods for Treasury flows.
 /// If you want to list the PaymentMethods attached to a Customer for payments, you should use the [List a Customer’s PaymentMethods](https://stripe.com/docs/api/payment_methods/customer_list) API instead.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListPaymentMethod<'a> {
-    inner: ListPaymentMethodBuilder<'a>,
+pub struct ListPaymentMethod {
+    inner: ListPaymentMethodBuilder,
 }
-impl<'a> ListPaymentMethod<'a> {
+impl ListPaymentMethod {
     /// Construct a new `ListPaymentMethod`.
     pub fn new() -> Self {
         Self { inner: ListPaymentMethodBuilder::new() }
     }
     /// The ID of the customer whose PaymentMethods will be retrieved.
-    pub fn customer(mut self, customer: &'a str) -> Self {
-        self.inner.customer = Some(customer);
+    pub fn customer(mut self, customer: impl Into<String>) -> Self {
+        self.inner.customer = Some(customer.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
     /// An optional filter on the list, based on the object `type` field.
     /// Without the filter, the list includes all current and future payment method types.
     /// If your integration expects only one type of payment method in the response, make sure to provide a type value in the request.
-    pub fn type_(mut self, type_: ListPaymentMethodType) -> Self {
-        self.inner.type_ = Some(type_);
+    pub fn type_(mut self, type_: impl Into<ListPaymentMethodType>) -> Self {
+        self.inner.type_ = Some(type_.into());
         self
     }
 }
-impl<'a> Default for ListPaymentMethod<'a> {
+impl Default for ListPaymentMethod {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListPaymentMethod<'_> {
+impl ListPaymentMethod {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -263,23 +263,23 @@ impl ListPaymentMethod<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::PaymentMethod>> {
-        stripe_client_core::ListPaginator::new_list("/payment_methods", self.inner)
+        stripe_client_core::ListPaginator::new_list("/payment_methods", &self.inner)
     }
 }
 
-impl StripeRequest for ListPaymentMethod<'_> {
+impl StripeRequest for ListPaymentMethod {
     type Output = stripe_types::List<stripe_shared::PaymentMethod>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/payment_methods").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrievePaymentMethodBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrievePaymentMethodBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrievePaymentMethodBuilder<'a> {
+impl RetrievePaymentMethodBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
@@ -287,22 +287,22 @@ impl<'a> RetrievePaymentMethodBuilder<'a> {
 /// Retrieves a PaymentMethod object attached to the StripeAccount.
 /// To retrieve a payment method attached to a Customer, you should use [Retrieve a Customer’s PaymentMethods](https://stripe.com/docs/api/payment_methods/customer).
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrievePaymentMethod<'a> {
-    inner: RetrievePaymentMethodBuilder<'a>,
-    payment_method: &'a stripe_shared::PaymentMethodId,
+pub struct RetrievePaymentMethod {
+    inner: RetrievePaymentMethodBuilder,
+    payment_method: stripe_shared::PaymentMethodId,
 }
-impl<'a> RetrievePaymentMethod<'a> {
+impl RetrievePaymentMethod {
     /// Construct a new `RetrievePaymentMethod`.
-    pub fn new(payment_method: &'a stripe_shared::PaymentMethodId) -> Self {
-        Self { payment_method, inner: RetrievePaymentMethodBuilder::new() }
+    pub fn new(payment_method: impl Into<stripe_shared::PaymentMethodId>) -> Self {
+        Self { payment_method: payment_method.into(), inner: RetrievePaymentMethodBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrievePaymentMethod<'_> {
+impl RetrievePaymentMethod {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -320,19 +320,19 @@ impl RetrievePaymentMethod<'_> {
     }
 }
 
-impl StripeRequest for RetrievePaymentMethod<'_> {
+impl StripeRequest for RetrievePaymentMethod {
     type Output = stripe_shared::PaymentMethod;
 
     fn build(&self) -> RequestBuilder {
-        let payment_method = self.payment_method;
+        let payment_method = &self.payment_method;
         RequestBuilder::new(StripeMethod::Get, format!("/payment_methods/{payment_method}"))
             .query(&self.inner)
     }
 }
 #[derive(Clone, Debug, serde::Serialize)]
-struct CreatePaymentMethodBuilder<'a> {
+struct CreatePaymentMethodBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    acss_debit: Option<CreatePaymentMethodAcssDebit<'a>>,
+    acss_debit: Option<CreatePaymentMethodAcssDebit>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
     affirm: Option<miniserde::json::Value>,
@@ -348,33 +348,33 @@ struct CreatePaymentMethodBuilder<'a> {
     #[serde(with = "stripe_types::with_serde_json_opt")]
     amazon_pay: Option<miniserde::json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    au_becs_debit: Option<CreatePaymentMethodAuBecsDebit<'a>>,
+    au_becs_debit: Option<CreatePaymentMethodAuBecsDebit>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    bacs_debit: Option<CreatePaymentMethodBacsDebit<'a>>,
+    bacs_debit: Option<CreatePaymentMethodBacsDebit>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
     bancontact: Option<miniserde::json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    billing_details: Option<BillingDetailsInnerParams<'a>>,
+    billing_details: Option<BillingDetailsInnerParams>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
     blik: Option<miniserde::json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    boleto: Option<CreatePaymentMethodBoleto<'a>>,
+    boleto: Option<CreatePaymentMethodBoleto>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    card: Option<CreatePaymentMethodCard<'a>>,
+    card: Option<CreatePaymentMethodCard>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
     cashapp: Option<miniserde::json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    customer: Option<&'a str>,
+    customer: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
     customer_balance: Option<miniserde::json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     eps: Option<CreatePaymentMethodEps>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     fpx: Option<CreatePaymentMethodFpx>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -397,7 +397,7 @@ struct CreatePaymentMethodBuilder<'a> {
     #[serde(with = "stripe_types::with_serde_json_opt")]
     link: Option<miniserde::json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
     mobilepay: Option<miniserde::json::Value>,
@@ -407,7 +407,7 @@ struct CreatePaymentMethodBuilder<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     p24: Option<CreatePaymentMethodP24>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_method: Option<&'a str>,
+    payment_method: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
     paynow: Option<miniserde::json::Value>,
@@ -421,12 +421,12 @@ struct CreatePaymentMethodBuilder<'a> {
     #[serde(with = "stripe_types::with_serde_json_opt")]
     promptpay: Option<miniserde::json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    radar_options: Option<CreatePaymentMethodRadarOptions<'a>>,
+    radar_options: Option<CreatePaymentMethodRadarOptions>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
     revolut_pay: Option<miniserde::json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    sepa_debit: Option<CreatePaymentMethodSepaDebit<'a>>,
+    sepa_debit: Option<CreatePaymentMethodSepaDebit>,
     #[serde(skip_serializing_if = "Option::is_none")]
     sofort: Option<CreatePaymentMethodSofort>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -436,7 +436,7 @@ struct CreatePaymentMethodBuilder<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     type_: Option<CreatePaymentMethodType>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    us_bank_account: Option<CreatePaymentMethodUsBankAccount<'a>>,
+    us_bank_account: Option<CreatePaymentMethodUsBankAccount>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
     wechat_pay: Option<miniserde::json::Value>,
@@ -444,7 +444,7 @@ struct CreatePaymentMethodBuilder<'a> {
     #[serde(with = "stripe_types::with_serde_json_opt")]
     zip: Option<miniserde::json::Value>,
 }
-impl<'a> CreatePaymentMethodBuilder<'a> {
+impl CreatePaymentMethodBuilder {
     fn new() -> Self {
         Self {
             acss_debit: None,
@@ -495,22 +495,26 @@ impl<'a> CreatePaymentMethodBuilder<'a> {
     }
 }
 /// If this is an `acss_debit` PaymentMethod, this hash contains details about the ACSS Debit payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentMethodAcssDebit<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentMethodAcssDebit {
     /// Customer's bank account number.
-    pub account_number: &'a str,
+    pub account_number: String,
     /// Institution number of the customer's bank.
-    pub institution_number: &'a str,
+    pub institution_number: String,
     /// Transit number of the customer's bank.
-    pub transit_number: &'a str,
+    pub transit_number: String,
 }
-impl<'a> CreatePaymentMethodAcssDebit<'a> {
+impl CreatePaymentMethodAcssDebit {
     pub fn new(
-        account_number: &'a str,
-        institution_number: &'a str,
-        transit_number: &'a str,
+        account_number: impl Into<String>,
+        institution_number: impl Into<String>,
+        transit_number: impl Into<String>,
     ) -> Self {
-        Self { account_number, institution_number, transit_number }
+        Self {
+            account_number: account_number.into(),
+            institution_number: institution_number.into(),
+            transit_number: transit_number.into(),
+        }
     }
 }
 /// This field indicates whether this payment method can be shown again to its customer in a checkout flow.
@@ -575,70 +579,70 @@ impl<'de> serde::Deserialize<'de> for CreatePaymentMethodAllowRedisplay {
     }
 }
 /// If this is an `au_becs_debit` PaymentMethod, this hash contains details about the bank account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentMethodAuBecsDebit<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentMethodAuBecsDebit {
     /// The account number for the bank account.
-    pub account_number: &'a str,
+    pub account_number: String,
     /// Bank-State-Branch number of the bank account.
-    pub bsb_number: &'a str,
+    pub bsb_number: String,
 }
-impl<'a> CreatePaymentMethodAuBecsDebit<'a> {
-    pub fn new(account_number: &'a str, bsb_number: &'a str) -> Self {
-        Self { account_number, bsb_number }
+impl CreatePaymentMethodAuBecsDebit {
+    pub fn new(account_number: impl Into<String>, bsb_number: impl Into<String>) -> Self {
+        Self { account_number: account_number.into(), bsb_number: bsb_number.into() }
     }
 }
 /// If this is a `bacs_debit` PaymentMethod, this hash contains details about the Bacs Direct Debit bank account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentMethodBacsDebit<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentMethodBacsDebit {
     /// Account number of the bank account that the funds will be debited from.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account_number: Option<&'a str>,
+    pub account_number: Option<String>,
     /// Sort code of the bank account. (e.g., `10-20-30`)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub sort_code: Option<&'a str>,
+    pub sort_code: Option<String>,
 }
-impl<'a> CreatePaymentMethodBacsDebit<'a> {
+impl CreatePaymentMethodBacsDebit {
     pub fn new() -> Self {
         Self { account_number: None, sort_code: None }
     }
 }
-impl<'a> Default for CreatePaymentMethodBacsDebit<'a> {
+impl Default for CreatePaymentMethodBacsDebit {
     fn default() -> Self {
         Self::new()
     }
 }
 /// If this is a `boleto` PaymentMethod, this hash contains details about the Boleto payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentMethodBoleto<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentMethodBoleto {
     /// The tax ID of the customer (CPF for individual consumers or CNPJ for businesses consumers)
-    pub tax_id: &'a str,
+    pub tax_id: String,
 }
-impl<'a> CreatePaymentMethodBoleto<'a> {
-    pub fn new(tax_id: &'a str) -> Self {
-        Self { tax_id }
+impl CreatePaymentMethodBoleto {
+    pub fn new(tax_id: impl Into<String>) -> Self {
+        Self { tax_id: tax_id.into() }
     }
 }
 /// If this is a `card` PaymentMethod, this hash contains the user's card details.
 /// For backwards compatibility, you can alternatively provide a Stripe token (e.g., for Apple Pay, Amex Express Checkout, or legacy Checkout) into the card hash with format `card: {token: "tok_visa"}`.
 /// When providing a card number, you must meet the requirements for [PCI compliance](https://stripe.com/docs/security#validating-pci-compliance).
 /// We strongly recommend using Stripe.js instead of interacting with this API directly.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
-pub enum CreatePaymentMethodCard<'a> {
+pub enum CreatePaymentMethodCard {
     #[serde(untagged)]
-    CardDetailsParams(CreatePaymentMethodCardDetailsParams<'a>),
+    CardDetailsParams(CreatePaymentMethodCardDetailsParams),
     #[serde(untagged)]
-    TokenParams(CreatePaymentMethodTokenParams<'a>),
+    TokenParams(CreatePaymentMethodTokenParams),
 }
 /// If this is a `card` PaymentMethod, this hash contains the user's card details.
 /// For backwards compatibility, you can alternatively provide a Stripe token (e.g., for Apple Pay, Amex Express Checkout, or legacy Checkout) into the card hash with format `card: {token: "tok_visa"}`.
 /// When providing a card number, you must meet the requirements for [PCI compliance](https://stripe.com/docs/security#validating-pci-compliance).
 /// We strongly recommend using Stripe.js instead of interacting with this API directly.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentMethodCardDetailsParams<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentMethodCardDetailsParams {
     /// The card's CVC. It is highly recommended to always include this value.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub cvc: Option<&'a str>,
+    pub cvc: Option<String>,
     /// Two-digit number representing the card's expiration month.
     pub exp_month: i64,
     /// Four-digit number representing the card's expiration year.
@@ -647,11 +651,21 @@ pub struct CreatePaymentMethodCardDetailsParams<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub networks: Option<CreatePaymentMethodCardDetailsParamsNetworks>,
     /// The card number, as a string without any separators.
-    pub number: &'a str,
+    pub number: String,
 }
-impl<'a> CreatePaymentMethodCardDetailsParams<'a> {
-    pub fn new(exp_month: i64, exp_year: i64, number: &'a str) -> Self {
-        Self { cvc: None, exp_month, exp_year, networks: None, number }
+impl CreatePaymentMethodCardDetailsParams {
+    pub fn new(
+        exp_month: impl Into<i64>,
+        exp_year: impl Into<i64>,
+        number: impl Into<String>,
+    ) -> Self {
+        Self {
+            cvc: None,
+            exp_month: exp_month.into(),
+            exp_year: exp_year.into(),
+            networks: None,
+            number: number.into(),
+        }
     }
 }
 /// Contains information about card networks used to process the payment.
@@ -740,14 +754,14 @@ impl<'de> serde::Deserialize<'de> for CreatePaymentMethodCardDetailsParamsNetwor
 /// For backwards compatibility, you can alternatively provide a Stripe token (e.g., for Apple Pay, Amex Express Checkout, or legacy Checkout) into the card hash with format `card: {token: "tok_visa"}`.
 /// When providing a card number, you must meet the requirements for [PCI compliance](https://stripe.com/docs/security#validating-pci-compliance).
 /// We strongly recommend using Stripe.js instead of interacting with this API directly.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentMethodTokenParams<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentMethodTokenParams {
     /// For backwards compatibility, you can alternatively provide a Stripe token (e.g., for Apple Pay, Amex Express Checkout, or legacy Checkout) into the card hash with format card: {token: "tok_visa"}.
-    pub token: &'a str,
+    pub token: String,
 }
-impl<'a> CreatePaymentMethodTokenParams<'a> {
-    pub fn new(token: &'a str) -> Self {
-        Self { token }
+impl CreatePaymentMethodTokenParams {
+    pub fn new(token: impl Into<String>) -> Self {
+        Self { token: token.into() }
     }
 }
 /// If this is an `eps` PaymentMethod, this hash contains details about the EPS payment method.
@@ -913,8 +927,8 @@ pub struct CreatePaymentMethodFpx {
     pub bank: CreatePaymentMethodFpxBank,
 }
 impl CreatePaymentMethodFpx {
-    pub fn new(bank: CreatePaymentMethodFpxBank) -> Self {
-        Self { account_holder_type: None, bank }
+    pub fn new(bank: impl Into<CreatePaymentMethodFpxBank>) -> Self {
+        Self { account_holder_type: None, bank: bank.into() }
     }
 }
 /// Account holder type for FPX transaction
@@ -1236,8 +1250,8 @@ pub struct CreatePaymentMethodKlarnaDob {
     pub year: i64,
 }
 impl CreatePaymentMethodKlarnaDob {
-    pub fn new(day: i64, month: i64, year: i64) -> Self {
-        Self { day, month, year }
+    pub fn new(day: impl Into<i64>, month: impl Into<i64>, year: impl Into<i64>) -> Self {
+        Self { day: day.into(), month: month.into(), year: year.into() }
     }
 }
 /// If this is a `p24` PaymentMethod, this hash contains details about the P24 payment method.
@@ -1389,31 +1403,31 @@ impl<'de> serde::Deserialize<'de> for CreatePaymentMethodP24Bank {
 }
 /// Options to configure Radar.
 /// See [Radar Session](https://stripe.com/docs/radar/radar-session) for more information.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentMethodRadarOptions<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentMethodRadarOptions {
     /// A [Radar Session](https://stripe.com/docs/radar/radar-session) is a snapshot of the browser metadata and device details that help Radar make more accurate predictions on your payments.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub session: Option<&'a str>,
+    pub session: Option<String>,
 }
-impl<'a> CreatePaymentMethodRadarOptions<'a> {
+impl CreatePaymentMethodRadarOptions {
     pub fn new() -> Self {
         Self { session: None }
     }
 }
-impl<'a> Default for CreatePaymentMethodRadarOptions<'a> {
+impl Default for CreatePaymentMethodRadarOptions {
     fn default() -> Self {
         Self::new()
     }
 }
 /// If this is a `sepa_debit` PaymentMethod, this hash contains details about the SEPA debit bank account.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentMethodSepaDebit<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentMethodSepaDebit {
     /// IBAN of the bank account.
-    pub iban: &'a str,
+    pub iban: String,
 }
-impl<'a> CreatePaymentMethodSepaDebit<'a> {
-    pub fn new(iban: &'a str) -> Self {
-        Self { iban }
+impl CreatePaymentMethodSepaDebit {
+    pub fn new(iban: impl Into<String>) -> Self {
+        Self { iban: iban.into() }
     }
 }
 /// If this is a `sofort` PaymentMethod, this hash contains details about the SOFORT payment method.
@@ -1423,8 +1437,8 @@ pub struct CreatePaymentMethodSofort {
     pub country: CreatePaymentMethodSofortCountry,
 }
 impl CreatePaymentMethodSofort {
-    pub fn new(country: CreatePaymentMethodSofortCountry) -> Self {
-        Self { country }
+    pub fn new(country: impl Into<CreatePaymentMethodSofortCountry>) -> Self {
+        Self { country: country.into() }
     }
 }
 /// Two-letter ISO code representing the country the bank account is located in.
@@ -1655,25 +1669,25 @@ impl<'de> serde::Deserialize<'de> for CreatePaymentMethodType {
     }
 }
 /// If this is an `us_bank_account` PaymentMethod, this hash contains details about the US bank account payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentMethodUsBankAccount<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePaymentMethodUsBankAccount {
     /// Account holder type: individual or company.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub account_holder_type: Option<CreatePaymentMethodUsBankAccountAccountHolderType>,
     /// Account number of the bank account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account_number: Option<&'a str>,
+    pub account_number: Option<String>,
     /// Account type: checkings or savings. Defaults to checking if omitted.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub account_type: Option<CreatePaymentMethodUsBankAccountAccountType>,
     /// The ID of a Financial Connections Account to use as a payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub financial_connections_account: Option<&'a str>,
+    pub financial_connections_account: Option<String>,
     /// Routing number of the bank account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub routing_number: Option<&'a str>,
+    pub routing_number: Option<String>,
 }
-impl<'a> CreatePaymentMethodUsBankAccount<'a> {
+impl CreatePaymentMethodUsBankAccount {
     pub fn new() -> Self {
         Self {
             account_holder_type: None,
@@ -1684,7 +1698,7 @@ impl<'a> CreatePaymentMethodUsBankAccount<'a> {
         }
     }
 }
-impl<'a> Default for CreatePaymentMethodUsBankAccount<'a> {
+impl Default for CreatePaymentMethodUsBankAccount {
     fn default() -> Self {
         Self::new()
     }
@@ -1810,255 +1824,273 @@ impl<'de> serde::Deserialize<'de> for CreatePaymentMethodUsBankAccountAccountTyp
 ///
 /// Instead of creating a PaymentMethod directly, we recommend using the [PaymentIntents](https://stripe.com/docs/payments/accept-a-payment) API to accept a payment immediately or the [SetupIntent](https://stripe.com/docs/payments/save-and-reuse) API to collect payment method details ahead of a future payment.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentMethod<'a> {
-    inner: CreatePaymentMethodBuilder<'a>,
+pub struct CreatePaymentMethod {
+    inner: CreatePaymentMethodBuilder,
 }
-impl<'a> CreatePaymentMethod<'a> {
+impl CreatePaymentMethod {
     /// Construct a new `CreatePaymentMethod`.
     pub fn new() -> Self {
         Self { inner: CreatePaymentMethodBuilder::new() }
     }
     /// If this is an `acss_debit` PaymentMethod, this hash contains details about the ACSS Debit payment method.
-    pub fn acss_debit(mut self, acss_debit: CreatePaymentMethodAcssDebit<'a>) -> Self {
-        self.inner.acss_debit = Some(acss_debit);
+    pub fn acss_debit(mut self, acss_debit: impl Into<CreatePaymentMethodAcssDebit>) -> Self {
+        self.inner.acss_debit = Some(acss_debit.into());
         self
     }
     /// If this is an `affirm` PaymentMethod, this hash contains details about the Affirm payment method.
-    pub fn affirm(mut self, affirm: miniserde::json::Value) -> Self {
-        self.inner.affirm = Some(affirm);
+    pub fn affirm(mut self, affirm: impl Into<miniserde::json::Value>) -> Self {
+        self.inner.affirm = Some(affirm.into());
         self
     }
     /// If this is an `AfterpayClearpay` PaymentMethod, this hash contains details about the AfterpayClearpay payment method.
-    pub fn afterpay_clearpay(mut self, afterpay_clearpay: miniserde::json::Value) -> Self {
-        self.inner.afterpay_clearpay = Some(afterpay_clearpay);
+    pub fn afterpay_clearpay(
+        mut self,
+        afterpay_clearpay: impl Into<miniserde::json::Value>,
+    ) -> Self {
+        self.inner.afterpay_clearpay = Some(afterpay_clearpay.into());
         self
     }
     /// If this is an `Alipay` PaymentMethod, this hash contains details about the Alipay payment method.
-    pub fn alipay(mut self, alipay: miniserde::json::Value) -> Self {
-        self.inner.alipay = Some(alipay);
+    pub fn alipay(mut self, alipay: impl Into<miniserde::json::Value>) -> Self {
+        self.inner.alipay = Some(alipay.into());
         self
     }
     /// This field indicates whether this payment method can be shown again to its customer in a checkout flow.
     /// Stripe products such as Checkout and Elements use this field to determine whether a payment method can be shown as a saved payment method in a checkout flow.
     /// The field defaults to `unspecified`.
-    pub fn allow_redisplay(mut self, allow_redisplay: CreatePaymentMethodAllowRedisplay) -> Self {
-        self.inner.allow_redisplay = Some(allow_redisplay);
+    pub fn allow_redisplay(
+        mut self,
+        allow_redisplay: impl Into<CreatePaymentMethodAllowRedisplay>,
+    ) -> Self {
+        self.inner.allow_redisplay = Some(allow_redisplay.into());
         self
     }
     /// If this is a AmazonPay PaymentMethod, this hash contains details about the AmazonPay payment method.
-    pub fn amazon_pay(mut self, amazon_pay: miniserde::json::Value) -> Self {
-        self.inner.amazon_pay = Some(amazon_pay);
+    pub fn amazon_pay(mut self, amazon_pay: impl Into<miniserde::json::Value>) -> Self {
+        self.inner.amazon_pay = Some(amazon_pay.into());
         self
     }
     /// If this is an `au_becs_debit` PaymentMethod, this hash contains details about the bank account.
-    pub fn au_becs_debit(mut self, au_becs_debit: CreatePaymentMethodAuBecsDebit<'a>) -> Self {
-        self.inner.au_becs_debit = Some(au_becs_debit);
+    pub fn au_becs_debit(
+        mut self,
+        au_becs_debit: impl Into<CreatePaymentMethodAuBecsDebit>,
+    ) -> Self {
+        self.inner.au_becs_debit = Some(au_becs_debit.into());
         self
     }
     /// If this is a `bacs_debit` PaymentMethod, this hash contains details about the Bacs Direct Debit bank account.
-    pub fn bacs_debit(mut self, bacs_debit: CreatePaymentMethodBacsDebit<'a>) -> Self {
-        self.inner.bacs_debit = Some(bacs_debit);
+    pub fn bacs_debit(mut self, bacs_debit: impl Into<CreatePaymentMethodBacsDebit>) -> Self {
+        self.inner.bacs_debit = Some(bacs_debit.into());
         self
     }
     /// If this is a `bancontact` PaymentMethod, this hash contains details about the Bancontact payment method.
-    pub fn bancontact(mut self, bancontact: miniserde::json::Value) -> Self {
-        self.inner.bancontact = Some(bancontact);
+    pub fn bancontact(mut self, bancontact: impl Into<miniserde::json::Value>) -> Self {
+        self.inner.bancontact = Some(bancontact.into());
         self
     }
     /// Billing information associated with the PaymentMethod that may be used or required by particular types of payment methods.
-    pub fn billing_details(mut self, billing_details: BillingDetailsInnerParams<'a>) -> Self {
-        self.inner.billing_details = Some(billing_details);
+    pub fn billing_details(
+        mut self,
+        billing_details: impl Into<BillingDetailsInnerParams>,
+    ) -> Self {
+        self.inner.billing_details = Some(billing_details.into());
         self
     }
     /// If this is a `blik` PaymentMethod, this hash contains details about the BLIK payment method.
-    pub fn blik(mut self, blik: miniserde::json::Value) -> Self {
-        self.inner.blik = Some(blik);
+    pub fn blik(mut self, blik: impl Into<miniserde::json::Value>) -> Self {
+        self.inner.blik = Some(blik.into());
         self
     }
     /// If this is a `boleto` PaymentMethod, this hash contains details about the Boleto payment method.
-    pub fn boleto(mut self, boleto: CreatePaymentMethodBoleto<'a>) -> Self {
-        self.inner.boleto = Some(boleto);
+    pub fn boleto(mut self, boleto: impl Into<CreatePaymentMethodBoleto>) -> Self {
+        self.inner.boleto = Some(boleto.into());
         self
     }
     /// If this is a `card` PaymentMethod, this hash contains the user's card details.
     /// For backwards compatibility, you can alternatively provide a Stripe token (e.g., for Apple Pay, Amex Express Checkout, or legacy Checkout) into the card hash with format `card: {token: "tok_visa"}`.
     /// When providing a card number, you must meet the requirements for [PCI compliance](https://stripe.com/docs/security#validating-pci-compliance).
     /// We strongly recommend using Stripe.js instead of interacting with this API directly.
-    pub fn card(mut self, card: CreatePaymentMethodCard<'a>) -> Self {
-        self.inner.card = Some(card);
+    pub fn card(mut self, card: impl Into<CreatePaymentMethodCard>) -> Self {
+        self.inner.card = Some(card.into());
         self
     }
     /// If this is a `cashapp` PaymentMethod, this hash contains details about the Cash App Pay payment method.
-    pub fn cashapp(mut self, cashapp: miniserde::json::Value) -> Self {
-        self.inner.cashapp = Some(cashapp);
+    pub fn cashapp(mut self, cashapp: impl Into<miniserde::json::Value>) -> Self {
+        self.inner.cashapp = Some(cashapp.into());
         self
     }
     /// The `Customer` to whom the original PaymentMethod is attached.
-    pub fn customer(mut self, customer: &'a str) -> Self {
-        self.inner.customer = Some(customer);
+    pub fn customer(mut self, customer: impl Into<String>) -> Self {
+        self.inner.customer = Some(customer.into());
         self
     }
     /// If this is a `customer_balance` PaymentMethod, this hash contains details about the CustomerBalance payment method.
-    pub fn customer_balance(mut self, customer_balance: miniserde::json::Value) -> Self {
-        self.inner.customer_balance = Some(customer_balance);
+    pub fn customer_balance(mut self, customer_balance: impl Into<miniserde::json::Value>) -> Self {
+        self.inner.customer_balance = Some(customer_balance.into());
         self
     }
     /// If this is an `eps` PaymentMethod, this hash contains details about the EPS payment method.
-    pub fn eps(mut self, eps: CreatePaymentMethodEps) -> Self {
-        self.inner.eps = Some(eps);
+    pub fn eps(mut self, eps: impl Into<CreatePaymentMethodEps>) -> Self {
+        self.inner.eps = Some(eps.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// If this is an `fpx` PaymentMethod, this hash contains details about the FPX payment method.
-    pub fn fpx(mut self, fpx: CreatePaymentMethodFpx) -> Self {
-        self.inner.fpx = Some(fpx);
+    pub fn fpx(mut self, fpx: impl Into<CreatePaymentMethodFpx>) -> Self {
+        self.inner.fpx = Some(fpx.into());
         self
     }
     /// If this is a `giropay` PaymentMethod, this hash contains details about the Giropay payment method.
-    pub fn giropay(mut self, giropay: miniserde::json::Value) -> Self {
-        self.inner.giropay = Some(giropay);
+    pub fn giropay(mut self, giropay: impl Into<miniserde::json::Value>) -> Self {
+        self.inner.giropay = Some(giropay.into());
         self
     }
     /// If this is a `grabpay` PaymentMethod, this hash contains details about the GrabPay payment method.
-    pub fn grabpay(mut self, grabpay: miniserde::json::Value) -> Self {
-        self.inner.grabpay = Some(grabpay);
+    pub fn grabpay(mut self, grabpay: impl Into<miniserde::json::Value>) -> Self {
+        self.inner.grabpay = Some(grabpay.into());
         self
     }
     /// If this is an `ideal` PaymentMethod, this hash contains details about the iDEAL payment method.
-    pub fn ideal(mut self, ideal: CreatePaymentMethodIdeal) -> Self {
-        self.inner.ideal = Some(ideal);
+    pub fn ideal(mut self, ideal: impl Into<CreatePaymentMethodIdeal>) -> Self {
+        self.inner.ideal = Some(ideal.into());
         self
     }
     /// If this is an `interac_present` PaymentMethod, this hash contains details about the Interac Present payment method.
-    pub fn interac_present(mut self, interac_present: miniserde::json::Value) -> Self {
-        self.inner.interac_present = Some(interac_present);
+    pub fn interac_present(mut self, interac_present: impl Into<miniserde::json::Value>) -> Self {
+        self.inner.interac_present = Some(interac_present.into());
         self
     }
     /// If this is a `klarna` PaymentMethod, this hash contains details about the Klarna payment method.
-    pub fn klarna(mut self, klarna: CreatePaymentMethodKlarna) -> Self {
-        self.inner.klarna = Some(klarna);
+    pub fn klarna(mut self, klarna: impl Into<CreatePaymentMethodKlarna>) -> Self {
+        self.inner.klarna = Some(klarna.into());
         self
     }
     /// If this is a `konbini` PaymentMethod, this hash contains details about the Konbini payment method.
-    pub fn konbini(mut self, konbini: miniserde::json::Value) -> Self {
-        self.inner.konbini = Some(konbini);
+    pub fn konbini(mut self, konbini: impl Into<miniserde::json::Value>) -> Self {
+        self.inner.konbini = Some(konbini.into());
         self
     }
     /// If this is an `Link` PaymentMethod, this hash contains details about the Link payment method.
-    pub fn link(mut self, link: miniserde::json::Value) -> Self {
-        self.inner.link = Some(link);
+    pub fn link(mut self, link: impl Into<miniserde::json::Value>) -> Self {
+        self.inner.link = Some(link.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// If this is a `mobilepay` PaymentMethod, this hash contains details about the MobilePay payment method.
-    pub fn mobilepay(mut self, mobilepay: miniserde::json::Value) -> Self {
-        self.inner.mobilepay = Some(mobilepay);
+    pub fn mobilepay(mut self, mobilepay: impl Into<miniserde::json::Value>) -> Self {
+        self.inner.mobilepay = Some(mobilepay.into());
         self
     }
     /// If this is an `oxxo` PaymentMethod, this hash contains details about the OXXO payment method.
-    pub fn oxxo(mut self, oxxo: miniserde::json::Value) -> Self {
-        self.inner.oxxo = Some(oxxo);
+    pub fn oxxo(mut self, oxxo: impl Into<miniserde::json::Value>) -> Self {
+        self.inner.oxxo = Some(oxxo.into());
         self
     }
     /// If this is a `p24` PaymentMethod, this hash contains details about the P24 payment method.
-    pub fn p24(mut self, p24: CreatePaymentMethodP24) -> Self {
-        self.inner.p24 = Some(p24);
+    pub fn p24(mut self, p24: impl Into<CreatePaymentMethodP24>) -> Self {
+        self.inner.p24 = Some(p24.into());
         self
     }
     /// The PaymentMethod to share.
-    pub fn payment_method(mut self, payment_method: &'a str) -> Self {
-        self.inner.payment_method = Some(payment_method);
+    pub fn payment_method(mut self, payment_method: impl Into<String>) -> Self {
+        self.inner.payment_method = Some(payment_method.into());
         self
     }
     /// If this is a `paynow` PaymentMethod, this hash contains details about the PayNow payment method.
-    pub fn paynow(mut self, paynow: miniserde::json::Value) -> Self {
-        self.inner.paynow = Some(paynow);
+    pub fn paynow(mut self, paynow: impl Into<miniserde::json::Value>) -> Self {
+        self.inner.paynow = Some(paynow.into());
         self
     }
     /// If this is a `paypal` PaymentMethod, this hash contains details about the PayPal payment method.
-    pub fn paypal(mut self, paypal: miniserde::json::Value) -> Self {
-        self.inner.paypal = Some(paypal);
+    pub fn paypal(mut self, paypal: impl Into<miniserde::json::Value>) -> Self {
+        self.inner.paypal = Some(paypal.into());
         self
     }
     /// If this is a `pix` PaymentMethod, this hash contains details about the Pix payment method.
-    pub fn pix(mut self, pix: miniserde::json::Value) -> Self {
-        self.inner.pix = Some(pix);
+    pub fn pix(mut self, pix: impl Into<miniserde::json::Value>) -> Self {
+        self.inner.pix = Some(pix.into());
         self
     }
     /// If this is a `promptpay` PaymentMethod, this hash contains details about the PromptPay payment method.
-    pub fn promptpay(mut self, promptpay: miniserde::json::Value) -> Self {
-        self.inner.promptpay = Some(promptpay);
+    pub fn promptpay(mut self, promptpay: impl Into<miniserde::json::Value>) -> Self {
+        self.inner.promptpay = Some(promptpay.into());
         self
     }
     /// Options to configure Radar.
     /// See [Radar Session](https://stripe.com/docs/radar/radar-session) for more information.
-    pub fn radar_options(mut self, radar_options: CreatePaymentMethodRadarOptions<'a>) -> Self {
-        self.inner.radar_options = Some(radar_options);
+    pub fn radar_options(
+        mut self,
+        radar_options: impl Into<CreatePaymentMethodRadarOptions>,
+    ) -> Self {
+        self.inner.radar_options = Some(radar_options.into());
         self
     }
     /// If this is a `Revolut Pay` PaymentMethod, this hash contains details about the Revolut Pay payment method.
-    pub fn revolut_pay(mut self, revolut_pay: miniserde::json::Value) -> Self {
-        self.inner.revolut_pay = Some(revolut_pay);
+    pub fn revolut_pay(mut self, revolut_pay: impl Into<miniserde::json::Value>) -> Self {
+        self.inner.revolut_pay = Some(revolut_pay.into());
         self
     }
     /// If this is a `sepa_debit` PaymentMethod, this hash contains details about the SEPA debit bank account.
-    pub fn sepa_debit(mut self, sepa_debit: CreatePaymentMethodSepaDebit<'a>) -> Self {
-        self.inner.sepa_debit = Some(sepa_debit);
+    pub fn sepa_debit(mut self, sepa_debit: impl Into<CreatePaymentMethodSepaDebit>) -> Self {
+        self.inner.sepa_debit = Some(sepa_debit.into());
         self
     }
     /// If this is a `sofort` PaymentMethod, this hash contains details about the SOFORT payment method.
-    pub fn sofort(mut self, sofort: CreatePaymentMethodSofort) -> Self {
-        self.inner.sofort = Some(sofort);
+    pub fn sofort(mut self, sofort: impl Into<CreatePaymentMethodSofort>) -> Self {
+        self.inner.sofort = Some(sofort.into());
         self
     }
     /// If this is a `swish` PaymentMethod, this hash contains details about the Swish payment method.
-    pub fn swish(mut self, swish: miniserde::json::Value) -> Self {
-        self.inner.swish = Some(swish);
+    pub fn swish(mut self, swish: impl Into<miniserde::json::Value>) -> Self {
+        self.inner.swish = Some(swish.into());
         self
     }
     /// The type of the PaymentMethod.
     /// An additional hash is included on the PaymentMethod with a name matching this value.
     /// It contains additional information specific to the PaymentMethod type.
-    pub fn type_(mut self, type_: CreatePaymentMethodType) -> Self {
-        self.inner.type_ = Some(type_);
+    pub fn type_(mut self, type_: impl Into<CreatePaymentMethodType>) -> Self {
+        self.inner.type_ = Some(type_.into());
         self
     }
     /// If this is an `us_bank_account` PaymentMethod, this hash contains details about the US bank account payment method.
     pub fn us_bank_account(
         mut self,
-        us_bank_account: CreatePaymentMethodUsBankAccount<'a>,
+        us_bank_account: impl Into<CreatePaymentMethodUsBankAccount>,
     ) -> Self {
-        self.inner.us_bank_account = Some(us_bank_account);
+        self.inner.us_bank_account = Some(us_bank_account.into());
         self
     }
     /// If this is an `wechat_pay` PaymentMethod, this hash contains details about the wechat_pay payment method.
-    pub fn wechat_pay(mut self, wechat_pay: miniserde::json::Value) -> Self {
-        self.inner.wechat_pay = Some(wechat_pay);
+    pub fn wechat_pay(mut self, wechat_pay: impl Into<miniserde::json::Value>) -> Self {
+        self.inner.wechat_pay = Some(wechat_pay.into());
         self
     }
     /// If this is a `zip` PaymentMethod, this hash contains details about the Zip payment method.
-    pub fn zip(mut self, zip: miniserde::json::Value) -> Self {
-        self.inner.zip = Some(zip);
+    pub fn zip(mut self, zip: impl Into<miniserde::json::Value>) -> Self {
+        self.inner.zip = Some(zip.into());
         self
     }
 }
-impl<'a> Default for CreatePaymentMethod<'a> {
+impl Default for CreatePaymentMethod {
     fn default() -> Self {
         Self::new()
     }
 }
-impl CreatePaymentMethod<'_> {
+impl CreatePaymentMethod {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -2076,7 +2108,7 @@ impl CreatePaymentMethod<'_> {
     }
 }
 
-impl StripeRequest for CreatePaymentMethod<'_> {
+impl StripeRequest for CreatePaymentMethod {
     type Output = stripe_shared::PaymentMethod;
 
     fn build(&self) -> RequestBuilder {
@@ -2084,24 +2116,24 @@ impl StripeRequest for CreatePaymentMethod<'_> {
     }
 }
 #[derive(Clone, Debug, serde::Serialize)]
-struct UpdatePaymentMethodBuilder<'a> {
+struct UpdatePaymentMethodBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     allow_redisplay: Option<UpdatePaymentMethodAllowRedisplay>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    billing_details: Option<BillingDetailsInnerParams<'a>>,
+    billing_details: Option<BillingDetailsInnerParams>,
     #[serde(skip_serializing_if = "Option::is_none")]
     card: Option<UpdatePaymentMethodCard>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(with = "stripe_types::with_serde_json_opt")]
     link: Option<miniserde::json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     us_bank_account: Option<UpdatePaymentMethodUsBankAccount>,
 }
-impl<'a> UpdatePaymentMethodBuilder<'a> {
+impl UpdatePaymentMethodBuilder {
     fn new() -> Self {
         Self {
             allow_redisplay: None,
@@ -2416,57 +2448,69 @@ impl<'de> serde::Deserialize<'de> for UpdatePaymentMethodUsBankAccountAccountTyp
 }
 /// Updates a PaymentMethod object. A PaymentMethod must be attached a customer to be updated.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentMethod<'a> {
-    inner: UpdatePaymentMethodBuilder<'a>,
-    payment_method: &'a stripe_shared::PaymentMethodId,
+pub struct UpdatePaymentMethod {
+    inner: UpdatePaymentMethodBuilder,
+    payment_method: stripe_shared::PaymentMethodId,
 }
-impl<'a> UpdatePaymentMethod<'a> {
+impl UpdatePaymentMethod {
     /// Construct a new `UpdatePaymentMethod`.
-    pub fn new(payment_method: &'a stripe_shared::PaymentMethodId) -> Self {
-        Self { payment_method, inner: UpdatePaymentMethodBuilder::new() }
+    pub fn new(payment_method: impl Into<stripe_shared::PaymentMethodId>) -> Self {
+        Self { payment_method: payment_method.into(), inner: UpdatePaymentMethodBuilder::new() }
     }
     /// This field indicates whether this payment method can be shown again to its customer in a checkout flow.
     /// Stripe products such as Checkout and Elements use this field to determine whether a payment method can be shown as a saved payment method in a checkout flow.
     /// The field defaults to `unspecified`.
-    pub fn allow_redisplay(mut self, allow_redisplay: UpdatePaymentMethodAllowRedisplay) -> Self {
-        self.inner.allow_redisplay = Some(allow_redisplay);
+    pub fn allow_redisplay(
+        mut self,
+        allow_redisplay: impl Into<UpdatePaymentMethodAllowRedisplay>,
+    ) -> Self {
+        self.inner.allow_redisplay = Some(allow_redisplay.into());
         self
     }
     /// Billing information associated with the PaymentMethod that may be used or required by particular types of payment methods.
-    pub fn billing_details(mut self, billing_details: BillingDetailsInnerParams<'a>) -> Self {
-        self.inner.billing_details = Some(billing_details);
+    pub fn billing_details(
+        mut self,
+        billing_details: impl Into<BillingDetailsInnerParams>,
+    ) -> Self {
+        self.inner.billing_details = Some(billing_details.into());
         self
     }
     /// If this is a `card` PaymentMethod, this hash contains the user's card details.
-    pub fn card(mut self, card: UpdatePaymentMethodCard) -> Self {
-        self.inner.card = Some(card);
+    pub fn card(mut self, card: impl Into<UpdatePaymentMethodCard>) -> Self {
+        self.inner.card = Some(card.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// If this is an `Link` PaymentMethod, this hash contains details about the Link payment method.
-    pub fn link(mut self, link: miniserde::json::Value) -> Self {
-        self.inner.link = Some(link);
+    pub fn link(mut self, link: impl Into<miniserde::json::Value>) -> Self {
+        self.inner.link = Some(link.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// If this is an `us_bank_account` PaymentMethod, this hash contains details about the US bank account payment method.
-    pub fn us_bank_account(mut self, us_bank_account: UpdatePaymentMethodUsBankAccount) -> Self {
-        self.inner.us_bank_account = Some(us_bank_account);
+    pub fn us_bank_account(
+        mut self,
+        us_bank_account: impl Into<UpdatePaymentMethodUsBankAccount>,
+    ) -> Self {
+        self.inner.us_bank_account = Some(us_bank_account.into());
         self
     }
 }
-impl UpdatePaymentMethod<'_> {
+impl UpdatePaymentMethod {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -2484,24 +2528,24 @@ impl UpdatePaymentMethod<'_> {
     }
 }
 
-impl StripeRequest for UpdatePaymentMethod<'_> {
+impl StripeRequest for UpdatePaymentMethod {
     type Output = stripe_shared::PaymentMethod;
 
     fn build(&self) -> RequestBuilder {
-        let payment_method = self.payment_method;
+        let payment_method = &self.payment_method;
         RequestBuilder::new(StripeMethod::Post, format!("/payment_methods/{payment_method}"))
             .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct AttachPaymentMethodBuilder<'a> {
-    customer: &'a str,
+#[derive(Clone, Debug, serde::Serialize)]
+struct AttachPaymentMethodBuilder {
+    customer: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> AttachPaymentMethodBuilder<'a> {
-    fn new(customer: &'a str) -> Self {
-        Self { customer, expand: None }
+impl AttachPaymentMethodBuilder {
+    fn new(customer: impl Into<String>) -> Self {
+        Self { customer: customer.into(), expand: None }
     }
 }
 /// Attaches a PaymentMethod object to a Customer.
@@ -2519,22 +2563,28 @@ impl<'a> AttachPaymentMethodBuilder<'a> {
 /// set <a href="/docs/api/customers/update#update_customer-invoice_settings-default_payment_method">`invoice_settings.default_payment_method`</a>,.
 /// on the Customer to the PaymentMethod’s ID.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct AttachPaymentMethod<'a> {
-    inner: AttachPaymentMethodBuilder<'a>,
-    payment_method: &'a stripe_shared::PaymentMethodId,
+pub struct AttachPaymentMethod {
+    inner: AttachPaymentMethodBuilder,
+    payment_method: stripe_shared::PaymentMethodId,
 }
-impl<'a> AttachPaymentMethod<'a> {
+impl AttachPaymentMethod {
     /// Construct a new `AttachPaymentMethod`.
-    pub fn new(payment_method: &'a stripe_shared::PaymentMethodId, customer: &'a str) -> Self {
-        Self { payment_method, inner: AttachPaymentMethodBuilder::new(customer) }
+    pub fn new(
+        payment_method: impl Into<stripe_shared::PaymentMethodId>,
+        customer: impl Into<String>,
+    ) -> Self {
+        Self {
+            payment_method: payment_method.into(),
+            inner: AttachPaymentMethodBuilder::new(customer.into()),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl AttachPaymentMethod<'_> {
+impl AttachPaymentMethod {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -2552,21 +2602,21 @@ impl AttachPaymentMethod<'_> {
     }
 }
 
-impl StripeRequest for AttachPaymentMethod<'_> {
+impl StripeRequest for AttachPaymentMethod {
     type Output = stripe_shared::PaymentMethod;
 
     fn build(&self) -> RequestBuilder {
-        let payment_method = self.payment_method;
+        let payment_method = &self.payment_method;
         RequestBuilder::new(StripeMethod::Post, format!("/payment_methods/{payment_method}/attach"))
             .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct DetachPaymentMethodBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct DetachPaymentMethodBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> DetachPaymentMethodBuilder<'a> {
+impl DetachPaymentMethodBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
@@ -2574,22 +2624,22 @@ impl<'a> DetachPaymentMethodBuilder<'a> {
 /// Detaches a PaymentMethod object from a Customer.
 /// After a PaymentMethod is detached, it can no longer be used for a payment or re-attached to a Customer.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct DetachPaymentMethod<'a> {
-    inner: DetachPaymentMethodBuilder<'a>,
-    payment_method: &'a stripe_shared::PaymentMethodId,
+pub struct DetachPaymentMethod {
+    inner: DetachPaymentMethodBuilder,
+    payment_method: stripe_shared::PaymentMethodId,
 }
-impl<'a> DetachPaymentMethod<'a> {
+impl DetachPaymentMethod {
     /// Construct a new `DetachPaymentMethod`.
-    pub fn new(payment_method: &'a stripe_shared::PaymentMethodId) -> Self {
-        Self { payment_method, inner: DetachPaymentMethodBuilder::new() }
+    pub fn new(payment_method: impl Into<stripe_shared::PaymentMethodId>) -> Self {
+        Self { payment_method: payment_method.into(), inner: DetachPaymentMethodBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl DetachPaymentMethod<'_> {
+impl DetachPaymentMethod {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -2607,68 +2657,68 @@ impl DetachPaymentMethod<'_> {
     }
 }
 
-impl StripeRequest for DetachPaymentMethod<'_> {
+impl StripeRequest for DetachPaymentMethod {
     type Output = stripe_shared::PaymentMethod;
 
     fn build(&self) -> RequestBuilder {
-        let payment_method = self.payment_method;
+        let payment_method = &self.payment_method;
         RequestBuilder::new(StripeMethod::Post, format!("/payment_methods/{payment_method}/detach"))
             .form(&self.inner)
     }
 }
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct BillingDetailsAddress<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct BillingDetailsAddress {
     /// City, district, suburb, town, or village.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<&'a str>,
+    pub city: Option<String>,
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub country: Option<&'a str>,
+    pub country: Option<String>,
     /// Address line 1 (e.g., street, PO Box, or company name).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line1: Option<&'a str>,
+    pub line1: Option<String>,
     /// Address line 2 (e.g., apartment, suite, unit, or building).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line2: Option<&'a str>,
+    pub line2: Option<String>,
     /// ZIP or postal code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<&'a str>,
+    pub postal_code: Option<String>,
     /// State, county, province, or region.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
 }
-impl<'a> BillingDetailsAddress<'a> {
+impl BillingDetailsAddress {
     pub fn new() -> Self {
         Self { city: None, country: None, line1: None, line2: None, postal_code: None, state: None }
     }
 }
-impl<'a> Default for BillingDetailsAddress<'a> {
+impl Default for BillingDetailsAddress {
     fn default() -> Self {
         Self::new()
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct BillingDetailsInnerParams<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct BillingDetailsInnerParams {
     /// Billing address.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub address: Option<BillingDetailsAddress<'a>>,
+    pub address: Option<BillingDetailsAddress>,
     /// Email address.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub email: Option<&'a str>,
+    pub email: Option<String>,
     /// Full name.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<&'a str>,
+    pub name: Option<String>,
     /// Billing phone number (including extension).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub phone: Option<&'a str>,
+    pub phone: Option<String>,
 }
-impl<'a> BillingDetailsInnerParams<'a> {
+impl BillingDetailsInnerParams {
     pub fn new() -> Self {
         Self { address: None, email: None, name: None, phone: None }
     }
 }
-impl<'a> Default for BillingDetailsInnerParams<'a> {
+impl Default for BillingDetailsInnerParams {
     fn default() -> Self {
         Self::new()
     }

--- a/generated/async-stripe-payment/src/payment_method_configuration/requests.rs
+++ b/generated/async-stripe-payment/src/payment_method_configuration/requests.rs
@@ -2,20 +2,20 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListPaymentMethodConfigurationBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListPaymentMethodConfigurationBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    application: Option<&'a str>,
+    application: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListPaymentMethodConfigurationBuilder<'a> {
+impl ListPaymentMethodConfigurationBuilder {
     fn new() -> Self {
         Self {
             application: None,
@@ -28,51 +28,51 @@ impl<'a> ListPaymentMethodConfigurationBuilder<'a> {
 }
 /// List payment method configurations
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListPaymentMethodConfiguration<'a> {
-    inner: ListPaymentMethodConfigurationBuilder<'a>,
+pub struct ListPaymentMethodConfiguration {
+    inner: ListPaymentMethodConfigurationBuilder,
 }
-impl<'a> ListPaymentMethodConfiguration<'a> {
+impl ListPaymentMethodConfiguration {
     /// Construct a new `ListPaymentMethodConfiguration`.
     pub fn new() -> Self {
         Self { inner: ListPaymentMethodConfigurationBuilder::new() }
     }
     /// The Connect application to filter by.
-    pub fn application(mut self, application: &'a str) -> Self {
-        self.inner.application = Some(application);
+    pub fn application(mut self, application: impl Into<String>) -> Self {
+        self.inner.application = Some(application.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl<'a> Default for ListPaymentMethodConfiguration<'a> {
+impl Default for ListPaymentMethodConfiguration {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListPaymentMethodConfiguration<'_> {
+impl ListPaymentMethodConfiguration {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -94,45 +94,48 @@ impl ListPaymentMethodConfiguration<'_> {
     ) -> stripe_client_core::ListPaginator<
         stripe_types::List<stripe_payment::PaymentMethodConfiguration>,
     > {
-        stripe_client_core::ListPaginator::new_list("/payment_method_configurations", self.inner)
+        stripe_client_core::ListPaginator::new_list("/payment_method_configurations", &self.inner)
     }
 }
 
-impl StripeRequest for ListPaymentMethodConfiguration<'_> {
+impl StripeRequest for ListPaymentMethodConfiguration {
     type Output = stripe_types::List<stripe_payment::PaymentMethodConfiguration>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/payment_method_configurations").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrievePaymentMethodConfigurationBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrievePaymentMethodConfigurationBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrievePaymentMethodConfigurationBuilder<'a> {
+impl RetrievePaymentMethodConfigurationBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieve payment method configuration
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrievePaymentMethodConfiguration<'a> {
-    inner: RetrievePaymentMethodConfigurationBuilder<'a>,
-    configuration: &'a stripe_payment::PaymentMethodConfigurationId,
+pub struct RetrievePaymentMethodConfiguration {
+    inner: RetrievePaymentMethodConfigurationBuilder,
+    configuration: stripe_payment::PaymentMethodConfigurationId,
 }
-impl<'a> RetrievePaymentMethodConfiguration<'a> {
+impl RetrievePaymentMethodConfiguration {
     /// Construct a new `RetrievePaymentMethodConfiguration`.
-    pub fn new(configuration: &'a stripe_payment::PaymentMethodConfigurationId) -> Self {
-        Self { configuration, inner: RetrievePaymentMethodConfigurationBuilder::new() }
+    pub fn new(configuration: impl Into<stripe_payment::PaymentMethodConfigurationId>) -> Self {
+        Self {
+            configuration: configuration.into(),
+            inner: RetrievePaymentMethodConfigurationBuilder::new(),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrievePaymentMethodConfiguration<'_> {
+impl RetrievePaymentMethodConfiguration {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -150,11 +153,11 @@ impl RetrievePaymentMethodConfiguration<'_> {
     }
 }
 
-impl StripeRequest for RetrievePaymentMethodConfiguration<'_> {
+impl StripeRequest for RetrievePaymentMethodConfiguration {
     type Output = stripe_payment::PaymentMethodConfiguration;
 
     fn build(&self) -> RequestBuilder {
-        let configuration = self.configuration;
+        let configuration = &self.configuration;
         RequestBuilder::new(
             StripeMethod::Get,
             format!("/payment_method_configurations/{configuration}"),
@@ -162,8 +165,8 @@ impl StripeRequest for RetrievePaymentMethodConfiguration<'_> {
         .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreatePaymentMethodConfigurationBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreatePaymentMethodConfigurationBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     acss_debit: Option<CreatePaymentMethodConfigurationAcssDebit>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -199,7 +202,7 @@ struct CreatePaymentMethodConfigurationBuilder<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     eps: Option<CreatePaymentMethodConfigurationEps>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     fpx: Option<CreatePaymentMethodConfigurationFpx>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -221,13 +224,13 @@ struct CreatePaymentMethodConfigurationBuilder<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     mobilepay: Option<CreatePaymentMethodConfigurationMobilepay>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    name: Option<&'a str>,
+    name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     oxxo: Option<CreatePaymentMethodConfigurationOxxo>,
     #[serde(skip_serializing_if = "Option::is_none")]
     p24: Option<CreatePaymentMethodConfigurationP24>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    parent: Option<&'a str>,
+    parent: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     paynow: Option<CreatePaymentMethodConfigurationPaynow>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -249,7 +252,7 @@ struct CreatePaymentMethodConfigurationBuilder<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     zip: Option<CreatePaymentMethodConfigurationZip>,
 }
-impl<'a> CreatePaymentMethodConfigurationBuilder<'a> {
+impl CreatePaymentMethodConfigurationBuilder {
     fn new() -> Self {
         Self {
             acss_debit: None,
@@ -4063,101 +4066,116 @@ impl<'de> serde::Deserialize<'de>
 }
 /// Creates a payment method configuration
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentMethodConfiguration<'a> {
-    inner: CreatePaymentMethodConfigurationBuilder<'a>,
+pub struct CreatePaymentMethodConfiguration {
+    inner: CreatePaymentMethodConfigurationBuilder,
 }
-impl<'a> CreatePaymentMethodConfiguration<'a> {
+impl CreatePaymentMethodConfiguration {
     /// Construct a new `CreatePaymentMethodConfiguration`.
     pub fn new() -> Self {
         Self { inner: CreatePaymentMethodConfigurationBuilder::new() }
     }
     /// Canadian pre-authorized debit payments, check this [page](https://stripe.com/docs/payments/acss-debit) for more details like country availability.
-    pub fn acss_debit(mut self, acss_debit: CreatePaymentMethodConfigurationAcssDebit) -> Self {
-        self.inner.acss_debit = Some(acss_debit);
+    pub fn acss_debit(
+        mut self,
+        acss_debit: impl Into<CreatePaymentMethodConfigurationAcssDebit>,
+    ) -> Self {
+        self.inner.acss_debit = Some(acss_debit.into());
         self
     }
     /// [Affirm](https://www.affirm.com/) gives your customers a way to split purchases over a series of payments.
     /// Depending on the purchase, they can pay with four interest-free payments (Split Pay) or pay over a longer term (Installments), which might include interest.
     /// Check this [page](https://stripe.com/docs/payments/affirm) for more details like country availability.
-    pub fn affirm(mut self, affirm: CreatePaymentMethodConfigurationAffirm) -> Self {
-        self.inner.affirm = Some(affirm);
+    pub fn affirm(mut self, affirm: impl Into<CreatePaymentMethodConfigurationAffirm>) -> Self {
+        self.inner.affirm = Some(affirm.into());
         self
     }
     /// Afterpay gives your customers a way to pay for purchases in installments, check this [page](https://stripe.com/docs/payments/afterpay-clearpay) for more details like country availability.
     /// Afterpay is particularly popular among businesses selling fashion, beauty, and sports products.
     pub fn afterpay_clearpay(
         mut self,
-        afterpay_clearpay: CreatePaymentMethodConfigurationAfterpayClearpay,
+        afterpay_clearpay: impl Into<CreatePaymentMethodConfigurationAfterpayClearpay>,
     ) -> Self {
-        self.inner.afterpay_clearpay = Some(afterpay_clearpay);
+        self.inner.afterpay_clearpay = Some(afterpay_clearpay.into());
         self
     }
     /// Alipay is a digital wallet in China that has more than a billion active users worldwide.
     /// Alipay users can pay on the web or on a mobile device using login credentials or their Alipay app.
     /// Alipay has a low dispute rate and reduces fraud by authenticating payments using the customer's login credentials.
     /// Check this [page](https://stripe.com/docs/payments/alipay) for more details.
-    pub fn alipay(mut self, alipay: CreatePaymentMethodConfigurationAlipay) -> Self {
-        self.inner.alipay = Some(alipay);
+    pub fn alipay(mut self, alipay: impl Into<CreatePaymentMethodConfigurationAlipay>) -> Self {
+        self.inner.alipay = Some(alipay.into());
         self
     }
     /// Amazon Pay is a wallet payment method that lets your customers check out the same way as on Amazon.
-    pub fn amazon_pay(mut self, amazon_pay: CreatePaymentMethodConfigurationAmazonPay) -> Self {
-        self.inner.amazon_pay = Some(amazon_pay);
+    pub fn amazon_pay(
+        mut self,
+        amazon_pay: impl Into<CreatePaymentMethodConfigurationAmazonPay>,
+    ) -> Self {
+        self.inner.amazon_pay = Some(amazon_pay.into());
         self
     }
     /// Stripe users can accept [Apple Pay](/payments/apple-pay) in iOS applications in iOS 9 and later, and on the web in Safari starting with iOS 10 or macOS Sierra.
     /// There are no additional fees to process Apple Pay payments, and the [pricing](/pricing) is the same as other card transactions.
     /// Check this [page](https://stripe.com/docs/apple-pay) for more details.
-    pub fn apple_pay(mut self, apple_pay: CreatePaymentMethodConfigurationApplePay) -> Self {
-        self.inner.apple_pay = Some(apple_pay);
+    pub fn apple_pay(
+        mut self,
+        apple_pay: impl Into<CreatePaymentMethodConfigurationApplePay>,
+    ) -> Self {
+        self.inner.apple_pay = Some(apple_pay.into());
         self
     }
     /// Apple Pay Later, a payment method for customers to buy now and pay later, gives your customers a way to split purchases into four installments across six weeks.
     pub fn apple_pay_later(
         mut self,
-        apple_pay_later: CreatePaymentMethodConfigurationApplePayLater,
+        apple_pay_later: impl Into<CreatePaymentMethodConfigurationApplePayLater>,
     ) -> Self {
-        self.inner.apple_pay_later = Some(apple_pay_later);
+        self.inner.apple_pay_later = Some(apple_pay_later.into());
         self
     }
     /// Stripe users in Australia can accept Bulk Electronic Clearing System (BECS) direct debit payments from customers with an Australian bank account.
     /// Check this [page](https://stripe.com/docs/payments/au-becs-debit) for more details.
     pub fn au_becs_debit(
         mut self,
-        au_becs_debit: CreatePaymentMethodConfigurationAuBecsDebit,
+        au_becs_debit: impl Into<CreatePaymentMethodConfigurationAuBecsDebit>,
     ) -> Self {
-        self.inner.au_becs_debit = Some(au_becs_debit);
+        self.inner.au_becs_debit = Some(au_becs_debit.into());
         self
     }
     /// Stripe users in the UK can accept Bacs Direct Debit payments from customers with a UK bank account, check this [page](https://stripe.com/docs/payments/payment-methods/bacs-debit) for more details.
-    pub fn bacs_debit(mut self, bacs_debit: CreatePaymentMethodConfigurationBacsDebit) -> Self {
-        self.inner.bacs_debit = Some(bacs_debit);
+    pub fn bacs_debit(
+        mut self,
+        bacs_debit: impl Into<CreatePaymentMethodConfigurationBacsDebit>,
+    ) -> Self {
+        self.inner.bacs_debit = Some(bacs_debit.into());
         self
     }
     /// Bancontact is the most popular online payment method in Belgium, with over 15 million cards in circulation.
     /// [Customers](https://stripe.com/docs/api/customers) use a Bancontact card or mobile app linked to a Belgian bank account to make online payments that are secure, guaranteed, and confirmed immediately.
     /// Check this [page](https://stripe.com/docs/payments/bancontact) for more details.
-    pub fn bancontact(mut self, bancontact: CreatePaymentMethodConfigurationBancontact) -> Self {
-        self.inner.bancontact = Some(bancontact);
+    pub fn bancontact(
+        mut self,
+        bancontact: impl Into<CreatePaymentMethodConfigurationBancontact>,
+    ) -> Self {
+        self.inner.bancontact = Some(bancontact.into());
         self
     }
     /// BLIK is a [single use](https://stripe.com/docs/payments/payment-methods#usage) payment method that requires customers to authenticate their payments.
     /// When customers want to pay online using BLIK, they request a six-digit code from their banking application and enter it into the payment collection form.
     /// Check this [page](https://stripe.com/docs/payments/blik) for more details.
-    pub fn blik(mut self, blik: CreatePaymentMethodConfigurationBlik) -> Self {
-        self.inner.blik = Some(blik);
+    pub fn blik(mut self, blik: impl Into<CreatePaymentMethodConfigurationBlik>) -> Self {
+        self.inner.blik = Some(blik.into());
         self
     }
     /// Boleto is an official (regulated by the Central Bank of Brazil) payment method in Brazil.
     /// Check this [page](https://stripe.com/docs/payments/boleto) for more details.
-    pub fn boleto(mut self, boleto: CreatePaymentMethodConfigurationBoleto) -> Self {
-        self.inner.boleto = Some(boleto);
+    pub fn boleto(mut self, boleto: impl Into<CreatePaymentMethodConfigurationBoleto>) -> Self {
+        self.inner.boleto = Some(boleto.into());
         self
     }
     /// Cards are a popular way for consumers and businesses to pay online or in person.
     /// Stripe supports global and local card networks.
-    pub fn card(mut self, card: CreatePaymentMethodConfigurationCard) -> Self {
-        self.inner.card = Some(card);
+    pub fn card(mut self, card: impl Into<CreatePaymentMethodConfigurationCard>) -> Self {
+        self.inner.card = Some(card.into());
         self
     }
     /// Cartes Bancaires is France's local card network.
@@ -4165,15 +4183,15 @@ impl<'a> CreatePaymentMethodConfiguration<'a> {
     /// Check this [page](https://stripe.com/docs/payments/cartes-bancaires) for more details.
     pub fn cartes_bancaires(
         mut self,
-        cartes_bancaires: CreatePaymentMethodConfigurationCartesBancaires,
+        cartes_bancaires: impl Into<CreatePaymentMethodConfigurationCartesBancaires>,
     ) -> Self {
-        self.inner.cartes_bancaires = Some(cartes_bancaires);
+        self.inner.cartes_bancaires = Some(cartes_bancaires.into());
         self
     }
     /// Cash App is a popular consumer app in the US that allows customers to bank, invest, send, and receive money using their digital wallet.
     /// Check this [page](https://stripe.com/docs/payments/cash-app-pay) for more details.
-    pub fn cashapp(mut self, cashapp: CreatePaymentMethodConfigurationCashapp) -> Self {
-        self.inner.cashapp = Some(cashapp);
+    pub fn cashapp(mut self, cashapp: impl Into<CreatePaymentMethodConfigurationCashapp>) -> Self {
+        self.inner.cashapp = Some(cashapp.into());
         self
     }
     /// Uses a customer’s [cash balance](https://stripe.com/docs/payments/customer-balance) for the payment.
@@ -4181,29 +4199,29 @@ impl<'a> CreatePaymentMethodConfiguration<'a> {
     /// Check this [page](https://stripe.com/docs/payments/bank-transfers) for more details.
     pub fn customer_balance(
         mut self,
-        customer_balance: CreatePaymentMethodConfigurationCustomerBalance,
+        customer_balance: impl Into<CreatePaymentMethodConfigurationCustomerBalance>,
     ) -> Self {
-        self.inner.customer_balance = Some(customer_balance);
+        self.inner.customer_balance = Some(customer_balance.into());
         self
     }
     /// EPS is an Austria-based payment method that allows customers to complete transactions online using their bank credentials.
     /// EPS is supported by all Austrian banks and is accepted by over 80% of Austrian online retailers.
     /// Check this [page](https://stripe.com/docs/payments/eps) for more details.
-    pub fn eps(mut self, eps: CreatePaymentMethodConfigurationEps) -> Self {
-        self.inner.eps = Some(eps);
+    pub fn eps(mut self, eps: impl Into<CreatePaymentMethodConfigurationEps>) -> Self {
+        self.inner.eps = Some(eps.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Financial Process Exchange (FPX) is a Malaysia-based payment method that allows customers to complete transactions online using their bank credentials.
     /// Bank Negara Malaysia (BNM), the Central Bank of Malaysia, and eleven other major Malaysian financial institutions are members of the PayNet Group, which owns and operates FPX.
     /// It is one of the most popular online payment methods in Malaysia, with nearly 90 million transactions in 2018 according to BNM.
     /// Check this [page](https://stripe.com/docs/payments/fpx) for more details.
-    pub fn fpx(mut self, fpx: CreatePaymentMethodConfigurationFpx) -> Self {
-        self.inner.fpx = Some(fpx);
+    pub fn fpx(mut self, fpx: impl Into<CreatePaymentMethodConfigurationFpx>) -> Self {
+        self.inner.fpx = Some(fpx.into());
         self
     }
     /// giropay is a German payment method based on online banking, introduced in 2006.
@@ -4211,162 +4229,180 @@ impl<'a> CreatePaymentMethodConfiguration<'a> {
     /// Depending on their bank, customers confirm payments on giropay using a second factor of authentication or a PIN.
     /// giropay accounts for 10% of online checkouts in Germany.
     /// Check this [page](https://stripe.com/docs/payments/giropay) for more details.
-    pub fn giropay(mut self, giropay: CreatePaymentMethodConfigurationGiropay) -> Self {
-        self.inner.giropay = Some(giropay);
+    pub fn giropay(mut self, giropay: impl Into<CreatePaymentMethodConfigurationGiropay>) -> Self {
+        self.inner.giropay = Some(giropay.into());
         self
     }
     /// Google Pay allows customers to make payments in your app or website using any credit or debit card saved to their Google Account, including those from Google Play, YouTube, Chrome, or an Android device.
     /// Use the Google Pay API to request any credit or debit card stored in your customer's Google account.
     /// Check this [page](https://stripe.com/docs/google-pay) for more details.
-    pub fn google_pay(mut self, google_pay: CreatePaymentMethodConfigurationGooglePay) -> Self {
-        self.inner.google_pay = Some(google_pay);
+    pub fn google_pay(
+        mut self,
+        google_pay: impl Into<CreatePaymentMethodConfigurationGooglePay>,
+    ) -> Self {
+        self.inner.google_pay = Some(google_pay.into());
         self
     }
     /// GrabPay is a payment method developed by [Grab](https://www.grab.com/sg/consumer/finance/pay/).
     /// GrabPay is a digital wallet - customers maintain a balance in their wallets that they pay out with.
     /// Check this [page](https://stripe.com/docs/payments/grabpay) for more details.
-    pub fn grabpay(mut self, grabpay: CreatePaymentMethodConfigurationGrabpay) -> Self {
-        self.inner.grabpay = Some(grabpay);
+    pub fn grabpay(mut self, grabpay: impl Into<CreatePaymentMethodConfigurationGrabpay>) -> Self {
+        self.inner.grabpay = Some(grabpay.into());
         self
     }
     /// iDEAL is a Netherlands-based payment method that allows customers to complete transactions online using their bank credentials.
     /// All major Dutch banks are members of Currence, the scheme that operates iDEAL, making it the most popular online payment method in the Netherlands with a share of online transactions close to 55%.
     /// Check this [page](https://stripe.com/docs/payments/ideal) for more details.
-    pub fn ideal(mut self, ideal: CreatePaymentMethodConfigurationIdeal) -> Self {
-        self.inner.ideal = Some(ideal);
+    pub fn ideal(mut self, ideal: impl Into<CreatePaymentMethodConfigurationIdeal>) -> Self {
+        self.inner.ideal = Some(ideal.into());
         self
     }
     /// JCB is a credit card company based in Japan.
     /// JCB is currently available in Japan to businesses approved by JCB, and available to all businesses in Australia, Canada, Hong Kong, Japan, New Zealand, Singapore, Switzerland, United Kingdom, United States, and all countries in the European Economic Area except Iceland.
     /// Check this [page](https://support.stripe.com/questions/accepting-japan-credit-bureau-%28jcb%29-payments) for more details.
-    pub fn jcb(mut self, jcb: CreatePaymentMethodConfigurationJcb) -> Self {
-        self.inner.jcb = Some(jcb);
+    pub fn jcb(mut self, jcb: impl Into<CreatePaymentMethodConfigurationJcb>) -> Self {
+        self.inner.jcb = Some(jcb.into());
         self
     }
     /// Klarna gives customers a range of [payment options](https://stripe.com/docs/payments/klarna#payment-options) during checkout.
     /// Available payment options vary depending on the customer's billing address and the transaction amount.
     /// These payment options make it convenient for customers to purchase items in all price ranges.
     /// Check this [page](https://stripe.com/docs/payments/klarna) for more details.
-    pub fn klarna(mut self, klarna: CreatePaymentMethodConfigurationKlarna) -> Self {
-        self.inner.klarna = Some(klarna);
+    pub fn klarna(mut self, klarna: impl Into<CreatePaymentMethodConfigurationKlarna>) -> Self {
+        self.inner.klarna = Some(klarna.into());
         self
     }
     /// Konbini allows customers in Japan to pay for bills and online purchases at convenience stores with cash.
     /// Check this [page](https://stripe.com/docs/payments/konbini) for more details.
-    pub fn konbini(mut self, konbini: CreatePaymentMethodConfigurationKonbini) -> Self {
-        self.inner.konbini = Some(konbini);
+    pub fn konbini(mut self, konbini: impl Into<CreatePaymentMethodConfigurationKonbini>) -> Self {
+        self.inner.konbini = Some(konbini.into());
         self
     }
     /// [Link](https://stripe.com/docs/payments/link) is a payment method network.
     /// With Link, users save their payment details once, then reuse that information to pay with one click for any business on the network.
-    pub fn link(mut self, link: CreatePaymentMethodConfigurationLink) -> Self {
-        self.inner.link = Some(link);
+    pub fn link(mut self, link: impl Into<CreatePaymentMethodConfigurationLink>) -> Self {
+        self.inner.link = Some(link.into());
         self
     }
     /// MobilePay is a [single-use](https://stripe.com/docs/payments/payment-methods#usage) card wallet payment method used in Denmark and Finland.
     /// It allows customers to [authenticate and approve](https://stripe.com/docs/payments/payment-methods#customer-actions) payments using the MobilePay app.
     /// Check this [page](https://stripe.com/docs/payments/mobilepay) for more details.
-    pub fn mobilepay(mut self, mobilepay: CreatePaymentMethodConfigurationMobilepay) -> Self {
-        self.inner.mobilepay = Some(mobilepay);
+    pub fn mobilepay(
+        mut self,
+        mobilepay: impl Into<CreatePaymentMethodConfigurationMobilepay>,
+    ) -> Self {
+        self.inner.mobilepay = Some(mobilepay.into());
         self
     }
     /// Configuration name.
-    pub fn name(mut self, name: &'a str) -> Self {
-        self.inner.name = Some(name);
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.inner.name = Some(name.into());
         self
     }
     /// OXXO is a Mexican chain of convenience stores with thousands of locations across Latin America and represents nearly 20% of online transactions in Mexico.
     /// OXXO allows customers to pay bills and online purchases in-store with cash.
     /// Check this [page](https://stripe.com/docs/payments/oxxo) for more details.
-    pub fn oxxo(mut self, oxxo: CreatePaymentMethodConfigurationOxxo) -> Self {
-        self.inner.oxxo = Some(oxxo);
+    pub fn oxxo(mut self, oxxo: impl Into<CreatePaymentMethodConfigurationOxxo>) -> Self {
+        self.inner.oxxo = Some(oxxo.into());
         self
     }
     /// Przelewy24 is a Poland-based payment method aggregator that allows customers to complete transactions online using bank transfers and other methods.
     /// Bank transfers account for 30% of online payments in Poland and Przelewy24 provides a way for customers to pay with over 165 banks.
     /// Check this [page](https://stripe.com/docs/payments/p24) for more details.
-    pub fn p24(mut self, p24: CreatePaymentMethodConfigurationP24) -> Self {
-        self.inner.p24 = Some(p24);
+    pub fn p24(mut self, p24: impl Into<CreatePaymentMethodConfigurationP24>) -> Self {
+        self.inner.p24 = Some(p24.into());
         self
     }
     /// Configuration's parent configuration. Specify to create a child configuration.
-    pub fn parent(mut self, parent: &'a str) -> Self {
-        self.inner.parent = Some(parent);
+    pub fn parent(mut self, parent: impl Into<String>) -> Self {
+        self.inner.parent = Some(parent.into());
         self
     }
     /// PayNow is a Singapore-based payment method that allows customers to make a payment using their preferred app from participating banks and participating non-bank financial institutions.
     /// Check this [page](https://stripe.com/docs/payments/paynow) for more details.
-    pub fn paynow(mut self, paynow: CreatePaymentMethodConfigurationPaynow) -> Self {
-        self.inner.paynow = Some(paynow);
+    pub fn paynow(mut self, paynow: impl Into<CreatePaymentMethodConfigurationPaynow>) -> Self {
+        self.inner.paynow = Some(paynow.into());
         self
     }
     /// PayPal, a digital wallet popular with customers in Europe, allows your customers worldwide to pay using their PayPal account.
     /// Check this [page](https://stripe.com/docs/payments/paypal) for more details.
-    pub fn paypal(mut self, paypal: CreatePaymentMethodConfigurationPaypal) -> Self {
-        self.inner.paypal = Some(paypal);
+    pub fn paypal(mut self, paypal: impl Into<CreatePaymentMethodConfigurationPaypal>) -> Self {
+        self.inner.paypal = Some(paypal.into());
         self
     }
     /// PromptPay is a Thailand-based payment method that allows customers to make a payment using their preferred app from participating banks.
     /// Check this [page](https://stripe.com/docs/payments/promptpay) for more details.
-    pub fn promptpay(mut self, promptpay: CreatePaymentMethodConfigurationPromptpay) -> Self {
-        self.inner.promptpay = Some(promptpay);
+    pub fn promptpay(
+        mut self,
+        promptpay: impl Into<CreatePaymentMethodConfigurationPromptpay>,
+    ) -> Self {
+        self.inner.promptpay = Some(promptpay.into());
         self
     }
     /// Revolut Pay, developed by Revolut, a global finance app, is a digital wallet payment method.
     /// Revolut Pay uses the customer’s stored balance or cards to fund the payment, and offers the option for non-Revolut customers to save their details after their first purchase.
-    pub fn revolut_pay(mut self, revolut_pay: CreatePaymentMethodConfigurationRevolutPay) -> Self {
-        self.inner.revolut_pay = Some(revolut_pay);
+    pub fn revolut_pay(
+        mut self,
+        revolut_pay: impl Into<CreatePaymentMethodConfigurationRevolutPay>,
+    ) -> Self {
+        self.inner.revolut_pay = Some(revolut_pay.into());
         self
     }
     /// The [Single Euro Payments Area (SEPA)](https://en.wikipedia.org/wiki/Single_Euro_Payments_Area) is an initiative of the European Union to simplify payments within and across member countries.
     /// SEPA established and enforced banking standards to allow for the direct debiting of every EUR-denominated bank account within the SEPA region, check this [page](https://stripe.com/docs/payments/sepa-debit) for more details.
-    pub fn sepa_debit(mut self, sepa_debit: CreatePaymentMethodConfigurationSepaDebit) -> Self {
-        self.inner.sepa_debit = Some(sepa_debit);
+    pub fn sepa_debit(
+        mut self,
+        sepa_debit: impl Into<CreatePaymentMethodConfigurationSepaDebit>,
+    ) -> Self {
+        self.inner.sepa_debit = Some(sepa_debit.into());
         self
     }
     /// Stripe users in Europe and the United States can use the [Payment Intents API](https://stripe.com/docs/payments/payment-intents)—a single integration path for creating payments using any supported method—to accept [Sofort](https://www.sofort.com/) payments from customers.
     /// Check this [page](https://stripe.com/docs/payments/sofort) for more details.
-    pub fn sofort(mut self, sofort: CreatePaymentMethodConfigurationSofort) -> Self {
-        self.inner.sofort = Some(sofort);
+    pub fn sofort(mut self, sofort: impl Into<CreatePaymentMethodConfigurationSofort>) -> Self {
+        self.inner.sofort = Some(sofort.into());
         self
     }
     /// Swish is a [real-time](https://stripe.com/docs/payments/real-time) payment method popular in Sweden.
     /// It allows customers to [authenticate and approve](https://stripe.com/docs/payments/payment-methods#customer-actions) payments using the Swish mobile app and the Swedish BankID mobile app.
     /// Check this [page](https://stripe.com/docs/payments/swish) for more details.
-    pub fn swish(mut self, swish: CreatePaymentMethodConfigurationSwish) -> Self {
-        self.inner.swish = Some(swish);
+    pub fn swish(mut self, swish: impl Into<CreatePaymentMethodConfigurationSwish>) -> Self {
+        self.inner.swish = Some(swish.into());
         self
     }
     /// Stripe users in the United States can accept ACH direct debit payments from customers with a US bank account using the Automated Clearing House (ACH) payments system operated by Nacha.
     /// Check this [page](https://stripe.com/docs/payments/ach-debit) for more details.
     pub fn us_bank_account(
         mut self,
-        us_bank_account: CreatePaymentMethodConfigurationUsBankAccount,
+        us_bank_account: impl Into<CreatePaymentMethodConfigurationUsBankAccount>,
     ) -> Self {
-        self.inner.us_bank_account = Some(us_bank_account);
+        self.inner.us_bank_account = Some(us_bank_account.into());
         self
     }
     /// WeChat, owned by Tencent, is China's leading mobile app with over 1 billion monthly active users.
     /// Chinese consumers can use WeChat Pay to pay for goods and services inside of businesses' apps and websites.
     /// WeChat Pay users buy most frequently in gaming, e-commerce, travel, online education, and food/nutrition.
     /// Check this [page](https://stripe.com/docs/payments/wechat-pay) for more details.
-    pub fn wechat_pay(mut self, wechat_pay: CreatePaymentMethodConfigurationWechatPay) -> Self {
-        self.inner.wechat_pay = Some(wechat_pay);
+    pub fn wechat_pay(
+        mut self,
+        wechat_pay: impl Into<CreatePaymentMethodConfigurationWechatPay>,
+    ) -> Self {
+        self.inner.wechat_pay = Some(wechat_pay.into());
         self
     }
     /// Zip gives your customers a way to split purchases over a series of payments.
     /// Check this [page](https://stripe.com/docs/payments/zip) for more details like country availability.
-    pub fn zip(mut self, zip: CreatePaymentMethodConfigurationZip) -> Self {
-        self.inner.zip = Some(zip);
+    pub fn zip(mut self, zip: impl Into<CreatePaymentMethodConfigurationZip>) -> Self {
+        self.inner.zip = Some(zip.into());
         self
     }
 }
-impl<'a> Default for CreatePaymentMethodConfiguration<'a> {
+impl Default for CreatePaymentMethodConfiguration {
     fn default() -> Self {
         Self::new()
     }
 }
-impl CreatePaymentMethodConfiguration<'_> {
+impl CreatePaymentMethodConfiguration {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -4384,15 +4420,15 @@ impl CreatePaymentMethodConfiguration<'_> {
     }
 }
 
-impl StripeRequest for CreatePaymentMethodConfiguration<'_> {
+impl StripeRequest for CreatePaymentMethodConfiguration {
     type Output = stripe_payment::PaymentMethodConfiguration;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Post, "/payment_method_configurations").form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdatePaymentMethodConfigurationBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdatePaymentMethodConfigurationBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     acss_debit: Option<UpdatePaymentMethodConfigurationAcssDebit>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -4430,7 +4466,7 @@ struct UpdatePaymentMethodConfigurationBuilder<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     eps: Option<UpdatePaymentMethodConfigurationEps>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     fpx: Option<UpdatePaymentMethodConfigurationFpx>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -4452,7 +4488,7 @@ struct UpdatePaymentMethodConfigurationBuilder<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     mobilepay: Option<UpdatePaymentMethodConfigurationMobilepay>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    name: Option<&'a str>,
+    name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     oxxo: Option<UpdatePaymentMethodConfigurationOxxo>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -4478,7 +4514,7 @@ struct UpdatePaymentMethodConfigurationBuilder<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     zip: Option<UpdatePaymentMethodConfigurationZip>,
 }
-impl<'a> UpdatePaymentMethodConfigurationBuilder<'a> {
+impl UpdatePaymentMethodConfigurationBuilder {
     fn new() -> Self {
         Self {
             acss_debit: None,
@@ -8292,107 +8328,125 @@ impl<'de> serde::Deserialize<'de>
 }
 /// Update payment method configuration
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentMethodConfiguration<'a> {
-    inner: UpdatePaymentMethodConfigurationBuilder<'a>,
-    configuration: &'a stripe_payment::PaymentMethodConfigurationId,
+pub struct UpdatePaymentMethodConfiguration {
+    inner: UpdatePaymentMethodConfigurationBuilder,
+    configuration: stripe_payment::PaymentMethodConfigurationId,
 }
-impl<'a> UpdatePaymentMethodConfiguration<'a> {
+impl UpdatePaymentMethodConfiguration {
     /// Construct a new `UpdatePaymentMethodConfiguration`.
-    pub fn new(configuration: &'a stripe_payment::PaymentMethodConfigurationId) -> Self {
-        Self { configuration, inner: UpdatePaymentMethodConfigurationBuilder::new() }
+    pub fn new(configuration: impl Into<stripe_payment::PaymentMethodConfigurationId>) -> Self {
+        Self {
+            configuration: configuration.into(),
+            inner: UpdatePaymentMethodConfigurationBuilder::new(),
+        }
     }
     /// Canadian pre-authorized debit payments, check this [page](https://stripe.com/docs/payments/acss-debit) for more details like country availability.
-    pub fn acss_debit(mut self, acss_debit: UpdatePaymentMethodConfigurationAcssDebit) -> Self {
-        self.inner.acss_debit = Some(acss_debit);
+    pub fn acss_debit(
+        mut self,
+        acss_debit: impl Into<UpdatePaymentMethodConfigurationAcssDebit>,
+    ) -> Self {
+        self.inner.acss_debit = Some(acss_debit.into());
         self
     }
     /// Whether the configuration can be used for new payments.
-    pub fn active(mut self, active: bool) -> Self {
-        self.inner.active = Some(active);
+    pub fn active(mut self, active: impl Into<bool>) -> Self {
+        self.inner.active = Some(active.into());
         self
     }
     /// [Affirm](https://www.affirm.com/) gives your customers a way to split purchases over a series of payments.
     /// Depending on the purchase, they can pay with four interest-free payments (Split Pay) or pay over a longer term (Installments), which might include interest.
     /// Check this [page](https://stripe.com/docs/payments/affirm) for more details like country availability.
-    pub fn affirm(mut self, affirm: UpdatePaymentMethodConfigurationAffirm) -> Self {
-        self.inner.affirm = Some(affirm);
+    pub fn affirm(mut self, affirm: impl Into<UpdatePaymentMethodConfigurationAffirm>) -> Self {
+        self.inner.affirm = Some(affirm.into());
         self
     }
     /// Afterpay gives your customers a way to pay for purchases in installments, check this [page](https://stripe.com/docs/payments/afterpay-clearpay) for more details like country availability.
     /// Afterpay is particularly popular among businesses selling fashion, beauty, and sports products.
     pub fn afterpay_clearpay(
         mut self,
-        afterpay_clearpay: UpdatePaymentMethodConfigurationAfterpayClearpay,
+        afterpay_clearpay: impl Into<UpdatePaymentMethodConfigurationAfterpayClearpay>,
     ) -> Self {
-        self.inner.afterpay_clearpay = Some(afterpay_clearpay);
+        self.inner.afterpay_clearpay = Some(afterpay_clearpay.into());
         self
     }
     /// Alipay is a digital wallet in China that has more than a billion active users worldwide.
     /// Alipay users can pay on the web or on a mobile device using login credentials or their Alipay app.
     /// Alipay has a low dispute rate and reduces fraud by authenticating payments using the customer's login credentials.
     /// Check this [page](https://stripe.com/docs/payments/alipay) for more details.
-    pub fn alipay(mut self, alipay: UpdatePaymentMethodConfigurationAlipay) -> Self {
-        self.inner.alipay = Some(alipay);
+    pub fn alipay(mut self, alipay: impl Into<UpdatePaymentMethodConfigurationAlipay>) -> Self {
+        self.inner.alipay = Some(alipay.into());
         self
     }
     /// Amazon Pay is a wallet payment method that lets your customers check out the same way as on Amazon.
-    pub fn amazon_pay(mut self, amazon_pay: UpdatePaymentMethodConfigurationAmazonPay) -> Self {
-        self.inner.amazon_pay = Some(amazon_pay);
+    pub fn amazon_pay(
+        mut self,
+        amazon_pay: impl Into<UpdatePaymentMethodConfigurationAmazonPay>,
+    ) -> Self {
+        self.inner.amazon_pay = Some(amazon_pay.into());
         self
     }
     /// Stripe users can accept [Apple Pay](/payments/apple-pay) in iOS applications in iOS 9 and later, and on the web in Safari starting with iOS 10 or macOS Sierra.
     /// There are no additional fees to process Apple Pay payments, and the [pricing](/pricing) is the same as other card transactions.
     /// Check this [page](https://stripe.com/docs/apple-pay) for more details.
-    pub fn apple_pay(mut self, apple_pay: UpdatePaymentMethodConfigurationApplePay) -> Self {
-        self.inner.apple_pay = Some(apple_pay);
+    pub fn apple_pay(
+        mut self,
+        apple_pay: impl Into<UpdatePaymentMethodConfigurationApplePay>,
+    ) -> Self {
+        self.inner.apple_pay = Some(apple_pay.into());
         self
     }
     /// Apple Pay Later, a payment method for customers to buy now and pay later, gives your customers a way to split purchases into four installments across six weeks.
     pub fn apple_pay_later(
         mut self,
-        apple_pay_later: UpdatePaymentMethodConfigurationApplePayLater,
+        apple_pay_later: impl Into<UpdatePaymentMethodConfigurationApplePayLater>,
     ) -> Self {
-        self.inner.apple_pay_later = Some(apple_pay_later);
+        self.inner.apple_pay_later = Some(apple_pay_later.into());
         self
     }
     /// Stripe users in Australia can accept Bulk Electronic Clearing System (BECS) direct debit payments from customers with an Australian bank account.
     /// Check this [page](https://stripe.com/docs/payments/au-becs-debit) for more details.
     pub fn au_becs_debit(
         mut self,
-        au_becs_debit: UpdatePaymentMethodConfigurationAuBecsDebit,
+        au_becs_debit: impl Into<UpdatePaymentMethodConfigurationAuBecsDebit>,
     ) -> Self {
-        self.inner.au_becs_debit = Some(au_becs_debit);
+        self.inner.au_becs_debit = Some(au_becs_debit.into());
         self
     }
     /// Stripe users in the UK can accept Bacs Direct Debit payments from customers with a UK bank account, check this [page](https://stripe.com/docs/payments/payment-methods/bacs-debit) for more details.
-    pub fn bacs_debit(mut self, bacs_debit: UpdatePaymentMethodConfigurationBacsDebit) -> Self {
-        self.inner.bacs_debit = Some(bacs_debit);
+    pub fn bacs_debit(
+        mut self,
+        bacs_debit: impl Into<UpdatePaymentMethodConfigurationBacsDebit>,
+    ) -> Self {
+        self.inner.bacs_debit = Some(bacs_debit.into());
         self
     }
     /// Bancontact is the most popular online payment method in Belgium, with over 15 million cards in circulation.
     /// [Customers](https://stripe.com/docs/api/customers) use a Bancontact card or mobile app linked to a Belgian bank account to make online payments that are secure, guaranteed, and confirmed immediately.
     /// Check this [page](https://stripe.com/docs/payments/bancontact) for more details.
-    pub fn bancontact(mut self, bancontact: UpdatePaymentMethodConfigurationBancontact) -> Self {
-        self.inner.bancontact = Some(bancontact);
+    pub fn bancontact(
+        mut self,
+        bancontact: impl Into<UpdatePaymentMethodConfigurationBancontact>,
+    ) -> Self {
+        self.inner.bancontact = Some(bancontact.into());
         self
     }
     /// BLIK is a [single use](https://stripe.com/docs/payments/payment-methods#usage) payment method that requires customers to authenticate their payments.
     /// When customers want to pay online using BLIK, they request a six-digit code from their banking application and enter it into the payment collection form.
     /// Check this [page](https://stripe.com/docs/payments/blik) for more details.
-    pub fn blik(mut self, blik: UpdatePaymentMethodConfigurationBlik) -> Self {
-        self.inner.blik = Some(blik);
+    pub fn blik(mut self, blik: impl Into<UpdatePaymentMethodConfigurationBlik>) -> Self {
+        self.inner.blik = Some(blik.into());
         self
     }
     /// Boleto is an official (regulated by the Central Bank of Brazil) payment method in Brazil.
     /// Check this [page](https://stripe.com/docs/payments/boleto) for more details.
-    pub fn boleto(mut self, boleto: UpdatePaymentMethodConfigurationBoleto) -> Self {
-        self.inner.boleto = Some(boleto);
+    pub fn boleto(mut self, boleto: impl Into<UpdatePaymentMethodConfigurationBoleto>) -> Self {
+        self.inner.boleto = Some(boleto.into());
         self
     }
     /// Cards are a popular way for consumers and businesses to pay online or in person.
     /// Stripe supports global and local card networks.
-    pub fn card(mut self, card: UpdatePaymentMethodConfigurationCard) -> Self {
-        self.inner.card = Some(card);
+    pub fn card(mut self, card: impl Into<UpdatePaymentMethodConfigurationCard>) -> Self {
+        self.inner.card = Some(card.into());
         self
     }
     /// Cartes Bancaires is France's local card network.
@@ -8400,15 +8454,15 @@ impl<'a> UpdatePaymentMethodConfiguration<'a> {
     /// Check this [page](https://stripe.com/docs/payments/cartes-bancaires) for more details.
     pub fn cartes_bancaires(
         mut self,
-        cartes_bancaires: UpdatePaymentMethodConfigurationCartesBancaires,
+        cartes_bancaires: impl Into<UpdatePaymentMethodConfigurationCartesBancaires>,
     ) -> Self {
-        self.inner.cartes_bancaires = Some(cartes_bancaires);
+        self.inner.cartes_bancaires = Some(cartes_bancaires.into());
         self
     }
     /// Cash App is a popular consumer app in the US that allows customers to bank, invest, send, and receive money using their digital wallet.
     /// Check this [page](https://stripe.com/docs/payments/cash-app-pay) for more details.
-    pub fn cashapp(mut self, cashapp: UpdatePaymentMethodConfigurationCashapp) -> Self {
-        self.inner.cashapp = Some(cashapp);
+    pub fn cashapp(mut self, cashapp: impl Into<UpdatePaymentMethodConfigurationCashapp>) -> Self {
+        self.inner.cashapp = Some(cashapp.into());
         self
     }
     /// Uses a customer’s [cash balance](https://stripe.com/docs/payments/customer-balance) for the payment.
@@ -8416,29 +8470,29 @@ impl<'a> UpdatePaymentMethodConfiguration<'a> {
     /// Check this [page](https://stripe.com/docs/payments/bank-transfers) for more details.
     pub fn customer_balance(
         mut self,
-        customer_balance: UpdatePaymentMethodConfigurationCustomerBalance,
+        customer_balance: impl Into<UpdatePaymentMethodConfigurationCustomerBalance>,
     ) -> Self {
-        self.inner.customer_balance = Some(customer_balance);
+        self.inner.customer_balance = Some(customer_balance.into());
         self
     }
     /// EPS is an Austria-based payment method that allows customers to complete transactions online using their bank credentials.
     /// EPS is supported by all Austrian banks and is accepted by over 80% of Austrian online retailers.
     /// Check this [page](https://stripe.com/docs/payments/eps) for more details.
-    pub fn eps(mut self, eps: UpdatePaymentMethodConfigurationEps) -> Self {
-        self.inner.eps = Some(eps);
+    pub fn eps(mut self, eps: impl Into<UpdatePaymentMethodConfigurationEps>) -> Self {
+        self.inner.eps = Some(eps.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Financial Process Exchange (FPX) is a Malaysia-based payment method that allows customers to complete transactions online using their bank credentials.
     /// Bank Negara Malaysia (BNM), the Central Bank of Malaysia, and eleven other major Malaysian financial institutions are members of the PayNet Group, which owns and operates FPX.
     /// It is one of the most popular online payment methods in Malaysia, with nearly 90 million transactions in 2018 according to BNM.
     /// Check this [page](https://stripe.com/docs/payments/fpx) for more details.
-    pub fn fpx(mut self, fpx: UpdatePaymentMethodConfigurationFpx) -> Self {
-        self.inner.fpx = Some(fpx);
+    pub fn fpx(mut self, fpx: impl Into<UpdatePaymentMethodConfigurationFpx>) -> Self {
+        self.inner.fpx = Some(fpx.into());
         self
     }
     /// giropay is a German payment method based on online banking, introduced in 2006.
@@ -8446,152 +8500,170 @@ impl<'a> UpdatePaymentMethodConfiguration<'a> {
     /// Depending on their bank, customers confirm payments on giropay using a second factor of authentication or a PIN.
     /// giropay accounts for 10% of online checkouts in Germany.
     /// Check this [page](https://stripe.com/docs/payments/giropay) for more details.
-    pub fn giropay(mut self, giropay: UpdatePaymentMethodConfigurationGiropay) -> Self {
-        self.inner.giropay = Some(giropay);
+    pub fn giropay(mut self, giropay: impl Into<UpdatePaymentMethodConfigurationGiropay>) -> Self {
+        self.inner.giropay = Some(giropay.into());
         self
     }
     /// Google Pay allows customers to make payments in your app or website using any credit or debit card saved to their Google Account, including those from Google Play, YouTube, Chrome, or an Android device.
     /// Use the Google Pay API to request any credit or debit card stored in your customer's Google account.
     /// Check this [page](https://stripe.com/docs/google-pay) for more details.
-    pub fn google_pay(mut self, google_pay: UpdatePaymentMethodConfigurationGooglePay) -> Self {
-        self.inner.google_pay = Some(google_pay);
+    pub fn google_pay(
+        mut self,
+        google_pay: impl Into<UpdatePaymentMethodConfigurationGooglePay>,
+    ) -> Self {
+        self.inner.google_pay = Some(google_pay.into());
         self
     }
     /// GrabPay is a payment method developed by [Grab](https://www.grab.com/sg/consumer/finance/pay/).
     /// GrabPay is a digital wallet - customers maintain a balance in their wallets that they pay out with.
     /// Check this [page](https://stripe.com/docs/payments/grabpay) for more details.
-    pub fn grabpay(mut self, grabpay: UpdatePaymentMethodConfigurationGrabpay) -> Self {
-        self.inner.grabpay = Some(grabpay);
+    pub fn grabpay(mut self, grabpay: impl Into<UpdatePaymentMethodConfigurationGrabpay>) -> Self {
+        self.inner.grabpay = Some(grabpay.into());
         self
     }
     /// iDEAL is a Netherlands-based payment method that allows customers to complete transactions online using their bank credentials.
     /// All major Dutch banks are members of Currence, the scheme that operates iDEAL, making it the most popular online payment method in the Netherlands with a share of online transactions close to 55%.
     /// Check this [page](https://stripe.com/docs/payments/ideal) for more details.
-    pub fn ideal(mut self, ideal: UpdatePaymentMethodConfigurationIdeal) -> Self {
-        self.inner.ideal = Some(ideal);
+    pub fn ideal(mut self, ideal: impl Into<UpdatePaymentMethodConfigurationIdeal>) -> Self {
+        self.inner.ideal = Some(ideal.into());
         self
     }
     /// JCB is a credit card company based in Japan.
     /// JCB is currently available in Japan to businesses approved by JCB, and available to all businesses in Australia, Canada, Hong Kong, Japan, New Zealand, Singapore, Switzerland, United Kingdom, United States, and all countries in the European Economic Area except Iceland.
     /// Check this [page](https://support.stripe.com/questions/accepting-japan-credit-bureau-%28jcb%29-payments) for more details.
-    pub fn jcb(mut self, jcb: UpdatePaymentMethodConfigurationJcb) -> Self {
-        self.inner.jcb = Some(jcb);
+    pub fn jcb(mut self, jcb: impl Into<UpdatePaymentMethodConfigurationJcb>) -> Self {
+        self.inner.jcb = Some(jcb.into());
         self
     }
     /// Klarna gives customers a range of [payment options](https://stripe.com/docs/payments/klarna#payment-options) during checkout.
     /// Available payment options vary depending on the customer's billing address and the transaction amount.
     /// These payment options make it convenient for customers to purchase items in all price ranges.
     /// Check this [page](https://stripe.com/docs/payments/klarna) for more details.
-    pub fn klarna(mut self, klarna: UpdatePaymentMethodConfigurationKlarna) -> Self {
-        self.inner.klarna = Some(klarna);
+    pub fn klarna(mut self, klarna: impl Into<UpdatePaymentMethodConfigurationKlarna>) -> Self {
+        self.inner.klarna = Some(klarna.into());
         self
     }
     /// Konbini allows customers in Japan to pay for bills and online purchases at convenience stores with cash.
     /// Check this [page](https://stripe.com/docs/payments/konbini) for more details.
-    pub fn konbini(mut self, konbini: UpdatePaymentMethodConfigurationKonbini) -> Self {
-        self.inner.konbini = Some(konbini);
+    pub fn konbini(mut self, konbini: impl Into<UpdatePaymentMethodConfigurationKonbini>) -> Self {
+        self.inner.konbini = Some(konbini.into());
         self
     }
     /// [Link](https://stripe.com/docs/payments/link) is a payment method network.
     /// With Link, users save their payment details once, then reuse that information to pay with one click for any business on the network.
-    pub fn link(mut self, link: UpdatePaymentMethodConfigurationLink) -> Self {
-        self.inner.link = Some(link);
+    pub fn link(mut self, link: impl Into<UpdatePaymentMethodConfigurationLink>) -> Self {
+        self.inner.link = Some(link.into());
         self
     }
     /// MobilePay is a [single-use](https://stripe.com/docs/payments/payment-methods#usage) card wallet payment method used in Denmark and Finland.
     /// It allows customers to [authenticate and approve](https://stripe.com/docs/payments/payment-methods#customer-actions) payments using the MobilePay app.
     /// Check this [page](https://stripe.com/docs/payments/mobilepay) for more details.
-    pub fn mobilepay(mut self, mobilepay: UpdatePaymentMethodConfigurationMobilepay) -> Self {
-        self.inner.mobilepay = Some(mobilepay);
+    pub fn mobilepay(
+        mut self,
+        mobilepay: impl Into<UpdatePaymentMethodConfigurationMobilepay>,
+    ) -> Self {
+        self.inner.mobilepay = Some(mobilepay.into());
         self
     }
     /// Configuration name.
-    pub fn name(mut self, name: &'a str) -> Self {
-        self.inner.name = Some(name);
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.inner.name = Some(name.into());
         self
     }
     /// OXXO is a Mexican chain of convenience stores with thousands of locations across Latin America and represents nearly 20% of online transactions in Mexico.
     /// OXXO allows customers to pay bills and online purchases in-store with cash.
     /// Check this [page](https://stripe.com/docs/payments/oxxo) for more details.
-    pub fn oxxo(mut self, oxxo: UpdatePaymentMethodConfigurationOxxo) -> Self {
-        self.inner.oxxo = Some(oxxo);
+    pub fn oxxo(mut self, oxxo: impl Into<UpdatePaymentMethodConfigurationOxxo>) -> Self {
+        self.inner.oxxo = Some(oxxo.into());
         self
     }
     /// Przelewy24 is a Poland-based payment method aggregator that allows customers to complete transactions online using bank transfers and other methods.
     /// Bank transfers account for 30% of online payments in Poland and Przelewy24 provides a way for customers to pay with over 165 banks.
     /// Check this [page](https://stripe.com/docs/payments/p24) for more details.
-    pub fn p24(mut self, p24: UpdatePaymentMethodConfigurationP24) -> Self {
-        self.inner.p24 = Some(p24);
+    pub fn p24(mut self, p24: impl Into<UpdatePaymentMethodConfigurationP24>) -> Self {
+        self.inner.p24 = Some(p24.into());
         self
     }
     /// PayNow is a Singapore-based payment method that allows customers to make a payment using their preferred app from participating banks and participating non-bank financial institutions.
     /// Check this [page](https://stripe.com/docs/payments/paynow) for more details.
-    pub fn paynow(mut self, paynow: UpdatePaymentMethodConfigurationPaynow) -> Self {
-        self.inner.paynow = Some(paynow);
+    pub fn paynow(mut self, paynow: impl Into<UpdatePaymentMethodConfigurationPaynow>) -> Self {
+        self.inner.paynow = Some(paynow.into());
         self
     }
     /// PayPal, a digital wallet popular with customers in Europe, allows your customers worldwide to pay using their PayPal account.
     /// Check this [page](https://stripe.com/docs/payments/paypal) for more details.
-    pub fn paypal(mut self, paypal: UpdatePaymentMethodConfigurationPaypal) -> Self {
-        self.inner.paypal = Some(paypal);
+    pub fn paypal(mut self, paypal: impl Into<UpdatePaymentMethodConfigurationPaypal>) -> Self {
+        self.inner.paypal = Some(paypal.into());
         self
     }
     /// PromptPay is a Thailand-based payment method that allows customers to make a payment using their preferred app from participating banks.
     /// Check this [page](https://stripe.com/docs/payments/promptpay) for more details.
-    pub fn promptpay(mut self, promptpay: UpdatePaymentMethodConfigurationPromptpay) -> Self {
-        self.inner.promptpay = Some(promptpay);
+    pub fn promptpay(
+        mut self,
+        promptpay: impl Into<UpdatePaymentMethodConfigurationPromptpay>,
+    ) -> Self {
+        self.inner.promptpay = Some(promptpay.into());
         self
     }
     /// Revolut Pay, developed by Revolut, a global finance app, is a digital wallet payment method.
     /// Revolut Pay uses the customer’s stored balance or cards to fund the payment, and offers the option for non-Revolut customers to save their details after their first purchase.
-    pub fn revolut_pay(mut self, revolut_pay: UpdatePaymentMethodConfigurationRevolutPay) -> Self {
-        self.inner.revolut_pay = Some(revolut_pay);
+    pub fn revolut_pay(
+        mut self,
+        revolut_pay: impl Into<UpdatePaymentMethodConfigurationRevolutPay>,
+    ) -> Self {
+        self.inner.revolut_pay = Some(revolut_pay.into());
         self
     }
     /// The [Single Euro Payments Area (SEPA)](https://en.wikipedia.org/wiki/Single_Euro_Payments_Area) is an initiative of the European Union to simplify payments within and across member countries.
     /// SEPA established and enforced banking standards to allow for the direct debiting of every EUR-denominated bank account within the SEPA region, check this [page](https://stripe.com/docs/payments/sepa-debit) for more details.
-    pub fn sepa_debit(mut self, sepa_debit: UpdatePaymentMethodConfigurationSepaDebit) -> Self {
-        self.inner.sepa_debit = Some(sepa_debit);
+    pub fn sepa_debit(
+        mut self,
+        sepa_debit: impl Into<UpdatePaymentMethodConfigurationSepaDebit>,
+    ) -> Self {
+        self.inner.sepa_debit = Some(sepa_debit.into());
         self
     }
     /// Stripe users in Europe and the United States can use the [Payment Intents API](https://stripe.com/docs/payments/payment-intents)—a single integration path for creating payments using any supported method—to accept [Sofort](https://www.sofort.com/) payments from customers.
     /// Check this [page](https://stripe.com/docs/payments/sofort) for more details.
-    pub fn sofort(mut self, sofort: UpdatePaymentMethodConfigurationSofort) -> Self {
-        self.inner.sofort = Some(sofort);
+    pub fn sofort(mut self, sofort: impl Into<UpdatePaymentMethodConfigurationSofort>) -> Self {
+        self.inner.sofort = Some(sofort.into());
         self
     }
     /// Swish is a [real-time](https://stripe.com/docs/payments/real-time) payment method popular in Sweden.
     /// It allows customers to [authenticate and approve](https://stripe.com/docs/payments/payment-methods#customer-actions) payments using the Swish mobile app and the Swedish BankID mobile app.
     /// Check this [page](https://stripe.com/docs/payments/swish) for more details.
-    pub fn swish(mut self, swish: UpdatePaymentMethodConfigurationSwish) -> Self {
-        self.inner.swish = Some(swish);
+    pub fn swish(mut self, swish: impl Into<UpdatePaymentMethodConfigurationSwish>) -> Self {
+        self.inner.swish = Some(swish.into());
         self
     }
     /// Stripe users in the United States can accept ACH direct debit payments from customers with a US bank account using the Automated Clearing House (ACH) payments system operated by Nacha.
     /// Check this [page](https://stripe.com/docs/payments/ach-debit) for more details.
     pub fn us_bank_account(
         mut self,
-        us_bank_account: UpdatePaymentMethodConfigurationUsBankAccount,
+        us_bank_account: impl Into<UpdatePaymentMethodConfigurationUsBankAccount>,
     ) -> Self {
-        self.inner.us_bank_account = Some(us_bank_account);
+        self.inner.us_bank_account = Some(us_bank_account.into());
         self
     }
     /// WeChat, owned by Tencent, is China's leading mobile app with over 1 billion monthly active users.
     /// Chinese consumers can use WeChat Pay to pay for goods and services inside of businesses' apps and websites.
     /// WeChat Pay users buy most frequently in gaming, e-commerce, travel, online education, and food/nutrition.
     /// Check this [page](https://stripe.com/docs/payments/wechat-pay) for more details.
-    pub fn wechat_pay(mut self, wechat_pay: UpdatePaymentMethodConfigurationWechatPay) -> Self {
-        self.inner.wechat_pay = Some(wechat_pay);
+    pub fn wechat_pay(
+        mut self,
+        wechat_pay: impl Into<UpdatePaymentMethodConfigurationWechatPay>,
+    ) -> Self {
+        self.inner.wechat_pay = Some(wechat_pay.into());
         self
     }
     /// Zip gives your customers a way to split purchases over a series of payments.
     /// Check this [page](https://stripe.com/docs/payments/zip) for more details like country availability.
-    pub fn zip(mut self, zip: UpdatePaymentMethodConfigurationZip) -> Self {
-        self.inner.zip = Some(zip);
+    pub fn zip(mut self, zip: impl Into<UpdatePaymentMethodConfigurationZip>) -> Self {
+        self.inner.zip = Some(zip.into());
         self
     }
 }
-impl UpdatePaymentMethodConfiguration<'_> {
+impl UpdatePaymentMethodConfiguration {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -8609,11 +8681,11 @@ impl UpdatePaymentMethodConfiguration<'_> {
     }
 }
 
-impl StripeRequest for UpdatePaymentMethodConfiguration<'_> {
+impl StripeRequest for UpdatePaymentMethodConfiguration {
     type Output = stripe_payment::PaymentMethodConfiguration;
 
     fn build(&self) -> RequestBuilder {
-        let configuration = self.configuration;
+        let configuration = &self.configuration;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/payment_method_configurations/{configuration}"),

--- a/generated/async-stripe-payment/src/payment_method_domain/requests.rs
+++ b/generated/async-stripe-payment/src/payment_method_domain/requests.rs
@@ -2,22 +2,22 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListPaymentMethodDomainBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListPaymentMethodDomainBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    domain_name: Option<&'a str>,
+    domain_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     enabled: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListPaymentMethodDomainBuilder<'a> {
+impl ListPaymentMethodDomainBuilder {
     fn new() -> Self {
         Self {
             domain_name: None,
@@ -31,57 +31,57 @@ impl<'a> ListPaymentMethodDomainBuilder<'a> {
 }
 /// Lists the details of existing payment method domains.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListPaymentMethodDomain<'a> {
-    inner: ListPaymentMethodDomainBuilder<'a>,
+pub struct ListPaymentMethodDomain {
+    inner: ListPaymentMethodDomainBuilder,
 }
-impl<'a> ListPaymentMethodDomain<'a> {
+impl ListPaymentMethodDomain {
     /// Construct a new `ListPaymentMethodDomain`.
     pub fn new() -> Self {
         Self { inner: ListPaymentMethodDomainBuilder::new() }
     }
     /// The domain name that this payment method domain object represents.
-    pub fn domain_name(mut self, domain_name: &'a str) -> Self {
-        self.inner.domain_name = Some(domain_name);
+    pub fn domain_name(mut self, domain_name: impl Into<String>) -> Self {
+        self.inner.domain_name = Some(domain_name.into());
         self
     }
     /// Whether this payment method domain is enabled.
     /// If the domain is not enabled, payment methods will not appear in Elements.
-    pub fn enabled(mut self, enabled: bool) -> Self {
-        self.inner.enabled = Some(enabled);
+    pub fn enabled(mut self, enabled: impl Into<bool>) -> Self {
+        self.inner.enabled = Some(enabled.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl<'a> Default for ListPaymentMethodDomain<'a> {
+impl Default for ListPaymentMethodDomain {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListPaymentMethodDomain<'_> {
+impl ListPaymentMethodDomain {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -102,45 +102,48 @@ impl ListPaymentMethodDomain<'_> {
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_payment::PaymentMethodDomain>>
     {
-        stripe_client_core::ListPaginator::new_list("/payment_method_domains", self.inner)
+        stripe_client_core::ListPaginator::new_list("/payment_method_domains", &self.inner)
     }
 }
 
-impl StripeRequest for ListPaymentMethodDomain<'_> {
+impl StripeRequest for ListPaymentMethodDomain {
     type Output = stripe_types::List<stripe_payment::PaymentMethodDomain>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/payment_method_domains").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrievePaymentMethodDomainBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrievePaymentMethodDomainBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrievePaymentMethodDomainBuilder<'a> {
+impl RetrievePaymentMethodDomainBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves the details of an existing payment method domain.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrievePaymentMethodDomain<'a> {
-    inner: RetrievePaymentMethodDomainBuilder<'a>,
-    payment_method_domain: &'a stripe_payment::PaymentMethodDomainId,
+pub struct RetrievePaymentMethodDomain {
+    inner: RetrievePaymentMethodDomainBuilder,
+    payment_method_domain: stripe_payment::PaymentMethodDomainId,
 }
-impl<'a> RetrievePaymentMethodDomain<'a> {
+impl RetrievePaymentMethodDomain {
     /// Construct a new `RetrievePaymentMethodDomain`.
-    pub fn new(payment_method_domain: &'a stripe_payment::PaymentMethodDomainId) -> Self {
-        Self { payment_method_domain, inner: RetrievePaymentMethodDomainBuilder::new() }
+    pub fn new(payment_method_domain: impl Into<stripe_payment::PaymentMethodDomainId>) -> Self {
+        Self {
+            payment_method_domain: payment_method_domain.into(),
+            inner: RetrievePaymentMethodDomainBuilder::new(),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrievePaymentMethodDomain<'_> {
+impl RetrievePaymentMethodDomain {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -158,11 +161,11 @@ impl RetrievePaymentMethodDomain<'_> {
     }
 }
 
-impl StripeRequest for RetrievePaymentMethodDomain<'_> {
+impl StripeRequest for RetrievePaymentMethodDomain {
     type Output = stripe_payment::PaymentMethodDomain;
 
     fn build(&self) -> RequestBuilder {
-        let payment_method_domain = self.payment_method_domain;
+        let payment_method_domain = &self.payment_method_domain;
         RequestBuilder::new(
             StripeMethod::Get,
             format!("/payment_method_domains/{payment_method_domain}"),
@@ -170,42 +173,42 @@ impl StripeRequest for RetrievePaymentMethodDomain<'_> {
         .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreatePaymentMethodDomainBuilder<'a> {
-    domain_name: &'a str,
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreatePaymentMethodDomainBuilder {
+    domain_name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     enabled: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> CreatePaymentMethodDomainBuilder<'a> {
-    fn new(domain_name: &'a str) -> Self {
-        Self { domain_name, enabled: None, expand: None }
+impl CreatePaymentMethodDomainBuilder {
+    fn new(domain_name: impl Into<String>) -> Self {
+        Self { domain_name: domain_name.into(), enabled: None, expand: None }
     }
 }
 /// Creates a payment method domain.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreatePaymentMethodDomain<'a> {
-    inner: CreatePaymentMethodDomainBuilder<'a>,
+pub struct CreatePaymentMethodDomain {
+    inner: CreatePaymentMethodDomainBuilder,
 }
-impl<'a> CreatePaymentMethodDomain<'a> {
+impl CreatePaymentMethodDomain {
     /// Construct a new `CreatePaymentMethodDomain`.
-    pub fn new(domain_name: &'a str) -> Self {
-        Self { inner: CreatePaymentMethodDomainBuilder::new(domain_name) }
+    pub fn new(domain_name: impl Into<String>) -> Self {
+        Self { inner: CreatePaymentMethodDomainBuilder::new(domain_name.into()) }
     }
     /// Whether this payment method domain is enabled.
     /// If the domain is not enabled, payment methods that require a payment method domain will not appear in Elements.
-    pub fn enabled(mut self, enabled: bool) -> Self {
-        self.inner.enabled = Some(enabled);
+    pub fn enabled(mut self, enabled: impl Into<bool>) -> Self {
+        self.inner.enabled = Some(enabled.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl CreatePaymentMethodDomain<'_> {
+impl CreatePaymentMethodDomain {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -223,49 +226,52 @@ impl CreatePaymentMethodDomain<'_> {
     }
 }
 
-impl StripeRequest for CreatePaymentMethodDomain<'_> {
+impl StripeRequest for CreatePaymentMethodDomain {
     type Output = stripe_payment::PaymentMethodDomain;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Post, "/payment_method_domains").form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdatePaymentMethodDomainBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdatePaymentMethodDomainBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     enabled: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> UpdatePaymentMethodDomainBuilder<'a> {
+impl UpdatePaymentMethodDomainBuilder {
     fn new() -> Self {
         Self { enabled: None, expand: None }
     }
 }
 /// Updates an existing payment method domain.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdatePaymentMethodDomain<'a> {
-    inner: UpdatePaymentMethodDomainBuilder<'a>,
-    payment_method_domain: &'a stripe_payment::PaymentMethodDomainId,
+pub struct UpdatePaymentMethodDomain {
+    inner: UpdatePaymentMethodDomainBuilder,
+    payment_method_domain: stripe_payment::PaymentMethodDomainId,
 }
-impl<'a> UpdatePaymentMethodDomain<'a> {
+impl UpdatePaymentMethodDomain {
     /// Construct a new `UpdatePaymentMethodDomain`.
-    pub fn new(payment_method_domain: &'a stripe_payment::PaymentMethodDomainId) -> Self {
-        Self { payment_method_domain, inner: UpdatePaymentMethodDomainBuilder::new() }
+    pub fn new(payment_method_domain: impl Into<stripe_payment::PaymentMethodDomainId>) -> Self {
+        Self {
+            payment_method_domain: payment_method_domain.into(),
+            inner: UpdatePaymentMethodDomainBuilder::new(),
+        }
     }
     /// Whether this payment method domain is enabled.
     /// If the domain is not enabled, payment methods that require a payment method domain will not appear in Elements.
-    pub fn enabled(mut self, enabled: bool) -> Self {
-        self.inner.enabled = Some(enabled);
+    pub fn enabled(mut self, enabled: impl Into<bool>) -> Self {
+        self.inner.enabled = Some(enabled.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl UpdatePaymentMethodDomain<'_> {
+impl UpdatePaymentMethodDomain {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -283,11 +289,11 @@ impl UpdatePaymentMethodDomain<'_> {
     }
 }
 
-impl StripeRequest for UpdatePaymentMethodDomain<'_> {
+impl StripeRequest for UpdatePaymentMethodDomain {
     type Output = stripe_payment::PaymentMethodDomain;
 
     fn build(&self) -> RequestBuilder {
-        let payment_method_domain = self.payment_method_domain;
+        let payment_method_domain = &self.payment_method_domain;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/payment_method_domains/{payment_method_domain}"),
@@ -295,12 +301,12 @@ impl StripeRequest for UpdatePaymentMethodDomain<'_> {
         .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ValidatePaymentMethodDomainBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ValidatePaymentMethodDomainBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> ValidatePaymentMethodDomainBuilder<'a> {
+impl ValidatePaymentMethodDomainBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
@@ -313,22 +319,25 @@ impl<'a> ValidatePaymentMethodDomainBuilder<'a> {
 ///
 /// Related guides: [Payment method domains](https://stripe.com/docs/payments/payment-methods/pmd-registration).
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ValidatePaymentMethodDomain<'a> {
-    inner: ValidatePaymentMethodDomainBuilder<'a>,
-    payment_method_domain: &'a stripe_payment::PaymentMethodDomainId,
+pub struct ValidatePaymentMethodDomain {
+    inner: ValidatePaymentMethodDomainBuilder,
+    payment_method_domain: stripe_payment::PaymentMethodDomainId,
 }
-impl<'a> ValidatePaymentMethodDomain<'a> {
+impl ValidatePaymentMethodDomain {
     /// Construct a new `ValidatePaymentMethodDomain`.
-    pub fn new(payment_method_domain: &'a stripe_payment::PaymentMethodDomainId) -> Self {
-        Self { payment_method_domain, inner: ValidatePaymentMethodDomainBuilder::new() }
+    pub fn new(payment_method_domain: impl Into<stripe_payment::PaymentMethodDomainId>) -> Self {
+        Self {
+            payment_method_domain: payment_method_domain.into(),
+            inner: ValidatePaymentMethodDomainBuilder::new(),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl ValidatePaymentMethodDomain<'_> {
+impl ValidatePaymentMethodDomain {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -346,11 +355,11 @@ impl ValidatePaymentMethodDomain<'_> {
     }
 }
 
-impl StripeRequest for ValidatePaymentMethodDomain<'_> {
+impl StripeRequest for ValidatePaymentMethodDomain {
     type Output = stripe_payment::PaymentMethodDomain;
 
     fn build(&self) -> RequestBuilder {
-        let payment_method_domain = self.payment_method_domain;
+        let payment_method_domain = &self.payment_method_domain;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/payment_method_domains/{payment_method_domain}/validate"),

--- a/generated/async-stripe-payment/src/source/requests.rs
+++ b/generated/async-stripe-payment/src/source/requests.rs
@@ -2,35 +2,35 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct DetachSourceBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct DetachSourceBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> DetachSourceBuilder<'a> {
+impl DetachSourceBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Delete a specified source for a given customer.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct DetachSource<'a> {
-    inner: DetachSourceBuilder<'a>,
-    customer: &'a stripe_shared::CustomerId,
-    id: &'a str,
+pub struct DetachSource {
+    inner: DetachSourceBuilder,
+    customer: stripe_shared::CustomerId,
+    id: String,
 }
-impl<'a> DetachSource<'a> {
+impl DetachSource {
     /// Construct a new `DetachSource`.
-    pub fn new(customer: &'a stripe_shared::CustomerId, id: &'a str) -> Self {
-        Self { customer, id, inner: DetachSourceBuilder::new() }
+    pub fn new(customer: impl Into<stripe_shared::CustomerId>, id: impl Into<String>) -> Self {
+        Self { customer: customer.into(), id: id.into(), inner: DetachSourceBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl DetachSource<'_> {
+impl DetachSource {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -48,12 +48,12 @@ impl DetachSource<'_> {
     }
 }
 
-impl StripeRequest for DetachSource<'_> {
+impl StripeRequest for DetachSource {
     type Output = DetachSourceReturned;
 
     fn build(&self) -> RequestBuilder {
-        let customer = self.customer;
-        let id = self.id;
+        let customer = &self.customer;
+        let id = &self.id;
         RequestBuilder::new(StripeMethod::Delete, format!("/customers/{customer}/sources/{id}"))
             .form(&self.inner)
     }
@@ -138,14 +138,14 @@ const _: () = {
     }
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveSourceBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveSourceBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    client_secret: Option<&'a str>,
+    client_secret: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveSourceBuilder<'a> {
+impl RetrieveSourceBuilder {
     fn new() -> Self {
         Self { client_secret: None, expand: None }
     }
@@ -153,27 +153,27 @@ impl<'a> RetrieveSourceBuilder<'a> {
 /// Retrieves an existing source object.
 /// Supply the unique source ID from a source creation request and Stripe will return the corresponding up-to-date source object information.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveSource<'a> {
-    inner: RetrieveSourceBuilder<'a>,
-    source: &'a stripe_shared::SourceId,
+pub struct RetrieveSource {
+    inner: RetrieveSourceBuilder,
+    source: stripe_shared::SourceId,
 }
-impl<'a> RetrieveSource<'a> {
+impl RetrieveSource {
     /// Construct a new `RetrieveSource`.
-    pub fn new(source: &'a stripe_shared::SourceId) -> Self {
-        Self { source, inner: RetrieveSourceBuilder::new() }
+    pub fn new(source: impl Into<stripe_shared::SourceId>) -> Self {
+        Self { source: source.into(), inner: RetrieveSourceBuilder::new() }
     }
     /// The client secret of the source. Required if a publishable key is used to retrieve the source.
-    pub fn client_secret(mut self, client_secret: &'a str) -> Self {
-        self.inner.client_secret = Some(client_secret);
+    pub fn client_secret(mut self, client_secret: impl Into<String>) -> Self {
+        self.inner.client_secret = Some(client_secret.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveSource<'_> {
+impl RetrieveSource {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -191,68 +191,68 @@ impl RetrieveSource<'_> {
     }
 }
 
-impl StripeRequest for RetrieveSource<'_> {
+impl StripeRequest for RetrieveSource {
     type Output = stripe_shared::Source;
 
     fn build(&self) -> RequestBuilder {
-        let source = self.source;
+        let source = &self.source;
         RequestBuilder::new(StripeMethod::Get, format!("/sources/{source}")).query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct SourceTransactionsSourceBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct SourceTransactionsSourceBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> SourceTransactionsSourceBuilder<'a> {
+impl SourceTransactionsSourceBuilder {
     fn new() -> Self {
         Self { ending_before: None, expand: None, limit: None, starting_after: None }
     }
 }
 /// List source transactions for a given source.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct SourceTransactionsSource<'a> {
-    inner: SourceTransactionsSourceBuilder<'a>,
-    source: &'a stripe_shared::SourceId,
+pub struct SourceTransactionsSource {
+    inner: SourceTransactionsSourceBuilder,
+    source: stripe_shared::SourceId,
 }
-impl<'a> SourceTransactionsSource<'a> {
+impl SourceTransactionsSource {
     /// Construct a new `SourceTransactionsSource`.
-    pub fn new(source: &'a stripe_shared::SourceId) -> Self {
-        Self { source, inner: SourceTransactionsSourceBuilder::new() }
+    pub fn new(source: impl Into<stripe_shared::SourceId>) -> Self {
+        Self { source: source.into(), inner: SourceTransactionsSourceBuilder::new() }
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl SourceTransactionsSource<'_> {
+impl SourceTransactionsSource {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -273,61 +273,61 @@ impl SourceTransactionsSource<'_> {
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::SourceTransaction>>
     {
-        let source = self.source;
+        let source = &self.source;
 
         stripe_client_core::ListPaginator::new_list(
             format!("/sources/{source}/source_transactions"),
-            self.inner,
+            &self.inner,
         )
     }
 }
 
-impl StripeRequest for SourceTransactionsSource<'_> {
+impl StripeRequest for SourceTransactionsSource {
     type Output = stripe_types::List<stripe_shared::SourceTransaction>;
 
     fn build(&self) -> RequestBuilder {
-        let source = self.source;
+        let source = &self.source;
         RequestBuilder::new(StripeMethod::Get, format!("/sources/{source}/source_transactions"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateSourceBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateSourceBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     amount: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     currency: Option<stripe_types::Currency>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    customer: Option<&'a str>,
+    customer: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     flow: Option<CreateSourceFlow>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    mandate: Option<CreateSourceMandate<'a>>,
+    mandate: Option<CreateSourceMandate>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    original_source: Option<&'a str>,
+    original_source: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    owner: Option<Owner<'a>>,
+    owner: Option<Owner>,
     #[serde(skip_serializing_if = "Option::is_none")]
     receiver: Option<CreateSourceReceiver>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    redirect: Option<CreateSourceRedirect<'a>>,
+    redirect: Option<CreateSourceRedirect>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    source_order: Option<CreateSourceSourceOrder<'a>>,
+    source_order: Option<CreateSourceSourceOrder>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    statement_descriptor: Option<&'a str>,
+    statement_descriptor: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    token: Option<&'a str>,
+    token: Option<String>,
     #[serde(rename = "type")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    type_: Option<&'a str>,
+    type_: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     usage: Option<CreateSourceUsage>,
 }
-impl<'a> CreateSourceBuilder<'a> {
+impl CreateSourceBuilder {
     fn new() -> Self {
         Self {
             amount: None,
@@ -413,11 +413,11 @@ impl<'de> serde::Deserialize<'de> for CreateSourceFlow {
     }
 }
 /// Information about a mandate possibility attached to a source object (generally for bank debits) as well as its acceptance status.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateSourceMandate<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateSourceMandate {
     /// The parameters required to notify Stripe of a mandate acceptance or refusal by the customer.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub acceptance: Option<CreateSourceMandateAcceptance<'a>>,
+    pub acceptance: Option<CreateSourceMandateAcceptance>,
     /// The amount specified by the mandate. (Leave null for a mandate covering all amounts)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub amount: Option<i64>,
@@ -433,7 +433,7 @@ pub struct CreateSourceMandate<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub notification_method: Option<CreateSourceMandateNotificationMethod>,
 }
-impl<'a> CreateSourceMandate<'a> {
+impl CreateSourceMandate {
     pub fn new() -> Self {
         Self {
             acceptance: None,
@@ -444,28 +444,28 @@ impl<'a> CreateSourceMandate<'a> {
         }
     }
 }
-impl<'a> Default for CreateSourceMandate<'a> {
+impl Default for CreateSourceMandate {
     fn default() -> Self {
         Self::new()
     }
 }
 /// The parameters required to notify Stripe of a mandate acceptance or refusal by the customer.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateSourceMandateAcceptance<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateSourceMandateAcceptance {
     /// The Unix timestamp (in seconds) when the mandate was accepted or refused by the customer.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub date: Option<stripe_types::Timestamp>,
     /// The IP address from which the mandate was accepted or refused by the customer.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ip: Option<&'a str>,
+    pub ip: Option<String>,
     /// The parameters required to store a mandate accepted offline.
     /// Should only be set if `mandate[type]` is `offline`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub offline: Option<MandateOfflineAcceptanceParams<'a>>,
+    pub offline: Option<MandateOfflineAcceptanceParams>,
     /// The parameters required to store a mandate accepted online.
     /// Should only be set if `mandate[type]` is `online`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub online: Option<MandateOnlineAcceptanceParams<'a>>,
+    pub online: Option<MandateOnlineAcceptanceParams>,
     /// The status of the mandate acceptance.
     /// Either `accepted` (the mandate was accepted) or `refused` (the mandate was refused).
     pub status: CreateSourceMandateAcceptanceStatus,
@@ -475,16 +475,16 @@ pub struct CreateSourceMandateAcceptance<'a> {
     pub type_: Option<CreateSourceMandateAcceptanceType>,
     /// The user agent of the browser from which the mandate was accepted or refused by the customer.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user_agent: Option<&'a str>,
+    pub user_agent: Option<String>,
 }
-impl<'a> CreateSourceMandateAcceptance<'a> {
-    pub fn new(status: CreateSourceMandateAcceptanceStatus) -> Self {
+impl CreateSourceMandateAcceptance {
+    pub fn new(status: impl Into<CreateSourceMandateAcceptanceStatus>) -> Self {
         Self {
             date: None,
             ip: None,
             offline: None,
             online: None,
-            status,
+            status: status.into(),
             type_: None,
             user_agent: None,
         }
@@ -817,51 +817,51 @@ impl<'de> serde::Deserialize<'de> for CreateSourceReceiverRefundAttributesMethod
 }
 /// Parameters required for the redirect flow.
 /// Required if the source is authenticated by a redirect (`flow` is `redirect`).
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateSourceRedirect<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateSourceRedirect {
     /// The URL you provide to redirect the customer back to you after they authenticated their payment.
     /// It can use your application URI scheme in the context of a mobile application.
-    pub return_url: &'a str,
+    pub return_url: String,
 }
-impl<'a> CreateSourceRedirect<'a> {
-    pub fn new(return_url: &'a str) -> Self {
-        Self { return_url }
+impl CreateSourceRedirect {
+    pub fn new(return_url: impl Into<String>) -> Self {
+        Self { return_url: return_url.into() }
     }
 }
 /// Information about the items and shipping associated with the source.
 /// Required for transactional credit (for example Klarna) sources before you can charge it.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateSourceSourceOrder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateSourceSourceOrder {
     /// List of items constituting the order.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub items: Option<&'a [CreateSourceSourceOrderItems<'a>]>,
+    pub items: Option<Vec<CreateSourceSourceOrderItems>>,
     /// Shipping address for the order.
     /// Required if any of the SKUs are for products that have `shippable` set to true.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub shipping: Option<OrderShipping<'a>>,
+    pub shipping: Option<OrderShipping>,
 }
-impl<'a> CreateSourceSourceOrder<'a> {
+impl CreateSourceSourceOrder {
     pub fn new() -> Self {
         Self { items: None, shipping: None }
     }
 }
-impl<'a> Default for CreateSourceSourceOrder<'a> {
+impl Default for CreateSourceSourceOrder {
     fn default() -> Self {
         Self::new()
     }
 }
 /// List of items constituting the order.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateSourceSourceOrderItems<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateSourceSourceOrderItems {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub amount: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub currency: Option<stripe_types::Currency>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<&'a str>,
+    pub description: Option<String>,
     /// The ID of the SKU being ordered.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub parent: Option<&'a str>,
+    pub parent: Option<String>,
     /// The quantity of this order item.
     /// When type is `sku`, this is the number of instances of the SKU to be ordered.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -870,7 +870,7 @@ pub struct CreateSourceSourceOrderItems<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub type_: Option<CreateSourceSourceOrderItemsType>,
 }
-impl<'a> CreateSourceSourceOrderItems<'a> {
+impl CreateSourceSourceOrderItems {
     pub fn new() -> Self {
         Self {
             amount: None,
@@ -882,7 +882,7 @@ impl<'a> CreateSourceSourceOrderItems<'a> {
         }
     }
 }
-impl<'a> Default for CreateSourceSourceOrderItems<'a> {
+impl Default for CreateSourceSourceOrderItems {
     fn default() -> Self {
         Self::new()
     }
@@ -1004,10 +1004,10 @@ impl<'de> serde::Deserialize<'de> for CreateSourceUsage {
 }
 /// Creates a new source object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateSource<'a> {
-    inner: CreateSourceBuilder<'a>,
+pub struct CreateSource {
+    inner: CreateSourceBuilder,
 }
-impl<'a> CreateSource<'a> {
+impl CreateSource {
     /// Construct a new `CreateSource`.
     pub fn new() -> Self {
         Self { inner: CreateSourceBuilder::new() }
@@ -1016,100 +1016,103 @@ impl<'a> CreateSource<'a> {
     /// This is the amount for which the source will be chargeable once ready.
     /// Required for `single_use` sources.
     /// Not supported for `receiver` type sources, where charge amount may not be specified until funds land.
-    pub fn amount(mut self, amount: i64) -> Self {
-        self.inner.amount = Some(amount);
+    pub fn amount(mut self, amount: impl Into<i64>) -> Self {
+        self.inner.amount = Some(amount.into());
         self
     }
     /// Three-letter [ISO code for the currency](https://stripe.com/docs/currencies) associated with the source.
     /// This is the currency for which the source will be chargeable once ready.
-    pub fn currency(mut self, currency: stripe_types::Currency) -> Self {
-        self.inner.currency = Some(currency);
+    pub fn currency(mut self, currency: impl Into<stripe_types::Currency>) -> Self {
+        self.inner.currency = Some(currency.into());
         self
     }
     /// The `Customer` to whom the original source is attached to.
     /// Must be set when the original source is not a `Source` (e.g., `Card`).
-    pub fn customer(mut self, customer: &'a str) -> Self {
-        self.inner.customer = Some(customer);
+    pub fn customer(mut self, customer: impl Into<String>) -> Self {
+        self.inner.customer = Some(customer.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// The authentication `flow` of the source to create.
     /// `flow` is one of `redirect`, `receiver`, `code_verification`, `none`.
     /// It is generally inferred unless a type supports multiple flows.
-    pub fn flow(mut self, flow: CreateSourceFlow) -> Self {
-        self.inner.flow = Some(flow);
+    pub fn flow(mut self, flow: impl Into<CreateSourceFlow>) -> Self {
+        self.inner.flow = Some(flow.into());
         self
     }
     /// Information about a mandate possibility attached to a source object (generally for bank debits) as well as its acceptance status.
-    pub fn mandate(mut self, mandate: CreateSourceMandate<'a>) -> Self {
-        self.inner.mandate = Some(mandate);
+    pub fn mandate(mut self, mandate: impl Into<CreateSourceMandate>) -> Self {
+        self.inner.mandate = Some(mandate.into());
         self
     }
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// The source to share.
-    pub fn original_source(mut self, original_source: &'a str) -> Self {
-        self.inner.original_source = Some(original_source);
+    pub fn original_source(mut self, original_source: impl Into<String>) -> Self {
+        self.inner.original_source = Some(original_source.into());
         self
     }
     /// Information about the owner of the payment instrument that may be used or required by particular source types.
-    pub fn owner(mut self, owner: Owner<'a>) -> Self {
-        self.inner.owner = Some(owner);
+    pub fn owner(mut self, owner: impl Into<Owner>) -> Self {
+        self.inner.owner = Some(owner.into());
         self
     }
     /// Optional parameters for the receiver flow.
     /// Can be set only if the source is a receiver (`flow` is `receiver`).
-    pub fn receiver(mut self, receiver: CreateSourceReceiver) -> Self {
-        self.inner.receiver = Some(receiver);
+    pub fn receiver(mut self, receiver: impl Into<CreateSourceReceiver>) -> Self {
+        self.inner.receiver = Some(receiver.into());
         self
     }
     /// Parameters required for the redirect flow.
     /// Required if the source is authenticated by a redirect (`flow` is `redirect`).
-    pub fn redirect(mut self, redirect: CreateSourceRedirect<'a>) -> Self {
-        self.inner.redirect = Some(redirect);
+    pub fn redirect(mut self, redirect: impl Into<CreateSourceRedirect>) -> Self {
+        self.inner.redirect = Some(redirect.into());
         self
     }
     /// Information about the items and shipping associated with the source.
     /// Required for transactional credit (for example Klarna) sources before you can charge it.
-    pub fn source_order(mut self, source_order: CreateSourceSourceOrder<'a>) -> Self {
-        self.inner.source_order = Some(source_order);
+    pub fn source_order(mut self, source_order: impl Into<CreateSourceSourceOrder>) -> Self {
+        self.inner.source_order = Some(source_order.into());
         self
     }
     /// An arbitrary string to be displayed on your customer's statement.
     /// As an example, if your website is `RunClub` and the item you're charging for is a race ticket, you may want to specify a `statement_descriptor` of `RunClub 5K race ticket.` While many payment types will display this information, some may not display it at all.
-    pub fn statement_descriptor(mut self, statement_descriptor: &'a str) -> Self {
-        self.inner.statement_descriptor = Some(statement_descriptor);
+    pub fn statement_descriptor(mut self, statement_descriptor: impl Into<String>) -> Self {
+        self.inner.statement_descriptor = Some(statement_descriptor.into());
         self
     }
     /// An optional token used to create the source.
     /// When passed, token properties will override source parameters.
-    pub fn token(mut self, token: &'a str) -> Self {
-        self.inner.token = Some(token);
+    pub fn token(mut self, token: impl Into<String>) -> Self {
+        self.inner.token = Some(token.into());
         self
     }
     /// The `type` of the source to create.
     /// Required unless `customer` and `original_source` are specified (see the [Cloning card Sources](https://stripe.com/docs/sources/connect#cloning-card-sources) guide).
-    pub fn type_(mut self, type_: &'a str) -> Self {
-        self.inner.type_ = Some(type_);
+    pub fn type_(mut self, type_: impl Into<String>) -> Self {
+        self.inner.type_ = Some(type_.into());
         self
     }
-    pub fn usage(mut self, usage: CreateSourceUsage) -> Self {
-        self.inner.usage = Some(usage);
+    pub fn usage(mut self, usage: impl Into<CreateSourceUsage>) -> Self {
+        self.inner.usage = Some(usage.into());
         self
     }
 }
-impl<'a> Default for CreateSource<'a> {
+impl Default for CreateSource {
     fn default() -> Self {
         Self::new()
     }
 }
-impl CreateSource<'_> {
+impl CreateSource {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -1127,29 +1130,29 @@ impl CreateSource<'_> {
     }
 }
 
-impl StripeRequest for CreateSource<'_> {
+impl StripeRequest for CreateSource {
     type Output = stripe_shared::Source;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Post, "/sources").form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdateSourceBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdateSourceBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     amount: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    mandate: Option<UpdateSourceMandate<'a>>,
+    mandate: Option<UpdateSourceMandate>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    owner: Option<Owner<'a>>,
+    owner: Option<Owner>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    source_order: Option<UpdateSourceSourceOrder<'a>>,
+    source_order: Option<UpdateSourceSourceOrder>,
 }
-impl<'a> UpdateSourceBuilder<'a> {
+impl UpdateSourceBuilder {
     fn new() -> Self {
         Self {
             amount: None,
@@ -1162,11 +1165,11 @@ impl<'a> UpdateSourceBuilder<'a> {
     }
 }
 /// Information about a mandate possibility attached to a source object (generally for bank debits) as well as its acceptance status.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateSourceMandate<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateSourceMandate {
     /// The parameters required to notify Stripe of a mandate acceptance or refusal by the customer.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub acceptance: Option<UpdateSourceMandateAcceptance<'a>>,
+    pub acceptance: Option<UpdateSourceMandateAcceptance>,
     /// The amount specified by the mandate. (Leave null for a mandate covering all amounts)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub amount: Option<i64>,
@@ -1182,7 +1185,7 @@ pub struct UpdateSourceMandate<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub notification_method: Option<UpdateSourceMandateNotificationMethod>,
 }
-impl<'a> UpdateSourceMandate<'a> {
+impl UpdateSourceMandate {
     pub fn new() -> Self {
         Self {
             acceptance: None,
@@ -1193,28 +1196,28 @@ impl<'a> UpdateSourceMandate<'a> {
         }
     }
 }
-impl<'a> Default for UpdateSourceMandate<'a> {
+impl Default for UpdateSourceMandate {
     fn default() -> Self {
         Self::new()
     }
 }
 /// The parameters required to notify Stripe of a mandate acceptance or refusal by the customer.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateSourceMandateAcceptance<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateSourceMandateAcceptance {
     /// The Unix timestamp (in seconds) when the mandate was accepted or refused by the customer.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub date: Option<stripe_types::Timestamp>,
     /// The IP address from which the mandate was accepted or refused by the customer.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ip: Option<&'a str>,
+    pub ip: Option<String>,
     /// The parameters required to store a mandate accepted offline.
     /// Should only be set if `mandate[type]` is `offline`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub offline: Option<MandateOfflineAcceptanceParams<'a>>,
+    pub offline: Option<MandateOfflineAcceptanceParams>,
     /// The parameters required to store a mandate accepted online.
     /// Should only be set if `mandate[type]` is `online`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub online: Option<MandateOnlineAcceptanceParams<'a>>,
+    pub online: Option<MandateOnlineAcceptanceParams>,
     /// The status of the mandate acceptance.
     /// Either `accepted` (the mandate was accepted) or `refused` (the mandate was refused).
     pub status: UpdateSourceMandateAcceptanceStatus,
@@ -1224,16 +1227,16 @@ pub struct UpdateSourceMandateAcceptance<'a> {
     pub type_: Option<UpdateSourceMandateAcceptanceType>,
     /// The user agent of the browser from which the mandate was accepted or refused by the customer.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user_agent: Option<&'a str>,
+    pub user_agent: Option<String>,
 }
-impl<'a> UpdateSourceMandateAcceptance<'a> {
-    pub fn new(status: UpdateSourceMandateAcceptanceStatus) -> Self {
+impl UpdateSourceMandateAcceptance {
+    pub fn new(status: impl Into<UpdateSourceMandateAcceptanceStatus>) -> Self {
         Self {
             date: None,
             ip: None,
             offline: None,
             online: None,
-            status,
+            status: status.into(),
             type_: None,
             user_agent: None,
         }
@@ -1485,38 +1488,38 @@ impl<'de> serde::Deserialize<'de> for UpdateSourceMandateNotificationMethod {
 }
 /// Information about the items and shipping associated with the source.
 /// Required for transactional credit (for example Klarna) sources before you can charge it.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateSourceSourceOrder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateSourceSourceOrder {
     /// List of items constituting the order.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub items: Option<&'a [UpdateSourceSourceOrderItems<'a>]>,
+    pub items: Option<Vec<UpdateSourceSourceOrderItems>>,
     /// Shipping address for the order.
     /// Required if any of the SKUs are for products that have `shippable` set to true.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub shipping: Option<OrderShipping<'a>>,
+    pub shipping: Option<OrderShipping>,
 }
-impl<'a> UpdateSourceSourceOrder<'a> {
+impl UpdateSourceSourceOrder {
     pub fn new() -> Self {
         Self { items: None, shipping: None }
     }
 }
-impl<'a> Default for UpdateSourceSourceOrder<'a> {
+impl Default for UpdateSourceSourceOrder {
     fn default() -> Self {
         Self::new()
     }
 }
 /// List of items constituting the order.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateSourceSourceOrderItems<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateSourceSourceOrderItems {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub amount: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub currency: Option<stripe_types::Currency>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<&'a str>,
+    pub description: Option<String>,
     /// The ID of the SKU being ordered.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub parent: Option<&'a str>,
+    pub parent: Option<String>,
     /// The quantity of this order item.
     /// When type is `sku`, this is the number of instances of the SKU to be ordered.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1525,7 +1528,7 @@ pub struct UpdateSourceSourceOrderItems<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub type_: Option<UpdateSourceSourceOrderItemsType>,
 }
-impl<'a> UpdateSourceSourceOrderItems<'a> {
+impl UpdateSourceSourceOrderItems {
     pub fn new() -> Self {
         Self {
             amount: None,
@@ -1537,7 +1540,7 @@ impl<'a> UpdateSourceSourceOrderItems<'a> {
         }
     }
 }
-impl<'a> Default for UpdateSourceSourceOrderItems<'a> {
+impl Default for UpdateSourceSourceOrderItems {
     fn default() -> Self {
         Self::new()
     }
@@ -1610,51 +1613,54 @@ impl<'de> serde::Deserialize<'de> for UpdateSourceSourceOrderItemsType {
 /// It is also possible to update type specific information for selected payment methods.
 /// Please refer to our [payment method guides](https://stripe.com/docs/sources) for more detail.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateSource<'a> {
-    inner: UpdateSourceBuilder<'a>,
-    source: &'a stripe_shared::SourceId,
+pub struct UpdateSource {
+    inner: UpdateSourceBuilder,
+    source: stripe_shared::SourceId,
 }
-impl<'a> UpdateSource<'a> {
+impl UpdateSource {
     /// Construct a new `UpdateSource`.
-    pub fn new(source: &'a stripe_shared::SourceId) -> Self {
-        Self { source, inner: UpdateSourceBuilder::new() }
+    pub fn new(source: impl Into<stripe_shared::SourceId>) -> Self {
+        Self { source: source.into(), inner: UpdateSourceBuilder::new() }
     }
     /// Amount associated with the source.
-    pub fn amount(mut self, amount: i64) -> Self {
-        self.inner.amount = Some(amount);
+    pub fn amount(mut self, amount: impl Into<i64>) -> Self {
+        self.inner.amount = Some(amount.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Information about a mandate possibility attached to a source object (generally for bank debits) as well as its acceptance status.
-    pub fn mandate(mut self, mandate: UpdateSourceMandate<'a>) -> Self {
-        self.inner.mandate = Some(mandate);
+    pub fn mandate(mut self, mandate: impl Into<UpdateSourceMandate>) -> Self {
+        self.inner.mandate = Some(mandate.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// Information about the owner of the payment instrument that may be used or required by particular source types.
-    pub fn owner(mut self, owner: Owner<'a>) -> Self {
-        self.inner.owner = Some(owner);
+    pub fn owner(mut self, owner: impl Into<Owner>) -> Self {
+        self.inner.owner = Some(owner.into());
         self
     }
     /// Information about the items and shipping associated with the source.
     /// Required for transactional credit (for example Klarna) sources before you can charge it.
-    pub fn source_order(mut self, source_order: UpdateSourceSourceOrder<'a>) -> Self {
-        self.inner.source_order = Some(source_order);
+    pub fn source_order(mut self, source_order: impl Into<UpdateSourceSourceOrder>) -> Self {
+        self.inner.source_order = Some(source_order.into());
         self
     }
 }
-impl UpdateSource<'_> {
+impl UpdateSource {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -1672,43 +1678,43 @@ impl UpdateSource<'_> {
     }
 }
 
-impl StripeRequest for UpdateSource<'_> {
+impl StripeRequest for UpdateSource {
     type Output = stripe_shared::Source;
 
     fn build(&self) -> RequestBuilder {
-        let source = self.source;
+        let source = &self.source;
         RequestBuilder::new(StripeMethod::Post, format!("/sources/{source}")).form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct VerifySourceBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct VerifySourceBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
-    values: &'a [&'a str],
+    expand: Option<Vec<String>>,
+    values: Vec<String>,
 }
-impl<'a> VerifySourceBuilder<'a> {
-    fn new(values: &'a [&'a str]) -> Self {
-        Self { expand: None, values }
+impl VerifySourceBuilder {
+    fn new(values: impl Into<Vec<String>>) -> Self {
+        Self { expand: None, values: values.into() }
     }
 }
 /// Verify a given source.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct VerifySource<'a> {
-    inner: VerifySourceBuilder<'a>,
-    source: &'a stripe_shared::SourceId,
+pub struct VerifySource {
+    inner: VerifySourceBuilder,
+    source: stripe_shared::SourceId,
 }
-impl<'a> VerifySource<'a> {
+impl VerifySource {
     /// Construct a new `VerifySource`.
-    pub fn new(source: &'a stripe_shared::SourceId, values: &'a [&'a str]) -> Self {
-        Self { source, inner: VerifySourceBuilder::new(values) }
+    pub fn new(source: impl Into<stripe_shared::SourceId>, values: impl Into<Vec<String>>) -> Self {
+        Self { source: source.into(), inner: VerifySourceBuilder::new(values.into()) }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl VerifySource<'_> {
+impl VerifySource {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -1726,149 +1732,162 @@ impl VerifySource<'_> {
     }
 }
 
-impl StripeRequest for VerifySource<'_> {
+impl StripeRequest for VerifySource {
     type Output = stripe_shared::Source;
 
     fn build(&self) -> RequestBuilder {
-        let source = self.source;
+        let source = &self.source;
         RequestBuilder::new(StripeMethod::Post, format!("/sources/{source}/verify"))
             .form(&self.inner)
     }
 }
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct MandateOfflineAcceptanceParams<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct MandateOfflineAcceptanceParams {
     /// An email to contact you with if a copy of the mandate is requested, required if `type` is `offline`.
-    pub contact_email: &'a str,
+    pub contact_email: String,
 }
-impl<'a> MandateOfflineAcceptanceParams<'a> {
-    pub fn new(contact_email: &'a str) -> Self {
-        Self { contact_email }
+impl MandateOfflineAcceptanceParams {
+    pub fn new(contact_email: impl Into<String>) -> Self {
+        Self { contact_email: contact_email.into() }
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct MandateOnlineAcceptanceParams<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct MandateOnlineAcceptanceParams {
     /// The Unix timestamp (in seconds) when the mandate was accepted or refused by the customer.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub date: Option<stripe_types::Timestamp>,
     /// The IP address from which the mandate was accepted or refused by the customer.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ip: Option<&'a str>,
+    pub ip: Option<String>,
     /// The user agent of the browser from which the mandate was accepted or refused by the customer.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub user_agent: Option<&'a str>,
+    pub user_agent: Option<String>,
 }
-impl<'a> MandateOnlineAcceptanceParams<'a> {
+impl MandateOnlineAcceptanceParams {
     pub fn new() -> Self {
         Self { date: None, ip: None, user_agent: None }
     }
 }
-impl<'a> Default for MandateOnlineAcceptanceParams<'a> {
+impl Default for MandateOnlineAcceptanceParams {
     fn default() -> Self {
         Self::new()
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct SourceAddress<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct SourceAddress {
     /// City, district, suburb, town, or village.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<&'a str>,
+    pub city: Option<String>,
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub country: Option<&'a str>,
+    pub country: Option<String>,
     /// Address line 1 (e.g., street, PO Box, or company name).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line1: Option<&'a str>,
+    pub line1: Option<String>,
     /// Address line 2 (e.g., apartment, suite, unit, or building).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line2: Option<&'a str>,
+    pub line2: Option<String>,
     /// ZIP or postal code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<&'a str>,
+    pub postal_code: Option<String>,
     /// State, county, province, or region.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
 }
-impl<'a> SourceAddress<'a> {
+impl SourceAddress {
     pub fn new() -> Self {
         Self { city: None, country: None, line1: None, line2: None, postal_code: None, state: None }
     }
 }
-impl<'a> Default for SourceAddress<'a> {
+impl Default for SourceAddress {
     fn default() -> Self {
         Self::new()
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct Address<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct Address {
     /// City, district, suburb, town, or village.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<&'a str>,
+    pub city: Option<String>,
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub country: Option<&'a str>,
+    pub country: Option<String>,
     /// Address line 1 (e.g., street, PO Box, or company name).
-    pub line1: &'a str,
+    pub line1: String,
     /// Address line 2 (e.g., apartment, suite, unit, or building).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line2: Option<&'a str>,
+    pub line2: Option<String>,
     /// ZIP or postal code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<&'a str>,
+    pub postal_code: Option<String>,
     /// State, county, province, or region.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
 }
-impl<'a> Address<'a> {
-    pub fn new(line1: &'a str) -> Self {
-        Self { city: None, country: None, line1, line2: None, postal_code: None, state: None }
+impl Address {
+    pub fn new(line1: impl Into<String>) -> Self {
+        Self {
+            city: None,
+            country: None,
+            line1: line1.into(),
+            line2: None,
+            postal_code: None,
+            state: None,
+        }
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct Owner<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct Owner {
     /// Owner's address.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub address: Option<SourceAddress<'a>>,
+    pub address: Option<SourceAddress>,
     /// Owner's email address.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub email: Option<&'a str>,
+    pub email: Option<String>,
     /// Owner's full name.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<&'a str>,
+    pub name: Option<String>,
     /// Owner's phone number.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub phone: Option<&'a str>,
+    pub phone: Option<String>,
 }
-impl<'a> Owner<'a> {
+impl Owner {
     pub fn new() -> Self {
         Self { address: None, email: None, name: None, phone: None }
     }
 }
-impl<'a> Default for Owner<'a> {
+impl Default for Owner {
     fn default() -> Self {
         Self::new()
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct OrderShipping<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct OrderShipping {
     /// Shipping address.
-    pub address: Address<'a>,
+    pub address: Address,
     /// The delivery service that shipped a physical product, such as Fedex, UPS, USPS, etc.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub carrier: Option<&'a str>,
+    pub carrier: Option<String>,
     /// Recipient name.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<&'a str>,
+    pub name: Option<String>,
     /// Recipient phone (including extension).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub phone: Option<&'a str>,
+    pub phone: Option<String>,
     /// The tracking number for a physical product, obtained from the delivery service.
     /// If multiple tracking numbers were generated for this purchase, please separate them with commas.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tracking_number: Option<&'a str>,
+    pub tracking_number: Option<String>,
 }
-impl<'a> OrderShipping<'a> {
-    pub fn new(address: Address<'a>) -> Self {
-        Self { address, carrier: None, name: None, phone: None, tracking_number: None }
+impl OrderShipping {
+    pub fn new(address: impl Into<Address>) -> Self {
+        Self {
+            address: address.into(),
+            carrier: None,
+            name: None,
+            phone: None,
+            tracking_number: None,
+        }
     }
 }

--- a/generated/async-stripe-product/src/coupon/requests.rs
+++ b/generated/async-stripe-product/src/coupon/requests.rs
@@ -6,16 +6,16 @@ use stripe_client_core::{
 /// However, deleting a coupon does not affect any customers who have already applied the coupon; it means that new customers can’t redeem the coupon.
 /// You can also delete coupons via the API.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct DeleteCoupon<'a> {
-    coupon: &'a stripe_shared::CouponId,
+pub struct DeleteCoupon {
+    coupon: stripe_shared::CouponId,
 }
-impl<'a> DeleteCoupon<'a> {
+impl DeleteCoupon {
     /// Construct a new `DeleteCoupon`.
-    pub fn new(coupon: &'a stripe_shared::CouponId) -> Self {
-        Self { coupon }
+    pub fn new(coupon: impl Into<stripe_shared::CouponId>) -> Self {
+        Self { coupon: coupon.into() }
     }
 }
-impl DeleteCoupon<'_> {
+impl DeleteCoupon {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -33,80 +33,80 @@ impl DeleteCoupon<'_> {
     }
 }
 
-impl StripeRequest for DeleteCoupon<'_> {
+impl StripeRequest for DeleteCoupon {
     type Output = stripe_shared::DeletedCoupon;
 
     fn build(&self) -> RequestBuilder {
-        let coupon = self.coupon;
+        let coupon = &self.coupon;
         RequestBuilder::new(StripeMethod::Delete, format!("/coupons/{coupon}"))
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListCouponBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListCouponBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     created: Option<stripe_types::RangeQueryTs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListCouponBuilder<'a> {
+impl ListCouponBuilder {
     fn new() -> Self {
         Self { created: None, ending_before: None, expand: None, limit: None, starting_after: None }
     }
 }
 /// Returns a list of your coupons.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListCoupon<'a> {
-    inner: ListCouponBuilder<'a>,
+pub struct ListCoupon {
+    inner: ListCouponBuilder,
 }
-impl<'a> ListCoupon<'a> {
+impl ListCoupon {
     /// Construct a new `ListCoupon`.
     pub fn new() -> Self {
         Self { inner: ListCouponBuilder::new() }
     }
     /// A filter on the list, based on the object `created` field.
     /// The value can be a string with an integer Unix timestamp, or it can be a dictionary with a number of different query options.
-    pub fn created(mut self, created: stripe_types::RangeQueryTs) -> Self {
-        self.inner.created = Some(created);
+    pub fn created(mut self, created: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.created = Some(created.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl<'a> Default for ListCoupon<'a> {
+impl Default for ListCoupon {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListCoupon<'_> {
+impl ListCoupon {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -126,45 +126,45 @@ impl ListCoupon<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::Coupon>> {
-        stripe_client_core::ListPaginator::new_list("/coupons", self.inner)
+        stripe_client_core::ListPaginator::new_list("/coupons", &self.inner)
     }
 }
 
-impl StripeRequest for ListCoupon<'_> {
+impl StripeRequest for ListCoupon {
     type Output = stripe_types::List<stripe_shared::Coupon>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/coupons").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveCouponBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveCouponBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveCouponBuilder<'a> {
+impl RetrieveCouponBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves the coupon with the given ID.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveCoupon<'a> {
-    inner: RetrieveCouponBuilder<'a>,
-    coupon: &'a stripe_shared::CouponId,
+pub struct RetrieveCoupon {
+    inner: RetrieveCouponBuilder,
+    coupon: stripe_shared::CouponId,
 }
-impl<'a> RetrieveCoupon<'a> {
+impl RetrieveCoupon {
     /// Construct a new `RetrieveCoupon`.
-    pub fn new(coupon: &'a stripe_shared::CouponId) -> Self {
-        Self { coupon, inner: RetrieveCouponBuilder::new() }
+    pub fn new(coupon: impl Into<stripe_shared::CouponId>) -> Self {
+        Self { coupon: coupon.into(), inner: RetrieveCouponBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveCoupon<'_> {
+impl RetrieveCoupon {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -182,44 +182,44 @@ impl RetrieveCoupon<'_> {
     }
 }
 
-impl StripeRequest for RetrieveCoupon<'_> {
+impl StripeRequest for RetrieveCoupon {
     type Output = stripe_shared::Coupon;
 
     fn build(&self) -> RequestBuilder {
-        let coupon = self.coupon;
+        let coupon = &self.coupon;
         RequestBuilder::new(StripeMethod::Get, format!("/coupons/{coupon}")).query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateCouponBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateCouponBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     amount_off: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    applies_to: Option<CreateCouponAppliesTo<'a>>,
+    applies_to: Option<CreateCouponAppliesTo>,
     #[serde(skip_serializing_if = "Option::is_none")]
     currency: Option<stripe_types::Currency>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    currency_options: Option<&'a std::collections::HashMap<stripe_types::Currency, CurrencyOption>>,
+    currency_options: Option<std::collections::HashMap<stripe_types::Currency, CurrencyOption>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     duration: Option<stripe_shared::CouponDuration>,
     #[serde(skip_serializing_if = "Option::is_none")]
     duration_in_months: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    id: Option<&'a str>,
+    id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     max_redemptions: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    name: Option<&'a str>,
+    name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     percent_off: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     redeem_by: Option<stripe_types::Timestamp>,
 }
-impl<'a> CreateCouponBuilder<'a> {
+impl CreateCouponBuilder {
     fn new() -> Self {
         Self {
             amount_off: None,
@@ -239,18 +239,18 @@ impl<'a> CreateCouponBuilder<'a> {
     }
 }
 /// A hash containing directions for what this Coupon will apply discounts to.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateCouponAppliesTo<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateCouponAppliesTo {
     /// An array of Product IDs that this Coupon will apply to.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub products: Option<&'a [&'a str]>,
+    pub products: Option<Vec<String>>,
 }
-impl<'a> CreateCouponAppliesTo<'a> {
+impl CreateCouponAppliesTo {
     pub fn new() -> Self {
         Self { products: None }
     }
 }
-impl<'a> Default for CreateCouponAppliesTo<'a> {
+impl Default for CreateCouponAppliesTo {
     fn default() -> Self {
         Self::new()
     }
@@ -262,97 +262,100 @@ impl<'a> Default for CreateCouponAppliesTo<'a> {
 /// If you set an `amount_off`, that amount will be subtracted from any invoice’s subtotal.
 /// For example, an invoice with a subtotal of $100 will have a final total of $0 if a coupon with an `amount_off` of 20000 is applied to it and an invoice with a subtotal of $300 will have a final total of $100 if a coupon with an `amount_off` of 20000 is applied to it.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateCoupon<'a> {
-    inner: CreateCouponBuilder<'a>,
+pub struct CreateCoupon {
+    inner: CreateCouponBuilder,
 }
-impl<'a> CreateCoupon<'a> {
+impl CreateCoupon {
     /// Construct a new `CreateCoupon`.
     pub fn new() -> Self {
         Self { inner: CreateCouponBuilder::new() }
     }
     /// A positive integer representing the amount to subtract from an invoice total (required if `percent_off` is not passed).
-    pub fn amount_off(mut self, amount_off: i64) -> Self {
-        self.inner.amount_off = Some(amount_off);
+    pub fn amount_off(mut self, amount_off: impl Into<i64>) -> Self {
+        self.inner.amount_off = Some(amount_off.into());
         self
     }
     /// A hash containing directions for what this Coupon will apply discounts to.
-    pub fn applies_to(mut self, applies_to: CreateCouponAppliesTo<'a>) -> Self {
-        self.inner.applies_to = Some(applies_to);
+    pub fn applies_to(mut self, applies_to: impl Into<CreateCouponAppliesTo>) -> Self {
+        self.inner.applies_to = Some(applies_to.into());
         self
     }
     /// Three-letter [ISO code for the currency](https://stripe.com/docs/currencies) of the `amount_off` parameter (required if `amount_off` is passed).
-    pub fn currency(mut self, currency: stripe_types::Currency) -> Self {
-        self.inner.currency = Some(currency);
+    pub fn currency(mut self, currency: impl Into<stripe_types::Currency>) -> Self {
+        self.inner.currency = Some(currency.into());
         self
     }
     /// Coupons defined in each available currency option (only supported if `amount_off` is passed).
     /// Each key must be a three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html) and a [supported currency](https://stripe.com/docs/currencies).
     pub fn currency_options(
         mut self,
-        currency_options: &'a std::collections::HashMap<stripe_types::Currency, CurrencyOption>,
+        currency_options: impl Into<std::collections::HashMap<stripe_types::Currency, CurrencyOption>>,
     ) -> Self {
-        self.inner.currency_options = Some(currency_options);
+        self.inner.currency_options = Some(currency_options.into());
         self
     }
     /// Specifies how long the discount will be in effect if used on a subscription. Defaults to `once`.
-    pub fn duration(mut self, duration: stripe_shared::CouponDuration) -> Self {
-        self.inner.duration = Some(duration);
+    pub fn duration(mut self, duration: impl Into<stripe_shared::CouponDuration>) -> Self {
+        self.inner.duration = Some(duration.into());
         self
     }
     /// Required only if `duration` is `repeating`, in which case it must be a positive integer that specifies the number of months the discount will be in effect.
-    pub fn duration_in_months(mut self, duration_in_months: i64) -> Self {
-        self.inner.duration_in_months = Some(duration_in_months);
+    pub fn duration_in_months(mut self, duration_in_months: impl Into<i64>) -> Self {
+        self.inner.duration_in_months = Some(duration_in_months.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Unique string of your choice that will be used to identify this coupon when applying it to a customer.
     /// If you don't want to specify a particular code, you can leave the ID blank and we'll generate a random code for you.
-    pub fn id(mut self, id: &'a str) -> Self {
-        self.inner.id = Some(id);
+    pub fn id(mut self, id: impl Into<String>) -> Self {
+        self.inner.id = Some(id.into());
         self
     }
     /// A positive integer specifying the number of times the coupon can be redeemed before it's no longer valid.
     /// For example, you might have a 50% off coupon that the first 20 readers of your blog can use.
-    pub fn max_redemptions(mut self, max_redemptions: i64) -> Self {
-        self.inner.max_redemptions = Some(max_redemptions);
+    pub fn max_redemptions(mut self, max_redemptions: impl Into<i64>) -> Self {
+        self.inner.max_redemptions = Some(max_redemptions.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// Name of the coupon displayed to customers on, for instance invoices, or receipts.
     /// By default the `id` is shown if `name` is not set.
-    pub fn name(mut self, name: &'a str) -> Self {
-        self.inner.name = Some(name);
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.inner.name = Some(name.into());
         self
     }
     /// A positive float larger than 0, and smaller or equal to 100, that represents the discount the coupon will apply (required if `amount_off` is not passed).
-    pub fn percent_off(mut self, percent_off: f64) -> Self {
-        self.inner.percent_off = Some(percent_off);
+    pub fn percent_off(mut self, percent_off: impl Into<f64>) -> Self {
+        self.inner.percent_off = Some(percent_off.into());
         self
     }
     /// Unix timestamp specifying the last time at which the coupon can be redeemed.
     /// After the redeem_by date, the coupon can no longer be applied to new customers.
-    pub fn redeem_by(mut self, redeem_by: stripe_types::Timestamp) -> Self {
-        self.inner.redeem_by = Some(redeem_by);
+    pub fn redeem_by(mut self, redeem_by: impl Into<stripe_types::Timestamp>) -> Self {
+        self.inner.redeem_by = Some(redeem_by.into());
         self
     }
 }
-impl<'a> Default for CreateCoupon<'a> {
+impl Default for CreateCoupon {
     fn default() -> Self {
         Self::new()
     }
 }
-impl CreateCoupon<'_> {
+impl CreateCoupon {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -370,25 +373,25 @@ impl CreateCoupon<'_> {
     }
 }
 
-impl StripeRequest for CreateCoupon<'_> {
+impl StripeRequest for CreateCoupon {
     type Output = stripe_shared::Coupon;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Post, "/coupons").form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdateCouponBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdateCouponBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    currency_options: Option<&'a std::collections::HashMap<stripe_types::Currency, CurrencyOption>>,
+    currency_options: Option<std::collections::HashMap<stripe_types::Currency, CurrencyOption>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    name: Option<&'a str>,
+    name: Option<String>,
 }
-impl<'a> UpdateCouponBuilder<'a> {
+impl UpdateCouponBuilder {
     fn new() -> Self {
         Self { currency_options: None, expand: None, metadata: None, name: None }
     }
@@ -396,45 +399,48 @@ impl<'a> UpdateCouponBuilder<'a> {
 /// Updates the metadata of a coupon.
 /// Other coupon details (currency, duration, amount_off) are, by design, not editable.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateCoupon<'a> {
-    inner: UpdateCouponBuilder<'a>,
-    coupon: &'a stripe_shared::CouponId,
+pub struct UpdateCoupon {
+    inner: UpdateCouponBuilder,
+    coupon: stripe_shared::CouponId,
 }
-impl<'a> UpdateCoupon<'a> {
+impl UpdateCoupon {
     /// Construct a new `UpdateCoupon`.
-    pub fn new(coupon: &'a stripe_shared::CouponId) -> Self {
-        Self { coupon, inner: UpdateCouponBuilder::new() }
+    pub fn new(coupon: impl Into<stripe_shared::CouponId>) -> Self {
+        Self { coupon: coupon.into(), inner: UpdateCouponBuilder::new() }
     }
     /// Coupons defined in each available currency option (only supported if the coupon is amount-based).
     /// Each key must be a three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html) and a [supported currency](https://stripe.com/docs/currencies).
     pub fn currency_options(
         mut self,
-        currency_options: &'a std::collections::HashMap<stripe_types::Currency, CurrencyOption>,
+        currency_options: impl Into<std::collections::HashMap<stripe_types::Currency, CurrencyOption>>,
     ) -> Self {
-        self.inner.currency_options = Some(currency_options);
+        self.inner.currency_options = Some(currency_options.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// Name of the coupon displayed to customers on, for instance invoices, or receipts.
     /// By default the `id` is shown if `name` is not set.
-    pub fn name(mut self, name: &'a str) -> Self {
-        self.inner.name = Some(name);
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.inner.name = Some(name.into());
         self
     }
 }
-impl UpdateCoupon<'_> {
+impl UpdateCoupon {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -452,11 +458,11 @@ impl UpdateCoupon<'_> {
     }
 }
 
-impl StripeRequest for UpdateCoupon<'_> {
+impl StripeRequest for UpdateCoupon {
     type Output = stripe_shared::Coupon;
 
     fn build(&self) -> RequestBuilder {
-        let coupon = self.coupon;
+        let coupon = &self.coupon;
         RequestBuilder::new(StripeMethod::Post, format!("/coupons/{coupon}")).form(&self.inner)
     }
 }
@@ -467,7 +473,7 @@ pub struct CurrencyOption {
     pub amount_off: i64,
 }
 impl CurrencyOption {
-    pub fn new(amount_off: i64) -> Self {
-        Self { amount_off }
+    pub fn new(amount_off: impl Into<i64>) -> Self {
+        Self { amount_off: amount_off.into() }
     }
 }

--- a/generated/async-stripe-product/src/price/requests.rs
+++ b/generated/async-stripe-product/src/price/requests.rs
@@ -2,8 +2,8 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListPriceBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListPriceBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     active: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -11,24 +11,24 @@ struct ListPriceBuilder<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     currency: Option<stripe_types::Currency>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    lookup_keys: Option<&'a [&'a str]>,
+    lookup_keys: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    product: Option<&'a str>,
+    product: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    recurring: Option<ListPriceRecurring<'a>>,
+    recurring: Option<ListPriceRecurring>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
     #[serde(rename = "type")]
     #[serde(skip_serializing_if = "Option::is_none")]
     type_: Option<stripe_shared::PriceType>,
 }
-impl<'a> ListPriceBuilder<'a> {
+impl ListPriceBuilder {
     fn new() -> Self {
         Self {
             active: None,
@@ -46,24 +46,24 @@ impl<'a> ListPriceBuilder<'a> {
     }
 }
 /// Only return prices with these recurring fields.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct ListPriceRecurring<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct ListPriceRecurring {
     /// Filter by billing frequency. Either `day`, `week`, `month` or `year`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub interval: Option<ListPriceRecurringInterval>,
     /// Filter by the price's meter.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub meter: Option<&'a str>,
+    pub meter: Option<String>,
     /// Filter by the usage type for this price. Can be either `metered` or `licensed`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub usage_type: Option<ListPriceRecurringUsageType>,
 }
-impl<'a> ListPriceRecurring<'a> {
+impl ListPriceRecurring {
     pub fn new() -> Self {
         Self { interval: None, meter: None, usage_type: None }
     }
 }
-impl<'a> Default for ListPriceRecurring<'a> {
+impl Default for ListPriceRecurring {
     fn default() -> Self {
         Self::new()
     }
@@ -187,82 +187,82 @@ impl<'de> serde::Deserialize<'de> for ListPriceRecurringUsageType {
 /// Returns a list of your active prices, excluding [inline prices](https://stripe.com/docs/products-prices/pricing-models#inline-pricing).
 /// For the list of inactive prices, set `active` to false.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListPrice<'a> {
-    inner: ListPriceBuilder<'a>,
+pub struct ListPrice {
+    inner: ListPriceBuilder,
 }
-impl<'a> ListPrice<'a> {
+impl ListPrice {
     /// Construct a new `ListPrice`.
     pub fn new() -> Self {
         Self { inner: ListPriceBuilder::new() }
     }
     /// Only return prices that are active or inactive (e.g., pass `false` to list all inactive prices).
-    pub fn active(mut self, active: bool) -> Self {
-        self.inner.active = Some(active);
+    pub fn active(mut self, active: impl Into<bool>) -> Self {
+        self.inner.active = Some(active.into());
         self
     }
     /// A filter on the list, based on the object `created` field.
     /// The value can be a string with an integer Unix timestamp, or it can be a dictionary with a number of different query options.
-    pub fn created(mut self, created: stripe_types::RangeQueryTs) -> Self {
-        self.inner.created = Some(created);
+    pub fn created(mut self, created: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.created = Some(created.into());
         self
     }
     /// Only return prices for the given currency.
-    pub fn currency(mut self, currency: stripe_types::Currency) -> Self {
-        self.inner.currency = Some(currency);
+    pub fn currency(mut self, currency: impl Into<stripe_types::Currency>) -> Self {
+        self.inner.currency = Some(currency.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// Only return the price with these lookup_keys, if any exist.
-    pub fn lookup_keys(mut self, lookup_keys: &'a [&'a str]) -> Self {
-        self.inner.lookup_keys = Some(lookup_keys);
+    pub fn lookup_keys(mut self, lookup_keys: impl Into<Vec<String>>) -> Self {
+        self.inner.lookup_keys = Some(lookup_keys.into());
         self
     }
     /// Only return prices for the given product.
-    pub fn product(mut self, product: &'a str) -> Self {
-        self.inner.product = Some(product);
+    pub fn product(mut self, product: impl Into<String>) -> Self {
+        self.inner.product = Some(product.into());
         self
     }
     /// Only return prices with these recurring fields.
-    pub fn recurring(mut self, recurring: ListPriceRecurring<'a>) -> Self {
-        self.inner.recurring = Some(recurring);
+    pub fn recurring(mut self, recurring: impl Into<ListPriceRecurring>) -> Self {
+        self.inner.recurring = Some(recurring.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
     /// Only return prices of type `recurring` or `one_time`.
-    pub fn type_(mut self, type_: stripe_shared::PriceType) -> Self {
-        self.inner.type_ = Some(type_);
+    pub fn type_(mut self, type_: impl Into<stripe_shared::PriceType>) -> Self {
+        self.inner.type_ = Some(type_.into());
         self
     }
 }
-impl<'a> Default for ListPrice<'a> {
+impl Default for ListPrice {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListPrice<'_> {
+impl ListPrice {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -282,45 +282,45 @@ impl ListPrice<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::Price>> {
-        stripe_client_core::ListPaginator::new_list("/prices", self.inner)
+        stripe_client_core::ListPaginator::new_list("/prices", &self.inner)
     }
 }
 
-impl StripeRequest for ListPrice<'_> {
+impl StripeRequest for ListPrice {
     type Output = stripe_types::List<stripe_shared::Price>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/prices").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrievePriceBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrievePriceBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrievePriceBuilder<'a> {
+impl RetrievePriceBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves the price with the given ID.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrievePrice<'a> {
-    inner: RetrievePriceBuilder<'a>,
-    price: &'a stripe_shared::PriceId,
+pub struct RetrievePrice {
+    inner: RetrievePriceBuilder,
+    price: stripe_shared::PriceId,
 }
-impl<'a> RetrievePrice<'a> {
+impl RetrievePrice {
     /// Construct a new `RetrievePrice`.
-    pub fn new(price: &'a stripe_shared::PriceId) -> Self {
-        Self { price, inner: RetrievePriceBuilder::new() }
+    pub fn new(price: impl Into<stripe_shared::PriceId>) -> Self {
+        Self { price: price.into(), inner: RetrievePriceBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrievePrice<'_> {
+impl RetrievePrice {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -338,27 +338,27 @@ impl RetrievePrice<'_> {
     }
 }
 
-impl StripeRequest for RetrievePrice<'_> {
+impl StripeRequest for RetrievePrice {
     type Output = stripe_shared::Price;
 
     fn build(&self) -> RequestBuilder {
-        let price = self.price;
+        let price = &self.price;
         RequestBuilder::new(StripeMethod::Get, format!("/prices/{price}")).query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct SearchPriceBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct SearchPriceBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    page: Option<&'a str>,
-    query: &'a str,
+    page: Option<String>,
+    query: String,
 }
-impl<'a> SearchPriceBuilder<'a> {
-    fn new(query: &'a str) -> Self {
-        Self { expand: None, limit: None, page: None, query }
+impl SearchPriceBuilder {
+    fn new(query: impl Into<String>) -> Self {
+        Self { expand: None, limit: None, page: None, query: query.into() }
     }
 }
 /// Search for prices you’ve previously created using Stripe’s [Search Query Language](https://stripe.com/docs/search#search-query-language).
@@ -368,34 +368,34 @@ impl<'a> SearchPriceBuilder<'a> {
 /// Occasionally, propagation of new or updated data can be up.
 /// to an hour behind during outages. Search functionality is not available to merchants in India.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct SearchPrice<'a> {
-    inner: SearchPriceBuilder<'a>,
+pub struct SearchPrice {
+    inner: SearchPriceBuilder,
 }
-impl<'a> SearchPrice<'a> {
+impl SearchPrice {
     /// Construct a new `SearchPrice`.
-    pub fn new(query: &'a str) -> Self {
-        Self { inner: SearchPriceBuilder::new(query) }
+    pub fn new(query: impl Into<String>) -> Self {
+        Self { inner: SearchPriceBuilder::new(query.into()) }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for pagination across multiple pages of results.
     /// Don't include this parameter on the first call.
     /// Use the next_page value returned in a previous response to request subsequent results.
-    pub fn page(mut self, page: &'a str) -> Self {
-        self.inner.page = Some(page);
+    pub fn page(mut self, page: impl Into<String>) -> Self {
+        self.inner.page = Some(page.into());
         self
     }
 }
-impl SearchPrice<'_> {
+impl SearchPrice {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -415,19 +415,19 @@ impl SearchPrice<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::SearchList<stripe_shared::Price>> {
-        stripe_client_core::ListPaginator::new_search_list("/prices/search", self.inner)
+        stripe_client_core::ListPaginator::new_search_list("/prices/search", &self.inner)
     }
 }
 
-impl StripeRequest for SearchPrice<'_> {
+impl StripeRequest for SearchPrice {
     type Output = stripe_types::SearchList<stripe_shared::Price>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/prices/search").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreatePriceBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreatePriceBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     active: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -435,27 +435,27 @@ struct CreatePriceBuilder<'a> {
     currency: stripe_types::Currency,
     #[serde(skip_serializing_if = "Option::is_none")]
     currency_options:
-        Option<&'a std::collections::HashMap<stripe_types::Currency, CreatePriceCurrencyOptions>>,
+        Option<std::collections::HashMap<stripe_types::Currency, CreatePriceCurrencyOptions>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     custom_unit_amount: Option<CustomUnitAmount>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    lookup_key: Option<&'a str>,
+    lookup_key: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    nickname: Option<&'a str>,
+    nickname: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    product: Option<&'a str>,
+    product: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    product_data: Option<CreatePriceProductData<'a>>,
+    product_data: Option<CreatePriceProductData>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    recurring: Option<CreatePriceRecurring<'a>>,
+    recurring: Option<CreatePriceRecurring>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tax_behavior: Option<stripe_shared::PriceTaxBehavior>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    tiers: Option<&'a [CreatePriceTiers<'a>]>,
+    tiers: Option<Vec<CreatePriceTiers>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tiers_mode: Option<stripe_shared::PriceTiersMode>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -465,14 +465,14 @@ struct CreatePriceBuilder<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     unit_amount: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    unit_amount_decimal: Option<&'a str>,
+    unit_amount_decimal: Option<String>,
 }
-impl<'a> CreatePriceBuilder<'a> {
-    fn new(currency: stripe_types::Currency) -> Self {
+impl CreatePriceBuilder {
+    fn new(currency: impl Into<stripe_types::Currency>) -> Self {
         Self {
             active: None,
             billing_scheme: None,
-            currency,
+            currency: currency.into(),
             currency_options: None,
             custom_unit_amount: None,
             expand: None,
@@ -559,13 +559,13 @@ pub struct CreatePriceCurrencyOptionsTiers {
     pub up_to: CreatePriceCurrencyOptionsTiersUpTo,
 }
 impl CreatePriceCurrencyOptionsTiers {
-    pub fn new(up_to: CreatePriceCurrencyOptionsTiersUpTo) -> Self {
+    pub fn new(up_to: impl Into<CreatePriceCurrencyOptionsTiersUpTo>) -> Self {
         Self {
             flat_amount: None,
             flat_amount_decimal: None,
             unit_amount: None,
             unit_amount_decimal: None,
-            up_to,
+            up_to: up_to.into(),
         }
     }
 }
@@ -580,8 +580,8 @@ pub enum CreatePriceCurrencyOptionsTiersUpTo {
     I64(i64),
 }
 /// These fields can be used to create a new product that this price will belong to.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePriceProductData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePriceProductData {
     /// Whether the product is currently available for purchase. Defaults to `true`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub active: Option<bool>,
@@ -589,15 +589,15 @@ pub struct CreatePriceProductData<'a> {
     /// Must be unique.
     /// If not provided, an identifier will be randomly generated.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub id: Option<&'a str>,
+    pub id: Option<String>,
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// The product's name, meant to be displayable to the customer.
-    pub name: &'a str,
+    pub name: String,
     /// An arbitrary string to be displayed on your customer's credit card or bank statement.
     /// While most banks display this information consistently, some may display it incorrectly or not at all.
     ///
@@ -605,22 +605,22 @@ pub struct CreatePriceProductData<'a> {
     /// The statement description may not include `<`, `>`, `\`, `"`, `'` characters, and will appear on your customer's statement in capital letters.
     /// Non-ASCII characters are automatically stripped.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub statement_descriptor: Option<&'a str>,
+    pub statement_descriptor: Option<String>,
     /// A [tax code](https://stripe.com/docs/tax/tax-categories) ID.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tax_code: Option<&'a str>,
+    pub tax_code: Option<String>,
     /// A label that represents units of this product.
     /// When set, this will be included in customers' receipts, invoices, Checkout, and the customer portal.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub unit_label: Option<&'a str>,
+    pub unit_label: Option<String>,
 }
-impl<'a> CreatePriceProductData<'a> {
-    pub fn new(name: &'a str) -> Self {
+impl CreatePriceProductData {
+    pub fn new(name: impl Into<String>) -> Self {
         Self {
             active: None,
             id: None,
             metadata: None,
-            name,
+            name: name.into(),
             statement_descriptor: None,
             tax_code: None,
             unit_label: None,
@@ -628,8 +628,8 @@ impl<'a> CreatePriceProductData<'a> {
     }
 }
 /// The recurring components of a price such as `interval` and `usage_type`.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePriceRecurring<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePriceRecurring {
     /// Specifies a usage aggregation strategy for prices of `usage_type=metered`. Defaults to `sum`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub aggregate_usage: Option<CreatePriceRecurringAggregateUsage>,
@@ -642,7 +642,7 @@ pub struct CreatePriceRecurring<'a> {
     pub interval_count: Option<u64>,
     /// The meter tracking the usage of a metered price
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub meter: Option<&'a str>,
+    pub meter: Option<String>,
     /// Default number of trial days when subscribing a customer to this price using [`trial_from_plan=true`](https://stripe.com/docs/api#create_subscription-trial_from_plan).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub trial_period_days: Option<u32>,
@@ -654,11 +654,11 @@ pub struct CreatePriceRecurring<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub usage_type: Option<CreatePriceRecurringUsageType>,
 }
-impl<'a> CreatePriceRecurring<'a> {
-    pub fn new(interval: CreatePriceRecurringInterval) -> Self {
+impl CreatePriceRecurring {
+    pub fn new(interval: impl Into<CreatePriceRecurringInterval>) -> Self {
         Self {
             aggregate_usage: None,
-            interval,
+            interval: interval.into(),
             interval_count: None,
             meter: None,
             trial_period_days: None,
@@ -852,35 +852,35 @@ impl<'de> serde::Deserialize<'de> for CreatePriceRecurringUsageType {
 /// Each element represents a pricing tier.
 /// This parameter requires `billing_scheme` to be set to `tiered`.
 /// See also the documentation for `billing_scheme`.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePriceTiers<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePriceTiers {
     /// The flat billing amount for an entire tier, regardless of the number of units in the tier.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub flat_amount: Option<i64>,
     /// Same as `flat_amount`, but accepts a decimal value representing an integer in the minor units of the currency.
     /// Only one of `flat_amount` and `flat_amount_decimal` can be set.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub flat_amount_decimal: Option<&'a str>,
+    pub flat_amount_decimal: Option<String>,
     /// The per unit billing amount for each individual unit for which this tier applies.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub unit_amount: Option<i64>,
     /// Same as `unit_amount`, but accepts a decimal value in cents (or local equivalent) with at most 12 decimal places.
     /// Only one of `unit_amount` and `unit_amount_decimal` can be set.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub unit_amount_decimal: Option<&'a str>,
+    pub unit_amount_decimal: Option<String>,
     /// Specifies the upper bound of this tier.
     /// The lower bound of a tier is the upper bound of the previous tier adding one.
     /// Use `inf` to define a fallback tier.
     pub up_to: CreatePriceTiersUpTo,
 }
-impl<'a> CreatePriceTiers<'a> {
-    pub fn new(up_to: CreatePriceTiersUpTo) -> Self {
+impl CreatePriceTiers {
+    pub fn new(up_to: impl Into<CreatePriceTiersUpTo>) -> Self {
         Self {
             flat_amount: None,
             flat_amount_decimal: None,
             unit_amount: None,
             unit_amount_decimal: None,
-            up_to,
+            up_to: up_to.into(),
         }
     }
 }
@@ -904,8 +904,11 @@ pub struct CreatePriceTransformQuantity {
     pub round: CreatePriceTransformQuantityRound,
 }
 impl CreatePriceTransformQuantity {
-    pub fn new(divide_by: i64, round: CreatePriceTransformQuantityRound) -> Self {
-        Self { divide_by, round }
+    pub fn new(
+        divide_by: impl Into<i64>,
+        round: impl Into<CreatePriceTransformQuantityRound>,
+    ) -> Self {
+        Self { divide_by: divide_by.into(), round: round.into() }
     }
 }
 /// After division, either round the result `up` or `down`.
@@ -966,129 +969,140 @@ impl<'de> serde::Deserialize<'de> for CreatePriceTransformQuantityRound {
 }
 /// Creates a new price for an existing product. The price can be recurring or one-time.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreatePrice<'a> {
-    inner: CreatePriceBuilder<'a>,
+pub struct CreatePrice {
+    inner: CreatePriceBuilder,
 }
-impl<'a> CreatePrice<'a> {
+impl CreatePrice {
     /// Construct a new `CreatePrice`.
-    pub fn new(currency: stripe_types::Currency) -> Self {
-        Self { inner: CreatePriceBuilder::new(currency) }
+    pub fn new(currency: impl Into<stripe_types::Currency>) -> Self {
+        Self { inner: CreatePriceBuilder::new(currency.into()) }
     }
     /// Whether the price can be used for new purchases. Defaults to `true`.
-    pub fn active(mut self, active: bool) -> Self {
-        self.inner.active = Some(active);
+    pub fn active(mut self, active: impl Into<bool>) -> Self {
+        self.inner.active = Some(active.into());
         self
     }
     /// Describes how to compute the price per period.
     /// Either `per_unit` or `tiered`.
     /// `per_unit` indicates that the fixed amount (specified in `unit_amount` or `unit_amount_decimal`) will be charged per unit in `quantity` (for prices with `usage_type=licensed`), or per unit of total usage (for prices with `usage_type=metered`).
     /// `tiered` indicates that the unit pricing will be computed using a tiering strategy as defined using the `tiers` and `tiers_mode` attributes.
-    pub fn billing_scheme(mut self, billing_scheme: stripe_shared::PriceBillingScheme) -> Self {
-        self.inner.billing_scheme = Some(billing_scheme);
+    pub fn billing_scheme(
+        mut self,
+        billing_scheme: impl Into<stripe_shared::PriceBillingScheme>,
+    ) -> Self {
+        self.inner.billing_scheme = Some(billing_scheme.into());
         self
     }
     /// Prices defined in each available currency option.
     /// Each key must be a three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html) and a [supported currency](https://stripe.com/docs/currencies).
     pub fn currency_options(
         mut self,
-        currency_options: &'a std::collections::HashMap<
-            stripe_types::Currency,
-            CreatePriceCurrencyOptions,
+        currency_options: impl Into<
+            std::collections::HashMap<stripe_types::Currency, CreatePriceCurrencyOptions>,
         >,
     ) -> Self {
-        self.inner.currency_options = Some(currency_options);
+        self.inner.currency_options = Some(currency_options.into());
         self
     }
     /// When set, provides configuration for the amount to be adjusted by the customer during Checkout Sessions and Payment Links.
-    pub fn custom_unit_amount(mut self, custom_unit_amount: CustomUnitAmount) -> Self {
-        self.inner.custom_unit_amount = Some(custom_unit_amount);
+    pub fn custom_unit_amount(mut self, custom_unit_amount: impl Into<CustomUnitAmount>) -> Self {
+        self.inner.custom_unit_amount = Some(custom_unit_amount.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A lookup key used to retrieve prices dynamically from a static string.
     /// This may be up to 200 characters.
-    pub fn lookup_key(mut self, lookup_key: &'a str) -> Self {
-        self.inner.lookup_key = Some(lookup_key);
+    pub fn lookup_key(mut self, lookup_key: impl Into<String>) -> Self {
+        self.inner.lookup_key = Some(lookup_key.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// A brief description of the price, hidden from customers.
-    pub fn nickname(mut self, nickname: &'a str) -> Self {
-        self.inner.nickname = Some(nickname);
+    pub fn nickname(mut self, nickname: impl Into<String>) -> Self {
+        self.inner.nickname = Some(nickname.into());
         self
     }
     /// The ID of the product that this price will belong to.
-    pub fn product(mut self, product: &'a str) -> Self {
-        self.inner.product = Some(product);
+    pub fn product(mut self, product: impl Into<String>) -> Self {
+        self.inner.product = Some(product.into());
         self
     }
     /// These fields can be used to create a new product that this price will belong to.
-    pub fn product_data(mut self, product_data: CreatePriceProductData<'a>) -> Self {
-        self.inner.product_data = Some(product_data);
+    pub fn product_data(mut self, product_data: impl Into<CreatePriceProductData>) -> Self {
+        self.inner.product_data = Some(product_data.into());
         self
     }
     /// The recurring components of a price such as `interval` and `usage_type`.
-    pub fn recurring(mut self, recurring: CreatePriceRecurring<'a>) -> Self {
-        self.inner.recurring = Some(recurring);
+    pub fn recurring(mut self, recurring: impl Into<CreatePriceRecurring>) -> Self {
+        self.inner.recurring = Some(recurring.into());
         self
     }
     /// Only required if a [default tax behavior](https://stripe.com/docs/tax/products-prices-tax-categories-tax-behavior#setting-a-default-tax-behavior-(recommended)) was not provided in the Stripe Tax settings.
     /// Specifies whether the price is considered inclusive of taxes or exclusive of taxes.
     /// One of `inclusive`, `exclusive`, or `unspecified`.
     /// Once specified as either `inclusive` or `exclusive`, it cannot be changed.
-    pub fn tax_behavior(mut self, tax_behavior: stripe_shared::PriceTaxBehavior) -> Self {
-        self.inner.tax_behavior = Some(tax_behavior);
+    pub fn tax_behavior(
+        mut self,
+        tax_behavior: impl Into<stripe_shared::PriceTaxBehavior>,
+    ) -> Self {
+        self.inner.tax_behavior = Some(tax_behavior.into());
         self
     }
     /// Each element represents a pricing tier.
     /// This parameter requires `billing_scheme` to be set to `tiered`.
     /// See also the documentation for `billing_scheme`.
-    pub fn tiers(mut self, tiers: &'a [CreatePriceTiers<'a>]) -> Self {
-        self.inner.tiers = Some(tiers);
+    pub fn tiers(mut self, tiers: impl Into<Vec<CreatePriceTiers>>) -> Self {
+        self.inner.tiers = Some(tiers.into());
         self
     }
     /// Defines if the tiering price should be `graduated` or `volume` based.
     /// In `volume`-based tiering, the maximum quantity within a period determines the per unit price, in `graduated` tiering pricing can successively change as the quantity grows.
-    pub fn tiers_mode(mut self, tiers_mode: stripe_shared::PriceTiersMode) -> Self {
-        self.inner.tiers_mode = Some(tiers_mode);
+    pub fn tiers_mode(mut self, tiers_mode: impl Into<stripe_shared::PriceTiersMode>) -> Self {
+        self.inner.tiers_mode = Some(tiers_mode.into());
         self
     }
     /// If set to true, will atomically remove the lookup key from the existing price, and assign it to this price.
-    pub fn transfer_lookup_key(mut self, transfer_lookup_key: bool) -> Self {
-        self.inner.transfer_lookup_key = Some(transfer_lookup_key);
+    pub fn transfer_lookup_key(mut self, transfer_lookup_key: impl Into<bool>) -> Self {
+        self.inner.transfer_lookup_key = Some(transfer_lookup_key.into());
         self
     }
     /// Apply a transformation to the reported usage or set quantity before computing the billed price.
     /// Cannot be combined with `tiers`.
-    pub fn transform_quantity(mut self, transform_quantity: CreatePriceTransformQuantity) -> Self {
-        self.inner.transform_quantity = Some(transform_quantity);
+    pub fn transform_quantity(
+        mut self,
+        transform_quantity: impl Into<CreatePriceTransformQuantity>,
+    ) -> Self {
+        self.inner.transform_quantity = Some(transform_quantity.into());
         self
     }
     /// A positive integer in cents (or local equivalent) (or 0 for a free price) representing how much to charge.
     /// One of `unit_amount`, `unit_amount_decimal`, or `custom_unit_amount` is required, unless `billing_scheme=tiered`.
-    pub fn unit_amount(mut self, unit_amount: i64) -> Self {
-        self.inner.unit_amount = Some(unit_amount);
+    pub fn unit_amount(mut self, unit_amount: impl Into<i64>) -> Self {
+        self.inner.unit_amount = Some(unit_amount.into());
         self
     }
     /// Same as `unit_amount`, but accepts a decimal value in cents (or local equivalent) with at most 12 decimal places.
     /// Only one of `unit_amount` and `unit_amount_decimal` can be set.
-    pub fn unit_amount_decimal(mut self, unit_amount_decimal: &'a str) -> Self {
-        self.inner.unit_amount_decimal = Some(unit_amount_decimal);
+    pub fn unit_amount_decimal(mut self, unit_amount_decimal: impl Into<String>) -> Self {
+        self.inner.unit_amount_decimal = Some(unit_amount_decimal.into());
         self
     }
 }
-impl CreatePrice<'_> {
+impl CreatePrice {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -1106,34 +1120,34 @@ impl CreatePrice<'_> {
     }
 }
 
-impl StripeRequest for CreatePrice<'_> {
+impl StripeRequest for CreatePrice {
     type Output = stripe_shared::Price;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Post, "/prices").form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdatePriceBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdatePriceBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     active: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     currency_options:
-        Option<&'a std::collections::HashMap<stripe_types::Currency, UpdatePriceCurrencyOptions>>,
+        Option<std::collections::HashMap<stripe_types::Currency, UpdatePriceCurrencyOptions>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    lookup_key: Option<&'a str>,
+    lookup_key: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    nickname: Option<&'a str>,
+    nickname: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tax_behavior: Option<stripe_shared::PriceTaxBehavior>,
     #[serde(skip_serializing_if = "Option::is_none")]
     transfer_lookup_key: Option<bool>,
 }
-impl<'a> UpdatePriceBuilder<'a> {
+impl UpdatePriceBuilder {
     fn new() -> Self {
         Self {
             active: None,
@@ -1214,13 +1228,13 @@ pub struct UpdatePriceCurrencyOptionsTiers {
     pub up_to: UpdatePriceCurrencyOptionsTiersUpTo,
 }
 impl UpdatePriceCurrencyOptionsTiers {
-    pub fn new(up_to: UpdatePriceCurrencyOptionsTiersUpTo) -> Self {
+    pub fn new(up_to: impl Into<UpdatePriceCurrencyOptionsTiersUpTo>) -> Self {
         Self {
             flat_amount: None,
             flat_amount_decimal: None,
             unit_amount: None,
             unit_amount_decimal: None,
-            up_to,
+            up_to: up_to.into(),
         }
     }
 }
@@ -1237,71 +1251,76 @@ pub enum UpdatePriceCurrencyOptionsTiersUpTo {
 /// Updates the specified price by setting the values of the parameters passed.
 /// Any parameters not provided are left unchanged.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdatePrice<'a> {
-    inner: UpdatePriceBuilder<'a>,
-    price: &'a stripe_shared::PriceId,
+pub struct UpdatePrice {
+    inner: UpdatePriceBuilder,
+    price: stripe_shared::PriceId,
 }
-impl<'a> UpdatePrice<'a> {
+impl UpdatePrice {
     /// Construct a new `UpdatePrice`.
-    pub fn new(price: &'a stripe_shared::PriceId) -> Self {
-        Self { price, inner: UpdatePriceBuilder::new() }
+    pub fn new(price: impl Into<stripe_shared::PriceId>) -> Self {
+        Self { price: price.into(), inner: UpdatePriceBuilder::new() }
     }
     /// Whether the price can be used for new purchases. Defaults to `true`.
-    pub fn active(mut self, active: bool) -> Self {
-        self.inner.active = Some(active);
+    pub fn active(mut self, active: impl Into<bool>) -> Self {
+        self.inner.active = Some(active.into());
         self
     }
     /// Prices defined in each available currency option.
     /// Each key must be a three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html) and a [supported currency](https://stripe.com/docs/currencies).
     pub fn currency_options(
         mut self,
-        currency_options: &'a std::collections::HashMap<
-            stripe_types::Currency,
-            UpdatePriceCurrencyOptions,
+        currency_options: impl Into<
+            std::collections::HashMap<stripe_types::Currency, UpdatePriceCurrencyOptions>,
         >,
     ) -> Self {
-        self.inner.currency_options = Some(currency_options);
+        self.inner.currency_options = Some(currency_options.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A lookup key used to retrieve prices dynamically from a static string.
     /// This may be up to 200 characters.
-    pub fn lookup_key(mut self, lookup_key: &'a str) -> Self {
-        self.inner.lookup_key = Some(lookup_key);
+    pub fn lookup_key(mut self, lookup_key: impl Into<String>) -> Self {
+        self.inner.lookup_key = Some(lookup_key.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// A brief description of the price, hidden from customers.
-    pub fn nickname(mut self, nickname: &'a str) -> Self {
-        self.inner.nickname = Some(nickname);
+    pub fn nickname(mut self, nickname: impl Into<String>) -> Self {
+        self.inner.nickname = Some(nickname.into());
         self
     }
     /// Only required if a [default tax behavior](https://stripe.com/docs/tax/products-prices-tax-categories-tax-behavior#setting-a-default-tax-behavior-(recommended)) was not provided in the Stripe Tax settings.
     /// Specifies whether the price is considered inclusive of taxes or exclusive of taxes.
     /// One of `inclusive`, `exclusive`, or `unspecified`.
     /// Once specified as either `inclusive` or `exclusive`, it cannot be changed.
-    pub fn tax_behavior(mut self, tax_behavior: stripe_shared::PriceTaxBehavior) -> Self {
-        self.inner.tax_behavior = Some(tax_behavior);
+    pub fn tax_behavior(
+        mut self,
+        tax_behavior: impl Into<stripe_shared::PriceTaxBehavior>,
+    ) -> Self {
+        self.inner.tax_behavior = Some(tax_behavior.into());
         self
     }
     /// If set to true, will atomically remove the lookup key from the existing price, and assign it to this price.
-    pub fn transfer_lookup_key(mut self, transfer_lookup_key: bool) -> Self {
-        self.inner.transfer_lookup_key = Some(transfer_lookup_key);
+    pub fn transfer_lookup_key(mut self, transfer_lookup_key: impl Into<bool>) -> Self {
+        self.inner.transfer_lookup_key = Some(transfer_lookup_key.into());
         self
     }
 }
-impl UpdatePrice<'_> {
+impl UpdatePrice {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -1319,11 +1338,11 @@ impl UpdatePrice<'_> {
     }
 }
 
-impl StripeRequest for UpdatePrice<'_> {
+impl StripeRequest for UpdatePrice {
     type Output = stripe_shared::Price;
 
     fn build(&self) -> RequestBuilder {
-        let price = self.price;
+        let price = &self.price;
         RequestBuilder::new(StripeMethod::Post, format!("/prices/{price}")).form(&self.inner)
     }
 }
@@ -1344,7 +1363,7 @@ pub struct CustomUnitAmount {
     pub preset: Option<i64>,
 }
 impl CustomUnitAmount {
-    pub fn new(enabled: bool) -> Self {
-        Self { enabled, maximum: None, minimum: None, preset: None }
+    pub fn new(enabled: impl Into<bool>) -> Self {
+        Self { enabled: enabled.into(), maximum: None, minimum: None, preset: None }
     }
 }

--- a/generated/async-stripe-product/src/product/requests.rs
+++ b/generated/async-stripe-product/src/product/requests.rs
@@ -6,16 +6,16 @@ use stripe_client_core::{
 /// Deleting a product is only possible if it has no prices associated with it.
 /// Additionally, deleting a product with `type=good` is only possible if it has no SKUs associated with it.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct DeleteProduct<'a> {
-    id: &'a stripe_shared::ProductId,
+pub struct DeleteProduct {
+    id: stripe_shared::ProductId,
 }
-impl<'a> DeleteProduct<'a> {
+impl DeleteProduct {
     /// Construct a new `DeleteProduct`.
-    pub fn new(id: &'a stripe_shared::ProductId) -> Self {
-        Self { id }
+    pub fn new(id: impl Into<stripe_shared::ProductId>) -> Self {
+        Self { id: id.into() }
     }
 }
-impl DeleteProduct<'_> {
+impl DeleteProduct {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -33,39 +33,39 @@ impl DeleteProduct<'_> {
     }
 }
 
-impl StripeRequest for DeleteProduct<'_> {
+impl StripeRequest for DeleteProduct {
     type Output = stripe_shared::DeletedProduct;
 
     fn build(&self) -> RequestBuilder {
-        let id = self.id;
+        let id = &self.id;
         RequestBuilder::new(StripeMethod::Delete, format!("/products/{id}"))
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListProductBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListProductBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     active: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     created: Option<stripe_types::RangeQueryTs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ids: Option<&'a [&'a str]>,
+    ids: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     shippable: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
     #[serde(rename = "type")]
     #[serde(skip_serializing_if = "Option::is_none")]
     type_: Option<stripe_shared::ProductType>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    url: Option<&'a str>,
+    url: Option<String>,
 }
-impl<'a> ListProductBuilder<'a> {
+impl ListProductBuilder {
     fn new() -> Self {
         Self {
             active: None,
@@ -84,77 +84,77 @@ impl<'a> ListProductBuilder<'a> {
 /// Returns a list of your products.
 /// The products are returned sorted by creation date, with the most recently created products appearing first.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListProduct<'a> {
-    inner: ListProductBuilder<'a>,
+pub struct ListProduct {
+    inner: ListProductBuilder,
 }
-impl<'a> ListProduct<'a> {
+impl ListProduct {
     /// Construct a new `ListProduct`.
     pub fn new() -> Self {
         Self { inner: ListProductBuilder::new() }
     }
     /// Only return products that are active or inactive (e.g., pass `false` to list all inactive products).
-    pub fn active(mut self, active: bool) -> Self {
-        self.inner.active = Some(active);
+    pub fn active(mut self, active: impl Into<bool>) -> Self {
+        self.inner.active = Some(active.into());
         self
     }
     /// Only return products that were created during the given date interval.
-    pub fn created(mut self, created: stripe_types::RangeQueryTs) -> Self {
-        self.inner.created = Some(created);
+    pub fn created(mut self, created: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.created = Some(created.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Only return products with the given IDs.
     /// Cannot be used with [starting_after](https://stripe.com/docs/api#list_products-starting_after) or [ending_before](https://stripe.com/docs/api#list_products-ending_before).
-    pub fn ids(mut self, ids: &'a [&'a str]) -> Self {
-        self.inner.ids = Some(ids);
+    pub fn ids(mut self, ids: impl Into<Vec<String>>) -> Self {
+        self.inner.ids = Some(ids.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// Only return products that can be shipped (i.e., physical, not digital products).
-    pub fn shippable(mut self, shippable: bool) -> Self {
-        self.inner.shippable = Some(shippable);
+    pub fn shippable(mut self, shippable: impl Into<bool>) -> Self {
+        self.inner.shippable = Some(shippable.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
     /// Only return products of this type.
-    pub fn type_(mut self, type_: stripe_shared::ProductType) -> Self {
-        self.inner.type_ = Some(type_);
+    pub fn type_(mut self, type_: impl Into<stripe_shared::ProductType>) -> Self {
+        self.inner.type_ = Some(type_.into());
         self
     }
     /// Only return products with the given url.
-    pub fn url(mut self, url: &'a str) -> Self {
-        self.inner.url = Some(url);
+    pub fn url(mut self, url: impl Into<String>) -> Self {
+        self.inner.url = Some(url.into());
         self
     }
 }
-impl<'a> Default for ListProduct<'a> {
+impl Default for ListProduct {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListProduct<'_> {
+impl ListProduct {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -174,23 +174,23 @@ impl ListProduct<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::Product>> {
-        stripe_client_core::ListPaginator::new_list("/products", self.inner)
+        stripe_client_core::ListPaginator::new_list("/products", &self.inner)
     }
 }
 
-impl StripeRequest for ListProduct<'_> {
+impl StripeRequest for ListProduct {
     type Output = stripe_types::List<stripe_shared::Product>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/products").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveProductBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveProductBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveProductBuilder<'a> {
+impl RetrieveProductBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
@@ -198,22 +198,22 @@ impl<'a> RetrieveProductBuilder<'a> {
 /// Retrieves the details of an existing product.
 /// Supply the unique product ID from either a product creation request or the product list, and Stripe will return the corresponding product information.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveProduct<'a> {
-    inner: RetrieveProductBuilder<'a>,
-    id: &'a stripe_shared::ProductId,
+pub struct RetrieveProduct {
+    inner: RetrieveProductBuilder,
+    id: stripe_shared::ProductId,
 }
-impl<'a> RetrieveProduct<'a> {
+impl RetrieveProduct {
     /// Construct a new `RetrieveProduct`.
-    pub fn new(id: &'a stripe_shared::ProductId) -> Self {
-        Self { id, inner: RetrieveProductBuilder::new() }
+    pub fn new(id: impl Into<stripe_shared::ProductId>) -> Self {
+        Self { id: id.into(), inner: RetrieveProductBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveProduct<'_> {
+impl RetrieveProduct {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -231,27 +231,27 @@ impl RetrieveProduct<'_> {
     }
 }
 
-impl StripeRequest for RetrieveProduct<'_> {
+impl StripeRequest for RetrieveProduct {
     type Output = stripe_shared::Product;
 
     fn build(&self) -> RequestBuilder {
-        let id = self.id;
+        let id = &self.id;
         RequestBuilder::new(StripeMethod::Get, format!("/products/{id}")).query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct SearchProductBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct SearchProductBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    page: Option<&'a str>,
-    query: &'a str,
+    page: Option<String>,
+    query: String,
 }
-impl<'a> SearchProductBuilder<'a> {
-    fn new(query: &'a str) -> Self {
-        Self { expand: None, limit: None, page: None, query }
+impl SearchProductBuilder {
+    fn new(query: impl Into<String>) -> Self {
+        Self { expand: None, limit: None, page: None, query: query.into() }
     }
 }
 /// Search for products you’ve previously created using Stripe’s [Search Query Language](https://stripe.com/docs/search#search-query-language).
@@ -261,34 +261,34 @@ impl<'a> SearchProductBuilder<'a> {
 /// Occasionally, propagation of new or updated data can be up.
 /// to an hour behind during outages. Search functionality is not available to merchants in India.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct SearchProduct<'a> {
-    inner: SearchProductBuilder<'a>,
+pub struct SearchProduct {
+    inner: SearchProductBuilder,
 }
-impl<'a> SearchProduct<'a> {
+impl SearchProduct {
     /// Construct a new `SearchProduct`.
-    pub fn new(query: &'a str) -> Self {
-        Self { inner: SearchProductBuilder::new(query) }
+    pub fn new(query: impl Into<String>) -> Self {
+        Self { inner: SearchProductBuilder::new(query.into()) }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for pagination across multiple pages of results.
     /// Don't include this parameter on the first call.
     /// Use the next_page value returned in a previous response to request subsequent results.
-    pub fn page(mut self, page: &'a str) -> Self {
-        self.inner.page = Some(page);
+    pub fn page(mut self, page: impl Into<String>) -> Self {
+        self.inner.page = Some(page.into());
         self
     }
 }
-impl SearchProduct<'_> {
+impl SearchProduct {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -308,54 +308,54 @@ impl SearchProduct<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::SearchList<stripe_shared::Product>> {
-        stripe_client_core::ListPaginator::new_search_list("/products/search", self.inner)
+        stripe_client_core::ListPaginator::new_search_list("/products/search", &self.inner)
     }
 }
 
-impl StripeRequest for SearchProduct<'_> {
+impl StripeRequest for SearchProduct {
     type Output = stripe_types::SearchList<stripe_shared::Product>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/products/search").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateProductBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateProductBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     active: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    default_price_data: Option<CreateProductDefaultPriceData<'a>>,
+    default_price_data: Option<CreateProductDefaultPriceData>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<&'a str>,
+    description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    id: Option<&'a str>,
+    id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    images: Option<&'a [&'a str]>,
+    images: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    marketing_features: Option<&'a [Features<'a>]>,
+    marketing_features: Option<Vec<Features>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
-    name: &'a str,
+    metadata: Option<std::collections::HashMap<String, String>>,
+    name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     package_dimensions: Option<PackageDimensionsSpecs>,
     #[serde(skip_serializing_if = "Option::is_none")]
     shippable: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    statement_descriptor: Option<&'a str>,
+    statement_descriptor: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    tax_code: Option<&'a str>,
+    tax_code: Option<String>,
     #[serde(rename = "type")]
     #[serde(skip_serializing_if = "Option::is_none")]
     type_: Option<stripe_shared::ProductType>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    unit_label: Option<&'a str>,
+    unit_label: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    url: Option<&'a str>,
+    url: Option<String>,
 }
-impl<'a> CreateProductBuilder<'a> {
-    fn new(name: &'a str) -> Self {
+impl CreateProductBuilder {
+    fn new(name: impl Into<String>) -> Self {
         Self {
             active: None,
             default_price_data: None,
@@ -365,7 +365,7 @@ impl<'a> CreateProductBuilder<'a> {
             images: None,
             marketing_features: None,
             metadata: None,
-            name,
+            name: name.into(),
             package_dimensions: None,
             shippable: None,
             statement_descriptor: None,
@@ -378,8 +378,8 @@ impl<'a> CreateProductBuilder<'a> {
 }
 /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object.
 /// This Price will be set as the default price for this product.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateProductDefaultPriceData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateProductDefaultPriceData {
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     /// Must be a [supported currency](https://stripe.com/docs/currencies).
     pub currency: stripe_types::Currency,
@@ -387,7 +387,7 @@ pub struct CreateProductDefaultPriceData<'a> {
     /// Each key must be a three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html) and a [supported currency](https://stripe.com/docs/currencies).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub currency_options: Option<
-        &'a std::collections::HashMap<
+        std::collections::HashMap<
             stripe_types::Currency,
             CreateProductDefaultPriceDataCurrencyOptions,
         >,
@@ -408,12 +408,12 @@ pub struct CreateProductDefaultPriceData<'a> {
     /// Same as `unit_amount`, but accepts a decimal value in cents (or local equivalent) with at most 12 decimal places.
     /// Only one of `unit_amount` and `unit_amount_decimal` can be set.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub unit_amount_decimal: Option<&'a str>,
+    pub unit_amount_decimal: Option<String>,
 }
-impl<'a> CreateProductDefaultPriceData<'a> {
-    pub fn new(currency: stripe_types::Currency) -> Self {
+impl CreateProductDefaultPriceData {
+    pub fn new(currency: impl Into<stripe_types::Currency>) -> Self {
         Self {
-            currency,
+            currency: currency.into(),
             currency_options: None,
             recurring: None,
             tax_behavior: None,
@@ -481,8 +481,8 @@ pub struct CreateProductDefaultPriceDataCurrencyOptionsCustomUnitAmount {
     pub preset: Option<i64>,
 }
 impl CreateProductDefaultPriceDataCurrencyOptionsCustomUnitAmount {
-    pub fn new(enabled: bool) -> Self {
-        Self { enabled, maximum: None, minimum: None, preset: None }
+    pub fn new(enabled: impl Into<bool>) -> Self {
+        Self { enabled: enabled.into(), maximum: None, minimum: None, preset: None }
     }
 }
 /// Only required if a [default tax behavior](https://stripe.com/docs/tax/products-prices-tax-categories-tax-behavior#setting-a-default-tax-behavior-(recommended)) was not provided in the Stripe Tax settings.
@@ -574,13 +574,13 @@ pub struct CreateProductDefaultPriceDataCurrencyOptionsTiers {
     pub up_to: CreateProductDefaultPriceDataCurrencyOptionsTiersUpTo,
 }
 impl CreateProductDefaultPriceDataCurrencyOptionsTiers {
-    pub fn new(up_to: CreateProductDefaultPriceDataCurrencyOptionsTiersUpTo) -> Self {
+    pub fn new(up_to: impl Into<CreateProductDefaultPriceDataCurrencyOptionsTiersUpTo>) -> Self {
         Self {
             flat_amount: None,
             flat_amount_decimal: None,
             unit_amount: None,
             unit_amount_decimal: None,
-            up_to,
+            up_to: up_to.into(),
         }
     }
 }
@@ -606,8 +606,8 @@ pub struct CreateProductDefaultPriceDataRecurring {
     pub interval_count: Option<u64>,
 }
 impl CreateProductDefaultPriceDataRecurring {
-    pub fn new(interval: CreateProductDefaultPriceDataRecurringInterval) -> Self {
-        Self { interval, interval_count: None }
+    pub fn new(interval: impl Into<CreateProductDefaultPriceDataRecurringInterval>) -> Self {
+        Self { interval: interval.into(), interval_count: None }
     }
 }
 /// Specifies billing frequency. Either `day`, `week`, `month` or `year`.
@@ -738,72 +738,78 @@ impl<'de> serde::Deserialize<'de> for CreateProductDefaultPriceDataTaxBehavior {
 }
 /// Creates a new product object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateProduct<'a> {
-    inner: CreateProductBuilder<'a>,
+pub struct CreateProduct {
+    inner: CreateProductBuilder,
 }
-impl<'a> CreateProduct<'a> {
+impl CreateProduct {
     /// Construct a new `CreateProduct`.
-    pub fn new(name: &'a str) -> Self {
-        Self { inner: CreateProductBuilder::new(name) }
+    pub fn new(name: impl Into<String>) -> Self {
+        Self { inner: CreateProductBuilder::new(name.into()) }
     }
     /// Whether the product is currently available for purchase. Defaults to `true`.
-    pub fn active(mut self, active: bool) -> Self {
-        self.inner.active = Some(active);
+    pub fn active(mut self, active: impl Into<bool>) -> Self {
+        self.inner.active = Some(active.into());
         self
     }
     /// Data used to generate a new [Price](https://stripe.com/docs/api/prices) object.
     /// This Price will be set as the default price for this product.
     pub fn default_price_data(
         mut self,
-        default_price_data: CreateProductDefaultPriceData<'a>,
+        default_price_data: impl Into<CreateProductDefaultPriceData>,
     ) -> Self {
-        self.inner.default_price_data = Some(default_price_data);
+        self.inner.default_price_data = Some(default_price_data.into());
         self
     }
     /// The product's description, meant to be displayable to the customer.
     /// Use this field to optionally store a long form explanation of the product being sold for your own rendering purposes.
-    pub fn description(mut self, description: &'a str) -> Self {
-        self.inner.description = Some(description);
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.inner.description = Some(description.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// An identifier will be randomly generated by Stripe.
     /// You can optionally override this ID, but the ID must be unique across all products in your Stripe account.
-    pub fn id(mut self, id: &'a str) -> Self {
-        self.inner.id = Some(id);
+    pub fn id(mut self, id: impl Into<String>) -> Self {
+        self.inner.id = Some(id.into());
         self
     }
     /// A list of up to 8 URLs of images for this product, meant to be displayable to the customer.
-    pub fn images(mut self, images: &'a [&'a str]) -> Self {
-        self.inner.images = Some(images);
+    pub fn images(mut self, images: impl Into<Vec<String>>) -> Self {
+        self.inner.images = Some(images.into());
         self
     }
     /// A list of up to 15 marketing features for this product.
     /// These are displayed in [pricing tables](https://stripe.com/docs/payments/checkout/pricing-table).
-    pub fn marketing_features(mut self, marketing_features: &'a [Features<'a>]) -> Self {
-        self.inner.marketing_features = Some(marketing_features);
+    pub fn marketing_features(mut self, marketing_features: impl Into<Vec<Features>>) -> Self {
+        self.inner.marketing_features = Some(marketing_features.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// The dimensions of this product for shipping purposes.
-    pub fn package_dimensions(mut self, package_dimensions: PackageDimensionsSpecs) -> Self {
-        self.inner.package_dimensions = Some(package_dimensions);
+    pub fn package_dimensions(
+        mut self,
+        package_dimensions: impl Into<PackageDimensionsSpecs>,
+    ) -> Self {
+        self.inner.package_dimensions = Some(package_dimensions.into());
         self
     }
     /// Whether this product is shipped (i.e., physical goods).
-    pub fn shippable(mut self, shippable: bool) -> Self {
-        self.inner.shippable = Some(shippable);
+    pub fn shippable(mut self, shippable: impl Into<bool>) -> Self {
+        self.inner.shippable = Some(shippable.into());
         self
     }
     /// An arbitrary string to be displayed on your customer's credit card or bank statement.
@@ -813,36 +819,36 @@ impl<'a> CreateProduct<'a> {
     /// The statement description may not include `<`, `>`, `\`, `"`, `'` characters, and will appear on your customer's statement in capital letters.
     /// Non-ASCII characters are automatically stripped.
     ///  It must contain at least one letter.
-    pub fn statement_descriptor(mut self, statement_descriptor: &'a str) -> Self {
-        self.inner.statement_descriptor = Some(statement_descriptor);
+    pub fn statement_descriptor(mut self, statement_descriptor: impl Into<String>) -> Self {
+        self.inner.statement_descriptor = Some(statement_descriptor.into());
         self
     }
     /// A [tax code](https://stripe.com/docs/tax/tax-categories) ID.
-    pub fn tax_code(mut self, tax_code: &'a str) -> Self {
-        self.inner.tax_code = Some(tax_code);
+    pub fn tax_code(mut self, tax_code: impl Into<String>) -> Self {
+        self.inner.tax_code = Some(tax_code.into());
         self
     }
     /// The type of the product.
     /// Defaults to `service` if not explicitly specified, enabling use of this product with Subscriptions and Plans.
     /// Set this parameter to `good` to use this product with Orders and SKUs.
     /// On API versions before `2018-02-05`, this field defaults to `good` for compatibility reasons.
-    pub fn type_(mut self, type_: stripe_shared::ProductType) -> Self {
-        self.inner.type_ = Some(type_);
+    pub fn type_(mut self, type_: impl Into<stripe_shared::ProductType>) -> Self {
+        self.inner.type_ = Some(type_.into());
         self
     }
     /// A label that represents units of this product.
     /// When set, this will be included in customers' receipts, invoices, Checkout, and the customer portal.
-    pub fn unit_label(mut self, unit_label: &'a str) -> Self {
-        self.inner.unit_label = Some(unit_label);
+    pub fn unit_label(mut self, unit_label: impl Into<String>) -> Self {
+        self.inner.unit_label = Some(unit_label.into());
         self
     }
     /// A URL of a publicly-accessible webpage for this product.
-    pub fn url(mut self, url: &'a str) -> Self {
-        self.inner.url = Some(url);
+    pub fn url(mut self, url: impl Into<String>) -> Self {
+        self.inner.url = Some(url.into());
         self
     }
 }
-impl CreateProduct<'_> {
+impl CreateProduct {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -860,45 +866,45 @@ impl CreateProduct<'_> {
     }
 }
 
-impl StripeRequest for CreateProduct<'_> {
+impl StripeRequest for CreateProduct {
     type Output = stripe_shared::Product;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Post, "/products").form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdateProductBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdateProductBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     active: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    default_price: Option<&'a str>,
+    default_price: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<&'a str>,
+    description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    images: Option<&'a [&'a str]>,
+    images: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    marketing_features: Option<&'a [Features<'a>]>,
+    marketing_features: Option<Vec<Features>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    name: Option<&'a str>,
+    name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     package_dimensions: Option<PackageDimensionsSpecs>,
     #[serde(skip_serializing_if = "Option::is_none")]
     shippable: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    statement_descriptor: Option<&'a str>,
+    statement_descriptor: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    tax_code: Option<&'a str>,
+    tax_code: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    unit_label: Option<&'a str>,
+    unit_label: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    url: Option<&'a str>,
+    url: Option<String>,
 }
-impl<'a> UpdateProductBuilder<'a> {
+impl UpdateProductBuilder {
     fn new() -> Self {
         Self {
             active: None,
@@ -921,68 +927,74 @@ impl<'a> UpdateProductBuilder<'a> {
 /// Updates the specific product by setting the values of the parameters passed.
 /// Any parameters not provided will be left unchanged.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateProduct<'a> {
-    inner: UpdateProductBuilder<'a>,
-    id: &'a stripe_shared::ProductId,
+pub struct UpdateProduct {
+    inner: UpdateProductBuilder,
+    id: stripe_shared::ProductId,
 }
-impl<'a> UpdateProduct<'a> {
+impl UpdateProduct {
     /// Construct a new `UpdateProduct`.
-    pub fn new(id: &'a stripe_shared::ProductId) -> Self {
-        Self { id, inner: UpdateProductBuilder::new() }
+    pub fn new(id: impl Into<stripe_shared::ProductId>) -> Self {
+        Self { id: id.into(), inner: UpdateProductBuilder::new() }
     }
     /// Whether the product is available for purchase.
-    pub fn active(mut self, active: bool) -> Self {
-        self.inner.active = Some(active);
+    pub fn active(mut self, active: impl Into<bool>) -> Self {
+        self.inner.active = Some(active.into());
         self
     }
     /// The ID of the [Price](https://stripe.com/docs/api/prices) object that is the default price for this product.
-    pub fn default_price(mut self, default_price: &'a str) -> Self {
-        self.inner.default_price = Some(default_price);
+    pub fn default_price(mut self, default_price: impl Into<String>) -> Self {
+        self.inner.default_price = Some(default_price.into());
         self
     }
     /// The product's description, meant to be displayable to the customer.
     /// Use this field to optionally store a long form explanation of the product being sold for your own rendering purposes.
-    pub fn description(mut self, description: &'a str) -> Self {
-        self.inner.description = Some(description);
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.inner.description = Some(description.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A list of up to 8 URLs of images for this product, meant to be displayable to the customer.
-    pub fn images(mut self, images: &'a [&'a str]) -> Self {
-        self.inner.images = Some(images);
+    pub fn images(mut self, images: impl Into<Vec<String>>) -> Self {
+        self.inner.images = Some(images.into());
         self
     }
     /// A list of up to 15 marketing features for this product.
     /// These are displayed in [pricing tables](https://stripe.com/docs/payments/checkout/pricing-table).
-    pub fn marketing_features(mut self, marketing_features: &'a [Features<'a>]) -> Self {
-        self.inner.marketing_features = Some(marketing_features);
+    pub fn marketing_features(mut self, marketing_features: impl Into<Vec<Features>>) -> Self {
+        self.inner.marketing_features = Some(marketing_features.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// The product's name, meant to be displayable to the customer.
-    pub fn name(mut self, name: &'a str) -> Self {
-        self.inner.name = Some(name);
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.inner.name = Some(name.into());
         self
     }
     /// The dimensions of this product for shipping purposes.
-    pub fn package_dimensions(mut self, package_dimensions: PackageDimensionsSpecs) -> Self {
-        self.inner.package_dimensions = Some(package_dimensions);
+    pub fn package_dimensions(
+        mut self,
+        package_dimensions: impl Into<PackageDimensionsSpecs>,
+    ) -> Self {
+        self.inner.package_dimensions = Some(package_dimensions.into());
         self
     }
     /// Whether this product is shipped (i.e., physical goods).
-    pub fn shippable(mut self, shippable: bool) -> Self {
-        self.inner.shippable = Some(shippable);
+    pub fn shippable(mut self, shippable: impl Into<bool>) -> Self {
+        self.inner.shippable = Some(shippable.into());
         self
     }
     /// An arbitrary string to be displayed on your customer's credit card or bank statement.
@@ -992,29 +1004,29 @@ impl<'a> UpdateProduct<'a> {
     /// The statement description may not include `<`, `>`, `\`, `"`, `'` characters, and will appear on your customer's statement in capital letters.
     /// Non-ASCII characters are automatically stripped.
     ///  It must contain at least one letter. May only be set if `type=service`.
-    pub fn statement_descriptor(mut self, statement_descriptor: &'a str) -> Self {
-        self.inner.statement_descriptor = Some(statement_descriptor);
+    pub fn statement_descriptor(mut self, statement_descriptor: impl Into<String>) -> Self {
+        self.inner.statement_descriptor = Some(statement_descriptor.into());
         self
     }
     /// A [tax code](https://stripe.com/docs/tax/tax-categories) ID.
-    pub fn tax_code(mut self, tax_code: &'a str) -> Self {
-        self.inner.tax_code = Some(tax_code);
+    pub fn tax_code(mut self, tax_code: impl Into<String>) -> Self {
+        self.inner.tax_code = Some(tax_code.into());
         self
     }
     /// A label that represents units of this product.
     /// When set, this will be included in customers' receipts, invoices, Checkout, and the customer portal.
     /// May only be set if `type=service`.
-    pub fn unit_label(mut self, unit_label: &'a str) -> Self {
-        self.inner.unit_label = Some(unit_label);
+    pub fn unit_label(mut self, unit_label: impl Into<String>) -> Self {
+        self.inner.unit_label = Some(unit_label.into());
         self
     }
     /// A URL of a publicly-accessible webpage for this product.
-    pub fn url(mut self, url: &'a str) -> Self {
-        self.inner.url = Some(url);
+    pub fn url(mut self, url: impl Into<String>) -> Self {
+        self.inner.url = Some(url.into());
         self
     }
 }
-impl UpdateProduct<'_> {
+impl UpdateProduct {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -1032,23 +1044,23 @@ impl UpdateProduct<'_> {
     }
 }
 
-impl StripeRequest for UpdateProduct<'_> {
+impl StripeRequest for UpdateProduct {
     type Output = stripe_shared::Product;
 
     fn build(&self) -> RequestBuilder {
-        let id = self.id;
+        let id = &self.id;
         RequestBuilder::new(StripeMethod::Post, format!("/products/{id}")).form(&self.inner)
     }
 }
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct Features<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct Features {
     /// The marketing feature name. Up to 80 characters long.
-    pub name: &'a str,
+    pub name: String,
 }
-impl<'a> Features<'a> {
-    pub fn new(name: &'a str) -> Self {
-        Self { name }
+impl Features {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self { name: name.into() }
     }
 }
 #[derive(Copy, Clone, Debug, serde::Serialize)]
@@ -1063,7 +1075,17 @@ pub struct PackageDimensionsSpecs {
     pub width: f64,
 }
 impl PackageDimensionsSpecs {
-    pub fn new(height: f64, length: f64, weight: f64, width: f64) -> Self {
-        Self { height, length, weight, width }
+    pub fn new(
+        height: impl Into<f64>,
+        length: impl Into<f64>,
+        weight: impl Into<f64>,
+        width: impl Into<f64>,
+    ) -> Self {
+        Self {
+            height: height.into(),
+            length: length.into(),
+            weight: weight.into(),
+            width: width.into(),
+        }
     }
 }

--- a/generated/async-stripe-product/src/product_feature/requests.rs
+++ b/generated/async-stripe-product/src/product_feature/requests.rs
@@ -4,17 +4,17 @@ use stripe_client_core::{
 
 /// Deletes the feature attachment to a product
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct DeleteProductFeature<'a> {
-    id: &'a str,
-    product: &'a stripe_shared::ProductId,
+pub struct DeleteProductFeature {
+    id: String,
+    product: stripe_shared::ProductId,
 }
-impl<'a> DeleteProductFeature<'a> {
+impl DeleteProductFeature {
     /// Construct a new `DeleteProductFeature`.
-    pub fn new(id: &'a str, product: &'a stripe_shared::ProductId) -> Self {
-        Self { id, product }
+    pub fn new(id: impl Into<String>, product: impl Into<stripe_shared::ProductId>) -> Self {
+        Self { id: id.into(), product: product.into() }
     }
 }
-impl DeleteProductFeature<'_> {
+impl DeleteProductFeature {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -32,69 +32,69 @@ impl DeleteProductFeature<'_> {
     }
 }
 
-impl StripeRequest for DeleteProductFeature<'_> {
+impl StripeRequest for DeleteProductFeature {
     type Output = stripe_product::DeletedProductFeature;
 
     fn build(&self) -> RequestBuilder {
-        let id = self.id;
-        let product = self.product;
+        let id = &self.id;
+        let product = &self.product;
         RequestBuilder::new(StripeMethod::Delete, format!("/products/{product}/features/{id}"))
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListProductProductFeatureBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListProductProductFeatureBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListProductProductFeatureBuilder<'a> {
+impl ListProductProductFeatureBuilder {
     fn new() -> Self {
         Self { ending_before: None, expand: None, limit: None, starting_after: None }
     }
 }
 /// Retrieve a list of features for a product
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListProductProductFeature<'a> {
-    inner: ListProductProductFeatureBuilder<'a>,
-    product: &'a stripe_shared::ProductId,
+pub struct ListProductProductFeature {
+    inner: ListProductProductFeatureBuilder,
+    product: stripe_shared::ProductId,
 }
-impl<'a> ListProductProductFeature<'a> {
+impl ListProductProductFeature {
     /// Construct a new `ListProductProductFeature`.
-    pub fn new(product: &'a stripe_shared::ProductId) -> Self {
-        Self { product, inner: ListProductProductFeatureBuilder::new() }
+    pub fn new(product: impl Into<stripe_shared::ProductId>) -> Self {
+        Self { product: product.into(), inner: ListProductProductFeatureBuilder::new() }
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl ListProductProductFeature<'_> {
+impl ListProductProductFeature {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -114,53 +114,53 @@ impl ListProductProductFeature<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_product::ProductFeature>> {
-        let product = self.product;
+        let product = &self.product;
 
         stripe_client_core::ListPaginator::new_list(
             format!("/products/{product}/features"),
-            self.inner,
+            &self.inner,
         )
     }
 }
 
-impl StripeRequest for ListProductProductFeature<'_> {
+impl StripeRequest for ListProductProductFeature {
     type Output = stripe_types::List<stripe_product::ProductFeature>;
 
     fn build(&self) -> RequestBuilder {
-        let product = self.product;
+        let product = &self.product;
         RequestBuilder::new(StripeMethod::Get, format!("/products/{product}/features"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveProductFeatureBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveProductFeatureBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveProductFeatureBuilder<'a> {
+impl RetrieveProductFeatureBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves a product_feature, which represents a feature attachment to a product
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveProductFeature<'a> {
-    inner: RetrieveProductFeatureBuilder<'a>,
-    id: &'a str,
-    product: &'a stripe_shared::ProductId,
+pub struct RetrieveProductFeature {
+    inner: RetrieveProductFeatureBuilder,
+    id: String,
+    product: stripe_shared::ProductId,
 }
-impl<'a> RetrieveProductFeature<'a> {
+impl RetrieveProductFeature {
     /// Construct a new `RetrieveProductFeature`.
-    pub fn new(id: &'a str, product: &'a stripe_shared::ProductId) -> Self {
-        Self { id, product, inner: RetrieveProductFeatureBuilder::new() }
+    pub fn new(id: impl Into<String>, product: impl Into<stripe_shared::ProductId>) -> Self {
+        Self { id: id.into(), product: product.into(), inner: RetrieveProductFeatureBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveProductFeature<'_> {
+impl RetrieveProductFeature {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -178,45 +178,51 @@ impl RetrieveProductFeature<'_> {
     }
 }
 
-impl StripeRequest for RetrieveProductFeature<'_> {
+impl StripeRequest for RetrieveProductFeature {
     type Output = stripe_product::ProductFeature;
 
     fn build(&self) -> RequestBuilder {
-        let id = self.id;
-        let product = self.product;
+        let id = &self.id;
+        let product = &self.product;
         RequestBuilder::new(StripeMethod::Get, format!("/products/{product}/features/{id}"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateProductProductFeatureBuilder<'a> {
-    entitlement_feature: &'a str,
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateProductProductFeatureBuilder {
+    entitlement_feature: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> CreateProductProductFeatureBuilder<'a> {
-    fn new(entitlement_feature: &'a str) -> Self {
-        Self { entitlement_feature, expand: None }
+impl CreateProductProductFeatureBuilder {
+    fn new(entitlement_feature: impl Into<String>) -> Self {
+        Self { entitlement_feature: entitlement_feature.into(), expand: None }
     }
 }
 /// Creates a product_feature, which represents a feature attachment to a product
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateProductProductFeature<'a> {
-    inner: CreateProductProductFeatureBuilder<'a>,
-    product: &'a stripe_shared::ProductId,
+pub struct CreateProductProductFeature {
+    inner: CreateProductProductFeatureBuilder,
+    product: stripe_shared::ProductId,
 }
-impl<'a> CreateProductProductFeature<'a> {
+impl CreateProductProductFeature {
     /// Construct a new `CreateProductProductFeature`.
-    pub fn new(product: &'a stripe_shared::ProductId, entitlement_feature: &'a str) -> Self {
-        Self { product, inner: CreateProductProductFeatureBuilder::new(entitlement_feature) }
+    pub fn new(
+        product: impl Into<stripe_shared::ProductId>,
+        entitlement_feature: impl Into<String>,
+    ) -> Self {
+        Self {
+            product: product.into(),
+            inner: CreateProductProductFeatureBuilder::new(entitlement_feature.into()),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl CreateProductProductFeature<'_> {
+impl CreateProductProductFeature {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -234,11 +240,11 @@ impl CreateProductProductFeature<'_> {
     }
 }
 
-impl StripeRequest for CreateProductProductFeature<'_> {
+impl StripeRequest for CreateProductProductFeature {
     type Output = stripe_product::ProductFeature;
 
     fn build(&self) -> RequestBuilder {
-        let product = self.product;
+        let product = &self.product;
         RequestBuilder::new(StripeMethod::Post, format!("/products/{product}/features"))
             .form(&self.inner)
     }

--- a/generated/async-stripe-product/src/promotion_code/requests.rs
+++ b/generated/async-stripe-product/src/promotion_code/requests.rs
@@ -2,28 +2,28 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListPromotionCodeBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListPromotionCodeBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     active: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    code: Option<&'a str>,
+    code: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    coupon: Option<&'a str>,
+    coupon: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     created: Option<stripe_types::RangeQueryTs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    customer: Option<&'a str>,
+    customer: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListPromotionCodeBuilder<'a> {
+impl ListPromotionCodeBuilder {
     fn new() -> Self {
         Self {
             active: None,
@@ -40,72 +40,72 @@ impl<'a> ListPromotionCodeBuilder<'a> {
 }
 /// Returns a list of your promotion codes.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListPromotionCode<'a> {
-    inner: ListPromotionCodeBuilder<'a>,
+pub struct ListPromotionCode {
+    inner: ListPromotionCodeBuilder,
 }
-impl<'a> ListPromotionCode<'a> {
+impl ListPromotionCode {
     /// Construct a new `ListPromotionCode`.
     pub fn new() -> Self {
         Self { inner: ListPromotionCodeBuilder::new() }
     }
     /// Filter promotion codes by whether they are active.
-    pub fn active(mut self, active: bool) -> Self {
-        self.inner.active = Some(active);
+    pub fn active(mut self, active: impl Into<bool>) -> Self {
+        self.inner.active = Some(active.into());
         self
     }
     /// Only return promotion codes that have this case-insensitive code.
-    pub fn code(mut self, code: &'a str) -> Self {
-        self.inner.code = Some(code);
+    pub fn code(mut self, code: impl Into<String>) -> Self {
+        self.inner.code = Some(code.into());
         self
     }
     /// Only return promotion codes for this coupon.
-    pub fn coupon(mut self, coupon: &'a str) -> Self {
-        self.inner.coupon = Some(coupon);
+    pub fn coupon(mut self, coupon: impl Into<String>) -> Self {
+        self.inner.coupon = Some(coupon.into());
         self
     }
     /// A filter on the list, based on the object `created` field.
     /// The value can be a string with an integer Unix timestamp, or it can be a dictionary with a number of different query options.
-    pub fn created(mut self, created: stripe_types::RangeQueryTs) -> Self {
-        self.inner.created = Some(created);
+    pub fn created(mut self, created: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.created = Some(created.into());
         self
     }
     /// Only return promotion codes that are restricted to this customer.
-    pub fn customer(mut self, customer: &'a str) -> Self {
-        self.inner.customer = Some(customer);
+    pub fn customer(mut self, customer: impl Into<String>) -> Self {
+        self.inner.customer = Some(customer.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl<'a> Default for ListPromotionCode<'a> {
+impl Default for ListPromotionCode {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListPromotionCode<'_> {
+impl ListPromotionCode {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -125,23 +125,23 @@ impl ListPromotionCode<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::PromotionCode>> {
-        stripe_client_core::ListPaginator::new_list("/promotion_codes", self.inner)
+        stripe_client_core::ListPaginator::new_list("/promotion_codes", &self.inner)
     }
 }
 
-impl StripeRequest for ListPromotionCode<'_> {
+impl StripeRequest for ListPromotionCode {
     type Output = stripe_types::List<stripe_shared::PromotionCode>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/promotion_codes").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrievePromotionCodeBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrievePromotionCodeBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrievePromotionCodeBuilder<'a> {
+impl RetrievePromotionCodeBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
@@ -149,22 +149,22 @@ impl<'a> RetrievePromotionCodeBuilder<'a> {
 /// Retrieves the promotion code with the given ID.
 /// In order to retrieve a promotion code by the customer-facing `code` use [list](https://stripe.com/docs/api/promotion_codes/list) with the desired `code`.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrievePromotionCode<'a> {
-    inner: RetrievePromotionCodeBuilder<'a>,
-    promotion_code: &'a stripe_shared::PromotionCodeId,
+pub struct RetrievePromotionCode {
+    inner: RetrievePromotionCodeBuilder,
+    promotion_code: stripe_shared::PromotionCodeId,
 }
-impl<'a> RetrievePromotionCode<'a> {
+impl RetrievePromotionCode {
     /// Construct a new `RetrievePromotionCode`.
-    pub fn new(promotion_code: &'a stripe_shared::PromotionCodeId) -> Self {
-        Self { promotion_code, inner: RetrievePromotionCodeBuilder::new() }
+    pub fn new(promotion_code: impl Into<stripe_shared::PromotionCodeId>) -> Self {
+        Self { promotion_code: promotion_code.into(), inner: RetrievePromotionCodeBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrievePromotionCode<'_> {
+impl RetrievePromotionCode {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -182,41 +182,41 @@ impl RetrievePromotionCode<'_> {
     }
 }
 
-impl StripeRequest for RetrievePromotionCode<'_> {
+impl StripeRequest for RetrievePromotionCode {
     type Output = stripe_shared::PromotionCode;
 
     fn build(&self) -> RequestBuilder {
-        let promotion_code = self.promotion_code;
+        let promotion_code = &self.promotion_code;
         RequestBuilder::new(StripeMethod::Get, format!("/promotion_codes/{promotion_code}"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreatePromotionCodeBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreatePromotionCodeBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     active: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    code: Option<&'a str>,
-    coupon: &'a str,
+    code: Option<String>,
+    coupon: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    customer: Option<&'a str>,
+    customer: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     expires_at: Option<stripe_types::Timestamp>,
     #[serde(skip_serializing_if = "Option::is_none")]
     max_redemptions: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    restrictions: Option<CreatePromotionCodeRestrictions<'a>>,
+    restrictions: Option<CreatePromotionCodeRestrictions>,
 }
-impl<'a> CreatePromotionCodeBuilder<'a> {
-    fn new(coupon: &'a str) -> Self {
+impl CreatePromotionCodeBuilder {
+    fn new(coupon: impl Into<String>) -> Self {
         Self {
             active: None,
             code: None,
-            coupon,
+            coupon: coupon.into(),
             customer: None,
             expand: None,
             expires_at: None,
@@ -227,13 +227,12 @@ impl<'a> CreatePromotionCodeBuilder<'a> {
     }
 }
 /// Settings that restrict the redemption of the promotion code.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreatePromotionCodeRestrictions<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreatePromotionCodeRestrictions {
     /// Promotion codes defined in each available currency option.
     /// Each key must be a three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html) and a [supported currency](https://stripe.com/docs/currencies).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub currency_options:
-        Option<&'a std::collections::HashMap<stripe_types::Currency, CurrencyOption>>,
+    pub currency_options: Option<std::collections::HashMap<stripe_types::Currency, CurrencyOption>>,
     /// A Boolean indicating if the Promotion Code should only be redeemed for Customers without any successful payments or invoices.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub first_time_transaction: Option<bool>,
@@ -244,7 +243,7 @@ pub struct CreatePromotionCodeRestrictions<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub minimum_amount_currency: Option<stripe_types::Currency>,
 }
-impl<'a> CreatePromotionCodeRestrictions<'a> {
+impl CreatePromotionCodeRestrictions {
     pub fn new() -> Self {
         Self {
             currency_options: None,
@@ -254,7 +253,7 @@ impl<'a> CreatePromotionCodeRestrictions<'a> {
         }
     }
 }
-impl<'a> Default for CreatePromotionCodeRestrictions<'a> {
+impl Default for CreatePromotionCodeRestrictions {
     fn default() -> Self {
         Self::new()
     }
@@ -262,64 +261,70 @@ impl<'a> Default for CreatePromotionCodeRestrictions<'a> {
 /// A promotion code points to a coupon.
 /// You can optionally restrict the code to a specific customer, redemption limit, and expiration date.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreatePromotionCode<'a> {
-    inner: CreatePromotionCodeBuilder<'a>,
+pub struct CreatePromotionCode {
+    inner: CreatePromotionCodeBuilder,
 }
-impl<'a> CreatePromotionCode<'a> {
+impl CreatePromotionCode {
     /// Construct a new `CreatePromotionCode`.
-    pub fn new(coupon: &'a str) -> Self {
-        Self { inner: CreatePromotionCodeBuilder::new(coupon) }
+    pub fn new(coupon: impl Into<String>) -> Self {
+        Self { inner: CreatePromotionCodeBuilder::new(coupon.into()) }
     }
     /// Whether the promotion code is currently active.
-    pub fn active(mut self, active: bool) -> Self {
-        self.inner.active = Some(active);
+    pub fn active(mut self, active: impl Into<bool>) -> Self {
+        self.inner.active = Some(active.into());
         self
     }
     /// The customer-facing code.
     /// Regardless of case, this code must be unique across all active promotion codes for a specific customer.
     /// If left blank, we will generate one automatically.
-    pub fn code(mut self, code: &'a str) -> Self {
-        self.inner.code = Some(code);
+    pub fn code(mut self, code: impl Into<String>) -> Self {
+        self.inner.code = Some(code.into());
         self
     }
     /// The customer that this promotion code can be used by.
     /// If not set, the promotion code can be used by all customers.
-    pub fn customer(mut self, customer: &'a str) -> Self {
-        self.inner.customer = Some(customer);
+    pub fn customer(mut self, customer: impl Into<String>) -> Self {
+        self.inner.customer = Some(customer.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// The timestamp at which this promotion code will expire.
     /// If the coupon has specified a `redeems_by`, then this value cannot be after the coupon's `redeems_by`.
-    pub fn expires_at(mut self, expires_at: stripe_types::Timestamp) -> Self {
-        self.inner.expires_at = Some(expires_at);
+    pub fn expires_at(mut self, expires_at: impl Into<stripe_types::Timestamp>) -> Self {
+        self.inner.expires_at = Some(expires_at.into());
         self
     }
     /// A positive integer specifying the number of times the promotion code can be redeemed.
     /// If the coupon has specified a `max_redemptions`, then this value cannot be greater than the coupon's `max_redemptions`.
-    pub fn max_redemptions(mut self, max_redemptions: i64) -> Self {
-        self.inner.max_redemptions = Some(max_redemptions);
+    pub fn max_redemptions(mut self, max_redemptions: impl Into<i64>) -> Self {
+        self.inner.max_redemptions = Some(max_redemptions.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// Settings that restrict the redemption of the promotion code.
-    pub fn restrictions(mut self, restrictions: CreatePromotionCodeRestrictions<'a>) -> Self {
-        self.inner.restrictions = Some(restrictions);
+    pub fn restrictions(
+        mut self,
+        restrictions: impl Into<CreatePromotionCodeRestrictions>,
+    ) -> Self {
+        self.inner.restrictions = Some(restrictions.into());
         self
     }
 }
-impl CreatePromotionCode<'_> {
+impl CreatePromotionCode {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -337,44 +342,43 @@ impl CreatePromotionCode<'_> {
     }
 }
 
-impl StripeRequest for CreatePromotionCode<'_> {
+impl StripeRequest for CreatePromotionCode {
     type Output = stripe_shared::PromotionCode;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Post, "/promotion_codes").form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdatePromotionCodeBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdatePromotionCodeBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     active: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    restrictions: Option<UpdatePromotionCodeRestrictions<'a>>,
+    restrictions: Option<UpdatePromotionCodeRestrictions>,
 }
-impl<'a> UpdatePromotionCodeBuilder<'a> {
+impl UpdatePromotionCodeBuilder {
     fn new() -> Self {
         Self { active: None, expand: None, metadata: None, restrictions: None }
     }
 }
 /// Settings that restrict the redemption of the promotion code.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdatePromotionCodeRestrictions<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdatePromotionCodeRestrictions {
     /// Promotion codes defined in each available currency option.
     /// Each key must be a three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html) and a [supported currency](https://stripe.com/docs/currencies).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub currency_options:
-        Option<&'a std::collections::HashMap<stripe_types::Currency, CurrencyOption>>,
+    pub currency_options: Option<std::collections::HashMap<stripe_types::Currency, CurrencyOption>>,
 }
-impl<'a> UpdatePromotionCodeRestrictions<'a> {
+impl UpdatePromotionCodeRestrictions {
     pub fn new() -> Self {
         Self { currency_options: None }
     }
 }
-impl<'a> Default for UpdatePromotionCodeRestrictions<'a> {
+impl Default for UpdatePromotionCodeRestrictions {
     fn default() -> Self {
         Self::new()
     }
@@ -382,41 +386,47 @@ impl<'a> Default for UpdatePromotionCodeRestrictions<'a> {
 /// Updates the specified promotion code by setting the values of the parameters passed.
 /// Most fields are, by design, not editable.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdatePromotionCode<'a> {
-    inner: UpdatePromotionCodeBuilder<'a>,
-    promotion_code: &'a stripe_shared::PromotionCodeId,
+pub struct UpdatePromotionCode {
+    inner: UpdatePromotionCodeBuilder,
+    promotion_code: stripe_shared::PromotionCodeId,
 }
-impl<'a> UpdatePromotionCode<'a> {
+impl UpdatePromotionCode {
     /// Construct a new `UpdatePromotionCode`.
-    pub fn new(promotion_code: &'a stripe_shared::PromotionCodeId) -> Self {
-        Self { promotion_code, inner: UpdatePromotionCodeBuilder::new() }
+    pub fn new(promotion_code: impl Into<stripe_shared::PromotionCodeId>) -> Self {
+        Self { promotion_code: promotion_code.into(), inner: UpdatePromotionCodeBuilder::new() }
     }
     /// Whether the promotion code is currently active.
     /// A promotion code can only be reactivated when the coupon is still valid and the promotion code is otherwise redeemable.
-    pub fn active(mut self, active: bool) -> Self {
-        self.inner.active = Some(active);
+    pub fn active(mut self, active: impl Into<bool>) -> Self {
+        self.inner.active = Some(active.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// Settings that restrict the redemption of the promotion code.
-    pub fn restrictions(mut self, restrictions: UpdatePromotionCodeRestrictions<'a>) -> Self {
-        self.inner.restrictions = Some(restrictions);
+    pub fn restrictions(
+        mut self,
+        restrictions: impl Into<UpdatePromotionCodeRestrictions>,
+    ) -> Self {
+        self.inner.restrictions = Some(restrictions.into());
         self
     }
 }
-impl UpdatePromotionCode<'_> {
+impl UpdatePromotionCode {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -434,11 +444,11 @@ impl UpdatePromotionCode<'_> {
     }
 }
 
-impl StripeRequest for UpdatePromotionCode<'_> {
+impl StripeRequest for UpdatePromotionCode {
     type Output = stripe_shared::PromotionCode;
 
     fn build(&self) -> RequestBuilder {
-        let promotion_code = self.promotion_code;
+        let promotion_code = &self.promotion_code;
         RequestBuilder::new(StripeMethod::Post, format!("/promotion_codes/{promotion_code}"))
             .form(&self.inner)
     }

--- a/generated/async-stripe-product/src/shipping_rate/requests.rs
+++ b/generated/async-stripe-product/src/shipping_rate/requests.rs
@@ -2,8 +2,8 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListShippingRateBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListShippingRateBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     active: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -11,15 +11,15 @@ struct ListShippingRateBuilder<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     currency: Option<stripe_types::Currency>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListShippingRateBuilder<'a> {
+impl ListShippingRateBuilder {
     fn new() -> Self {
         Self {
             active: None,
@@ -34,62 +34,62 @@ impl<'a> ListShippingRateBuilder<'a> {
 }
 /// Returns a list of your shipping rates.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListShippingRate<'a> {
-    inner: ListShippingRateBuilder<'a>,
+pub struct ListShippingRate {
+    inner: ListShippingRateBuilder,
 }
-impl<'a> ListShippingRate<'a> {
+impl ListShippingRate {
     /// Construct a new `ListShippingRate`.
     pub fn new() -> Self {
         Self { inner: ListShippingRateBuilder::new() }
     }
     /// Only return shipping rates that are active or inactive.
-    pub fn active(mut self, active: bool) -> Self {
-        self.inner.active = Some(active);
+    pub fn active(mut self, active: impl Into<bool>) -> Self {
+        self.inner.active = Some(active.into());
         self
     }
     /// A filter on the list, based on the object `created` field.
     /// The value can be a string with an integer Unix timestamp, or it can be a dictionary with a number of different query options.
-    pub fn created(mut self, created: stripe_types::RangeQueryTs) -> Self {
-        self.inner.created = Some(created);
+    pub fn created(mut self, created: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.created = Some(created.into());
         self
     }
     /// Only return shipping rates for the given currency.
-    pub fn currency(mut self, currency: stripe_types::Currency) -> Self {
-        self.inner.currency = Some(currency);
+    pub fn currency(mut self, currency: impl Into<stripe_types::Currency>) -> Self {
+        self.inner.currency = Some(currency.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl<'a> Default for ListShippingRate<'a> {
+impl Default for ListShippingRate {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListShippingRate<'_> {
+impl ListShippingRate {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -109,45 +109,48 @@ impl ListShippingRate<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::ShippingRate>> {
-        stripe_client_core::ListPaginator::new_list("/shipping_rates", self.inner)
+        stripe_client_core::ListPaginator::new_list("/shipping_rates", &self.inner)
     }
 }
 
-impl StripeRequest for ListShippingRate<'_> {
+impl StripeRequest for ListShippingRate {
     type Output = stripe_types::List<stripe_shared::ShippingRate>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/shipping_rates").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveShippingRateBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveShippingRateBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveShippingRateBuilder<'a> {
+impl RetrieveShippingRateBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Returns the shipping rate object with the given ID.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveShippingRate<'a> {
-    inner: RetrieveShippingRateBuilder<'a>,
-    shipping_rate_token: &'a stripe_shared::ShippingRateId,
+pub struct RetrieveShippingRate {
+    inner: RetrieveShippingRateBuilder,
+    shipping_rate_token: stripe_shared::ShippingRateId,
 }
-impl<'a> RetrieveShippingRate<'a> {
+impl RetrieveShippingRate {
     /// Construct a new `RetrieveShippingRate`.
-    pub fn new(shipping_rate_token: &'a stripe_shared::ShippingRateId) -> Self {
-        Self { shipping_rate_token, inner: RetrieveShippingRateBuilder::new() }
+    pub fn new(shipping_rate_token: impl Into<stripe_shared::ShippingRateId>) -> Self {
+        Self {
+            shipping_rate_token: shipping_rate_token.into(),
+            inner: RetrieveShippingRateBuilder::new(),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveShippingRate<'_> {
+impl RetrieveShippingRate {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -165,39 +168,39 @@ impl RetrieveShippingRate<'_> {
     }
 }
 
-impl StripeRequest for RetrieveShippingRate<'_> {
+impl StripeRequest for RetrieveShippingRate {
     type Output = stripe_shared::ShippingRate;
 
     fn build(&self) -> RequestBuilder {
-        let shipping_rate_token = self.shipping_rate_token;
+        let shipping_rate_token = &self.shipping_rate_token;
         RequestBuilder::new(StripeMethod::Get, format!("/shipping_rates/{shipping_rate_token}"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateShippingRateBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateShippingRateBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     delivery_estimate: Option<CreateShippingRateDeliveryEstimate>,
-    display_name: &'a str,
+    display_name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    fixed_amount: Option<CreateShippingRateFixedAmount<'a>>,
+    fixed_amount: Option<CreateShippingRateFixedAmount>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tax_behavior: Option<stripe_shared::ShippingRateTaxBehavior>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    tax_code: Option<&'a str>,
+    tax_code: Option<String>,
     #[serde(rename = "type")]
     #[serde(skip_serializing_if = "Option::is_none")]
     type_: Option<stripe_shared::ShippingRateType>,
 }
-impl<'a> CreateShippingRateBuilder<'a> {
-    fn new(display_name: &'a str) -> Self {
+impl CreateShippingRateBuilder {
+    fn new(display_name: impl Into<String>) -> Self {
         Self {
             delivery_estimate: None,
-            display_name,
+            display_name: display_name.into(),
             expand: None,
             fixed_amount: None,
             metadata: None,
@@ -237,8 +240,11 @@ pub struct CreateShippingRateDeliveryEstimateMaximum {
     pub value: i64,
 }
 impl CreateShippingRateDeliveryEstimateMaximum {
-    pub fn new(unit: CreateShippingRateDeliveryEstimateMaximumUnit, value: i64) -> Self {
-        Self { unit, value }
+    pub fn new(
+        unit: impl Into<CreateShippingRateDeliveryEstimateMaximumUnit>,
+        value: impl Into<i64>,
+    ) -> Self {
+        Self { unit: unit.into(), value: value.into() }
     }
 }
 /// A unit of time.
@@ -317,8 +323,11 @@ pub struct CreateShippingRateDeliveryEstimateMinimum {
     pub value: i64,
 }
 impl CreateShippingRateDeliveryEstimateMinimum {
-    pub fn new(unit: CreateShippingRateDeliveryEstimateMinimumUnit, value: i64) -> Self {
-        Self { unit, value }
+    pub fn new(
+        unit: impl Into<CreateShippingRateDeliveryEstimateMinimumUnit>,
+        value: impl Into<i64>,
+    ) -> Self {
+        Self { unit: unit.into(), value: value.into() }
     }
 }
 /// A unit of time.
@@ -389,8 +398,8 @@ impl<'de> serde::Deserialize<'de> for CreateShippingRateDeliveryEstimateMinimumU
     }
 }
 /// Describes a fixed amount to charge for shipping. Must be present if type is `fixed_amount`.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateShippingRateFixedAmount<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateShippingRateFixedAmount {
     /// A non-negative integer in cents representing how much to charge.
     pub amount: i64,
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
@@ -400,15 +409,15 @@ pub struct CreateShippingRateFixedAmount<'a> {
     /// Each key must be a three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html) and a [supported currency](https://stripe.com/docs/currencies).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub currency_options: Option<
-        &'a std::collections::HashMap<
+        std::collections::HashMap<
             stripe_types::Currency,
             CreateShippingRateFixedAmountCurrencyOptions,
         >,
     >,
 }
-impl<'a> CreateShippingRateFixedAmount<'a> {
-    pub fn new(amount: i64, currency: stripe_types::Currency) -> Self {
-        Self { amount, currency, currency_options: None }
+impl CreateShippingRateFixedAmount {
+    pub fn new(amount: impl Into<i64>, currency: impl Into<stripe_types::Currency>) -> Self {
+        Self { amount: amount.into(), currency: currency.into(), currency_options: None }
     }
 }
 /// Shipping rates defined in each available currency option.
@@ -423,66 +432,72 @@ pub struct CreateShippingRateFixedAmountCurrencyOptions {
     pub tax_behavior: Option<stripe_shared::ShippingRateTaxBehavior>,
 }
 impl CreateShippingRateFixedAmountCurrencyOptions {
-    pub fn new(amount: i64) -> Self {
-        Self { amount, tax_behavior: None }
+    pub fn new(amount: impl Into<i64>) -> Self {
+        Self { amount: amount.into(), tax_behavior: None }
     }
 }
 /// Creates a new shipping rate object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateShippingRate<'a> {
-    inner: CreateShippingRateBuilder<'a>,
+pub struct CreateShippingRate {
+    inner: CreateShippingRateBuilder,
 }
-impl<'a> CreateShippingRate<'a> {
+impl CreateShippingRate {
     /// Construct a new `CreateShippingRate`.
-    pub fn new(display_name: &'a str) -> Self {
-        Self { inner: CreateShippingRateBuilder::new(display_name) }
+    pub fn new(display_name: impl Into<String>) -> Self {
+        Self { inner: CreateShippingRateBuilder::new(display_name.into()) }
     }
     /// The estimated range for how long shipping will take, meant to be displayable to the customer.
     /// This will appear on CheckoutSessions.
     pub fn delivery_estimate(
         mut self,
-        delivery_estimate: CreateShippingRateDeliveryEstimate,
+        delivery_estimate: impl Into<CreateShippingRateDeliveryEstimate>,
     ) -> Self {
-        self.inner.delivery_estimate = Some(delivery_estimate);
+        self.inner.delivery_estimate = Some(delivery_estimate.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Describes a fixed amount to charge for shipping. Must be present if type is `fixed_amount`.
-    pub fn fixed_amount(mut self, fixed_amount: CreateShippingRateFixedAmount<'a>) -> Self {
-        self.inner.fixed_amount = Some(fixed_amount);
+    pub fn fixed_amount(mut self, fixed_amount: impl Into<CreateShippingRateFixedAmount>) -> Self {
+        self.inner.fixed_amount = Some(fixed_amount.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// Specifies whether the rate is considered inclusive of taxes or exclusive of taxes.
     /// One of `inclusive`, `exclusive`, or `unspecified`.
-    pub fn tax_behavior(mut self, tax_behavior: stripe_shared::ShippingRateTaxBehavior) -> Self {
-        self.inner.tax_behavior = Some(tax_behavior);
+    pub fn tax_behavior(
+        mut self,
+        tax_behavior: impl Into<stripe_shared::ShippingRateTaxBehavior>,
+    ) -> Self {
+        self.inner.tax_behavior = Some(tax_behavior.into());
         self
     }
     /// A [tax code](https://stripe.com/docs/tax/tax-categories) ID.
     /// The Shipping tax code is `txcd_92010001`.
-    pub fn tax_code(mut self, tax_code: &'a str) -> Self {
-        self.inner.tax_code = Some(tax_code);
+    pub fn tax_code(mut self, tax_code: impl Into<String>) -> Self {
+        self.inner.tax_code = Some(tax_code.into());
         self
     }
     /// The type of calculation to use on the shipping rate. Can only be `fixed_amount` for now.
-    pub fn type_(mut self, type_: stripe_shared::ShippingRateType) -> Self {
-        self.inner.type_ = Some(type_);
+    pub fn type_(mut self, type_: impl Into<stripe_shared::ShippingRateType>) -> Self {
+        self.inner.type_ = Some(type_.into());
         self
     }
 }
-impl CreateShippingRate<'_> {
+impl CreateShippingRate {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -500,50 +515,50 @@ impl CreateShippingRate<'_> {
     }
 }
 
-impl StripeRequest for CreateShippingRate<'_> {
+impl StripeRequest for CreateShippingRate {
     type Output = stripe_shared::ShippingRate;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Post, "/shipping_rates").form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdateShippingRateBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdateShippingRateBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     active: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    fixed_amount: Option<UpdateShippingRateFixedAmount<'a>>,
+    fixed_amount: Option<UpdateShippingRateFixedAmount>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tax_behavior: Option<stripe_shared::ShippingRateTaxBehavior>,
 }
-impl<'a> UpdateShippingRateBuilder<'a> {
+impl UpdateShippingRateBuilder {
     fn new() -> Self {
         Self { active: None, expand: None, fixed_amount: None, metadata: None, tax_behavior: None }
     }
 }
 /// Describes a fixed amount to charge for shipping. Must be present if type is `fixed_amount`.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateShippingRateFixedAmount<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateShippingRateFixedAmount {
     /// Shipping rates defined in each available currency option.
     /// Each key must be a three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html) and a [supported currency](https://stripe.com/docs/currencies).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub currency_options: Option<
-        &'a std::collections::HashMap<
+        std::collections::HashMap<
             stripe_types::Currency,
             UpdateShippingRateFixedAmountCurrencyOptions,
         >,
     >,
 }
-impl<'a> UpdateShippingRateFixedAmount<'a> {
+impl UpdateShippingRateFixedAmount {
     pub fn new() -> Self {
         Self { currency_options: None }
     }
 }
-impl<'a> Default for UpdateShippingRateFixedAmount<'a> {
+impl Default for UpdateShippingRateFixedAmount {
     fn default() -> Self {
         Self::new()
     }
@@ -572,46 +587,55 @@ impl Default for UpdateShippingRateFixedAmountCurrencyOptions {
 }
 /// Updates an existing shipping rate object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateShippingRate<'a> {
-    inner: UpdateShippingRateBuilder<'a>,
-    shipping_rate_token: &'a stripe_shared::ShippingRateId,
+pub struct UpdateShippingRate {
+    inner: UpdateShippingRateBuilder,
+    shipping_rate_token: stripe_shared::ShippingRateId,
 }
-impl<'a> UpdateShippingRate<'a> {
+impl UpdateShippingRate {
     /// Construct a new `UpdateShippingRate`.
-    pub fn new(shipping_rate_token: &'a stripe_shared::ShippingRateId) -> Self {
-        Self { shipping_rate_token, inner: UpdateShippingRateBuilder::new() }
+    pub fn new(shipping_rate_token: impl Into<stripe_shared::ShippingRateId>) -> Self {
+        Self {
+            shipping_rate_token: shipping_rate_token.into(),
+            inner: UpdateShippingRateBuilder::new(),
+        }
     }
     /// Whether the shipping rate can be used for new purchases. Defaults to `true`.
-    pub fn active(mut self, active: bool) -> Self {
-        self.inner.active = Some(active);
+    pub fn active(mut self, active: impl Into<bool>) -> Self {
+        self.inner.active = Some(active.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Describes a fixed amount to charge for shipping. Must be present if type is `fixed_amount`.
-    pub fn fixed_amount(mut self, fixed_amount: UpdateShippingRateFixedAmount<'a>) -> Self {
-        self.inner.fixed_amount = Some(fixed_amount);
+    pub fn fixed_amount(mut self, fixed_amount: impl Into<UpdateShippingRateFixedAmount>) -> Self {
+        self.inner.fixed_amount = Some(fixed_amount.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// Specifies whether the rate is considered inclusive of taxes or exclusive of taxes.
     /// One of `inclusive`, `exclusive`, or `unspecified`.
-    pub fn tax_behavior(mut self, tax_behavior: stripe_shared::ShippingRateTaxBehavior) -> Self {
-        self.inner.tax_behavior = Some(tax_behavior);
+    pub fn tax_behavior(
+        mut self,
+        tax_behavior: impl Into<stripe_shared::ShippingRateTaxBehavior>,
+    ) -> Self {
+        self.inner.tax_behavior = Some(tax_behavior.into());
         self
     }
 }
-impl UpdateShippingRate<'_> {
+impl UpdateShippingRate {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -629,11 +653,11 @@ impl UpdateShippingRate<'_> {
     }
 }
 
-impl StripeRequest for UpdateShippingRate<'_> {
+impl StripeRequest for UpdateShippingRate {
     type Output = stripe_shared::ShippingRate;
 
     fn build(&self) -> RequestBuilder {
-        let shipping_rate_token = self.shipping_rate_token;
+        let shipping_rate_token = &self.shipping_rate_token;
         RequestBuilder::new(StripeMethod::Post, format!("/shipping_rates/{shipping_rate_token}"))
             .form(&self.inner)
     }

--- a/generated/async-stripe-product/src/tax_code/requests.rs
+++ b/generated/async-stripe-product/src/tax_code/requests.rs
@@ -2,28 +2,28 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListTaxCodeBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListTaxCodeBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListTaxCodeBuilder<'a> {
+impl ListTaxCodeBuilder {
     fn new() -> Self {
         Self { ending_before: None, expand: None, limit: None, starting_after: None }
     }
 }
 /// A list of [all tax codes available](https://stripe.com/docs/tax/tax-categories) to add to Products in order to allow specific tax calculations.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListTaxCode<'a> {
-    inner: ListTaxCodeBuilder<'a>,
+pub struct ListTaxCode {
+    inner: ListTaxCodeBuilder,
 }
-impl<'a> ListTaxCode<'a> {
+impl ListTaxCode {
     /// Construct a new `ListTaxCode`.
     pub fn new() -> Self {
         Self { inner: ListTaxCodeBuilder::new() }
@@ -31,35 +31,35 @@ impl<'a> ListTaxCode<'a> {
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl<'a> Default for ListTaxCode<'a> {
+impl Default for ListTaxCode {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListTaxCode<'_> {
+impl ListTaxCode {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -79,23 +79,23 @@ impl ListTaxCode<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::TaxCode>> {
-        stripe_client_core::ListPaginator::new_list("/tax_codes", self.inner)
+        stripe_client_core::ListPaginator::new_list("/tax_codes", &self.inner)
     }
 }
 
-impl StripeRequest for ListTaxCode<'_> {
+impl StripeRequest for ListTaxCode {
     type Output = stripe_types::List<stripe_shared::TaxCode>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/tax_codes").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveTaxCodeBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveTaxCodeBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveTaxCodeBuilder<'a> {
+impl RetrieveTaxCodeBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
@@ -103,22 +103,22 @@ impl<'a> RetrieveTaxCodeBuilder<'a> {
 /// Retrieves the details of an existing tax code.
 /// Supply the unique tax code ID and Stripe will return the corresponding tax code information.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveTaxCode<'a> {
-    inner: RetrieveTaxCodeBuilder<'a>,
-    id: &'a stripe_shared::TaxCodeId,
+pub struct RetrieveTaxCode {
+    inner: RetrieveTaxCodeBuilder,
+    id: stripe_shared::TaxCodeId,
 }
-impl<'a> RetrieveTaxCode<'a> {
+impl RetrieveTaxCode {
     /// Construct a new `RetrieveTaxCode`.
-    pub fn new(id: &'a stripe_shared::TaxCodeId) -> Self {
-        Self { id, inner: RetrieveTaxCodeBuilder::new() }
+    pub fn new(id: impl Into<stripe_shared::TaxCodeId>) -> Self {
+        Self { id: id.into(), inner: RetrieveTaxCodeBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveTaxCode<'_> {
+impl RetrieveTaxCode {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -136,11 +136,11 @@ impl RetrieveTaxCode<'_> {
     }
 }
 
-impl StripeRequest for RetrieveTaxCode<'_> {
+impl StripeRequest for RetrieveTaxCode {
     type Output = stripe_shared::TaxCode;
 
     fn build(&self) -> RequestBuilder {
-        let id = self.id;
+        let id = &self.id;
         RequestBuilder::new(StripeMethod::Get, format!("/tax_codes/{id}")).query(&self.inner)
     }
 }

--- a/generated/async-stripe-product/src/tax_rate/requests.rs
+++ b/generated/async-stripe-product/src/tax_rate/requests.rs
@@ -2,24 +2,24 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListTaxRateBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListTaxRateBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     active: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     created: Option<stripe_types::RangeQueryTs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     inclusive: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListTaxRateBuilder<'a> {
+impl ListTaxRateBuilder {
     fn new() -> Self {
         Self {
             active: None,
@@ -35,61 +35,61 @@ impl<'a> ListTaxRateBuilder<'a> {
 /// Returns a list of your tax rates.
 /// Tax rates are returned sorted by creation date, with the most recently created tax rates appearing first.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListTaxRate<'a> {
-    inner: ListTaxRateBuilder<'a>,
+pub struct ListTaxRate {
+    inner: ListTaxRateBuilder,
 }
-impl<'a> ListTaxRate<'a> {
+impl ListTaxRate {
     /// Construct a new `ListTaxRate`.
     pub fn new() -> Self {
         Self { inner: ListTaxRateBuilder::new() }
     }
     /// Optional flag to filter by tax rates that are either active or inactive (archived).
-    pub fn active(mut self, active: bool) -> Self {
-        self.inner.active = Some(active);
+    pub fn active(mut self, active: impl Into<bool>) -> Self {
+        self.inner.active = Some(active.into());
         self
     }
     /// Optional range for filtering created date.
-    pub fn created(mut self, created: stripe_types::RangeQueryTs) -> Self {
-        self.inner.created = Some(created);
+    pub fn created(mut self, created: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.created = Some(created.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Optional flag to filter by tax rates that are inclusive (or those that are not inclusive).
-    pub fn inclusive(mut self, inclusive: bool) -> Self {
-        self.inner.inclusive = Some(inclusive);
+    pub fn inclusive(mut self, inclusive: impl Into<bool>) -> Self {
+        self.inner.inclusive = Some(inclusive.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl<'a> Default for ListTaxRate<'a> {
+impl Default for ListTaxRate {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListTaxRate<'_> {
+impl ListTaxRate {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -109,45 +109,45 @@ impl ListTaxRate<'_> {
     pub fn paginate(
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_shared::TaxRate>> {
-        stripe_client_core::ListPaginator::new_list("/tax_rates", self.inner)
+        stripe_client_core::ListPaginator::new_list("/tax_rates", &self.inner)
     }
 }
 
-impl StripeRequest for ListTaxRate<'_> {
+impl StripeRequest for ListTaxRate {
     type Output = stripe_types::List<stripe_shared::TaxRate>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/tax_rates").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveTaxRateBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveTaxRateBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveTaxRateBuilder<'a> {
+impl RetrieveTaxRateBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves a tax rate with the given ID
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveTaxRate<'a> {
-    inner: RetrieveTaxRateBuilder<'a>,
-    tax_rate: &'a stripe_shared::TaxRateId,
+pub struct RetrieveTaxRate {
+    inner: RetrieveTaxRateBuilder,
+    tax_rate: stripe_shared::TaxRateId,
 }
-impl<'a> RetrieveTaxRate<'a> {
+impl RetrieveTaxRate {
     /// Construct a new `RetrieveTaxRate`.
-    pub fn new(tax_rate: &'a stripe_shared::TaxRateId) -> Self {
-        Self { tax_rate, inner: RetrieveTaxRateBuilder::new() }
+    pub fn new(tax_rate: impl Into<stripe_shared::TaxRateId>) -> Self {
+        Self { tax_rate: tax_rate.into(), inner: RetrieveTaxRateBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveTaxRate<'_> {
+impl RetrieveTaxRate {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -165,48 +165,52 @@ impl RetrieveTaxRate<'_> {
     }
 }
 
-impl StripeRequest for RetrieveTaxRate<'_> {
+impl StripeRequest for RetrieveTaxRate {
     type Output = stripe_shared::TaxRate;
 
     fn build(&self) -> RequestBuilder {
-        let tax_rate = self.tax_rate;
+        let tax_rate = &self.tax_rate;
         RequestBuilder::new(StripeMethod::Get, format!("/tax_rates/{tax_rate}")).query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateTaxRateBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateTaxRateBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     active: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    country: Option<&'a str>,
+    country: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<&'a str>,
-    display_name: &'a str,
+    description: Option<String>,
+    display_name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     inclusive: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
-    jurisdiction: Option<&'a str>,
+    jurisdiction: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     percentage: f64,
     #[serde(skip_serializing_if = "Option::is_none")]
-    state: Option<&'a str>,
+    state: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tax_type: Option<stripe_shared::TaxRateTaxType>,
 }
-impl<'a> CreateTaxRateBuilder<'a> {
-    fn new(display_name: &'a str, inclusive: bool, percentage: f64) -> Self {
+impl CreateTaxRateBuilder {
+    fn new(
+        display_name: impl Into<String>,
+        inclusive: impl Into<bool>,
+        percentage: impl Into<f64>,
+    ) -> Self {
         Self {
             active: None,
             country: None,
             description: None,
-            display_name,
+            display_name: display_name.into(),
             expand: None,
-            inclusive,
+            inclusive: inclusive.into(),
             jurisdiction: None,
             metadata: None,
-            percentage,
+            percentage: percentage.into(),
             state: None,
             tax_type: None,
         }
@@ -214,64 +218,77 @@ impl<'a> CreateTaxRateBuilder<'a> {
 }
 /// Creates a new tax rate.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateTaxRate<'a> {
-    inner: CreateTaxRateBuilder<'a>,
+pub struct CreateTaxRate {
+    inner: CreateTaxRateBuilder,
 }
-impl<'a> CreateTaxRate<'a> {
+impl CreateTaxRate {
     /// Construct a new `CreateTaxRate`.
-    pub fn new(display_name: &'a str, inclusive: bool, percentage: f64) -> Self {
-        Self { inner: CreateTaxRateBuilder::new(display_name, inclusive, percentage) }
+    pub fn new(
+        display_name: impl Into<String>,
+        inclusive: impl Into<bool>,
+        percentage: impl Into<f64>,
+    ) -> Self {
+        Self {
+            inner: CreateTaxRateBuilder::new(
+                display_name.into(),
+                inclusive.into(),
+                percentage.into(),
+            ),
+        }
     }
     /// Flag determining whether the tax rate is active or inactive (archived).
     /// Inactive tax rates cannot be used with new applications or Checkout Sessions, but will still work for subscriptions and invoices that already have it set.
-    pub fn active(mut self, active: bool) -> Self {
-        self.inner.active = Some(active);
+    pub fn active(mut self, active: impl Into<bool>) -> Self {
+        self.inner.active = Some(active.into());
         self
     }
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
-    pub fn country(mut self, country: &'a str) -> Self {
-        self.inner.country = Some(country);
+    pub fn country(mut self, country: impl Into<String>) -> Self {
+        self.inner.country = Some(country.into());
         self
     }
     /// An arbitrary string attached to the tax rate for your internal use only.
     /// It will not be visible to your customers.
-    pub fn description(mut self, description: &'a str) -> Self {
-        self.inner.description = Some(description);
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.inner.description = Some(description.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// The jurisdiction for the tax rate.
     /// You can use this label field for tax reporting purposes.
     /// It also appears on your customer’s invoice.
-    pub fn jurisdiction(mut self, jurisdiction: &'a str) -> Self {
-        self.inner.jurisdiction = Some(jurisdiction);
+    pub fn jurisdiction(mut self, jurisdiction: impl Into<String>) -> Self {
+        self.inner.jurisdiction = Some(jurisdiction.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// [ISO 3166-2 subdivision code](https://en.wikipedia.org/wiki/ISO_3166-2:US), without country prefix.
     /// For example, "NY" for New York, United States.
-    pub fn state(mut self, state: &'a str) -> Self {
-        self.inner.state = Some(state);
+    pub fn state(mut self, state: impl Into<String>) -> Self {
+        self.inner.state = Some(state.into());
         self
     }
     /// The high-level tax type, such as `vat` or `sales_tax`.
-    pub fn tax_type(mut self, tax_type: stripe_shared::TaxRateTaxType) -> Self {
-        self.inner.tax_type = Some(tax_type);
+    pub fn tax_type(mut self, tax_type: impl Into<stripe_shared::TaxRateTaxType>) -> Self {
+        self.inner.tax_type = Some(tax_type.into());
         self
     }
 }
-impl CreateTaxRate<'_> {
+impl CreateTaxRate {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -289,35 +306,35 @@ impl CreateTaxRate<'_> {
     }
 }
 
-impl StripeRequest for CreateTaxRate<'_> {
+impl StripeRequest for CreateTaxRate {
     type Output = stripe_shared::TaxRate;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Post, "/tax_rates").form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdateTaxRateBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdateTaxRateBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     active: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    country: Option<&'a str>,
+    country: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<&'a str>,
+    description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    display_name: Option<&'a str>,
+    display_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    jurisdiction: Option<&'a str>,
+    jurisdiction: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    state: Option<&'a str>,
+    state: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tax_type: Option<stripe_shared::TaxRateTaxType>,
 }
-impl<'a> UpdateTaxRateBuilder<'a> {
+impl UpdateTaxRateBuilder {
     fn new() -> Self {
         Self {
             active: None,
@@ -334,70 +351,73 @@ impl<'a> UpdateTaxRateBuilder<'a> {
 }
 /// Updates an existing tax rate.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateTaxRate<'a> {
-    inner: UpdateTaxRateBuilder<'a>,
-    tax_rate: &'a stripe_shared::TaxRateId,
+pub struct UpdateTaxRate {
+    inner: UpdateTaxRateBuilder,
+    tax_rate: stripe_shared::TaxRateId,
 }
-impl<'a> UpdateTaxRate<'a> {
+impl UpdateTaxRate {
     /// Construct a new `UpdateTaxRate`.
-    pub fn new(tax_rate: &'a stripe_shared::TaxRateId) -> Self {
-        Self { tax_rate, inner: UpdateTaxRateBuilder::new() }
+    pub fn new(tax_rate: impl Into<stripe_shared::TaxRateId>) -> Self {
+        Self { tax_rate: tax_rate.into(), inner: UpdateTaxRateBuilder::new() }
     }
     /// Flag determining whether the tax rate is active or inactive (archived).
     /// Inactive tax rates cannot be used with new applications or Checkout Sessions, but will still work for subscriptions and invoices that already have it set.
-    pub fn active(mut self, active: bool) -> Self {
-        self.inner.active = Some(active);
+    pub fn active(mut self, active: impl Into<bool>) -> Self {
+        self.inner.active = Some(active.into());
         self
     }
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
-    pub fn country(mut self, country: &'a str) -> Self {
-        self.inner.country = Some(country);
+    pub fn country(mut self, country: impl Into<String>) -> Self {
+        self.inner.country = Some(country.into());
         self
     }
     /// An arbitrary string attached to the tax rate for your internal use only.
     /// It will not be visible to your customers.
-    pub fn description(mut self, description: &'a str) -> Self {
-        self.inner.description = Some(description);
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.inner.description = Some(description.into());
         self
     }
     /// The display name of the tax rate, which will be shown to users.
-    pub fn display_name(mut self, display_name: &'a str) -> Self {
-        self.inner.display_name = Some(display_name);
+    pub fn display_name(mut self, display_name: impl Into<String>) -> Self {
+        self.inner.display_name = Some(display_name.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// The jurisdiction for the tax rate.
     /// You can use this label field for tax reporting purposes.
     /// It also appears on your customer’s invoice.
-    pub fn jurisdiction(mut self, jurisdiction: &'a str) -> Self {
-        self.inner.jurisdiction = Some(jurisdiction);
+    pub fn jurisdiction(mut self, jurisdiction: impl Into<String>) -> Self {
+        self.inner.jurisdiction = Some(jurisdiction.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// [ISO 3166-2 subdivision code](https://en.wikipedia.org/wiki/ISO_3166-2:US), without country prefix.
     /// For example, "NY" for New York, United States.
-    pub fn state(mut self, state: &'a str) -> Self {
-        self.inner.state = Some(state);
+    pub fn state(mut self, state: impl Into<String>) -> Self {
+        self.inner.state = Some(state.into());
         self
     }
     /// The high-level tax type, such as `vat` or `sales_tax`.
-    pub fn tax_type(mut self, tax_type: stripe_shared::TaxRateTaxType) -> Self {
-        self.inner.tax_type = Some(tax_type);
+    pub fn tax_type(mut self, tax_type: impl Into<stripe_shared::TaxRateTaxType>) -> Self {
+        self.inner.tax_type = Some(tax_type.into());
         self
     }
 }
-impl UpdateTaxRate<'_> {
+impl UpdateTaxRate {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -415,11 +435,11 @@ impl UpdateTaxRate<'_> {
     }
 }
 
-impl StripeRequest for UpdateTaxRate<'_> {
+impl StripeRequest for UpdateTaxRate {
     type Output = stripe_shared::TaxRate;
 
     fn build(&self) -> RequestBuilder {
-        let tax_rate = self.tax_rate;
+        let tax_rate = &self.tax_rate;
         RequestBuilder::new(StripeMethod::Post, format!("/tax_rates/{tax_rate}")).form(&self.inner)
     }
 }

--- a/generated/async-stripe-terminal/src/terminal_configuration/requests.rs
+++ b/generated/async-stripe-terminal/src/terminal_configuration/requests.rs
@@ -4,16 +4,16 @@ use stripe_client_core::{
 
 /// Deletes a `Configuration` object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct DeleteTerminalConfiguration<'a> {
-    configuration: &'a stripe_terminal::TerminalConfigurationId,
+pub struct DeleteTerminalConfiguration {
+    configuration: stripe_terminal::TerminalConfigurationId,
 }
-impl<'a> DeleteTerminalConfiguration<'a> {
+impl DeleteTerminalConfiguration {
     /// Construct a new `DeleteTerminalConfiguration`.
-    pub fn new(configuration: &'a stripe_terminal::TerminalConfigurationId) -> Self {
-        Self { configuration }
+    pub fn new(configuration: impl Into<stripe_terminal::TerminalConfigurationId>) -> Self {
+        Self { configuration: configuration.into() }
     }
 }
-impl DeleteTerminalConfiguration<'_> {
+impl DeleteTerminalConfiguration {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -31,31 +31,31 @@ impl DeleteTerminalConfiguration<'_> {
     }
 }
 
-impl StripeRequest for DeleteTerminalConfiguration<'_> {
+impl StripeRequest for DeleteTerminalConfiguration {
     type Output = stripe_terminal::DeletedTerminalConfiguration;
 
     fn build(&self) -> RequestBuilder {
-        let configuration = self.configuration;
+        let configuration = &self.configuration;
         RequestBuilder::new(
             StripeMethod::Delete,
             format!("/terminal/configurations/{configuration}"),
         )
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListTerminalConfigurationBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListTerminalConfigurationBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     is_account_default: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListTerminalConfigurationBuilder<'a> {
+impl ListTerminalConfigurationBuilder {
     fn new() -> Self {
         Self {
             ending_before: None,
@@ -68,10 +68,10 @@ impl<'a> ListTerminalConfigurationBuilder<'a> {
 }
 /// Returns a list of `Configuration` objects.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListTerminalConfiguration<'a> {
-    inner: ListTerminalConfigurationBuilder<'a>,
+pub struct ListTerminalConfiguration {
+    inner: ListTerminalConfigurationBuilder,
 }
-impl<'a> ListTerminalConfiguration<'a> {
+impl ListTerminalConfiguration {
     /// Construct a new `ListTerminalConfiguration`.
     pub fn new() -> Self {
         Self { inner: ListTerminalConfigurationBuilder::new() }
@@ -79,40 +79,40 @@ impl<'a> ListTerminalConfiguration<'a> {
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// if present, only return the account default or non-default configurations.
-    pub fn is_account_default(mut self, is_account_default: bool) -> Self {
-        self.inner.is_account_default = Some(is_account_default);
+    pub fn is_account_default(mut self, is_account_default: impl Into<bool>) -> Self {
+        self.inner.is_account_default = Some(is_account_default.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl<'a> Default for ListTerminalConfiguration<'a> {
+impl Default for ListTerminalConfiguration {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListTerminalConfiguration<'_> {
+impl ListTerminalConfiguration {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -133,45 +133,48 @@ impl ListTerminalConfiguration<'_> {
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_terminal::TerminalConfiguration>>
     {
-        stripe_client_core::ListPaginator::new_list("/terminal/configurations", self.inner)
+        stripe_client_core::ListPaginator::new_list("/terminal/configurations", &self.inner)
     }
 }
 
-impl StripeRequest for ListTerminalConfiguration<'_> {
+impl StripeRequest for ListTerminalConfiguration {
     type Output = stripe_types::List<stripe_terminal::TerminalConfiguration>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/terminal/configurations").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveTerminalConfigurationBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveTerminalConfigurationBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveTerminalConfigurationBuilder<'a> {
+impl RetrieveTerminalConfigurationBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves a `Configuration` object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveTerminalConfiguration<'a> {
-    inner: RetrieveTerminalConfigurationBuilder<'a>,
-    configuration: &'a stripe_terminal::TerminalConfigurationId,
+pub struct RetrieveTerminalConfiguration {
+    inner: RetrieveTerminalConfigurationBuilder,
+    configuration: stripe_terminal::TerminalConfigurationId,
 }
-impl<'a> RetrieveTerminalConfiguration<'a> {
+impl RetrieveTerminalConfiguration {
     /// Construct a new `RetrieveTerminalConfiguration`.
-    pub fn new(configuration: &'a stripe_terminal::TerminalConfigurationId) -> Self {
-        Self { configuration, inner: RetrieveTerminalConfigurationBuilder::new() }
+    pub fn new(configuration: impl Into<stripe_terminal::TerminalConfigurationId>) -> Self {
+        Self {
+            configuration: configuration.into(),
+            inner: RetrieveTerminalConfigurationBuilder::new(),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveTerminalConfiguration<'_> {
+impl RetrieveTerminalConfiguration {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -189,11 +192,11 @@ impl RetrieveTerminalConfiguration<'_> {
     }
 }
 
-impl StripeRequest for RetrieveTerminalConfiguration<'_> {
+impl StripeRequest for RetrieveTerminalConfiguration {
     type Output = RetrieveTerminalConfigurationReturned;
 
     fn build(&self) -> RequestBuilder {
-        let configuration = self.configuration;
+        let configuration = &self.configuration;
         RequestBuilder::new(StripeMethod::Get, format!("/terminal/configurations/{configuration}"))
             .query(&self.inner)
     }
@@ -280,22 +283,22 @@ const _: () = {
     }
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateTerminalConfigurationBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateTerminalConfigurationBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    bbpos_wisepos_e: Option<CreateTerminalConfigurationBbposWiseposE<'a>>,
+    bbpos_wisepos_e: Option<CreateTerminalConfigurationBbposWiseposE>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    name: Option<&'a str>,
+    name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     offline: Option<Offline>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    tipping: Option<Tipping<'a>>,
+    tipping: Option<Tipping>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    verifone_p400: Option<CreateTerminalConfigurationVerifoneP400<'a>>,
+    verifone_p400: Option<CreateTerminalConfigurationVerifoneP400>,
 }
-impl<'a> CreateTerminalConfigurationBuilder<'a> {
+impl CreateTerminalConfigurationBuilder {
     fn new() -> Self {
         Self {
             bbpos_wisepos_e: None,
@@ -308,45 +311,45 @@ impl<'a> CreateTerminalConfigurationBuilder<'a> {
     }
 }
 /// An object containing device type specific settings for BBPOS WisePOS E readers
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateTerminalConfigurationBbposWiseposE<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateTerminalConfigurationBbposWiseposE {
     /// A File ID representing an image you would like displayed on the reader.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub splashscreen: Option<&'a str>,
+    pub splashscreen: Option<String>,
 }
-impl<'a> CreateTerminalConfigurationBbposWiseposE<'a> {
+impl CreateTerminalConfigurationBbposWiseposE {
     pub fn new() -> Self {
         Self { splashscreen: None }
     }
 }
-impl<'a> Default for CreateTerminalConfigurationBbposWiseposE<'a> {
+impl Default for CreateTerminalConfigurationBbposWiseposE {
     fn default() -> Self {
         Self::new()
     }
 }
 /// An object containing device type specific settings for Verifone P400 readers
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateTerminalConfigurationVerifoneP400<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateTerminalConfigurationVerifoneP400 {
     /// A File ID representing an image you would like displayed on the reader.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub splashscreen: Option<&'a str>,
+    pub splashscreen: Option<String>,
 }
-impl<'a> CreateTerminalConfigurationVerifoneP400<'a> {
+impl CreateTerminalConfigurationVerifoneP400 {
     pub fn new() -> Self {
         Self { splashscreen: None }
     }
 }
-impl<'a> Default for CreateTerminalConfigurationVerifoneP400<'a> {
+impl Default for CreateTerminalConfigurationVerifoneP400 {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Creates a new `Configuration` object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateTerminalConfiguration<'a> {
-    inner: CreateTerminalConfigurationBuilder<'a>,
+pub struct CreateTerminalConfiguration {
+    inner: CreateTerminalConfigurationBuilder,
 }
-impl<'a> CreateTerminalConfiguration<'a> {
+impl CreateTerminalConfiguration {
     /// Construct a new `CreateTerminalConfiguration`.
     pub fn new() -> Self {
         Self { inner: CreateTerminalConfigurationBuilder::new() }
@@ -354,46 +357,46 @@ impl<'a> CreateTerminalConfiguration<'a> {
     /// An object containing device type specific settings for BBPOS WisePOS E readers
     pub fn bbpos_wisepos_e(
         mut self,
-        bbpos_wisepos_e: CreateTerminalConfigurationBbposWiseposE<'a>,
+        bbpos_wisepos_e: impl Into<CreateTerminalConfigurationBbposWiseposE>,
     ) -> Self {
-        self.inner.bbpos_wisepos_e = Some(bbpos_wisepos_e);
+        self.inner.bbpos_wisepos_e = Some(bbpos_wisepos_e.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Name of the configuration
-    pub fn name(mut self, name: &'a str) -> Self {
-        self.inner.name = Some(name);
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.inner.name = Some(name.into());
         self
     }
     /// Configurations for collecting transactions offline.
-    pub fn offline(mut self, offline: Offline) -> Self {
-        self.inner.offline = Some(offline);
+    pub fn offline(mut self, offline: impl Into<Offline>) -> Self {
+        self.inner.offline = Some(offline.into());
         self
     }
     /// Tipping configurations for readers supporting on-reader tips
-    pub fn tipping(mut self, tipping: Tipping<'a>) -> Self {
-        self.inner.tipping = Some(tipping);
+    pub fn tipping(mut self, tipping: impl Into<Tipping>) -> Self {
+        self.inner.tipping = Some(tipping.into());
         self
     }
     /// An object containing device type specific settings for Verifone P400 readers
     pub fn verifone_p400(
         mut self,
-        verifone_p400: CreateTerminalConfigurationVerifoneP400<'a>,
+        verifone_p400: impl Into<CreateTerminalConfigurationVerifoneP400>,
     ) -> Self {
-        self.inner.verifone_p400 = Some(verifone_p400);
+        self.inner.verifone_p400 = Some(verifone_p400.into());
         self
     }
 }
-impl<'a> Default for CreateTerminalConfiguration<'a> {
+impl Default for CreateTerminalConfiguration {
     fn default() -> Self {
         Self::new()
     }
 }
-impl CreateTerminalConfiguration<'_> {
+impl CreateTerminalConfiguration {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -411,29 +414,29 @@ impl CreateTerminalConfiguration<'_> {
     }
 }
 
-impl StripeRequest for CreateTerminalConfiguration<'_> {
+impl StripeRequest for CreateTerminalConfiguration {
     type Output = stripe_terminal::TerminalConfiguration;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Post, "/terminal/configurations").form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdateTerminalConfigurationBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdateTerminalConfigurationBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    bbpos_wisepos_e: Option<UpdateTerminalConfigurationBbposWiseposE<'a>>,
+    bbpos_wisepos_e: Option<UpdateTerminalConfigurationBbposWiseposE>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    name: Option<&'a str>,
+    name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     offline: Option<Offline>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    tipping: Option<Tipping<'a>>,
+    tipping: Option<Tipping>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    verifone_p400: Option<UpdateTerminalConfigurationVerifoneP400<'a>>,
+    verifone_p400: Option<UpdateTerminalConfigurationVerifoneP400>,
 }
-impl<'a> UpdateTerminalConfigurationBuilder<'a> {
+impl UpdateTerminalConfigurationBuilder {
     fn new() -> Self {
         Self {
             bbpos_wisepos_e: None,
@@ -446,88 +449,91 @@ impl<'a> UpdateTerminalConfigurationBuilder<'a> {
     }
 }
 /// An object containing device type specific settings for BBPOS WisePOS E readers
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateTerminalConfigurationBbposWiseposE<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateTerminalConfigurationBbposWiseposE {
     /// A File ID representing an image you would like displayed on the reader.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub splashscreen: Option<&'a str>,
+    pub splashscreen: Option<String>,
 }
-impl<'a> UpdateTerminalConfigurationBbposWiseposE<'a> {
+impl UpdateTerminalConfigurationBbposWiseposE {
     pub fn new() -> Self {
         Self { splashscreen: None }
     }
 }
-impl<'a> Default for UpdateTerminalConfigurationBbposWiseposE<'a> {
+impl Default for UpdateTerminalConfigurationBbposWiseposE {
     fn default() -> Self {
         Self::new()
     }
 }
 /// An object containing device type specific settings for Verifone P400 readers
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateTerminalConfigurationVerifoneP400<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateTerminalConfigurationVerifoneP400 {
     /// A File ID representing an image you would like displayed on the reader.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub splashscreen: Option<&'a str>,
+    pub splashscreen: Option<String>,
 }
-impl<'a> UpdateTerminalConfigurationVerifoneP400<'a> {
+impl UpdateTerminalConfigurationVerifoneP400 {
     pub fn new() -> Self {
         Self { splashscreen: None }
     }
 }
-impl<'a> Default for UpdateTerminalConfigurationVerifoneP400<'a> {
+impl Default for UpdateTerminalConfigurationVerifoneP400 {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Updates a new `Configuration` object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateTerminalConfiguration<'a> {
-    inner: UpdateTerminalConfigurationBuilder<'a>,
-    configuration: &'a stripe_terminal::TerminalConfigurationId,
+pub struct UpdateTerminalConfiguration {
+    inner: UpdateTerminalConfigurationBuilder,
+    configuration: stripe_terminal::TerminalConfigurationId,
 }
-impl<'a> UpdateTerminalConfiguration<'a> {
+impl UpdateTerminalConfiguration {
     /// Construct a new `UpdateTerminalConfiguration`.
-    pub fn new(configuration: &'a stripe_terminal::TerminalConfigurationId) -> Self {
-        Self { configuration, inner: UpdateTerminalConfigurationBuilder::new() }
+    pub fn new(configuration: impl Into<stripe_terminal::TerminalConfigurationId>) -> Self {
+        Self {
+            configuration: configuration.into(),
+            inner: UpdateTerminalConfigurationBuilder::new(),
+        }
     }
     /// An object containing device type specific settings for BBPOS WisePOS E readers
     pub fn bbpos_wisepos_e(
         mut self,
-        bbpos_wisepos_e: UpdateTerminalConfigurationBbposWiseposE<'a>,
+        bbpos_wisepos_e: impl Into<UpdateTerminalConfigurationBbposWiseposE>,
     ) -> Self {
-        self.inner.bbpos_wisepos_e = Some(bbpos_wisepos_e);
+        self.inner.bbpos_wisepos_e = Some(bbpos_wisepos_e.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Name of the configuration
-    pub fn name(mut self, name: &'a str) -> Self {
-        self.inner.name = Some(name);
+    pub fn name(mut self, name: impl Into<String>) -> Self {
+        self.inner.name = Some(name.into());
         self
     }
     /// Configurations for collecting transactions offline.
-    pub fn offline(mut self, offline: Offline) -> Self {
-        self.inner.offline = Some(offline);
+    pub fn offline(mut self, offline: impl Into<Offline>) -> Self {
+        self.inner.offline = Some(offline.into());
         self
     }
     /// Tipping configurations for readers supporting on-reader tips
-    pub fn tipping(mut self, tipping: Tipping<'a>) -> Self {
-        self.inner.tipping = Some(tipping);
+    pub fn tipping(mut self, tipping: impl Into<Tipping>) -> Self {
+        self.inner.tipping = Some(tipping.into());
         self
     }
     /// An object containing device type specific settings for Verifone P400 readers
     pub fn verifone_p400(
         mut self,
-        verifone_p400: UpdateTerminalConfigurationVerifoneP400<'a>,
+        verifone_p400: impl Into<UpdateTerminalConfigurationVerifoneP400>,
     ) -> Self {
-        self.inner.verifone_p400 = Some(verifone_p400);
+        self.inner.verifone_p400 = Some(verifone_p400.into());
         self
     }
 }
-impl UpdateTerminalConfiguration<'_> {
+impl UpdateTerminalConfiguration {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -545,11 +551,11 @@ impl UpdateTerminalConfiguration<'_> {
     }
 }
 
-impl StripeRequest for UpdateTerminalConfiguration<'_> {
+impl StripeRequest for UpdateTerminalConfiguration {
     type Output = UpdateTerminalConfigurationReturned;
 
     fn build(&self) -> RequestBuilder {
-        let configuration = self.configuration;
+        let configuration = &self.configuration;
         RequestBuilder::new(StripeMethod::Post, format!("/terminal/configurations/{configuration}"))
             .form(&self.inner)
     }
@@ -643,78 +649,78 @@ pub struct Offline {
     pub enabled: bool,
 }
 impl Offline {
-    pub fn new(enabled: bool) -> Self {
-        Self { enabled }
+    pub fn new(enabled: impl Into<bool>) -> Self {
+        Self { enabled: enabled.into() }
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CurrencySpecificConfig<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CurrencySpecificConfig {
     /// Fixed amounts displayed when collecting a tip
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub fixed_amounts: Option<&'a [i64]>,
+    pub fixed_amounts: Option<Vec<i64>>,
     /// Percentages displayed when collecting a tip
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub percentages: Option<&'a [i64]>,
+    pub percentages: Option<Vec<i64>>,
     /// Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
     #[serde(skip_serializing_if = "Option::is_none")]
     pub smart_tip_threshold: Option<i64>,
 }
-impl<'a> CurrencySpecificConfig<'a> {
+impl CurrencySpecificConfig {
     pub fn new() -> Self {
         Self { fixed_amounts: None, percentages: None, smart_tip_threshold: None }
     }
 }
-impl<'a> Default for CurrencySpecificConfig<'a> {
+impl Default for CurrencySpecificConfig {
     fn default() -> Self {
         Self::new()
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct Tipping<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct Tipping {
     /// Tipping configuration for AUD
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub aud: Option<CurrencySpecificConfig<'a>>,
+    pub aud: Option<CurrencySpecificConfig>,
     /// Tipping configuration for CAD
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub cad: Option<CurrencySpecificConfig<'a>>,
+    pub cad: Option<CurrencySpecificConfig>,
     /// Tipping configuration for CHF
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub chf: Option<CurrencySpecificConfig<'a>>,
+    pub chf: Option<CurrencySpecificConfig>,
     /// Tipping configuration for CZK
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub czk: Option<CurrencySpecificConfig<'a>>,
+    pub czk: Option<CurrencySpecificConfig>,
     /// Tipping configuration for DKK
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub dkk: Option<CurrencySpecificConfig<'a>>,
+    pub dkk: Option<CurrencySpecificConfig>,
     /// Tipping configuration for EUR
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub eur: Option<CurrencySpecificConfig<'a>>,
+    pub eur: Option<CurrencySpecificConfig>,
     /// Tipping configuration for GBP
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub gbp: Option<CurrencySpecificConfig<'a>>,
+    pub gbp: Option<CurrencySpecificConfig>,
     /// Tipping configuration for HKD
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub hkd: Option<CurrencySpecificConfig<'a>>,
+    pub hkd: Option<CurrencySpecificConfig>,
     /// Tipping configuration for MYR
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub myr: Option<CurrencySpecificConfig<'a>>,
+    pub myr: Option<CurrencySpecificConfig>,
     /// Tipping configuration for NOK
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub nok: Option<CurrencySpecificConfig<'a>>,
+    pub nok: Option<CurrencySpecificConfig>,
     /// Tipping configuration for NZD
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub nzd: Option<CurrencySpecificConfig<'a>>,
+    pub nzd: Option<CurrencySpecificConfig>,
     /// Tipping configuration for SEK
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub sek: Option<CurrencySpecificConfig<'a>>,
+    pub sek: Option<CurrencySpecificConfig>,
     /// Tipping configuration for SGD
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub sgd: Option<CurrencySpecificConfig<'a>>,
+    pub sgd: Option<CurrencySpecificConfig>,
     /// Tipping configuration for USD
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub usd: Option<CurrencySpecificConfig<'a>>,
+    pub usd: Option<CurrencySpecificConfig>,
 }
-impl<'a> Tipping<'a> {
+impl Tipping {
     pub fn new() -> Self {
         Self {
             aud: None,
@@ -734,7 +740,7 @@ impl<'a> Tipping<'a> {
         }
     }
 }
-impl<'a> Default for Tipping<'a> {
+impl Default for Tipping {
     fn default() -> Self {
         Self::new()
     }

--- a/generated/async-stripe-terminal/src/terminal_connection_token/requests.rs
+++ b/generated/async-stripe-terminal/src/terminal_connection_token/requests.rs
@@ -2,14 +2,14 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateTerminalConnectionTokenBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateTerminalConnectionTokenBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    location: Option<&'a str>,
+    location: Option<String>,
 }
-impl<'a> CreateTerminalConnectionTokenBuilder<'a> {
+impl CreateTerminalConnectionTokenBuilder {
     fn new() -> Self {
         Self { expand: None, location: None }
     }
@@ -17,34 +17,34 @@ impl<'a> CreateTerminalConnectionTokenBuilder<'a> {
 /// To connect to a reader the Stripe Terminal SDK needs to retrieve a short-lived connection token from Stripe, proxied through your server.
 /// On your backend, add an endpoint that creates and returns a connection token.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateTerminalConnectionToken<'a> {
-    inner: CreateTerminalConnectionTokenBuilder<'a>,
+pub struct CreateTerminalConnectionToken {
+    inner: CreateTerminalConnectionTokenBuilder,
 }
-impl<'a> CreateTerminalConnectionToken<'a> {
+impl CreateTerminalConnectionToken {
     /// Construct a new `CreateTerminalConnectionToken`.
     pub fn new() -> Self {
         Self { inner: CreateTerminalConnectionTokenBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// The id of the location that this connection token is scoped to.
     /// If specified the connection token will only be usable with readers assigned to that location, otherwise the connection token will be usable with all readers.
     /// Note that location scoping only applies to internet-connected readers.
     /// For more details, see [the docs on scoping connection tokens](https://stripe.com/docs/terminal/fleet/locations#connection-tokens).
-    pub fn location(mut self, location: &'a str) -> Self {
-        self.inner.location = Some(location);
+    pub fn location(mut self, location: impl Into<String>) -> Self {
+        self.inner.location = Some(location.into());
         self
     }
 }
-impl<'a> Default for CreateTerminalConnectionToken<'a> {
+impl Default for CreateTerminalConnectionToken {
     fn default() -> Self {
         Self::new()
     }
 }
-impl CreateTerminalConnectionToken<'_> {
+impl CreateTerminalConnectionToken {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -62,7 +62,7 @@ impl CreateTerminalConnectionToken<'_> {
     }
 }
 
-impl StripeRequest for CreateTerminalConnectionToken<'_> {
+impl StripeRequest for CreateTerminalConnectionToken {
     type Output = stripe_terminal::TerminalConnectionToken;
 
     fn build(&self) -> RequestBuilder {

--- a/generated/async-stripe-terminal/src/terminal_location/requests.rs
+++ b/generated/async-stripe-terminal/src/terminal_location/requests.rs
@@ -4,16 +4,16 @@ use stripe_client_core::{
 
 /// Deletes a `Location` object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct DeleteTerminalLocation<'a> {
-    location: &'a stripe_terminal::TerminalLocationId,
+pub struct DeleteTerminalLocation {
+    location: stripe_terminal::TerminalLocationId,
 }
-impl<'a> DeleteTerminalLocation<'a> {
+impl DeleteTerminalLocation {
     /// Construct a new `DeleteTerminalLocation`.
-    pub fn new(location: &'a stripe_terminal::TerminalLocationId) -> Self {
-        Self { location }
+    pub fn new(location: impl Into<stripe_terminal::TerminalLocationId>) -> Self {
+        Self { location: location.into() }
     }
 }
-impl DeleteTerminalLocation<'_> {
+impl DeleteTerminalLocation {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -31,36 +31,36 @@ impl DeleteTerminalLocation<'_> {
     }
 }
 
-impl StripeRequest for DeleteTerminalLocation<'_> {
+impl StripeRequest for DeleteTerminalLocation {
     type Output = stripe_terminal::DeletedTerminalLocation;
 
     fn build(&self) -> RequestBuilder {
-        let location = self.location;
+        let location = &self.location;
         RequestBuilder::new(StripeMethod::Delete, format!("/terminal/locations/{location}"))
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListTerminalLocationBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListTerminalLocationBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListTerminalLocationBuilder<'a> {
+impl ListTerminalLocationBuilder {
     fn new() -> Self {
         Self { ending_before: None, expand: None, limit: None, starting_after: None }
     }
 }
 /// Returns a list of `Location` objects.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListTerminalLocation<'a> {
-    inner: ListTerminalLocationBuilder<'a>,
+pub struct ListTerminalLocation {
+    inner: ListTerminalLocationBuilder,
 }
-impl<'a> ListTerminalLocation<'a> {
+impl ListTerminalLocation {
     /// Construct a new `ListTerminalLocation`.
     pub fn new() -> Self {
         Self { inner: ListTerminalLocationBuilder::new() }
@@ -68,35 +68,35 @@ impl<'a> ListTerminalLocation<'a> {
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl<'a> Default for ListTerminalLocation<'a> {
+impl Default for ListTerminalLocation {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListTerminalLocation<'_> {
+impl ListTerminalLocation {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -117,45 +117,45 @@ impl ListTerminalLocation<'_> {
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_terminal::TerminalLocation>>
     {
-        stripe_client_core::ListPaginator::new_list("/terminal/locations", self.inner)
+        stripe_client_core::ListPaginator::new_list("/terminal/locations", &self.inner)
     }
 }
 
-impl StripeRequest for ListTerminalLocation<'_> {
+impl StripeRequest for ListTerminalLocation {
     type Output = stripe_types::List<stripe_terminal::TerminalLocation>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/terminal/locations").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveTerminalLocationBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveTerminalLocationBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveTerminalLocationBuilder<'a> {
+impl RetrieveTerminalLocationBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves a `Location` object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveTerminalLocation<'a> {
-    inner: RetrieveTerminalLocationBuilder<'a>,
-    location: &'a stripe_terminal::TerminalLocationId,
+pub struct RetrieveTerminalLocation {
+    inner: RetrieveTerminalLocationBuilder,
+    location: stripe_terminal::TerminalLocationId,
 }
-impl<'a> RetrieveTerminalLocation<'a> {
+impl RetrieveTerminalLocation {
     /// Construct a new `RetrieveTerminalLocation`.
-    pub fn new(location: &'a stripe_terminal::TerminalLocationId) -> Self {
-        Self { location, inner: RetrieveTerminalLocationBuilder::new() }
+    pub fn new(location: impl Into<stripe_terminal::TerminalLocationId>) -> Self {
+        Self { location: location.into(), inner: RetrieveTerminalLocationBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveTerminalLocation<'_> {
+impl RetrieveTerminalLocation {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -173,11 +173,11 @@ impl RetrieveTerminalLocation<'_> {
     }
 }
 
-impl StripeRequest for RetrieveTerminalLocation<'_> {
+impl StripeRequest for RetrieveTerminalLocation {
     type Output = RetrieveTerminalLocationReturned;
 
     fn build(&self) -> RequestBuilder {
-        let location = self.location;
+        let location = &self.location;
         RequestBuilder::new(StripeMethod::Get, format!("/terminal/locations/{location}"))
             .query(&self.inner)
     }
@@ -264,79 +264,101 @@ const _: () = {
     }
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateTerminalLocationBuilder<'a> {
-    address: CreateTerminalLocationAddress<'a>,
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateTerminalLocationBuilder {
+    address: CreateTerminalLocationAddress,
     #[serde(skip_serializing_if = "Option::is_none")]
-    configuration_overrides: Option<&'a str>,
-    display_name: &'a str,
+    configuration_overrides: Option<String>,
+    display_name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
 }
-impl<'a> CreateTerminalLocationBuilder<'a> {
-    fn new(address: CreateTerminalLocationAddress<'a>, display_name: &'a str) -> Self {
-        Self { address, configuration_overrides: None, display_name, expand: None, metadata: None }
+impl CreateTerminalLocationBuilder {
+    fn new(
+        address: impl Into<CreateTerminalLocationAddress>,
+        display_name: impl Into<String>,
+    ) -> Self {
+        Self {
+            address: address.into(),
+            configuration_overrides: None,
+            display_name: display_name.into(),
+            expand: None,
+            metadata: None,
+        }
     }
 }
 /// The full address of the location.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateTerminalLocationAddress<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateTerminalLocationAddress {
     /// City, district, suburb, town, or village.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<&'a str>,
+    pub city: Option<String>,
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
-    pub country: &'a str,
+    pub country: String,
     /// Address line 1 (e.g., street, PO Box, or company name).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line1: Option<&'a str>,
+    pub line1: Option<String>,
     /// Address line 2 (e.g., apartment, suite, unit, or building).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line2: Option<&'a str>,
+    pub line2: Option<String>,
     /// ZIP or postal code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<&'a str>,
+    pub postal_code: Option<String>,
     /// State, county, province, or region.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
 }
-impl<'a> CreateTerminalLocationAddress<'a> {
-    pub fn new(country: &'a str) -> Self {
-        Self { city: None, country, line1: None, line2: None, postal_code: None, state: None }
+impl CreateTerminalLocationAddress {
+    pub fn new(country: impl Into<String>) -> Self {
+        Self {
+            city: None,
+            country: country.into(),
+            line1: None,
+            line2: None,
+            postal_code: None,
+            state: None,
+        }
     }
 }
 /// Creates a new `Location` object.
 /// For further details, including which address fields are required in each country, see the [Manage locations](https://stripe.com/docs/terminal/fleet/locations) guide.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateTerminalLocation<'a> {
-    inner: CreateTerminalLocationBuilder<'a>,
+pub struct CreateTerminalLocation {
+    inner: CreateTerminalLocationBuilder,
 }
-impl<'a> CreateTerminalLocation<'a> {
+impl CreateTerminalLocation {
     /// Construct a new `CreateTerminalLocation`.
-    pub fn new(address: CreateTerminalLocationAddress<'a>, display_name: &'a str) -> Self {
-        Self { inner: CreateTerminalLocationBuilder::new(address, display_name) }
+    pub fn new(
+        address: impl Into<CreateTerminalLocationAddress>,
+        display_name: impl Into<String>,
+    ) -> Self {
+        Self { inner: CreateTerminalLocationBuilder::new(address.into(), display_name.into()) }
     }
     /// The ID of a configuration that will be used to customize all readers in this location.
-    pub fn configuration_overrides(mut self, configuration_overrides: &'a str) -> Self {
-        self.inner.configuration_overrides = Some(configuration_overrides);
+    pub fn configuration_overrides(mut self, configuration_overrides: impl Into<String>) -> Self {
+        self.inner.configuration_overrides = Some(configuration_overrides.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
 }
-impl CreateTerminalLocation<'_> {
+impl CreateTerminalLocation {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -354,27 +376,27 @@ impl CreateTerminalLocation<'_> {
     }
 }
 
-impl StripeRequest for CreateTerminalLocation<'_> {
+impl StripeRequest for CreateTerminalLocation {
     type Output = stripe_terminal::TerminalLocation;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Post, "/terminal/locations").form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdateTerminalLocationBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdateTerminalLocationBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    address: Option<UpdateTerminalLocationAddress<'a>>,
+    address: Option<UpdateTerminalLocationAddress>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    configuration_overrides: Option<&'a str>,
+    configuration_overrides: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    display_name: Option<&'a str>,
+    display_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
 }
-impl<'a> UpdateTerminalLocationBuilder<'a> {
+impl UpdateTerminalLocationBuilder {
     fn new() -> Self {
         Self {
             address: None,
@@ -386,33 +408,33 @@ impl<'a> UpdateTerminalLocationBuilder<'a> {
     }
 }
 /// The full address of the location.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct UpdateTerminalLocationAddress<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct UpdateTerminalLocationAddress {
     /// City, district, suburb, town, or village.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<&'a str>,
+    pub city: Option<String>,
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub country: Option<&'a str>,
+    pub country: Option<String>,
     /// Address line 1 (e.g., street, PO Box, or company name).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line1: Option<&'a str>,
+    pub line1: Option<String>,
     /// Address line 2 (e.g., apartment, suite, unit, or building).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line2: Option<&'a str>,
+    pub line2: Option<String>,
     /// ZIP or postal code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<&'a str>,
+    pub postal_code: Option<String>,
     /// State, county, province, or region.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
 }
-impl<'a> UpdateTerminalLocationAddress<'a> {
+impl UpdateTerminalLocationAddress {
     pub fn new() -> Self {
         Self { city: None, country: None, line1: None, line2: None, postal_code: None, state: None }
     }
 }
-impl<'a> Default for UpdateTerminalLocationAddress<'a> {
+impl Default for UpdateTerminalLocationAddress {
     fn default() -> Self {
         Self::new()
     }
@@ -420,45 +442,48 @@ impl<'a> Default for UpdateTerminalLocationAddress<'a> {
 /// Updates a `Location` object by setting the values of the parameters passed.
 /// Any parameters not provided will be left unchanged.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateTerminalLocation<'a> {
-    inner: UpdateTerminalLocationBuilder<'a>,
-    location: &'a stripe_terminal::TerminalLocationId,
+pub struct UpdateTerminalLocation {
+    inner: UpdateTerminalLocationBuilder,
+    location: stripe_terminal::TerminalLocationId,
 }
-impl<'a> UpdateTerminalLocation<'a> {
+impl UpdateTerminalLocation {
     /// Construct a new `UpdateTerminalLocation`.
-    pub fn new(location: &'a stripe_terminal::TerminalLocationId) -> Self {
-        Self { location, inner: UpdateTerminalLocationBuilder::new() }
+    pub fn new(location: impl Into<stripe_terminal::TerminalLocationId>) -> Self {
+        Self { location: location.into(), inner: UpdateTerminalLocationBuilder::new() }
     }
     /// The full address of the location.
-    pub fn address(mut self, address: UpdateTerminalLocationAddress<'a>) -> Self {
-        self.inner.address = Some(address);
+    pub fn address(mut self, address: impl Into<UpdateTerminalLocationAddress>) -> Self {
+        self.inner.address = Some(address.into());
         self
     }
     /// The ID of a configuration that will be used to customize all readers in this location.
-    pub fn configuration_overrides(mut self, configuration_overrides: &'a str) -> Self {
-        self.inner.configuration_overrides = Some(configuration_overrides);
+    pub fn configuration_overrides(mut self, configuration_overrides: impl Into<String>) -> Self {
+        self.inner.configuration_overrides = Some(configuration_overrides.into());
         self
     }
     /// A name for the location.
-    pub fn display_name(mut self, display_name: &'a str) -> Self {
-        self.inner.display_name = Some(display_name);
+    pub fn display_name(mut self, display_name: impl Into<String>) -> Self {
+        self.inner.display_name = Some(display_name.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
 }
-impl UpdateTerminalLocation<'_> {
+impl UpdateTerminalLocation {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -476,11 +501,11 @@ impl UpdateTerminalLocation<'_> {
     }
 }
 
-impl StripeRequest for UpdateTerminalLocation<'_> {
+impl StripeRequest for UpdateTerminalLocation {
     type Output = UpdateTerminalLocationReturned;
 
     fn build(&self) -> RequestBuilder {
-        let location = self.location;
+        let location = &self.location;
         RequestBuilder::new(StripeMethod::Post, format!("/terminal/locations/{location}"))
             .form(&self.inner)
     }

--- a/generated/async-stripe-terminal/src/terminal_reader/requests.rs
+++ b/generated/async-stripe-terminal/src/terminal_reader/requests.rs
@@ -4,16 +4,16 @@ use stripe_client_core::{
 
 /// Deletes a `Reader` object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct DeleteTerminalReader<'a> {
-    reader: &'a stripe_terminal::TerminalReaderId,
+pub struct DeleteTerminalReader {
+    reader: stripe_terminal::TerminalReaderId,
 }
-impl<'a> DeleteTerminalReader<'a> {
+impl DeleteTerminalReader {
     /// Construct a new `DeleteTerminalReader`.
-    pub fn new(reader: &'a stripe_terminal::TerminalReaderId) -> Self {
-        Self { reader }
+    pub fn new(reader: impl Into<stripe_terminal::TerminalReaderId>) -> Self {
+        Self { reader: reader.into() }
     }
 }
-impl DeleteTerminalReader<'_> {
+impl DeleteTerminalReader {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -31,34 +31,34 @@ impl DeleteTerminalReader<'_> {
     }
 }
 
-impl StripeRequest for DeleteTerminalReader<'_> {
+impl StripeRequest for DeleteTerminalReader {
     type Output = stripe_terminal::DeletedTerminalReader;
 
     fn build(&self) -> RequestBuilder {
-        let reader = self.reader;
+        let reader = &self.reader;
         RequestBuilder::new(StripeMethod::Delete, format!("/terminal/readers/{reader}"))
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListTerminalReaderBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListTerminalReaderBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     device_type: Option<stripe_terminal::TerminalReaderDeviceType>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    location: Option<&'a str>,
+    location: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    serial_number: Option<&'a str>,
+    serial_number: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     status: Option<stripe_terminal::TerminalReaderStatus>,
 }
-impl<'a> ListTerminalReaderBuilder<'a> {
+impl ListTerminalReaderBuilder {
     fn new() -> Self {
         Self {
             device_type: None,
@@ -74,66 +74,69 @@ impl<'a> ListTerminalReaderBuilder<'a> {
 }
 /// Returns a list of `Reader` objects.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListTerminalReader<'a> {
-    inner: ListTerminalReaderBuilder<'a>,
+pub struct ListTerminalReader {
+    inner: ListTerminalReaderBuilder,
 }
-impl<'a> ListTerminalReader<'a> {
+impl ListTerminalReader {
     /// Construct a new `ListTerminalReader`.
     pub fn new() -> Self {
         Self { inner: ListTerminalReaderBuilder::new() }
     }
     /// Filters readers by device type
-    pub fn device_type(mut self, device_type: stripe_terminal::TerminalReaderDeviceType) -> Self {
-        self.inner.device_type = Some(device_type);
+    pub fn device_type(
+        mut self,
+        device_type: impl Into<stripe_terminal::TerminalReaderDeviceType>,
+    ) -> Self {
+        self.inner.device_type = Some(device_type.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A location ID to filter the response list to only readers at the specific location
-    pub fn location(mut self, location: &'a str) -> Self {
-        self.inner.location = Some(location);
+    pub fn location(mut self, location: impl Into<String>) -> Self {
+        self.inner.location = Some(location.into());
         self
     }
     /// Filters readers by serial number
-    pub fn serial_number(mut self, serial_number: &'a str) -> Self {
-        self.inner.serial_number = Some(serial_number);
+    pub fn serial_number(mut self, serial_number: impl Into<String>) -> Self {
+        self.inner.serial_number = Some(serial_number.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
     /// A status filter to filter readers to only offline or online readers
-    pub fn status(mut self, status: stripe_terminal::TerminalReaderStatus) -> Self {
-        self.inner.status = Some(status);
+    pub fn status(mut self, status: impl Into<stripe_terminal::TerminalReaderStatus>) -> Self {
+        self.inner.status = Some(status.into());
         self
     }
 }
-impl<'a> Default for ListTerminalReader<'a> {
+impl Default for ListTerminalReader {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListTerminalReader<'_> {
+impl ListTerminalReader {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -154,45 +157,45 @@ impl ListTerminalReader<'_> {
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_terminal::TerminalReader>>
     {
-        stripe_client_core::ListPaginator::new_list("/terminal/readers", self.inner)
+        stripe_client_core::ListPaginator::new_list("/terminal/readers", &self.inner)
     }
 }
 
-impl StripeRequest for ListTerminalReader<'_> {
+impl StripeRequest for ListTerminalReader {
     type Output = stripe_types::List<stripe_terminal::TerminalReader>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/terminal/readers").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveTerminalReaderBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveTerminalReaderBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveTerminalReaderBuilder<'a> {
+impl RetrieveTerminalReaderBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves a `Reader` object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveTerminalReader<'a> {
-    inner: RetrieveTerminalReaderBuilder<'a>,
-    reader: &'a stripe_terminal::TerminalReaderId,
+pub struct RetrieveTerminalReader {
+    inner: RetrieveTerminalReaderBuilder,
+    reader: stripe_terminal::TerminalReaderId,
 }
-impl<'a> RetrieveTerminalReader<'a> {
+impl RetrieveTerminalReader {
     /// Construct a new `RetrieveTerminalReader`.
-    pub fn new(reader: &'a stripe_terminal::TerminalReaderId) -> Self {
-        Self { reader, inner: RetrieveTerminalReaderBuilder::new() }
+    pub fn new(reader: impl Into<stripe_terminal::TerminalReaderId>) -> Self {
+        Self { reader: reader.into(), inner: RetrieveTerminalReaderBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveTerminalReader<'_> {
+impl RetrieveTerminalReader {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -210,11 +213,11 @@ impl RetrieveTerminalReader<'_> {
     }
 }
 
-impl StripeRequest for RetrieveTerminalReader<'_> {
+impl StripeRequest for RetrieveTerminalReader {
     type Output = RetrieveTerminalReaderReturned;
 
     fn build(&self) -> RequestBuilder {
-        let reader = self.reader;
+        let reader = &self.reader;
         RequestBuilder::new(StripeMethod::Get, format!("/terminal/readers/{reader}"))
             .query(&self.inner)
     }
@@ -301,59 +304,68 @@ const _: () = {
     }
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateTerminalReaderBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateTerminalReaderBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    label: Option<&'a str>,
+    label: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    location: Option<&'a str>,
+    location: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
-    registration_code: &'a str,
+    metadata: Option<std::collections::HashMap<String, String>>,
+    registration_code: String,
 }
-impl<'a> CreateTerminalReaderBuilder<'a> {
-    fn new(registration_code: &'a str) -> Self {
-        Self { expand: None, label: None, location: None, metadata: None, registration_code }
+impl CreateTerminalReaderBuilder {
+    fn new(registration_code: impl Into<String>) -> Self {
+        Self {
+            expand: None,
+            label: None,
+            location: None,
+            metadata: None,
+            registration_code: registration_code.into(),
+        }
     }
 }
 /// Creates a new `Reader` object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateTerminalReader<'a> {
-    inner: CreateTerminalReaderBuilder<'a>,
+pub struct CreateTerminalReader {
+    inner: CreateTerminalReaderBuilder,
 }
-impl<'a> CreateTerminalReader<'a> {
+impl CreateTerminalReader {
     /// Construct a new `CreateTerminalReader`.
-    pub fn new(registration_code: &'a str) -> Self {
-        Self { inner: CreateTerminalReaderBuilder::new(registration_code) }
+    pub fn new(registration_code: impl Into<String>) -> Self {
+        Self { inner: CreateTerminalReaderBuilder::new(registration_code.into()) }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Custom label given to the reader for easier identification.
     /// If no label is specified, the registration code will be used.
-    pub fn label(mut self, label: &'a str) -> Self {
-        self.inner.label = Some(label);
+    pub fn label(mut self, label: impl Into<String>) -> Self {
+        self.inner.label = Some(label.into());
         self
     }
     /// The location to assign the reader to.
-    pub fn location(mut self, location: &'a str) -> Self {
-        self.inner.location = Some(location);
+    pub fn location(mut self, location: impl Into<String>) -> Self {
+        self.inner.location = Some(location.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
 }
-impl CreateTerminalReader<'_> {
+impl CreateTerminalReader {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -371,23 +383,23 @@ impl CreateTerminalReader<'_> {
     }
 }
 
-impl StripeRequest for CreateTerminalReader<'_> {
+impl StripeRequest for CreateTerminalReader {
     type Output = stripe_terminal::TerminalReader;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Post, "/terminal/readers").form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdateTerminalReaderBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdateTerminalReaderBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    label: Option<&'a str>,
+    label: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
 }
-impl<'a> UpdateTerminalReaderBuilder<'a> {
+impl UpdateTerminalReaderBuilder {
     fn new() -> Self {
         Self { expand: None, label: None, metadata: None }
     }
@@ -395,35 +407,38 @@ impl<'a> UpdateTerminalReaderBuilder<'a> {
 /// Updates a `Reader` object by setting the values of the parameters passed.
 /// Any parameters not provided will be left unchanged.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateTerminalReader<'a> {
-    inner: UpdateTerminalReaderBuilder<'a>,
-    reader: &'a stripe_terminal::TerminalReaderId,
+pub struct UpdateTerminalReader {
+    inner: UpdateTerminalReaderBuilder,
+    reader: stripe_terminal::TerminalReaderId,
 }
-impl<'a> UpdateTerminalReader<'a> {
+impl UpdateTerminalReader {
     /// Construct a new `UpdateTerminalReader`.
-    pub fn new(reader: &'a stripe_terminal::TerminalReaderId) -> Self {
-        Self { reader, inner: UpdateTerminalReaderBuilder::new() }
+    pub fn new(reader: impl Into<stripe_terminal::TerminalReaderId>) -> Self {
+        Self { reader: reader.into(), inner: UpdateTerminalReaderBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// The new label of the reader.
-    pub fn label(mut self, label: &'a str) -> Self {
-        self.inner.label = Some(label);
+    pub fn label(mut self, label: impl Into<String>) -> Self {
+        self.inner.label = Some(label.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
 }
-impl UpdateTerminalReader<'_> {
+impl UpdateTerminalReader {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -441,11 +456,11 @@ impl UpdateTerminalReader<'_> {
     }
 }
 
-impl StripeRequest for UpdateTerminalReader<'_> {
+impl StripeRequest for UpdateTerminalReader {
     type Output = UpdateTerminalReaderReturned;
 
     fn build(&self) -> RequestBuilder {
-        let reader = self.reader;
+        let reader = &self.reader;
         RequestBuilder::new(StripeMethod::Post, format!("/terminal/readers/{reader}"))
             .form(&self.inner)
     }
@@ -532,34 +547,34 @@ const _: () = {
     }
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CancelActionTerminalReaderBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CancelActionTerminalReaderBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> CancelActionTerminalReaderBuilder<'a> {
+impl CancelActionTerminalReaderBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Cancels the current reader action.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CancelActionTerminalReader<'a> {
-    inner: CancelActionTerminalReaderBuilder<'a>,
-    reader: &'a stripe_terminal::TerminalReaderId,
+pub struct CancelActionTerminalReader {
+    inner: CancelActionTerminalReaderBuilder,
+    reader: stripe_terminal::TerminalReaderId,
 }
-impl<'a> CancelActionTerminalReader<'a> {
+impl CancelActionTerminalReader {
     /// Construct a new `CancelActionTerminalReader`.
-    pub fn new(reader: &'a stripe_terminal::TerminalReaderId) -> Self {
-        Self { reader, inner: CancelActionTerminalReaderBuilder::new() }
+    pub fn new(reader: impl Into<stripe_terminal::TerminalReaderId>) -> Self {
+        Self { reader: reader.into(), inner: CancelActionTerminalReaderBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl CancelActionTerminalReader<'_> {
+impl CancelActionTerminalReader {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -577,26 +592,26 @@ impl CancelActionTerminalReader<'_> {
     }
 }
 
-impl StripeRequest for CancelActionTerminalReader<'_> {
+impl StripeRequest for CancelActionTerminalReader {
     type Output = stripe_terminal::TerminalReader;
 
     fn build(&self) -> RequestBuilder {
-        let reader = self.reader;
+        let reader = &self.reader;
         RequestBuilder::new(StripeMethod::Post, format!("/terminal/readers/{reader}/cancel_action"))
             .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ProcessPaymentIntentTerminalReaderBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ProcessPaymentIntentTerminalReaderBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
-    payment_intent: &'a str,
+    expand: Option<Vec<String>>,
+    payment_intent: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     process_config: Option<ProcessPaymentIntentTerminalReaderProcessConfig>,
 }
-impl<'a> ProcessPaymentIntentTerminalReaderBuilder<'a> {
-    fn new(payment_intent: &'a str) -> Self {
-        Self { expand: None, payment_intent, process_config: None }
+impl ProcessPaymentIntentTerminalReaderBuilder {
+    fn new(payment_intent: impl Into<String>) -> Self {
+        Self { expand: None, payment_intent: payment_intent.into(), process_config: None }
     }
 }
 /// Configuration overrides
@@ -642,30 +657,36 @@ impl Default for ProcessPaymentIntentTerminalReaderProcessConfigTipping {
 }
 /// Initiates a payment flow on a Reader.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ProcessPaymentIntentTerminalReader<'a> {
-    inner: ProcessPaymentIntentTerminalReaderBuilder<'a>,
-    reader: &'a stripe_terminal::TerminalReaderId,
+pub struct ProcessPaymentIntentTerminalReader {
+    inner: ProcessPaymentIntentTerminalReaderBuilder,
+    reader: stripe_terminal::TerminalReaderId,
 }
-impl<'a> ProcessPaymentIntentTerminalReader<'a> {
+impl ProcessPaymentIntentTerminalReader {
     /// Construct a new `ProcessPaymentIntentTerminalReader`.
-    pub fn new(reader: &'a stripe_terminal::TerminalReaderId, payment_intent: &'a str) -> Self {
-        Self { reader, inner: ProcessPaymentIntentTerminalReaderBuilder::new(payment_intent) }
+    pub fn new(
+        reader: impl Into<stripe_terminal::TerminalReaderId>,
+        payment_intent: impl Into<String>,
+    ) -> Self {
+        Self {
+            reader: reader.into(),
+            inner: ProcessPaymentIntentTerminalReaderBuilder::new(payment_intent.into()),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Configuration overrides
     pub fn process_config(
         mut self,
-        process_config: ProcessPaymentIntentTerminalReaderProcessConfig,
+        process_config: impl Into<ProcessPaymentIntentTerminalReaderProcessConfig>,
     ) -> Self {
-        self.inner.process_config = Some(process_config);
+        self.inner.process_config = Some(process_config.into());
         self
     }
 }
-impl ProcessPaymentIntentTerminalReader<'_> {
+impl ProcessPaymentIntentTerminalReader {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -683,11 +704,11 @@ impl ProcessPaymentIntentTerminalReader<'_> {
     }
 }
 
-impl StripeRequest for ProcessPaymentIntentTerminalReader<'_> {
+impl StripeRequest for ProcessPaymentIntentTerminalReader {
     type Output = stripe_terminal::TerminalReader;
 
     fn build(&self) -> RequestBuilder {
-        let reader = self.reader;
+        let reader = &self.reader;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/terminal/readers/{reader}/process_payment_intent"),
@@ -695,18 +716,23 @@ impl StripeRequest for ProcessPaymentIntentTerminalReader<'_> {
         .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ProcessSetupIntentTerminalReaderBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ProcessSetupIntentTerminalReaderBuilder {
     customer_consent_collected: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     process_config: Option<ProcessSetupIntentTerminalReaderProcessConfig>,
-    setup_intent: &'a str,
+    setup_intent: String,
 }
-impl<'a> ProcessSetupIntentTerminalReaderBuilder<'a> {
-    fn new(customer_consent_collected: bool, setup_intent: &'a str) -> Self {
-        Self { customer_consent_collected, expand: None, process_config: None, setup_intent }
+impl ProcessSetupIntentTerminalReaderBuilder {
+    fn new(customer_consent_collected: impl Into<bool>, setup_intent: impl Into<String>) -> Self {
+        Self {
+            customer_consent_collected: customer_consent_collected.into(),
+            expand: None,
+            process_config: None,
+            setup_intent: setup_intent.into(),
+        }
     }
 }
 /// Configuration overrides
@@ -728,40 +754,40 @@ impl Default for ProcessSetupIntentTerminalReaderProcessConfig {
 }
 /// Initiates a setup intent flow on a Reader.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ProcessSetupIntentTerminalReader<'a> {
-    inner: ProcessSetupIntentTerminalReaderBuilder<'a>,
-    reader: &'a stripe_terminal::TerminalReaderId,
+pub struct ProcessSetupIntentTerminalReader {
+    inner: ProcessSetupIntentTerminalReaderBuilder,
+    reader: stripe_terminal::TerminalReaderId,
 }
-impl<'a> ProcessSetupIntentTerminalReader<'a> {
+impl ProcessSetupIntentTerminalReader {
     /// Construct a new `ProcessSetupIntentTerminalReader`.
     pub fn new(
-        reader: &'a stripe_terminal::TerminalReaderId,
-        customer_consent_collected: bool,
-        setup_intent: &'a str,
+        reader: impl Into<stripe_terminal::TerminalReaderId>,
+        customer_consent_collected: impl Into<bool>,
+        setup_intent: impl Into<String>,
     ) -> Self {
         Self {
-            reader,
+            reader: reader.into(),
             inner: ProcessSetupIntentTerminalReaderBuilder::new(
-                customer_consent_collected,
-                setup_intent,
+                customer_consent_collected.into(),
+                setup_intent.into(),
             ),
         }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Configuration overrides
     pub fn process_config(
         mut self,
-        process_config: ProcessSetupIntentTerminalReaderProcessConfig,
+        process_config: impl Into<ProcessSetupIntentTerminalReaderProcessConfig>,
     ) -> Self {
-        self.inner.process_config = Some(process_config);
+        self.inner.process_config = Some(process_config.into());
         self
     }
 }
-impl ProcessSetupIntentTerminalReader<'_> {
+impl ProcessSetupIntentTerminalReader {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -779,11 +805,11 @@ impl ProcessSetupIntentTerminalReader<'_> {
     }
 }
 
-impl StripeRequest for ProcessSetupIntentTerminalReader<'_> {
+impl StripeRequest for ProcessSetupIntentTerminalReader {
     type Output = stripe_terminal::TerminalReader;
 
     fn build(&self) -> RequestBuilder {
-        let reader = self.reader;
+        let reader = &self.reader;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/terminal/readers/{reader}/process_setup_intent"),
@@ -791,18 +817,18 @@ impl StripeRequest for ProcessSetupIntentTerminalReader<'_> {
         .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RefundPaymentTerminalReaderBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RefundPaymentTerminalReaderBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     amount: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    charge: Option<&'a str>,
+    charge: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    payment_intent: Option<&'a str>,
+    payment_intent: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     refund_application_fee: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -810,7 +836,7 @@ struct RefundPaymentTerminalReaderBuilder<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     reverse_transfer: Option<bool>,
 }
-impl<'a> RefundPaymentTerminalReaderBuilder<'a> {
+impl RefundPaymentTerminalReaderBuilder {
     fn new() -> Self {
         Self {
             amount: None,
@@ -843,68 +869,71 @@ impl Default for RefundPaymentTerminalReaderRefundPaymentConfig {
 }
 /// Initiates a refund on a Reader
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RefundPaymentTerminalReader<'a> {
-    inner: RefundPaymentTerminalReaderBuilder<'a>,
-    reader: &'a stripe_terminal::TerminalReaderId,
+pub struct RefundPaymentTerminalReader {
+    inner: RefundPaymentTerminalReaderBuilder,
+    reader: stripe_terminal::TerminalReaderId,
 }
-impl<'a> RefundPaymentTerminalReader<'a> {
+impl RefundPaymentTerminalReader {
     /// Construct a new `RefundPaymentTerminalReader`.
-    pub fn new(reader: &'a stripe_terminal::TerminalReaderId) -> Self {
-        Self { reader, inner: RefundPaymentTerminalReaderBuilder::new() }
+    pub fn new(reader: impl Into<stripe_terminal::TerminalReaderId>) -> Self {
+        Self { reader: reader.into(), inner: RefundPaymentTerminalReaderBuilder::new() }
     }
     /// A positive integer in __cents__ representing how much of this charge to refund.
-    pub fn amount(mut self, amount: i64) -> Self {
-        self.inner.amount = Some(amount);
+    pub fn amount(mut self, amount: impl Into<i64>) -> Self {
+        self.inner.amount = Some(amount.into());
         self
     }
     /// ID of the Charge to refund.
-    pub fn charge(mut self, charge: &'a str) -> Self {
-        self.inner.charge = Some(charge);
+    pub fn charge(mut self, charge: impl Into<String>) -> Self {
+        self.inner.charge = Some(charge.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// ID of the PaymentIntent to refund.
-    pub fn payment_intent(mut self, payment_intent: &'a str) -> Self {
-        self.inner.payment_intent = Some(payment_intent);
+    pub fn payment_intent(mut self, payment_intent: impl Into<String>) -> Self {
+        self.inner.payment_intent = Some(payment_intent.into());
         self
     }
     /// Boolean indicating whether the application fee should be refunded when refunding this charge.
     /// If a full charge refund is given, the full application fee will be refunded.
     /// Otherwise, the application fee will be refunded in an amount proportional to the amount of the charge refunded.
     /// An application fee can be refunded only by the application that created the charge.
-    pub fn refund_application_fee(mut self, refund_application_fee: bool) -> Self {
-        self.inner.refund_application_fee = Some(refund_application_fee);
+    pub fn refund_application_fee(mut self, refund_application_fee: impl Into<bool>) -> Self {
+        self.inner.refund_application_fee = Some(refund_application_fee.into());
         self
     }
     /// Configuration overrides
     pub fn refund_payment_config(
         mut self,
-        refund_payment_config: RefundPaymentTerminalReaderRefundPaymentConfig,
+        refund_payment_config: impl Into<RefundPaymentTerminalReaderRefundPaymentConfig>,
     ) -> Self {
-        self.inner.refund_payment_config = Some(refund_payment_config);
+        self.inner.refund_payment_config = Some(refund_payment_config.into());
         self
     }
     /// Boolean indicating whether the transfer should be reversed when refunding this charge.
     /// The transfer will be reversed proportionally to the amount being refunded (either the entire or partial amount).
     /// A transfer can be reversed only by the application that created the charge.
-    pub fn reverse_transfer(mut self, reverse_transfer: bool) -> Self {
-        self.inner.reverse_transfer = Some(reverse_transfer);
+    pub fn reverse_transfer(mut self, reverse_transfer: impl Into<bool>) -> Self {
+        self.inner.reverse_transfer = Some(reverse_transfer.into());
         self
     }
 }
-impl RefundPaymentTerminalReader<'_> {
+impl RefundPaymentTerminalReader {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -922,11 +951,11 @@ impl RefundPaymentTerminalReader<'_> {
     }
 }
 
-impl StripeRequest for RefundPaymentTerminalReader<'_> {
+impl StripeRequest for RefundPaymentTerminalReader {
     type Output = stripe_terminal::TerminalReader;
 
     fn build(&self) -> RequestBuilder {
-        let reader = self.reader;
+        let reader = &self.reader;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/terminal/readers/{reader}/refund_payment"),
@@ -934,56 +963,65 @@ impl StripeRequest for RefundPaymentTerminalReader<'_> {
         .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct SetReaderDisplayTerminalReaderBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct SetReaderDisplayTerminalReaderBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    cart: Option<SetReaderDisplayTerminalReaderCart<'a>>,
+    cart: Option<SetReaderDisplayTerminalReaderCart>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(rename = "type")]
     type_: SetReaderDisplayTerminalReaderType,
 }
-impl<'a> SetReaderDisplayTerminalReaderBuilder<'a> {
-    fn new(type_: SetReaderDisplayTerminalReaderType) -> Self {
-        Self { cart: None, expand: None, type_ }
+impl SetReaderDisplayTerminalReaderBuilder {
+    fn new(type_: impl Into<SetReaderDisplayTerminalReaderType>) -> Self {
+        Self { cart: None, expand: None, type_: type_.into() }
     }
 }
 /// Cart
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct SetReaderDisplayTerminalReaderCart<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct SetReaderDisplayTerminalReaderCart {
     /// Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
     /// Must be a [supported currency](https://stripe.com/docs/currencies).
     pub currency: stripe_types::Currency,
     /// Array of line items that were purchased.
-    pub line_items: &'a [SetReaderDisplayTerminalReaderCartLineItems<'a>],
+    pub line_items: Vec<SetReaderDisplayTerminalReaderCartLineItems>,
     /// The amount of tax in cents.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tax: Option<i64>,
     /// Total balance of cart due in cents.
     pub total: i64,
 }
-impl<'a> SetReaderDisplayTerminalReaderCart<'a> {
+impl SetReaderDisplayTerminalReaderCart {
     pub fn new(
-        currency: stripe_types::Currency,
-        line_items: &'a [SetReaderDisplayTerminalReaderCartLineItems<'a>],
-        total: i64,
+        currency: impl Into<stripe_types::Currency>,
+        line_items: impl Into<Vec<SetReaderDisplayTerminalReaderCartLineItems>>,
+        total: impl Into<i64>,
     ) -> Self {
-        Self { currency, line_items, tax: None, total }
+        Self {
+            currency: currency.into(),
+            line_items: line_items.into(),
+            tax: None,
+            total: total.into(),
+        }
     }
 }
 /// Array of line items that were purchased.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct SetReaderDisplayTerminalReaderCartLineItems<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct SetReaderDisplayTerminalReaderCartLineItems {
     /// The price of the item in cents.
     pub amount: i64,
     /// The description or name of the item.
-    pub description: &'a str,
+    pub description: String,
     /// The quantity of the line item being purchased.
     pub quantity: u64,
 }
-impl<'a> SetReaderDisplayTerminalReaderCartLineItems<'a> {
-    pub fn new(amount: i64, description: &'a str, quantity: u64) -> Self {
-        Self { amount, description, quantity }
+impl SetReaderDisplayTerminalReaderCartLineItems {
+    pub fn new(
+        amount: impl Into<i64>,
+        description: impl Into<String>,
+        quantity: impl Into<u64>,
+    ) -> Self {
+        Self { amount: amount.into(), description: description.into(), quantity: quantity.into() }
     }
 }
 /// Type
@@ -1041,30 +1079,33 @@ impl<'de> serde::Deserialize<'de> for SetReaderDisplayTerminalReaderType {
 }
 /// Sets reader display to show cart details.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct SetReaderDisplayTerminalReader<'a> {
-    inner: SetReaderDisplayTerminalReaderBuilder<'a>,
-    reader: &'a stripe_terminal::TerminalReaderId,
+pub struct SetReaderDisplayTerminalReader {
+    inner: SetReaderDisplayTerminalReaderBuilder,
+    reader: stripe_terminal::TerminalReaderId,
 }
-impl<'a> SetReaderDisplayTerminalReader<'a> {
+impl SetReaderDisplayTerminalReader {
     /// Construct a new `SetReaderDisplayTerminalReader`.
     pub fn new(
-        reader: &'a stripe_terminal::TerminalReaderId,
-        type_: SetReaderDisplayTerminalReaderType,
+        reader: impl Into<stripe_terminal::TerminalReaderId>,
+        type_: impl Into<SetReaderDisplayTerminalReaderType>,
     ) -> Self {
-        Self { reader, inner: SetReaderDisplayTerminalReaderBuilder::new(type_) }
+        Self {
+            reader: reader.into(),
+            inner: SetReaderDisplayTerminalReaderBuilder::new(type_.into()),
+        }
     }
     /// Cart
-    pub fn cart(mut self, cart: SetReaderDisplayTerminalReaderCart<'a>) -> Self {
-        self.inner.cart = Some(cart);
+    pub fn cart(mut self, cart: impl Into<SetReaderDisplayTerminalReaderCart>) -> Self {
+        self.inner.cart = Some(cart.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl SetReaderDisplayTerminalReader<'_> {
+impl SetReaderDisplayTerminalReader {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -1082,11 +1123,11 @@ impl SetReaderDisplayTerminalReader<'_> {
     }
 }
 
-impl StripeRequest for SetReaderDisplayTerminalReader<'_> {
+impl StripeRequest for SetReaderDisplayTerminalReader {
     type Output = stripe_terminal::TerminalReader;
 
     fn build(&self) -> RequestBuilder {
-        let reader = self.reader;
+        let reader = &self.reader;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/terminal/readers/{reader}/set_reader_display"),
@@ -1094,21 +1135,21 @@ impl StripeRequest for SetReaderDisplayTerminalReader<'_> {
         .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct PresentPaymentMethodTerminalReaderBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct PresentPaymentMethodTerminalReaderBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     amount_tip: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    card_present: Option<PresentPaymentMethodTerminalReaderCardPresent<'a>>,
+    card_present: Option<PresentPaymentMethodTerminalReaderCardPresent>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    interac_present: Option<PresentPaymentMethodTerminalReaderInteracPresent<'a>>,
+    interac_present: Option<PresentPaymentMethodTerminalReaderInteracPresent>,
     #[serde(rename = "type")]
     #[serde(skip_serializing_if = "Option::is_none")]
     type_: Option<PresentPaymentMethodTerminalReaderType>,
 }
-impl<'a> PresentPaymentMethodTerminalReaderBuilder<'a> {
+impl PresentPaymentMethodTerminalReaderBuilder {
     fn new() -> Self {
         Self {
             amount_tip: None,
@@ -1120,35 +1161,35 @@ impl<'a> PresentPaymentMethodTerminalReaderBuilder<'a> {
     }
 }
 /// Simulated data for the card_present payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct PresentPaymentMethodTerminalReaderCardPresent<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct PresentPaymentMethodTerminalReaderCardPresent {
     /// The card number, as a string without any separators.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub number: Option<&'a str>,
+    pub number: Option<String>,
 }
-impl<'a> PresentPaymentMethodTerminalReaderCardPresent<'a> {
+impl PresentPaymentMethodTerminalReaderCardPresent {
     pub fn new() -> Self {
         Self { number: None }
     }
 }
-impl<'a> Default for PresentPaymentMethodTerminalReaderCardPresent<'a> {
+impl Default for PresentPaymentMethodTerminalReaderCardPresent {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Simulated data for the interac_present payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct PresentPaymentMethodTerminalReaderInteracPresent<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct PresentPaymentMethodTerminalReaderInteracPresent {
     /// Card Number
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub number: Option<&'a str>,
+    pub number: Option<String>,
 }
-impl<'a> PresentPaymentMethodTerminalReaderInteracPresent<'a> {
+impl PresentPaymentMethodTerminalReaderInteracPresent {
     pub fn new() -> Self {
         Self { number: None }
     }
 }
-impl<'a> Default for PresentPaymentMethodTerminalReaderInteracPresent<'a> {
+impl Default for PresentPaymentMethodTerminalReaderInteracPresent {
     fn default() -> Self {
         Self::new()
     }
@@ -1212,48 +1253,48 @@ impl<'de> serde::Deserialize<'de> for PresentPaymentMethodTerminalReaderType {
 /// Presents a payment method on a simulated reader.
 /// Can be used to simulate accepting a payment, saving a card or refunding a transaction.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct PresentPaymentMethodTerminalReader<'a> {
-    inner: PresentPaymentMethodTerminalReaderBuilder<'a>,
-    reader: &'a str,
+pub struct PresentPaymentMethodTerminalReader {
+    inner: PresentPaymentMethodTerminalReaderBuilder,
+    reader: String,
 }
-impl<'a> PresentPaymentMethodTerminalReader<'a> {
+impl PresentPaymentMethodTerminalReader {
     /// Construct a new `PresentPaymentMethodTerminalReader`.
-    pub fn new(reader: &'a str) -> Self {
-        Self { reader, inner: PresentPaymentMethodTerminalReaderBuilder::new() }
+    pub fn new(reader: impl Into<String>) -> Self {
+        Self { reader: reader.into(), inner: PresentPaymentMethodTerminalReaderBuilder::new() }
     }
     /// Simulated on-reader tip amount.
-    pub fn amount_tip(mut self, amount_tip: i64) -> Self {
-        self.inner.amount_tip = Some(amount_tip);
+    pub fn amount_tip(mut self, amount_tip: impl Into<i64>) -> Self {
+        self.inner.amount_tip = Some(amount_tip.into());
         self
     }
     /// Simulated data for the card_present payment method.
     pub fn card_present(
         mut self,
-        card_present: PresentPaymentMethodTerminalReaderCardPresent<'a>,
+        card_present: impl Into<PresentPaymentMethodTerminalReaderCardPresent>,
     ) -> Self {
-        self.inner.card_present = Some(card_present);
+        self.inner.card_present = Some(card_present.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Simulated data for the interac_present payment method.
     pub fn interac_present(
         mut self,
-        interac_present: PresentPaymentMethodTerminalReaderInteracPresent<'a>,
+        interac_present: impl Into<PresentPaymentMethodTerminalReaderInteracPresent>,
     ) -> Self {
-        self.inner.interac_present = Some(interac_present);
+        self.inner.interac_present = Some(interac_present.into());
         self
     }
     /// Simulated payment type.
-    pub fn type_(mut self, type_: PresentPaymentMethodTerminalReaderType) -> Self {
-        self.inner.type_ = Some(type_);
+    pub fn type_(mut self, type_: impl Into<PresentPaymentMethodTerminalReaderType>) -> Self {
+        self.inner.type_ = Some(type_.into());
         self
     }
 }
-impl PresentPaymentMethodTerminalReader<'_> {
+impl PresentPaymentMethodTerminalReader {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -1271,11 +1312,11 @@ impl PresentPaymentMethodTerminalReader<'_> {
     }
 }
 
-impl StripeRequest for PresentPaymentMethodTerminalReader<'_> {
+impl StripeRequest for PresentPaymentMethodTerminalReader {
     type Output = stripe_terminal::TerminalReader;
 
     fn build(&self) -> RequestBuilder {
-        let reader = self.reader;
+        let reader = &self.reader;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/test_helpers/terminal/readers/{reader}/present_payment_method"),

--- a/generated/async-stripe-treasury/src/treasury_credit_reversal/requests.rs
+++ b/generated/async-stripe-treasury/src/treasury_credit_reversal/requests.rs
@@ -2,28 +2,28 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListTreasuryCreditReversalBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListTreasuryCreditReversalBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
-    financial_account: &'a str,
+    expand: Option<Vec<String>>,
+    financial_account: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    received_credit: Option<&'a str>,
+    received_credit: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     status: Option<stripe_treasury::TreasuryCreditReversalStatus>,
 }
-impl<'a> ListTreasuryCreditReversalBuilder<'a> {
-    fn new(financial_account: &'a str) -> Self {
+impl ListTreasuryCreditReversalBuilder {
+    fn new(financial_account: impl Into<String>) -> Self {
         Self {
             ending_before: None,
             expand: None,
-            financial_account,
+            financial_account: financial_account.into(),
             limit: None,
             received_credit: None,
             starting_after: None,
@@ -33,51 +33,54 @@ impl<'a> ListTreasuryCreditReversalBuilder<'a> {
 }
 /// Returns a list of CreditReversals.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListTreasuryCreditReversal<'a> {
-    inner: ListTreasuryCreditReversalBuilder<'a>,
+pub struct ListTreasuryCreditReversal {
+    inner: ListTreasuryCreditReversalBuilder,
 }
-impl<'a> ListTreasuryCreditReversal<'a> {
+impl ListTreasuryCreditReversal {
     /// Construct a new `ListTreasuryCreditReversal`.
-    pub fn new(financial_account: &'a str) -> Self {
-        Self { inner: ListTreasuryCreditReversalBuilder::new(financial_account) }
+    pub fn new(financial_account: impl Into<String>) -> Self {
+        Self { inner: ListTreasuryCreditReversalBuilder::new(financial_account.into()) }
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// Only return CreditReversals for the ReceivedCredit ID.
-    pub fn received_credit(mut self, received_credit: &'a str) -> Self {
-        self.inner.received_credit = Some(received_credit);
+    pub fn received_credit(mut self, received_credit: impl Into<String>) -> Self {
+        self.inner.received_credit = Some(received_credit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
     /// Only return CreditReversals for a given status.
-    pub fn status(mut self, status: stripe_treasury::TreasuryCreditReversalStatus) -> Self {
-        self.inner.status = Some(status);
+    pub fn status(
+        mut self,
+        status: impl Into<stripe_treasury::TreasuryCreditReversalStatus>,
+    ) -> Self {
+        self.inner.status = Some(status.into());
         self
     }
 }
-impl ListTreasuryCreditReversal<'_> {
+impl ListTreasuryCreditReversal {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -99,45 +102,48 @@ impl ListTreasuryCreditReversal<'_> {
     ) -> stripe_client_core::ListPaginator<
         stripe_types::List<stripe_treasury::TreasuryCreditReversal>,
     > {
-        stripe_client_core::ListPaginator::new_list("/treasury/credit_reversals", self.inner)
+        stripe_client_core::ListPaginator::new_list("/treasury/credit_reversals", &self.inner)
     }
 }
 
-impl StripeRequest for ListTreasuryCreditReversal<'_> {
+impl StripeRequest for ListTreasuryCreditReversal {
     type Output = stripe_types::List<stripe_treasury::TreasuryCreditReversal>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/treasury/credit_reversals").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveTreasuryCreditReversalBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveTreasuryCreditReversalBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveTreasuryCreditReversalBuilder<'a> {
+impl RetrieveTreasuryCreditReversalBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves the details of an existing CreditReversal by passing the unique CreditReversal ID from either the CreditReversal creation request or CreditReversal list.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveTreasuryCreditReversal<'a> {
-    inner: RetrieveTreasuryCreditReversalBuilder<'a>,
-    credit_reversal: &'a stripe_treasury::TreasuryCreditReversalId,
+pub struct RetrieveTreasuryCreditReversal {
+    inner: RetrieveTreasuryCreditReversalBuilder,
+    credit_reversal: stripe_treasury::TreasuryCreditReversalId,
 }
-impl<'a> RetrieveTreasuryCreditReversal<'a> {
+impl RetrieveTreasuryCreditReversal {
     /// Construct a new `RetrieveTreasuryCreditReversal`.
-    pub fn new(credit_reversal: &'a stripe_treasury::TreasuryCreditReversalId) -> Self {
-        Self { credit_reversal, inner: RetrieveTreasuryCreditReversalBuilder::new() }
+    pub fn new(credit_reversal: impl Into<stripe_treasury::TreasuryCreditReversalId>) -> Self {
+        Self {
+            credit_reversal: credit_reversal.into(),
+            inner: RetrieveTreasuryCreditReversalBuilder::new(),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveTreasuryCreditReversal<'_> {
+impl RetrieveTreasuryCreditReversal {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -155,11 +161,11 @@ impl RetrieveTreasuryCreditReversal<'_> {
     }
 }
 
-impl StripeRequest for RetrieveTreasuryCreditReversal<'_> {
+impl StripeRequest for RetrieveTreasuryCreditReversal {
     type Output = stripe_treasury::TreasuryCreditReversal;
 
     fn build(&self) -> RequestBuilder {
-        let credit_reversal = self.credit_reversal;
+        let credit_reversal = &self.credit_reversal;
         RequestBuilder::new(
             StripeMethod::Get,
             format!("/treasury/credit_reversals/{credit_reversal}"),
@@ -167,44 +173,47 @@ impl StripeRequest for RetrieveTreasuryCreditReversal<'_> {
         .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateTreasuryCreditReversalBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateTreasuryCreditReversalBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
-    received_credit: &'a str,
+    metadata: Option<std::collections::HashMap<String, String>>,
+    received_credit: String,
 }
-impl<'a> CreateTreasuryCreditReversalBuilder<'a> {
-    fn new(received_credit: &'a str) -> Self {
-        Self { expand: None, metadata: None, received_credit }
+impl CreateTreasuryCreditReversalBuilder {
+    fn new(received_credit: impl Into<String>) -> Self {
+        Self { expand: None, metadata: None, received_credit: received_credit.into() }
     }
 }
 /// Reverses a ReceivedCredit and creates a CreditReversal object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateTreasuryCreditReversal<'a> {
-    inner: CreateTreasuryCreditReversalBuilder<'a>,
+pub struct CreateTreasuryCreditReversal {
+    inner: CreateTreasuryCreditReversalBuilder,
 }
-impl<'a> CreateTreasuryCreditReversal<'a> {
+impl CreateTreasuryCreditReversal {
     /// Construct a new `CreateTreasuryCreditReversal`.
-    pub fn new(received_credit: &'a str) -> Self {
-        Self { inner: CreateTreasuryCreditReversalBuilder::new(received_credit) }
+    pub fn new(received_credit: impl Into<String>) -> Self {
+        Self { inner: CreateTreasuryCreditReversalBuilder::new(received_credit.into()) }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
 }
-impl CreateTreasuryCreditReversal<'_> {
+impl CreateTreasuryCreditReversal {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -222,7 +231,7 @@ impl CreateTreasuryCreditReversal<'_> {
     }
 }
 
-impl StripeRequest for CreateTreasuryCreditReversal<'_> {
+impl StripeRequest for CreateTreasuryCreditReversal {
     type Output = stripe_treasury::TreasuryCreditReversal;
 
     fn build(&self) -> RequestBuilder {

--- a/generated/async-stripe-treasury/src/treasury_debit_reversal/requests.rs
+++ b/generated/async-stripe-treasury/src/treasury_debit_reversal/requests.rs
@@ -2,30 +2,30 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListTreasuryDebitReversalBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListTreasuryDebitReversalBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
-    financial_account: &'a str,
+    expand: Option<Vec<String>>,
+    financial_account: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    received_debit: Option<&'a str>,
+    received_debit: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     resolution: Option<ListTreasuryDebitReversalResolution>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     status: Option<ListTreasuryDebitReversalStatus>,
 }
-impl<'a> ListTreasuryDebitReversalBuilder<'a> {
-    fn new(financial_account: &'a str) -> Self {
+impl ListTreasuryDebitReversalBuilder {
+    fn new(financial_account: impl Into<String>) -> Self {
         Self {
             ending_before: None,
             expand: None,
-            financial_account,
+            financial_account: financial_account.into(),
             limit: None,
             received_debit: None,
             resolution: None,
@@ -151,56 +151,59 @@ impl<'de> serde::Deserialize<'de> for ListTreasuryDebitReversalStatus {
 }
 /// Returns a list of DebitReversals.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListTreasuryDebitReversal<'a> {
-    inner: ListTreasuryDebitReversalBuilder<'a>,
+pub struct ListTreasuryDebitReversal {
+    inner: ListTreasuryDebitReversalBuilder,
 }
-impl<'a> ListTreasuryDebitReversal<'a> {
+impl ListTreasuryDebitReversal {
     /// Construct a new `ListTreasuryDebitReversal`.
-    pub fn new(financial_account: &'a str) -> Self {
-        Self { inner: ListTreasuryDebitReversalBuilder::new(financial_account) }
+    pub fn new(financial_account: impl Into<String>) -> Self {
+        Self { inner: ListTreasuryDebitReversalBuilder::new(financial_account.into()) }
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// Only return DebitReversals for the ReceivedDebit ID.
-    pub fn received_debit(mut self, received_debit: &'a str) -> Self {
-        self.inner.received_debit = Some(received_debit);
+    pub fn received_debit(mut self, received_debit: impl Into<String>) -> Self {
+        self.inner.received_debit = Some(received_debit.into());
         self
     }
     /// Only return DebitReversals for a given resolution.
-    pub fn resolution(mut self, resolution: ListTreasuryDebitReversalResolution) -> Self {
-        self.inner.resolution = Some(resolution);
+    pub fn resolution(
+        mut self,
+        resolution: impl Into<ListTreasuryDebitReversalResolution>,
+    ) -> Self {
+        self.inner.resolution = Some(resolution.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
     /// Only return DebitReversals for a given status.
-    pub fn status(mut self, status: ListTreasuryDebitReversalStatus) -> Self {
-        self.inner.status = Some(status);
+    pub fn status(mut self, status: impl Into<ListTreasuryDebitReversalStatus>) -> Self {
+        self.inner.status = Some(status.into());
         self
     }
 }
-impl ListTreasuryDebitReversal<'_> {
+impl ListTreasuryDebitReversal {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -221,45 +224,48 @@ impl ListTreasuryDebitReversal<'_> {
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_treasury::TreasuryDebitReversal>>
     {
-        stripe_client_core::ListPaginator::new_list("/treasury/debit_reversals", self.inner)
+        stripe_client_core::ListPaginator::new_list("/treasury/debit_reversals", &self.inner)
     }
 }
 
-impl StripeRequest for ListTreasuryDebitReversal<'_> {
+impl StripeRequest for ListTreasuryDebitReversal {
     type Output = stripe_types::List<stripe_treasury::TreasuryDebitReversal>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/treasury/debit_reversals").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveTreasuryDebitReversalBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveTreasuryDebitReversalBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveTreasuryDebitReversalBuilder<'a> {
+impl RetrieveTreasuryDebitReversalBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves a DebitReversal object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveTreasuryDebitReversal<'a> {
-    inner: RetrieveTreasuryDebitReversalBuilder<'a>,
-    debit_reversal: &'a stripe_treasury::TreasuryDebitReversalId,
+pub struct RetrieveTreasuryDebitReversal {
+    inner: RetrieveTreasuryDebitReversalBuilder,
+    debit_reversal: stripe_treasury::TreasuryDebitReversalId,
 }
-impl<'a> RetrieveTreasuryDebitReversal<'a> {
+impl RetrieveTreasuryDebitReversal {
     /// Construct a new `RetrieveTreasuryDebitReversal`.
-    pub fn new(debit_reversal: &'a stripe_treasury::TreasuryDebitReversalId) -> Self {
-        Self { debit_reversal, inner: RetrieveTreasuryDebitReversalBuilder::new() }
+    pub fn new(debit_reversal: impl Into<stripe_treasury::TreasuryDebitReversalId>) -> Self {
+        Self {
+            debit_reversal: debit_reversal.into(),
+            inner: RetrieveTreasuryDebitReversalBuilder::new(),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveTreasuryDebitReversal<'_> {
+impl RetrieveTreasuryDebitReversal {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -277,11 +283,11 @@ impl RetrieveTreasuryDebitReversal<'_> {
     }
 }
 
-impl StripeRequest for RetrieveTreasuryDebitReversal<'_> {
+impl StripeRequest for RetrieveTreasuryDebitReversal {
     type Output = stripe_treasury::TreasuryDebitReversal;
 
     fn build(&self) -> RequestBuilder {
-        let debit_reversal = self.debit_reversal;
+        let debit_reversal = &self.debit_reversal;
         RequestBuilder::new(
             StripeMethod::Get,
             format!("/treasury/debit_reversals/{debit_reversal}"),
@@ -289,44 +295,47 @@ impl StripeRequest for RetrieveTreasuryDebitReversal<'_> {
         .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateTreasuryDebitReversalBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateTreasuryDebitReversalBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
-    received_debit: &'a str,
+    metadata: Option<std::collections::HashMap<String, String>>,
+    received_debit: String,
 }
-impl<'a> CreateTreasuryDebitReversalBuilder<'a> {
-    fn new(received_debit: &'a str) -> Self {
-        Self { expand: None, metadata: None, received_debit }
+impl CreateTreasuryDebitReversalBuilder {
+    fn new(received_debit: impl Into<String>) -> Self {
+        Self { expand: None, metadata: None, received_debit: received_debit.into() }
     }
 }
 /// Reverses a ReceivedDebit and creates a DebitReversal object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateTreasuryDebitReversal<'a> {
-    inner: CreateTreasuryDebitReversalBuilder<'a>,
+pub struct CreateTreasuryDebitReversal {
+    inner: CreateTreasuryDebitReversalBuilder,
 }
-impl<'a> CreateTreasuryDebitReversal<'a> {
+impl CreateTreasuryDebitReversal {
     /// Construct a new `CreateTreasuryDebitReversal`.
-    pub fn new(received_debit: &'a str) -> Self {
-        Self { inner: CreateTreasuryDebitReversalBuilder::new(received_debit) }
+    pub fn new(received_debit: impl Into<String>) -> Self {
+        Self { inner: CreateTreasuryDebitReversalBuilder::new(received_debit.into()) }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
 }
-impl CreateTreasuryDebitReversal<'_> {
+impl CreateTreasuryDebitReversal {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -344,7 +353,7 @@ impl CreateTreasuryDebitReversal<'_> {
     }
 }
 
-impl StripeRequest for CreateTreasuryDebitReversal<'_> {
+impl StripeRequest for CreateTreasuryDebitReversal {
     type Output = stripe_treasury::TreasuryDebitReversal;
 
     fn build(&self) -> RequestBuilder {

--- a/generated/async-stripe-treasury/src/treasury_financial_account/requests.rs
+++ b/generated/async-stripe-treasury/src/treasury_financial_account/requests.rs
@@ -2,66 +2,66 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListTreasuryFinancialAccountBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListTreasuryFinancialAccountBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     created: Option<stripe_types::RangeQueryTs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
 }
-impl<'a> ListTreasuryFinancialAccountBuilder<'a> {
+impl ListTreasuryFinancialAccountBuilder {
     fn new() -> Self {
         Self { created: None, ending_before: None, expand: None, limit: None, starting_after: None }
     }
 }
 /// Returns a list of FinancialAccounts.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListTreasuryFinancialAccount<'a> {
-    inner: ListTreasuryFinancialAccountBuilder<'a>,
+pub struct ListTreasuryFinancialAccount {
+    inner: ListTreasuryFinancialAccountBuilder,
 }
-impl<'a> ListTreasuryFinancialAccount<'a> {
+impl ListTreasuryFinancialAccount {
     /// Construct a new `ListTreasuryFinancialAccount`.
     pub fn new() -> Self {
         Self { inner: ListTreasuryFinancialAccountBuilder::new() }
     }
     /// Only return FinancialAccounts that were created during the given date interval.
-    pub fn created(mut self, created: stripe_types::RangeQueryTs) -> Self {
-        self.inner.created = Some(created);
+    pub fn created(mut self, created: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.created = Some(created.into());
         self
     }
     /// An object ID cursor for use in pagination.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit ranging from 1 to 100 (defaults to 10).
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// An object ID cursor for use in pagination.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
 }
-impl<'a> Default for ListTreasuryFinancialAccount<'a> {
+impl Default for ListTreasuryFinancialAccount {
     fn default() -> Self {
         Self::new()
     }
 }
-impl ListTreasuryFinancialAccount<'_> {
+impl ListTreasuryFinancialAccount {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -83,45 +83,48 @@ impl ListTreasuryFinancialAccount<'_> {
     ) -> stripe_client_core::ListPaginator<
         stripe_types::List<stripe_treasury::TreasuryFinancialAccount>,
     > {
-        stripe_client_core::ListPaginator::new_list("/treasury/financial_accounts", self.inner)
+        stripe_client_core::ListPaginator::new_list("/treasury/financial_accounts", &self.inner)
     }
 }
 
-impl StripeRequest for ListTreasuryFinancialAccount<'_> {
+impl StripeRequest for ListTreasuryFinancialAccount {
     type Output = stripe_types::List<stripe_treasury::TreasuryFinancialAccount>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/treasury/financial_accounts").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveTreasuryFinancialAccountBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveTreasuryFinancialAccountBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveTreasuryFinancialAccountBuilder<'a> {
+impl RetrieveTreasuryFinancialAccountBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves the details of a FinancialAccount.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveTreasuryFinancialAccount<'a> {
-    inner: RetrieveTreasuryFinancialAccountBuilder<'a>,
-    financial_account: &'a stripe_treasury::TreasuryFinancialAccountId,
+pub struct RetrieveTreasuryFinancialAccount {
+    inner: RetrieveTreasuryFinancialAccountBuilder,
+    financial_account: stripe_treasury::TreasuryFinancialAccountId,
 }
-impl<'a> RetrieveTreasuryFinancialAccount<'a> {
+impl RetrieveTreasuryFinancialAccount {
     /// Construct a new `RetrieveTreasuryFinancialAccount`.
-    pub fn new(financial_account: &'a stripe_treasury::TreasuryFinancialAccountId) -> Self {
-        Self { financial_account, inner: RetrieveTreasuryFinancialAccountBuilder::new() }
+    pub fn new(financial_account: impl Into<stripe_treasury::TreasuryFinancialAccountId>) -> Self {
+        Self {
+            financial_account: financial_account.into(),
+            inner: RetrieveTreasuryFinancialAccountBuilder::new(),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveTreasuryFinancialAccount<'_> {
+impl RetrieveTreasuryFinancialAccount {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -139,11 +142,11 @@ impl RetrieveTreasuryFinancialAccount<'_> {
     }
 }
 
-impl StripeRequest for RetrieveTreasuryFinancialAccount<'_> {
+impl StripeRequest for RetrieveTreasuryFinancialAccount {
     type Output = stripe_treasury::TreasuryFinancialAccount;
 
     fn build(&self) -> RequestBuilder {
-        let financial_account = self.financial_account;
+        let financial_account = &self.financial_account;
         RequestBuilder::new(
             StripeMethod::Get,
             format!("/treasury/financial_accounts/{financial_account}"),
@@ -151,34 +154,37 @@ impl StripeRequest for RetrieveTreasuryFinancialAccount<'_> {
         .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveFeaturesTreasuryFinancialAccountBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveFeaturesTreasuryFinancialAccountBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveFeaturesTreasuryFinancialAccountBuilder<'a> {
+impl RetrieveFeaturesTreasuryFinancialAccountBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves Features information associated with the FinancialAccount.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveFeaturesTreasuryFinancialAccount<'a> {
-    inner: RetrieveFeaturesTreasuryFinancialAccountBuilder<'a>,
-    financial_account: &'a stripe_treasury::TreasuryFinancialAccountId,
+pub struct RetrieveFeaturesTreasuryFinancialAccount {
+    inner: RetrieveFeaturesTreasuryFinancialAccountBuilder,
+    financial_account: stripe_treasury::TreasuryFinancialAccountId,
 }
-impl<'a> RetrieveFeaturesTreasuryFinancialAccount<'a> {
+impl RetrieveFeaturesTreasuryFinancialAccount {
     /// Construct a new `RetrieveFeaturesTreasuryFinancialAccount`.
-    pub fn new(financial_account: &'a stripe_treasury::TreasuryFinancialAccountId) -> Self {
-        Self { financial_account, inner: RetrieveFeaturesTreasuryFinancialAccountBuilder::new() }
+    pub fn new(financial_account: impl Into<stripe_treasury::TreasuryFinancialAccountId>) -> Self {
+        Self {
+            financial_account: financial_account.into(),
+            inner: RetrieveFeaturesTreasuryFinancialAccountBuilder::new(),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveFeaturesTreasuryFinancialAccount<'_> {
+impl RetrieveFeaturesTreasuryFinancialAccount {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -196,11 +202,11 @@ impl RetrieveFeaturesTreasuryFinancialAccount<'_> {
     }
 }
 
-impl StripeRequest for RetrieveFeaturesTreasuryFinancialAccount<'_> {
+impl StripeRequest for RetrieveFeaturesTreasuryFinancialAccount {
     type Output = stripe_treasury::TreasuryFinancialAccountFeatures;
 
     fn build(&self) -> RequestBuilder {
-        let financial_account = self.financial_account;
+        let financial_account = &self.financial_account;
         RequestBuilder::new(
             StripeMethod::Get,
             format!("/treasury/financial_accounts/{financial_account}/features"),
@@ -208,26 +214,26 @@ impl StripeRequest for RetrieveFeaturesTreasuryFinancialAccount<'_> {
         .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateTreasuryFinancialAccountBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateTreasuryFinancialAccountBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     features: Option<CreateTreasuryFinancialAccountFeatures>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     platform_restrictions: Option<CreateTreasuryFinancialAccountPlatformRestrictions>,
-    supported_currencies: &'a [&'a str],
+    supported_currencies: Vec<String>,
 }
-impl<'a> CreateTreasuryFinancialAccountBuilder<'a> {
-    fn new(supported_currencies: &'a [&'a str]) -> Self {
+impl CreateTreasuryFinancialAccountBuilder {
+    fn new(supported_currencies: impl Into<Vec<String>>) -> Self {
         Self {
             expand: None,
             features: None,
             metadata: None,
             platform_restrictions: None,
-            supported_currencies,
+            supported_currencies: supported_currencies.into(),
         }
     }
 }
@@ -283,8 +289,8 @@ pub struct CreateTreasuryFinancialAccountFeaturesCardIssuing {
     pub requested: bool,
 }
 impl CreateTreasuryFinancialAccountFeaturesCardIssuing {
-    pub fn new(requested: bool) -> Self {
-        Self { requested }
+    pub fn new(requested: impl Into<bool>) -> Self {
+        Self { requested: requested.into() }
     }
 }
 /// Represents whether this FinancialAccount is eligible for deposit insurance.
@@ -295,8 +301,8 @@ pub struct CreateTreasuryFinancialAccountFeaturesDepositInsurance {
     pub requested: bool,
 }
 impl CreateTreasuryFinancialAccountFeaturesDepositInsurance {
-    pub fn new(requested: bool) -> Self {
-        Self { requested }
+    pub fn new(requested: impl Into<bool>) -> Self {
+        Self { requested: requested.into() }
     }
 }
 /// Contains Features that add FinancialAddresses to the FinancialAccount.
@@ -323,8 +329,8 @@ pub struct CreateTreasuryFinancialAccountFeaturesFinancialAddressesAba {
     pub requested: bool,
 }
 impl CreateTreasuryFinancialAccountFeaturesFinancialAddressesAba {
-    pub fn new(requested: bool) -> Self {
-        Self { requested }
+    pub fn new(requested: impl Into<bool>) -> Self {
+        Self { requested: requested.into() }
     }
 }
 /// Contains settings related to adding funds to a FinancialAccount from another Account with the same owner.
@@ -351,8 +357,8 @@ pub struct CreateTreasuryFinancialAccountFeaturesInboundTransfersAch {
     pub requested: bool,
 }
 impl CreateTreasuryFinancialAccountFeaturesInboundTransfersAch {
-    pub fn new(requested: bool) -> Self {
-        Self { requested }
+    pub fn new(requested: impl Into<bool>) -> Self {
+        Self { requested: requested.into() }
     }
 }
 /// Represents the ability for the FinancialAccount to send money to, or receive money from other FinancialAccounts (for example, via OutboundPayment).
@@ -362,8 +368,8 @@ pub struct CreateTreasuryFinancialAccountFeaturesIntraStripeFlows {
     pub requested: bool,
 }
 impl CreateTreasuryFinancialAccountFeaturesIntraStripeFlows {
-    pub fn new(requested: bool) -> Self {
-        Self { requested }
+    pub fn new(requested: impl Into<bool>) -> Self {
+        Self { requested: requested.into() }
     }
 }
 /// Includes Features related to initiating money movement out of the FinancialAccount to someone else's bucket of money.
@@ -394,8 +400,8 @@ pub struct CreateTreasuryFinancialAccountFeaturesOutboundPaymentsAch {
     pub requested: bool,
 }
 impl CreateTreasuryFinancialAccountFeaturesOutboundPaymentsAch {
-    pub fn new(requested: bool) -> Self {
-        Self { requested }
+    pub fn new(requested: impl Into<bool>) -> Self {
+        Self { requested: requested.into() }
     }
 }
 /// Enables US domestic wire transfers via the OutboundPayments API.
@@ -405,8 +411,8 @@ pub struct CreateTreasuryFinancialAccountFeaturesOutboundPaymentsUsDomesticWire 
     pub requested: bool,
 }
 impl CreateTreasuryFinancialAccountFeaturesOutboundPaymentsUsDomesticWire {
-    pub fn new(requested: bool) -> Self {
-        Self { requested }
+    pub fn new(requested: impl Into<bool>) -> Self {
+        Self { requested: requested.into() }
     }
 }
 /// Contains a Feature and settings related to moving money out of the FinancialAccount into another Account with the same owner.
@@ -437,8 +443,8 @@ pub struct CreateTreasuryFinancialAccountFeaturesOutboundTransfersAch {
     pub requested: bool,
 }
 impl CreateTreasuryFinancialAccountFeaturesOutboundTransfersAch {
-    pub fn new(requested: bool) -> Self {
-        Self { requested }
+    pub fn new(requested: impl Into<bool>) -> Self {
+        Self { requested: requested.into() }
     }
 }
 /// Enables US domestic wire transfers via the OutboundTransfers API.
@@ -448,8 +454,8 @@ pub struct CreateTreasuryFinancialAccountFeaturesOutboundTransfersUsDomesticWire
     pub requested: bool,
 }
 impl CreateTreasuryFinancialAccountFeaturesOutboundTransfersUsDomesticWire {
-    pub fn new(requested: bool) -> Self {
-        Self { requested }
+    pub fn new(requested: impl Into<bool>) -> Self {
+        Self { requested: requested.into() }
     }
 }
 /// The set of functionalities that the platform can restrict on the FinancialAccount.
@@ -594,43 +600,46 @@ impl<'de> serde::Deserialize<'de>
 }
 /// Creates a new FinancialAccount. For now, each connected account can only have one FinancialAccount.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateTreasuryFinancialAccount<'a> {
-    inner: CreateTreasuryFinancialAccountBuilder<'a>,
+pub struct CreateTreasuryFinancialAccount {
+    inner: CreateTreasuryFinancialAccountBuilder,
 }
-impl<'a> CreateTreasuryFinancialAccount<'a> {
+impl CreateTreasuryFinancialAccount {
     /// Construct a new `CreateTreasuryFinancialAccount`.
-    pub fn new(supported_currencies: &'a [&'a str]) -> Self {
-        Self { inner: CreateTreasuryFinancialAccountBuilder::new(supported_currencies) }
+    pub fn new(supported_currencies: impl Into<Vec<String>>) -> Self {
+        Self { inner: CreateTreasuryFinancialAccountBuilder::new(supported_currencies.into()) }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Encodes whether a FinancialAccount has access to a particular feature.
     /// Stripe or the platform can control features via the requested field.
-    pub fn features(mut self, features: CreateTreasuryFinancialAccountFeatures) -> Self {
-        self.inner.features = Some(features);
+    pub fn features(mut self, features: impl Into<CreateTreasuryFinancialAccountFeatures>) -> Self {
+        self.inner.features = Some(features.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// The set of functionalities that the platform can restrict on the FinancialAccount.
     pub fn platform_restrictions(
         mut self,
-        platform_restrictions: CreateTreasuryFinancialAccountPlatformRestrictions,
+        platform_restrictions: impl Into<CreateTreasuryFinancialAccountPlatformRestrictions>,
     ) -> Self {
-        self.inner.platform_restrictions = Some(platform_restrictions);
+        self.inner.platform_restrictions = Some(platform_restrictions.into());
         self
     }
 }
-impl CreateTreasuryFinancialAccount<'_> {
+impl CreateTreasuryFinancialAccount {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -648,25 +657,25 @@ impl CreateTreasuryFinancialAccount<'_> {
     }
 }
 
-impl StripeRequest for CreateTreasuryFinancialAccount<'_> {
+impl StripeRequest for CreateTreasuryFinancialAccount {
     type Output = stripe_treasury::TreasuryFinancialAccount;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Post, "/treasury/financial_accounts").form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdateTreasuryFinancialAccountBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdateTreasuryFinancialAccountBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     features: Option<UpdateTreasuryFinancialAccountFeatures>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     platform_restrictions: Option<UpdateTreasuryFinancialAccountPlatformRestrictions>,
 }
-impl<'a> UpdateTreasuryFinancialAccountBuilder<'a> {
+impl UpdateTreasuryFinancialAccountBuilder {
     fn new() -> Self {
         Self { expand: None, features: None, metadata: None, platform_restrictions: None }
     }
@@ -723,8 +732,8 @@ pub struct UpdateTreasuryFinancialAccountFeaturesCardIssuing {
     pub requested: bool,
 }
 impl UpdateTreasuryFinancialAccountFeaturesCardIssuing {
-    pub fn new(requested: bool) -> Self {
-        Self { requested }
+    pub fn new(requested: impl Into<bool>) -> Self {
+        Self { requested: requested.into() }
     }
 }
 /// Represents whether this FinancialAccount is eligible for deposit insurance.
@@ -735,8 +744,8 @@ pub struct UpdateTreasuryFinancialAccountFeaturesDepositInsurance {
     pub requested: bool,
 }
 impl UpdateTreasuryFinancialAccountFeaturesDepositInsurance {
-    pub fn new(requested: bool) -> Self {
-        Self { requested }
+    pub fn new(requested: impl Into<bool>) -> Self {
+        Self { requested: requested.into() }
     }
 }
 /// Contains Features that add FinancialAddresses to the FinancialAccount.
@@ -763,8 +772,8 @@ pub struct UpdateTreasuryFinancialAccountFeaturesFinancialAddressesAba {
     pub requested: bool,
 }
 impl UpdateTreasuryFinancialAccountFeaturesFinancialAddressesAba {
-    pub fn new(requested: bool) -> Self {
-        Self { requested }
+    pub fn new(requested: impl Into<bool>) -> Self {
+        Self { requested: requested.into() }
     }
 }
 /// Contains settings related to adding funds to a FinancialAccount from another Account with the same owner.
@@ -791,8 +800,8 @@ pub struct UpdateTreasuryFinancialAccountFeaturesInboundTransfersAch {
     pub requested: bool,
 }
 impl UpdateTreasuryFinancialAccountFeaturesInboundTransfersAch {
-    pub fn new(requested: bool) -> Self {
-        Self { requested }
+    pub fn new(requested: impl Into<bool>) -> Self {
+        Self { requested: requested.into() }
     }
 }
 /// Represents the ability for the FinancialAccount to send money to, or receive money from other FinancialAccounts (for example, via OutboundPayment).
@@ -802,8 +811,8 @@ pub struct UpdateTreasuryFinancialAccountFeaturesIntraStripeFlows {
     pub requested: bool,
 }
 impl UpdateTreasuryFinancialAccountFeaturesIntraStripeFlows {
-    pub fn new(requested: bool) -> Self {
-        Self { requested }
+    pub fn new(requested: impl Into<bool>) -> Self {
+        Self { requested: requested.into() }
     }
 }
 /// Includes Features related to initiating money movement out of the FinancialAccount to someone else's bucket of money.
@@ -834,8 +843,8 @@ pub struct UpdateTreasuryFinancialAccountFeaturesOutboundPaymentsAch {
     pub requested: bool,
 }
 impl UpdateTreasuryFinancialAccountFeaturesOutboundPaymentsAch {
-    pub fn new(requested: bool) -> Self {
-        Self { requested }
+    pub fn new(requested: impl Into<bool>) -> Self {
+        Self { requested: requested.into() }
     }
 }
 /// Enables US domestic wire transfers via the OutboundPayments API.
@@ -845,8 +854,8 @@ pub struct UpdateTreasuryFinancialAccountFeaturesOutboundPaymentsUsDomesticWire 
     pub requested: bool,
 }
 impl UpdateTreasuryFinancialAccountFeaturesOutboundPaymentsUsDomesticWire {
-    pub fn new(requested: bool) -> Self {
-        Self { requested }
+    pub fn new(requested: impl Into<bool>) -> Self {
+        Self { requested: requested.into() }
     }
 }
 /// Contains a Feature and settings related to moving money out of the FinancialAccount into another Account with the same owner.
@@ -877,8 +886,8 @@ pub struct UpdateTreasuryFinancialAccountFeaturesOutboundTransfersAch {
     pub requested: bool,
 }
 impl UpdateTreasuryFinancialAccountFeaturesOutboundTransfersAch {
-    pub fn new(requested: bool) -> Self {
-        Self { requested }
+    pub fn new(requested: impl Into<bool>) -> Self {
+        Self { requested: requested.into() }
     }
 }
 /// Enables US domestic wire transfers via the OutboundTransfers API.
@@ -888,8 +897,8 @@ pub struct UpdateTreasuryFinancialAccountFeaturesOutboundTransfersUsDomesticWire
     pub requested: bool,
 }
 impl UpdateTreasuryFinancialAccountFeaturesOutboundTransfersUsDomesticWire {
-    pub fn new(requested: bool) -> Self {
-        Self { requested }
+    pub fn new(requested: impl Into<bool>) -> Self {
+        Self { requested: requested.into() }
     }
 }
 /// The set of functionalities that the platform can restrict on the FinancialAccount.
@@ -1034,44 +1043,50 @@ impl<'de> serde::Deserialize<'de>
 }
 /// Updates the details of a FinancialAccount.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateTreasuryFinancialAccount<'a> {
-    inner: UpdateTreasuryFinancialAccountBuilder<'a>,
-    financial_account: &'a stripe_treasury::TreasuryFinancialAccountId,
+pub struct UpdateTreasuryFinancialAccount {
+    inner: UpdateTreasuryFinancialAccountBuilder,
+    financial_account: stripe_treasury::TreasuryFinancialAccountId,
 }
-impl<'a> UpdateTreasuryFinancialAccount<'a> {
+impl UpdateTreasuryFinancialAccount {
     /// Construct a new `UpdateTreasuryFinancialAccount`.
-    pub fn new(financial_account: &'a stripe_treasury::TreasuryFinancialAccountId) -> Self {
-        Self { financial_account, inner: UpdateTreasuryFinancialAccountBuilder::new() }
+    pub fn new(financial_account: impl Into<stripe_treasury::TreasuryFinancialAccountId>) -> Self {
+        Self {
+            financial_account: financial_account.into(),
+            inner: UpdateTreasuryFinancialAccountBuilder::new(),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Encodes whether a FinancialAccount has access to a particular feature, with a status enum and associated `status_details`.
     /// Stripe or the platform may control features via the requested field.
-    pub fn features(mut self, features: UpdateTreasuryFinancialAccountFeatures) -> Self {
-        self.inner.features = Some(features);
+    pub fn features(mut self, features: impl Into<UpdateTreasuryFinancialAccountFeatures>) -> Self {
+        self.inner.features = Some(features.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// The set of functionalities that the platform can restrict on the FinancialAccount.
     pub fn platform_restrictions(
         mut self,
-        platform_restrictions: UpdateTreasuryFinancialAccountPlatformRestrictions,
+        platform_restrictions: impl Into<UpdateTreasuryFinancialAccountPlatformRestrictions>,
     ) -> Self {
-        self.inner.platform_restrictions = Some(platform_restrictions);
+        self.inner.platform_restrictions = Some(platform_restrictions.into());
         self
     }
 }
-impl UpdateTreasuryFinancialAccount<'_> {
+impl UpdateTreasuryFinancialAccount {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -1089,11 +1104,11 @@ impl UpdateTreasuryFinancialAccount<'_> {
     }
 }
 
-impl StripeRequest for UpdateTreasuryFinancialAccount<'_> {
+impl StripeRequest for UpdateTreasuryFinancialAccount {
     type Output = stripe_treasury::TreasuryFinancialAccount;
 
     fn build(&self) -> RequestBuilder {
-        let financial_account = self.financial_account;
+        let financial_account = &self.financial_account;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/treasury/financial_accounts/{financial_account}"),
@@ -1101,14 +1116,14 @@ impl StripeRequest for UpdateTreasuryFinancialAccount<'_> {
         .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct UpdateFeaturesTreasuryFinancialAccountBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct UpdateFeaturesTreasuryFinancialAccountBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     card_issuing: Option<UpdateFeaturesTreasuryFinancialAccountCardIssuing>,
     #[serde(skip_serializing_if = "Option::is_none")]
     deposit_insurance: Option<UpdateFeaturesTreasuryFinancialAccountDepositInsurance>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     financial_addresses: Option<UpdateFeaturesTreasuryFinancialAccountFinancialAddresses>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1120,7 +1135,7 @@ struct UpdateFeaturesTreasuryFinancialAccountBuilder<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     outbound_transfers: Option<UpdateFeaturesTreasuryFinancialAccountOutboundTransfers>,
 }
-impl<'a> UpdateFeaturesTreasuryFinancialAccountBuilder<'a> {
+impl UpdateFeaturesTreasuryFinancialAccountBuilder {
     fn new() -> Self {
         Self {
             card_issuing: None,
@@ -1141,8 +1156,8 @@ pub struct UpdateFeaturesTreasuryFinancialAccountCardIssuing {
     pub requested: bool,
 }
 impl UpdateFeaturesTreasuryFinancialAccountCardIssuing {
-    pub fn new(requested: bool) -> Self {
-        Self { requested }
+    pub fn new(requested: impl Into<bool>) -> Self {
+        Self { requested: requested.into() }
     }
 }
 /// Represents whether this FinancialAccount is eligible for deposit insurance.
@@ -1153,8 +1168,8 @@ pub struct UpdateFeaturesTreasuryFinancialAccountDepositInsurance {
     pub requested: bool,
 }
 impl UpdateFeaturesTreasuryFinancialAccountDepositInsurance {
-    pub fn new(requested: bool) -> Self {
-        Self { requested }
+    pub fn new(requested: impl Into<bool>) -> Self {
+        Self { requested: requested.into() }
     }
 }
 /// Contains Features that add FinancialAddresses to the FinancialAccount.
@@ -1181,8 +1196,8 @@ pub struct UpdateFeaturesTreasuryFinancialAccountFinancialAddressesAba {
     pub requested: bool,
 }
 impl UpdateFeaturesTreasuryFinancialAccountFinancialAddressesAba {
-    pub fn new(requested: bool) -> Self {
-        Self { requested }
+    pub fn new(requested: impl Into<bool>) -> Self {
+        Self { requested: requested.into() }
     }
 }
 /// Contains settings related to adding funds to a FinancialAccount from another Account with the same owner.
@@ -1209,8 +1224,8 @@ pub struct UpdateFeaturesTreasuryFinancialAccountInboundTransfersAch {
     pub requested: bool,
 }
 impl UpdateFeaturesTreasuryFinancialAccountInboundTransfersAch {
-    pub fn new(requested: bool) -> Self {
-        Self { requested }
+    pub fn new(requested: impl Into<bool>) -> Self {
+        Self { requested: requested.into() }
     }
 }
 /// Represents the ability for the FinancialAccount to send money to, or receive money from other FinancialAccounts (for example, via OutboundPayment).
@@ -1220,8 +1235,8 @@ pub struct UpdateFeaturesTreasuryFinancialAccountIntraStripeFlows {
     pub requested: bool,
 }
 impl UpdateFeaturesTreasuryFinancialAccountIntraStripeFlows {
-    pub fn new(requested: bool) -> Self {
-        Self { requested }
+    pub fn new(requested: impl Into<bool>) -> Self {
+        Self { requested: requested.into() }
     }
 }
 /// Includes Features related to initiating money movement out of the FinancialAccount to someone else's bucket of money.
@@ -1252,8 +1267,8 @@ pub struct UpdateFeaturesTreasuryFinancialAccountOutboundPaymentsAch {
     pub requested: bool,
 }
 impl UpdateFeaturesTreasuryFinancialAccountOutboundPaymentsAch {
-    pub fn new(requested: bool) -> Self {
-        Self { requested }
+    pub fn new(requested: impl Into<bool>) -> Self {
+        Self { requested: requested.into() }
     }
 }
 /// Enables US domestic wire transfers via the OutboundPayments API.
@@ -1263,8 +1278,8 @@ pub struct UpdateFeaturesTreasuryFinancialAccountOutboundPaymentsUsDomesticWire 
     pub requested: bool,
 }
 impl UpdateFeaturesTreasuryFinancialAccountOutboundPaymentsUsDomesticWire {
-    pub fn new(requested: bool) -> Self {
-        Self { requested }
+    pub fn new(requested: impl Into<bool>) -> Self {
+        Self { requested: requested.into() }
     }
 }
 /// Contains a Feature and settings related to moving money out of the FinancialAccount into another Account with the same owner.
@@ -1295,8 +1310,8 @@ pub struct UpdateFeaturesTreasuryFinancialAccountOutboundTransfersAch {
     pub requested: bool,
 }
 impl UpdateFeaturesTreasuryFinancialAccountOutboundTransfersAch {
-    pub fn new(requested: bool) -> Self {
-        Self { requested }
+    pub fn new(requested: impl Into<bool>) -> Self {
+        Self { requested: requested.into() }
     }
 }
 /// Enables US domestic wire transfers via the OutboundTransfers API.
@@ -1306,85 +1321,88 @@ pub struct UpdateFeaturesTreasuryFinancialAccountOutboundTransfersUsDomesticWire
     pub requested: bool,
 }
 impl UpdateFeaturesTreasuryFinancialAccountOutboundTransfersUsDomesticWire {
-    pub fn new(requested: bool) -> Self {
-        Self { requested }
+    pub fn new(requested: impl Into<bool>) -> Self {
+        Self { requested: requested.into() }
     }
 }
 /// Updates the Features associated with a FinancialAccount.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct UpdateFeaturesTreasuryFinancialAccount<'a> {
-    inner: UpdateFeaturesTreasuryFinancialAccountBuilder<'a>,
-    financial_account: &'a stripe_treasury::TreasuryFinancialAccountId,
+pub struct UpdateFeaturesTreasuryFinancialAccount {
+    inner: UpdateFeaturesTreasuryFinancialAccountBuilder,
+    financial_account: stripe_treasury::TreasuryFinancialAccountId,
 }
-impl<'a> UpdateFeaturesTreasuryFinancialAccount<'a> {
+impl UpdateFeaturesTreasuryFinancialAccount {
     /// Construct a new `UpdateFeaturesTreasuryFinancialAccount`.
-    pub fn new(financial_account: &'a stripe_treasury::TreasuryFinancialAccountId) -> Self {
-        Self { financial_account, inner: UpdateFeaturesTreasuryFinancialAccountBuilder::new() }
+    pub fn new(financial_account: impl Into<stripe_treasury::TreasuryFinancialAccountId>) -> Self {
+        Self {
+            financial_account: financial_account.into(),
+            inner: UpdateFeaturesTreasuryFinancialAccountBuilder::new(),
+        }
     }
     /// Encodes the FinancialAccount's ability to be used with the Issuing product, including attaching cards to and drawing funds from the FinancialAccount.
     pub fn card_issuing(
         mut self,
-        card_issuing: UpdateFeaturesTreasuryFinancialAccountCardIssuing,
+        card_issuing: impl Into<UpdateFeaturesTreasuryFinancialAccountCardIssuing>,
     ) -> Self {
-        self.inner.card_issuing = Some(card_issuing);
+        self.inner.card_issuing = Some(card_issuing.into());
         self
     }
     /// Represents whether this FinancialAccount is eligible for deposit insurance.
     /// Various factors determine the insurance amount.
     pub fn deposit_insurance(
         mut self,
-        deposit_insurance: UpdateFeaturesTreasuryFinancialAccountDepositInsurance,
+        deposit_insurance: impl Into<UpdateFeaturesTreasuryFinancialAccountDepositInsurance>,
     ) -> Self {
-        self.inner.deposit_insurance = Some(deposit_insurance);
+        self.inner.deposit_insurance = Some(deposit_insurance.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Contains Features that add FinancialAddresses to the FinancialAccount.
     pub fn financial_addresses(
         mut self,
-        financial_addresses: UpdateFeaturesTreasuryFinancialAccountFinancialAddresses,
+        financial_addresses: impl Into<UpdateFeaturesTreasuryFinancialAccountFinancialAddresses>,
     ) -> Self {
-        self.inner.financial_addresses = Some(financial_addresses);
+        self.inner.financial_addresses = Some(financial_addresses.into());
         self
     }
     /// Contains settings related to adding funds to a FinancialAccount from another Account with the same owner.
     pub fn inbound_transfers(
         mut self,
-        inbound_transfers: UpdateFeaturesTreasuryFinancialAccountInboundTransfers,
+        inbound_transfers: impl Into<UpdateFeaturesTreasuryFinancialAccountInboundTransfers>,
     ) -> Self {
-        self.inner.inbound_transfers = Some(inbound_transfers);
+        self.inner.inbound_transfers = Some(inbound_transfers.into());
         self
     }
     /// Represents the ability for the FinancialAccount to send money to, or receive money from other FinancialAccounts (for example, via OutboundPayment).
     pub fn intra_stripe_flows(
         mut self,
-        intra_stripe_flows: UpdateFeaturesTreasuryFinancialAccountIntraStripeFlows,
+        intra_stripe_flows: impl Into<UpdateFeaturesTreasuryFinancialAccountIntraStripeFlows>,
     ) -> Self {
-        self.inner.intra_stripe_flows = Some(intra_stripe_flows);
+        self.inner.intra_stripe_flows = Some(intra_stripe_flows.into());
         self
     }
     /// Includes Features related to initiating money movement out of the FinancialAccount to someone else's bucket of money.
     pub fn outbound_payments(
         mut self,
-        outbound_payments: UpdateFeaturesTreasuryFinancialAccountOutboundPayments,
+        outbound_payments: impl Into<UpdateFeaturesTreasuryFinancialAccountOutboundPayments>,
     ) -> Self {
-        self.inner.outbound_payments = Some(outbound_payments);
+        self.inner.outbound_payments = Some(outbound_payments.into());
         self
     }
     /// Contains a Feature and settings related to moving money out of the FinancialAccount into another Account with the same owner.
     pub fn outbound_transfers(
         mut self,
-        outbound_transfers: UpdateFeaturesTreasuryFinancialAccountOutboundTransfers,
+        outbound_transfers: impl Into<UpdateFeaturesTreasuryFinancialAccountOutboundTransfers>,
     ) -> Self {
-        self.inner.outbound_transfers = Some(outbound_transfers);
+        self.inner.outbound_transfers = Some(outbound_transfers.into());
         self
     }
 }
-impl UpdateFeaturesTreasuryFinancialAccount<'_> {
+impl UpdateFeaturesTreasuryFinancialAccount {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -1402,11 +1420,11 @@ impl UpdateFeaturesTreasuryFinancialAccount<'_> {
     }
 }
 
-impl StripeRequest for UpdateFeaturesTreasuryFinancialAccount<'_> {
+impl StripeRequest for UpdateFeaturesTreasuryFinancialAccount {
     type Output = stripe_treasury::TreasuryFinancialAccountFeatures;
 
     fn build(&self) -> RequestBuilder {
-        let financial_account = self.financial_account;
+        let financial_account = &self.financial_account;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/treasury/financial_accounts/{financial_account}/features"),

--- a/generated/async-stripe-treasury/src/treasury_inbound_transfer/requests.rs
+++ b/generated/async-stripe-treasury/src/treasury_inbound_transfer/requests.rs
@@ -2,26 +2,26 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListTreasuryInboundTransferBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListTreasuryInboundTransferBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
-    financial_account: &'a str,
+    expand: Option<Vec<String>>,
+    financial_account: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     status: Option<stripe_treasury::TreasuryInboundTransferStatus>,
 }
-impl<'a> ListTreasuryInboundTransferBuilder<'a> {
-    fn new(financial_account: &'a str) -> Self {
+impl ListTreasuryInboundTransferBuilder {
+    fn new(financial_account: impl Into<String>) -> Self {
         Self {
             ending_before: None,
             expand: None,
-            financial_account,
+            financial_account: financial_account.into(),
             limit: None,
             starting_after: None,
             status: None,
@@ -30,46 +30,49 @@ impl<'a> ListTreasuryInboundTransferBuilder<'a> {
 }
 /// Returns a list of InboundTransfers sent from the specified FinancialAccount.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListTreasuryInboundTransfer<'a> {
-    inner: ListTreasuryInboundTransferBuilder<'a>,
+pub struct ListTreasuryInboundTransfer {
+    inner: ListTreasuryInboundTransferBuilder,
 }
-impl<'a> ListTreasuryInboundTransfer<'a> {
+impl ListTreasuryInboundTransfer {
     /// Construct a new `ListTreasuryInboundTransfer`.
-    pub fn new(financial_account: &'a str) -> Self {
-        Self { inner: ListTreasuryInboundTransferBuilder::new(financial_account) }
+    pub fn new(financial_account: impl Into<String>) -> Self {
+        Self { inner: ListTreasuryInboundTransferBuilder::new(financial_account.into()) }
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
     /// Only return InboundTransfers that have the given status: `processing`, `succeeded`, `failed` or `canceled`.
-    pub fn status(mut self, status: stripe_treasury::TreasuryInboundTransferStatus) -> Self {
-        self.inner.status = Some(status);
+    pub fn status(
+        mut self,
+        status: impl Into<stripe_treasury::TreasuryInboundTransferStatus>,
+    ) -> Self {
+        self.inner.status = Some(status.into());
         self
     }
 }
-impl ListTreasuryInboundTransfer<'_> {
+impl ListTreasuryInboundTransfer {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -91,45 +94,45 @@ impl ListTreasuryInboundTransfer<'_> {
     ) -> stripe_client_core::ListPaginator<
         stripe_types::List<stripe_treasury::TreasuryInboundTransfer>,
     > {
-        stripe_client_core::ListPaginator::new_list("/treasury/inbound_transfers", self.inner)
+        stripe_client_core::ListPaginator::new_list("/treasury/inbound_transfers", &self.inner)
     }
 }
 
-impl StripeRequest for ListTreasuryInboundTransfer<'_> {
+impl StripeRequest for ListTreasuryInboundTransfer {
     type Output = stripe_types::List<stripe_treasury::TreasuryInboundTransfer>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/treasury/inbound_transfers").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveTreasuryInboundTransferBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveTreasuryInboundTransferBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveTreasuryInboundTransferBuilder<'a> {
+impl RetrieveTreasuryInboundTransferBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves the details of an existing InboundTransfer.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveTreasuryInboundTransfer<'a> {
-    inner: RetrieveTreasuryInboundTransferBuilder<'a>,
-    id: &'a stripe_treasury::TreasuryInboundTransferId,
+pub struct RetrieveTreasuryInboundTransfer {
+    inner: RetrieveTreasuryInboundTransferBuilder,
+    id: stripe_treasury::TreasuryInboundTransferId,
 }
-impl<'a> RetrieveTreasuryInboundTransfer<'a> {
+impl RetrieveTreasuryInboundTransfer {
     /// Construct a new `RetrieveTreasuryInboundTransfer`.
-    pub fn new(id: &'a stripe_treasury::TreasuryInboundTransferId) -> Self {
-        Self { id, inner: RetrieveTreasuryInboundTransferBuilder::new() }
+    pub fn new(id: impl Into<stripe_treasury::TreasuryInboundTransferId>) -> Self {
+        Self { id: id.into(), inner: RetrieveTreasuryInboundTransferBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveTreasuryInboundTransfer<'_> {
+impl RetrieveTreasuryInboundTransfer {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -147,23 +150,23 @@ impl RetrieveTreasuryInboundTransfer<'_> {
     }
 }
 
-impl StripeRequest for RetrieveTreasuryInboundTransfer<'_> {
+impl StripeRequest for RetrieveTreasuryInboundTransfer {
     type Output = stripe_treasury::TreasuryInboundTransfer;
 
     fn build(&self) -> RequestBuilder {
-        let id = self.id;
+        let id = &self.id;
         RequestBuilder::new(StripeMethod::Get, format!("/treasury/inbound_transfers/{id}"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct FailTreasuryInboundTransferBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct FailTreasuryInboundTransferBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     failure_details: Option<FailTreasuryInboundTransferFailureDetails>,
 }
-impl<'a> FailTreasuryInboundTransferBuilder<'a> {
+impl FailTreasuryInboundTransferBuilder {
     fn new() -> Self {
         Self { expand: None, failure_details: None }
     }
@@ -279,30 +282,30 @@ impl<'de> serde::Deserialize<'de> for FailTreasuryInboundTransferFailureDetailsC
 /// Transitions a test mode created InboundTransfer to the `failed` status.
 /// The InboundTransfer must already be in the `processing` state.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct FailTreasuryInboundTransfer<'a> {
-    inner: FailTreasuryInboundTransferBuilder<'a>,
-    id: &'a str,
+pub struct FailTreasuryInboundTransfer {
+    inner: FailTreasuryInboundTransferBuilder,
+    id: String,
 }
-impl<'a> FailTreasuryInboundTransfer<'a> {
+impl FailTreasuryInboundTransfer {
     /// Construct a new `FailTreasuryInboundTransfer`.
-    pub fn new(id: &'a str) -> Self {
-        Self { id, inner: FailTreasuryInboundTransferBuilder::new() }
+    pub fn new(id: impl Into<String>) -> Self {
+        Self { id: id.into(), inner: FailTreasuryInboundTransferBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Details about a failed InboundTransfer.
     pub fn failure_details(
         mut self,
-        failure_details: FailTreasuryInboundTransferFailureDetails,
+        failure_details: impl Into<FailTreasuryInboundTransferFailureDetails>,
     ) -> Self {
-        self.inner.failure_details = Some(failure_details);
+        self.inner.failure_details = Some(failure_details.into());
         self
     }
 }
-impl FailTreasuryInboundTransfer<'_> {
+impl FailTreasuryInboundTransfer {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -320,11 +323,11 @@ impl FailTreasuryInboundTransfer<'_> {
     }
 }
 
-impl StripeRequest for FailTreasuryInboundTransfer<'_> {
+impl StripeRequest for FailTreasuryInboundTransfer {
     type Output = stripe_treasury::TreasuryInboundTransfer;
 
     fn build(&self) -> RequestBuilder {
-        let id = self.id;
+        let id = &self.id;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/test_helpers/treasury/inbound_transfers/{id}/fail"),
@@ -332,12 +335,12 @@ impl StripeRequest for FailTreasuryInboundTransfer<'_> {
         .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ReturnInboundTransferTreasuryInboundTransferBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ReturnInboundTransferTreasuryInboundTransferBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> ReturnInboundTransferTreasuryInboundTransferBuilder<'a> {
+impl ReturnInboundTransferTreasuryInboundTransferBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
@@ -345,22 +348,22 @@ impl<'a> ReturnInboundTransferTreasuryInboundTransferBuilder<'a> {
 /// Marks the test mode InboundTransfer object as returned and links the InboundTransfer to a ReceivedDebit.
 /// The InboundTransfer must already be in the `succeeded` state.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ReturnInboundTransferTreasuryInboundTransfer<'a> {
-    inner: ReturnInboundTransferTreasuryInboundTransferBuilder<'a>,
-    id: &'a str,
+pub struct ReturnInboundTransferTreasuryInboundTransfer {
+    inner: ReturnInboundTransferTreasuryInboundTransferBuilder,
+    id: String,
 }
-impl<'a> ReturnInboundTransferTreasuryInboundTransfer<'a> {
+impl ReturnInboundTransferTreasuryInboundTransfer {
     /// Construct a new `ReturnInboundTransferTreasuryInboundTransfer`.
-    pub fn new(id: &'a str) -> Self {
-        Self { id, inner: ReturnInboundTransferTreasuryInboundTransferBuilder::new() }
+    pub fn new(id: impl Into<String>) -> Self {
+        Self { id: id.into(), inner: ReturnInboundTransferTreasuryInboundTransferBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl ReturnInboundTransferTreasuryInboundTransfer<'_> {
+impl ReturnInboundTransferTreasuryInboundTransfer {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -378,11 +381,11 @@ impl ReturnInboundTransferTreasuryInboundTransfer<'_> {
     }
 }
 
-impl StripeRequest for ReturnInboundTransferTreasuryInboundTransfer<'_> {
+impl StripeRequest for ReturnInboundTransferTreasuryInboundTransfer {
     type Output = stripe_treasury::TreasuryInboundTransfer;
 
     fn build(&self) -> RequestBuilder {
-        let id = self.id;
+        let id = &self.id;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/test_helpers/treasury/inbound_transfers/{id}/return"),
@@ -390,12 +393,12 @@ impl StripeRequest for ReturnInboundTransferTreasuryInboundTransfer<'_> {
         .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct SucceedTreasuryInboundTransferBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct SucceedTreasuryInboundTransferBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> SucceedTreasuryInboundTransferBuilder<'a> {
+impl SucceedTreasuryInboundTransferBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
@@ -403,22 +406,22 @@ impl<'a> SucceedTreasuryInboundTransferBuilder<'a> {
 /// Transitions a test mode created InboundTransfer to the `succeeded` status.
 /// The InboundTransfer must already be in the `processing` state.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct SucceedTreasuryInboundTransfer<'a> {
-    inner: SucceedTreasuryInboundTransferBuilder<'a>,
-    id: &'a str,
+pub struct SucceedTreasuryInboundTransfer {
+    inner: SucceedTreasuryInboundTransferBuilder,
+    id: String,
 }
-impl<'a> SucceedTreasuryInboundTransfer<'a> {
+impl SucceedTreasuryInboundTransfer {
     /// Construct a new `SucceedTreasuryInboundTransfer`.
-    pub fn new(id: &'a str) -> Self {
-        Self { id, inner: SucceedTreasuryInboundTransferBuilder::new() }
+    pub fn new(id: impl Into<String>) -> Self {
+        Self { id: id.into(), inner: SucceedTreasuryInboundTransferBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl SucceedTreasuryInboundTransfer<'_> {
+impl SucceedTreasuryInboundTransfer {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -436,11 +439,11 @@ impl SucceedTreasuryInboundTransfer<'_> {
     }
 }
 
-impl StripeRequest for SucceedTreasuryInboundTransfer<'_> {
+impl StripeRequest for SucceedTreasuryInboundTransfer {
     type Output = stripe_treasury::TreasuryInboundTransfer;
 
     fn build(&self) -> RequestBuilder {
-        let id = self.id;
+        let id = &self.id;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/test_helpers/treasury/inbound_transfers/{id}/succeed"),
@@ -448,87 +451,90 @@ impl StripeRequest for SucceedTreasuryInboundTransfer<'_> {
         .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateTreasuryInboundTransferBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateTreasuryInboundTransferBuilder {
     amount: i64,
     currency: stripe_types::Currency,
     #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<&'a str>,
+    description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
-    financial_account: &'a str,
+    expand: Option<Vec<String>>,
+    financial_account: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
-    origin_payment_method: &'a str,
+    metadata: Option<std::collections::HashMap<String, String>>,
+    origin_payment_method: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    statement_descriptor: Option<&'a str>,
+    statement_descriptor: Option<String>,
 }
-impl<'a> CreateTreasuryInboundTransferBuilder<'a> {
+impl CreateTreasuryInboundTransferBuilder {
     fn new(
-        amount: i64,
-        currency: stripe_types::Currency,
-        financial_account: &'a str,
-        origin_payment_method: &'a str,
+        amount: impl Into<i64>,
+        currency: impl Into<stripe_types::Currency>,
+        financial_account: impl Into<String>,
+        origin_payment_method: impl Into<String>,
     ) -> Self {
         Self {
-            amount,
-            currency,
+            amount: amount.into(),
+            currency: currency.into(),
             description: None,
             expand: None,
-            financial_account,
+            financial_account: financial_account.into(),
             metadata: None,
-            origin_payment_method,
+            origin_payment_method: origin_payment_method.into(),
             statement_descriptor: None,
         }
     }
 }
 /// Creates an InboundTransfer.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateTreasuryInboundTransfer<'a> {
-    inner: CreateTreasuryInboundTransferBuilder<'a>,
+pub struct CreateTreasuryInboundTransfer {
+    inner: CreateTreasuryInboundTransferBuilder,
 }
-impl<'a> CreateTreasuryInboundTransfer<'a> {
+impl CreateTreasuryInboundTransfer {
     /// Construct a new `CreateTreasuryInboundTransfer`.
     pub fn new(
-        amount: i64,
-        currency: stripe_types::Currency,
-        financial_account: &'a str,
-        origin_payment_method: &'a str,
+        amount: impl Into<i64>,
+        currency: impl Into<stripe_types::Currency>,
+        financial_account: impl Into<String>,
+        origin_payment_method: impl Into<String>,
     ) -> Self {
         Self {
             inner: CreateTreasuryInboundTransferBuilder::new(
-                amount,
-                currency,
-                financial_account,
-                origin_payment_method,
+                amount.into(),
+                currency.into(),
+                financial_account.into(),
+                origin_payment_method.into(),
             ),
         }
     }
     /// An arbitrary string attached to the object. Often useful for displaying to users.
-    pub fn description(mut self, description: &'a str) -> Self {
-        self.inner.description = Some(description);
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.inner.description = Some(description.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// The complete description that appears on your customers' statements. Maximum 10 characters.
-    pub fn statement_descriptor(mut self, statement_descriptor: &'a str) -> Self {
-        self.inner.statement_descriptor = Some(statement_descriptor);
+    pub fn statement_descriptor(mut self, statement_descriptor: impl Into<String>) -> Self {
+        self.inner.statement_descriptor = Some(statement_descriptor.into());
         self
     }
 }
-impl CreateTreasuryInboundTransfer<'_> {
+impl CreateTreasuryInboundTransfer {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -546,41 +552,44 @@ impl CreateTreasuryInboundTransfer<'_> {
     }
 }
 
-impl StripeRequest for CreateTreasuryInboundTransfer<'_> {
+impl StripeRequest for CreateTreasuryInboundTransfer {
     type Output = stripe_treasury::TreasuryInboundTransfer;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Post, "/treasury/inbound_transfers").form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CancelTreasuryInboundTransferBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CancelTreasuryInboundTransferBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> CancelTreasuryInboundTransferBuilder<'a> {
+impl CancelTreasuryInboundTransferBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Cancels an InboundTransfer.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CancelTreasuryInboundTransfer<'a> {
-    inner: CancelTreasuryInboundTransferBuilder<'a>,
-    inbound_transfer: &'a stripe_treasury::TreasuryInboundTransferId,
+pub struct CancelTreasuryInboundTransfer {
+    inner: CancelTreasuryInboundTransferBuilder,
+    inbound_transfer: stripe_treasury::TreasuryInboundTransferId,
 }
-impl<'a> CancelTreasuryInboundTransfer<'a> {
+impl CancelTreasuryInboundTransfer {
     /// Construct a new `CancelTreasuryInboundTransfer`.
-    pub fn new(inbound_transfer: &'a stripe_treasury::TreasuryInboundTransferId) -> Self {
-        Self { inbound_transfer, inner: CancelTreasuryInboundTransferBuilder::new() }
+    pub fn new(inbound_transfer: impl Into<stripe_treasury::TreasuryInboundTransferId>) -> Self {
+        Self {
+            inbound_transfer: inbound_transfer.into(),
+            inner: CancelTreasuryInboundTransferBuilder::new(),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl CancelTreasuryInboundTransfer<'_> {
+impl CancelTreasuryInboundTransfer {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -598,11 +607,11 @@ impl CancelTreasuryInboundTransfer<'_> {
     }
 }
 
-impl StripeRequest for CancelTreasuryInboundTransfer<'_> {
+impl StripeRequest for CancelTreasuryInboundTransfer {
     type Output = stripe_treasury::TreasuryInboundTransfer;
 
     fn build(&self) -> RequestBuilder {
-        let inbound_transfer = self.inbound_transfer;
+        let inbound_transfer = &self.inbound_transfer;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/treasury/inbound_transfers/{inbound_transfer}/cancel"),

--- a/generated/async-stripe-treasury/src/treasury_outbound_payment/requests.rs
+++ b/generated/async-stripe-treasury/src/treasury_outbound_payment/requests.rs
@@ -2,32 +2,32 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListTreasuryOutboundPaymentBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListTreasuryOutboundPaymentBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     created: Option<stripe_types::RangeQueryTs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    customer: Option<&'a str>,
+    customer: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
-    financial_account: &'a str,
+    expand: Option<Vec<String>>,
+    financial_account: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     status: Option<stripe_treasury::TreasuryOutboundPaymentStatus>,
 }
-impl<'a> ListTreasuryOutboundPaymentBuilder<'a> {
-    fn new(financial_account: &'a str) -> Self {
+impl ListTreasuryOutboundPaymentBuilder {
+    fn new(financial_account: impl Into<String>) -> Self {
         Self {
             created: None,
             customer: None,
             ending_before: None,
             expand: None,
-            financial_account,
+            financial_account: financial_account.into(),
             limit: None,
             starting_after: None,
             status: None,
@@ -36,56 +36,59 @@ impl<'a> ListTreasuryOutboundPaymentBuilder<'a> {
 }
 /// Returns a list of OutboundPayments sent from the specified FinancialAccount.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListTreasuryOutboundPayment<'a> {
-    inner: ListTreasuryOutboundPaymentBuilder<'a>,
+pub struct ListTreasuryOutboundPayment {
+    inner: ListTreasuryOutboundPaymentBuilder,
 }
-impl<'a> ListTreasuryOutboundPayment<'a> {
+impl ListTreasuryOutboundPayment {
     /// Construct a new `ListTreasuryOutboundPayment`.
-    pub fn new(financial_account: &'a str) -> Self {
-        Self { inner: ListTreasuryOutboundPaymentBuilder::new(financial_account) }
+    pub fn new(financial_account: impl Into<String>) -> Self {
+        Self { inner: ListTreasuryOutboundPaymentBuilder::new(financial_account.into()) }
     }
     /// Only return OutboundPayments that were created during the given date interval.
-    pub fn created(mut self, created: stripe_types::RangeQueryTs) -> Self {
-        self.inner.created = Some(created);
+    pub fn created(mut self, created: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.created = Some(created.into());
         self
     }
     /// Only return OutboundPayments sent to this customer.
-    pub fn customer(mut self, customer: &'a str) -> Self {
-        self.inner.customer = Some(customer);
+    pub fn customer(mut self, customer: impl Into<String>) -> Self {
+        self.inner.customer = Some(customer.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
     /// Only return OutboundPayments that have the given status: `processing`, `failed`, `posted`, `returned`, or `canceled`.
-    pub fn status(mut self, status: stripe_treasury::TreasuryOutboundPaymentStatus) -> Self {
-        self.inner.status = Some(status);
+    pub fn status(
+        mut self,
+        status: impl Into<stripe_treasury::TreasuryOutboundPaymentStatus>,
+    ) -> Self {
+        self.inner.status = Some(status.into());
         self
     }
 }
-impl ListTreasuryOutboundPayment<'_> {
+impl ListTreasuryOutboundPayment {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -107,45 +110,45 @@ impl ListTreasuryOutboundPayment<'_> {
     ) -> stripe_client_core::ListPaginator<
         stripe_types::List<stripe_treasury::TreasuryOutboundPayment>,
     > {
-        stripe_client_core::ListPaginator::new_list("/treasury/outbound_payments", self.inner)
+        stripe_client_core::ListPaginator::new_list("/treasury/outbound_payments", &self.inner)
     }
 }
 
-impl StripeRequest for ListTreasuryOutboundPayment<'_> {
+impl StripeRequest for ListTreasuryOutboundPayment {
     type Output = stripe_types::List<stripe_treasury::TreasuryOutboundPayment>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/treasury/outbound_payments").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveTreasuryOutboundPaymentBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveTreasuryOutboundPaymentBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveTreasuryOutboundPaymentBuilder<'a> {
+impl RetrieveTreasuryOutboundPaymentBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves the details of an existing OutboundPayment by passing the unique OutboundPayment ID from either the OutboundPayment creation request or OutboundPayment list.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveTreasuryOutboundPayment<'a> {
-    inner: RetrieveTreasuryOutboundPaymentBuilder<'a>,
-    id: &'a stripe_treasury::TreasuryOutboundPaymentId,
+pub struct RetrieveTreasuryOutboundPayment {
+    inner: RetrieveTreasuryOutboundPaymentBuilder,
+    id: stripe_treasury::TreasuryOutboundPaymentId,
 }
-impl<'a> RetrieveTreasuryOutboundPayment<'a> {
+impl RetrieveTreasuryOutboundPayment {
     /// Construct a new `RetrieveTreasuryOutboundPayment`.
-    pub fn new(id: &'a stripe_treasury::TreasuryOutboundPaymentId) -> Self {
-        Self { id, inner: RetrieveTreasuryOutboundPaymentBuilder::new() }
+    pub fn new(id: impl Into<stripe_treasury::TreasuryOutboundPaymentId>) -> Self {
+        Self { id: id.into(), inner: RetrieveTreasuryOutboundPaymentBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveTreasuryOutboundPayment<'_> {
+impl RetrieveTreasuryOutboundPayment {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -163,21 +166,21 @@ impl RetrieveTreasuryOutboundPayment<'_> {
     }
 }
 
-impl StripeRequest for RetrieveTreasuryOutboundPayment<'_> {
+impl StripeRequest for RetrieveTreasuryOutboundPayment {
     type Output = stripe_treasury::TreasuryOutboundPayment;
 
     fn build(&self) -> RequestBuilder {
-        let id = self.id;
+        let id = &self.id;
         RequestBuilder::new(StripeMethod::Get, format!("/treasury/outbound_payments/{id}"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct FailTreasuryOutboundPaymentBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct FailTreasuryOutboundPaymentBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> FailTreasuryOutboundPaymentBuilder<'a> {
+impl FailTreasuryOutboundPaymentBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
@@ -185,22 +188,22 @@ impl<'a> FailTreasuryOutboundPaymentBuilder<'a> {
 /// Transitions a test mode created OutboundPayment to the `failed` status.
 /// The OutboundPayment must already be in the `processing` state.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct FailTreasuryOutboundPayment<'a> {
-    inner: FailTreasuryOutboundPaymentBuilder<'a>,
-    id: &'a str,
+pub struct FailTreasuryOutboundPayment {
+    inner: FailTreasuryOutboundPaymentBuilder,
+    id: String,
 }
-impl<'a> FailTreasuryOutboundPayment<'a> {
+impl FailTreasuryOutboundPayment {
     /// Construct a new `FailTreasuryOutboundPayment`.
-    pub fn new(id: &'a str) -> Self {
-        Self { id, inner: FailTreasuryOutboundPaymentBuilder::new() }
+    pub fn new(id: impl Into<String>) -> Self {
+        Self { id: id.into(), inner: FailTreasuryOutboundPaymentBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl FailTreasuryOutboundPayment<'_> {
+impl FailTreasuryOutboundPayment {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -218,11 +221,11 @@ impl FailTreasuryOutboundPayment<'_> {
     }
 }
 
-impl StripeRequest for FailTreasuryOutboundPayment<'_> {
+impl StripeRequest for FailTreasuryOutboundPayment {
     type Output = stripe_treasury::TreasuryOutboundPayment;
 
     fn build(&self) -> RequestBuilder {
-        let id = self.id;
+        let id = &self.id;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/test_helpers/treasury/outbound_payments/{id}/fail"),
@@ -230,12 +233,12 @@ impl StripeRequest for FailTreasuryOutboundPayment<'_> {
         .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct PostTreasuryOutboundPaymentBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct PostTreasuryOutboundPaymentBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> PostTreasuryOutboundPaymentBuilder<'a> {
+impl PostTreasuryOutboundPaymentBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
@@ -243,22 +246,22 @@ impl<'a> PostTreasuryOutboundPaymentBuilder<'a> {
 /// Transitions a test mode created OutboundPayment to the `posted` status.
 /// The OutboundPayment must already be in the `processing` state.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct PostTreasuryOutboundPayment<'a> {
-    inner: PostTreasuryOutboundPaymentBuilder<'a>,
-    id: &'a str,
+pub struct PostTreasuryOutboundPayment {
+    inner: PostTreasuryOutboundPaymentBuilder,
+    id: String,
 }
-impl<'a> PostTreasuryOutboundPayment<'a> {
+impl PostTreasuryOutboundPayment {
     /// Construct a new `PostTreasuryOutboundPayment`.
-    pub fn new(id: &'a str) -> Self {
-        Self { id, inner: PostTreasuryOutboundPaymentBuilder::new() }
+    pub fn new(id: impl Into<String>) -> Self {
+        Self { id: id.into(), inner: PostTreasuryOutboundPaymentBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl PostTreasuryOutboundPayment<'_> {
+impl PostTreasuryOutboundPayment {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -276,11 +279,11 @@ impl PostTreasuryOutboundPayment<'_> {
     }
 }
 
-impl StripeRequest for PostTreasuryOutboundPayment<'_> {
+impl StripeRequest for PostTreasuryOutboundPayment {
     type Output = stripe_treasury::TreasuryOutboundPayment;
 
     fn build(&self) -> RequestBuilder {
-        let id = self.id;
+        let id = &self.id;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/test_helpers/treasury/outbound_payments/{id}/post"),
@@ -288,14 +291,14 @@ impl StripeRequest for PostTreasuryOutboundPayment<'_> {
         .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ReturnOutboundPaymentTreasuryOutboundPaymentBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ReturnOutboundPaymentTreasuryOutboundPaymentBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     returned_details: Option<ReturnOutboundPaymentTreasuryOutboundPaymentReturnedDetails>,
 }
-impl<'a> ReturnOutboundPaymentTreasuryOutboundPaymentBuilder<'a> {
+impl ReturnOutboundPaymentTreasuryOutboundPaymentBuilder {
     fn new() -> Self {
         Self { expand: None, returned_details: None }
     }
@@ -404,30 +407,30 @@ impl<'de> serde::Deserialize<'de>
 /// Transitions a test mode created OutboundPayment to the `returned` status.
 /// The OutboundPayment must already be in the `processing` state.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ReturnOutboundPaymentTreasuryOutboundPayment<'a> {
-    inner: ReturnOutboundPaymentTreasuryOutboundPaymentBuilder<'a>,
-    id: &'a str,
+pub struct ReturnOutboundPaymentTreasuryOutboundPayment {
+    inner: ReturnOutboundPaymentTreasuryOutboundPaymentBuilder,
+    id: String,
 }
-impl<'a> ReturnOutboundPaymentTreasuryOutboundPayment<'a> {
+impl ReturnOutboundPaymentTreasuryOutboundPayment {
     /// Construct a new `ReturnOutboundPaymentTreasuryOutboundPayment`.
-    pub fn new(id: &'a str) -> Self {
-        Self { id, inner: ReturnOutboundPaymentTreasuryOutboundPaymentBuilder::new() }
+    pub fn new(id: impl Into<String>) -> Self {
+        Self { id: id.into(), inner: ReturnOutboundPaymentTreasuryOutboundPaymentBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Optional hash to set the the return code.
     pub fn returned_details(
         mut self,
-        returned_details: ReturnOutboundPaymentTreasuryOutboundPaymentReturnedDetails,
+        returned_details: impl Into<ReturnOutboundPaymentTreasuryOutboundPaymentReturnedDetails>,
     ) -> Self {
-        self.inner.returned_details = Some(returned_details);
+        self.inner.returned_details = Some(returned_details.into());
         self
     }
 }
-impl ReturnOutboundPaymentTreasuryOutboundPayment<'_> {
+impl ReturnOutboundPaymentTreasuryOutboundPayment {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -445,11 +448,11 @@ impl ReturnOutboundPaymentTreasuryOutboundPayment<'_> {
     }
 }
 
-impl StripeRequest for ReturnOutboundPaymentTreasuryOutboundPayment<'_> {
+impl StripeRequest for ReturnOutboundPaymentTreasuryOutboundPayment {
     type Output = stripe_treasury::TreasuryOutboundPayment;
 
     fn build(&self) -> RequestBuilder {
-        let id = self.id;
+        let id = &self.id;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/test_helpers/treasury/outbound_payments/{id}/return"),
@@ -457,37 +460,41 @@ impl StripeRequest for ReturnOutboundPaymentTreasuryOutboundPayment<'_> {
         .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateTreasuryOutboundPaymentBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateTreasuryOutboundPaymentBuilder {
     amount: i64,
     currency: stripe_types::Currency,
     #[serde(skip_serializing_if = "Option::is_none")]
-    customer: Option<&'a str>,
+    customer: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<&'a str>,
+    description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    destination_payment_method: Option<&'a str>,
+    destination_payment_method: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     destination_payment_method_data:
-        Option<CreateTreasuryOutboundPaymentDestinationPaymentMethodData<'a>>,
+        Option<CreateTreasuryOutboundPaymentDestinationPaymentMethodData>,
     #[serde(skip_serializing_if = "Option::is_none")]
     destination_payment_method_options:
         Option<CreateTreasuryOutboundPaymentDestinationPaymentMethodOptions>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    end_user_details: Option<CreateTreasuryOutboundPaymentEndUserDetails<'a>>,
+    end_user_details: Option<CreateTreasuryOutboundPaymentEndUserDetails>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
-    financial_account: &'a str,
+    expand: Option<Vec<String>>,
+    financial_account: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    statement_descriptor: Option<&'a str>,
+    statement_descriptor: Option<String>,
 }
-impl<'a> CreateTreasuryOutboundPaymentBuilder<'a> {
-    fn new(amount: i64, currency: stripe_types::Currency, financial_account: &'a str) -> Self {
+impl CreateTreasuryOutboundPaymentBuilder {
+    fn new(
+        amount: impl Into<i64>,
+        currency: impl Into<stripe_types::Currency>,
+        financial_account: impl Into<String>,
+    ) -> Self {
         Self {
-            amount,
-            currency,
+            amount: amount.into(),
+            currency: currency.into(),
             customer: None,
             description: None,
             destination_payment_method: None,
@@ -495,7 +502,7 @@ impl<'a> CreateTreasuryOutboundPaymentBuilder<'a> {
             destination_payment_method_options: None,
             end_user_details: None,
             expand: None,
-            financial_account,
+            financial_account: financial_account.into(),
             metadata: None,
             statement_descriptor: None,
         }
@@ -503,21 +510,21 @@ impl<'a> CreateTreasuryOutboundPaymentBuilder<'a> {
 }
 /// Hash used to generate the PaymentMethod to be used for this OutboundPayment.
 /// Exclusive with `destination_payment_method`.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateTreasuryOutboundPaymentDestinationPaymentMethodData<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateTreasuryOutboundPaymentDestinationPaymentMethodData {
     /// Billing information associated with the PaymentMethod that may be used or required by particular types of payment methods.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub billing_details:
-        Option<CreateTreasuryOutboundPaymentDestinationPaymentMethodDataBillingDetails<'a>>,
+        Option<CreateTreasuryOutboundPaymentDestinationPaymentMethodDataBillingDetails>,
     /// Required if type is set to `financial_account`. The FinancialAccount ID to send funds to.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub financial_account: Option<&'a str>,
+    pub financial_account: Option<String>,
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<&'a std::collections::HashMap<String, String>>,
+    pub metadata: Option<std::collections::HashMap<String, String>>,
     /// The type of the PaymentMethod.
     /// An additional hash is included on the PaymentMethod with a name matching this value.
     /// It contains additional information specific to the PaymentMethod type.
@@ -526,76 +533,76 @@ pub struct CreateTreasuryOutboundPaymentDestinationPaymentMethodData<'a> {
     /// Required hash if type is set to `us_bank_account`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub us_bank_account:
-        Option<CreateTreasuryOutboundPaymentDestinationPaymentMethodDataUsBankAccount<'a>>,
+        Option<CreateTreasuryOutboundPaymentDestinationPaymentMethodDataUsBankAccount>,
 }
-impl<'a> CreateTreasuryOutboundPaymentDestinationPaymentMethodData<'a> {
-    pub fn new(type_: CreateTreasuryOutboundPaymentDestinationPaymentMethodDataType) -> Self {
+impl CreateTreasuryOutboundPaymentDestinationPaymentMethodData {
+    pub fn new(
+        type_: impl Into<CreateTreasuryOutboundPaymentDestinationPaymentMethodDataType>,
+    ) -> Self {
         Self {
             billing_details: None,
             financial_account: None,
             metadata: None,
-            type_,
+            type_: type_.into(),
             us_bank_account: None,
         }
     }
 }
 /// Billing information associated with the PaymentMethod that may be used or required by particular types of payment methods.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateTreasuryOutboundPaymentDestinationPaymentMethodDataBillingDetails<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateTreasuryOutboundPaymentDestinationPaymentMethodDataBillingDetails {
     /// Billing address.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub address:
-        Option<CreateTreasuryOutboundPaymentDestinationPaymentMethodDataBillingDetailsAddress<'a>>,
+        Option<CreateTreasuryOutboundPaymentDestinationPaymentMethodDataBillingDetailsAddress>,
     /// Email address.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub email: Option<&'a str>,
+    pub email: Option<String>,
     /// Full name.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub name: Option<&'a str>,
+    pub name: Option<String>,
     /// Billing phone number (including extension).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub phone: Option<&'a str>,
+    pub phone: Option<String>,
 }
-impl<'a> CreateTreasuryOutboundPaymentDestinationPaymentMethodDataBillingDetails<'a> {
+impl CreateTreasuryOutboundPaymentDestinationPaymentMethodDataBillingDetails {
     pub fn new() -> Self {
         Self { address: None, email: None, name: None, phone: None }
     }
 }
-impl<'a> Default for CreateTreasuryOutboundPaymentDestinationPaymentMethodDataBillingDetails<'a> {
+impl Default for CreateTreasuryOutboundPaymentDestinationPaymentMethodDataBillingDetails {
     fn default() -> Self {
         Self::new()
     }
 }
 /// Billing address.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateTreasuryOutboundPaymentDestinationPaymentMethodDataBillingDetailsAddress<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateTreasuryOutboundPaymentDestinationPaymentMethodDataBillingDetailsAddress {
     /// City, district, suburb, town, or village.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub city: Option<&'a str>,
+    pub city: Option<String>,
     /// Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub country: Option<&'a str>,
+    pub country: Option<String>,
     /// Address line 1 (e.g., street, PO Box, or company name).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line1: Option<&'a str>,
+    pub line1: Option<String>,
     /// Address line 2 (e.g., apartment, suite, unit, or building).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line2: Option<&'a str>,
+    pub line2: Option<String>,
     /// ZIP or postal code.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub postal_code: Option<&'a str>,
+    pub postal_code: Option<String>,
     /// State, county, province, or region.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub state: Option<&'a str>,
+    pub state: Option<String>,
 }
-impl<'a> CreateTreasuryOutboundPaymentDestinationPaymentMethodDataBillingDetailsAddress<'a> {
+impl CreateTreasuryOutboundPaymentDestinationPaymentMethodDataBillingDetailsAddress {
     pub fn new() -> Self {
         Self { city: None, country: None, line1: None, line2: None, postal_code: None, state: None }
     }
 }
-impl<'a> Default
-    for CreateTreasuryOutboundPaymentDestinationPaymentMethodDataBillingDetailsAddress<'a>
-{
+impl Default for CreateTreasuryOutboundPaymentDestinationPaymentMethodDataBillingDetailsAddress {
     fn default() -> Self {
         Self::new()
     }
@@ -663,8 +670,8 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// Required hash if type is set to `us_bank_account`.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateTreasuryOutboundPaymentDestinationPaymentMethodDataUsBankAccount<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateTreasuryOutboundPaymentDestinationPaymentMethodDataUsBankAccount {
     /// Account holder type: individual or company.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub account_holder_type: Option<
@@ -672,19 +679,19 @@ pub struct CreateTreasuryOutboundPaymentDestinationPaymentMethodDataUsBankAccoun
     >,
     /// Account number of the bank account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account_number: Option<&'a str>,
+    pub account_number: Option<String>,
     /// Account type: checkings or savings. Defaults to checking if omitted.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub account_type:
         Option<CreateTreasuryOutboundPaymentDestinationPaymentMethodDataUsBankAccountAccountType>,
     /// The ID of a Financial Connections Account to use as a payment method.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub financial_connections_account: Option<&'a str>,
+    pub financial_connections_account: Option<String>,
     /// Routing number of the bank account.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub routing_number: Option<&'a str>,
+    pub routing_number: Option<String>,
 }
-impl<'a> CreateTreasuryOutboundPaymentDestinationPaymentMethodDataUsBankAccount<'a> {
+impl CreateTreasuryOutboundPaymentDestinationPaymentMethodDataUsBankAccount {
     pub fn new() -> Self {
         Self {
             account_holder_type: None,
@@ -695,7 +702,7 @@ impl<'a> CreateTreasuryOutboundPaymentDestinationPaymentMethodDataUsBankAccount<
         }
     }
 }
-impl<'a> Default for CreateTreasuryOutboundPaymentDestinationPaymentMethodDataUsBankAccount<'a> {
+impl Default for CreateTreasuryOutboundPaymentDestinationPaymentMethodDataUsBankAccount {
     fn default() -> Self {
         Self::new()
     }
@@ -933,99 +940,116 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// End user details.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateTreasuryOutboundPaymentEndUserDetails<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateTreasuryOutboundPaymentEndUserDetails {
     /// IP address of the user initiating the OutboundPayment.
     /// Must be supplied if `present` is set to `true`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ip_address: Option<&'a str>,
+    pub ip_address: Option<String>,
     /// `True` if the OutboundPayment creation request is being made on behalf of an end user by a platform.
     /// Otherwise, `false`.
     pub present: bool,
 }
-impl<'a> CreateTreasuryOutboundPaymentEndUserDetails<'a> {
-    pub fn new(present: bool) -> Self {
-        Self { ip_address: None, present }
+impl CreateTreasuryOutboundPaymentEndUserDetails {
+    pub fn new(present: impl Into<bool>) -> Self {
+        Self { ip_address: None, present: present.into() }
     }
 }
 /// Creates an OutboundPayment.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateTreasuryOutboundPayment<'a> {
-    inner: CreateTreasuryOutboundPaymentBuilder<'a>,
+pub struct CreateTreasuryOutboundPayment {
+    inner: CreateTreasuryOutboundPaymentBuilder,
 }
-impl<'a> CreateTreasuryOutboundPayment<'a> {
+impl CreateTreasuryOutboundPayment {
     /// Construct a new `CreateTreasuryOutboundPayment`.
-    pub fn new(amount: i64, currency: stripe_types::Currency, financial_account: &'a str) -> Self {
+    pub fn new(
+        amount: impl Into<i64>,
+        currency: impl Into<stripe_types::Currency>,
+        financial_account: impl Into<String>,
+    ) -> Self {
         Self {
-            inner: CreateTreasuryOutboundPaymentBuilder::new(amount, currency, financial_account),
+            inner: CreateTreasuryOutboundPaymentBuilder::new(
+                amount.into(),
+                currency.into(),
+                financial_account.into(),
+            ),
         }
     }
     /// ID of the customer to whom the OutboundPayment is sent.
     /// Must match the Customer attached to the `destination_payment_method` passed in.
-    pub fn customer(mut self, customer: &'a str) -> Self {
-        self.inner.customer = Some(customer);
+    pub fn customer(mut self, customer: impl Into<String>) -> Self {
+        self.inner.customer = Some(customer.into());
         self
     }
     /// An arbitrary string attached to the object. Often useful for displaying to users.
-    pub fn description(mut self, description: &'a str) -> Self {
-        self.inner.description = Some(description);
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.inner.description = Some(description.into());
         self
     }
     /// The PaymentMethod to use as the payment instrument for the OutboundPayment.
     /// Exclusive with `destination_payment_method_data`.
-    pub fn destination_payment_method(mut self, destination_payment_method: &'a str) -> Self {
-        self.inner.destination_payment_method = Some(destination_payment_method);
+    pub fn destination_payment_method(
+        mut self,
+        destination_payment_method: impl Into<String>,
+    ) -> Self {
+        self.inner.destination_payment_method = Some(destination_payment_method.into());
         self
     }
     /// Hash used to generate the PaymentMethod to be used for this OutboundPayment.
     /// Exclusive with `destination_payment_method`.
     pub fn destination_payment_method_data(
         mut self,
-        destination_payment_method_data: CreateTreasuryOutboundPaymentDestinationPaymentMethodData<
-            'a,
+        destination_payment_method_data: impl Into<
+            CreateTreasuryOutboundPaymentDestinationPaymentMethodData,
         >,
     ) -> Self {
-        self.inner.destination_payment_method_data = Some(destination_payment_method_data);
+        self.inner.destination_payment_method_data = Some(destination_payment_method_data.into());
         self
     }
     /// Payment method-specific configuration for this OutboundPayment.
     pub fn destination_payment_method_options(
         mut self,
-        destination_payment_method_options: CreateTreasuryOutboundPaymentDestinationPaymentMethodOptions,
+        destination_payment_method_options: impl Into<
+            CreateTreasuryOutboundPaymentDestinationPaymentMethodOptions,
+        >,
     ) -> Self {
-        self.inner.destination_payment_method_options = Some(destination_payment_method_options);
+        self.inner.destination_payment_method_options =
+            Some(destination_payment_method_options.into());
         self
     }
     /// End user details.
     pub fn end_user_details(
         mut self,
-        end_user_details: CreateTreasuryOutboundPaymentEndUserDetails<'a>,
+        end_user_details: impl Into<CreateTreasuryOutboundPaymentEndUserDetails>,
     ) -> Self {
-        self.inner.end_user_details = Some(end_user_details);
+        self.inner.end_user_details = Some(end_user_details.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// The description that appears on the receiving end for this OutboundPayment (for example, bank statement for external bank transfer).
     /// Maximum 10 characters for `ach` payments, 140 characters for `us_domestic_wire` payments, or 500 characters for `stripe` network transfers.
     /// The default value is "payment".
-    pub fn statement_descriptor(mut self, statement_descriptor: &'a str) -> Self {
-        self.inner.statement_descriptor = Some(statement_descriptor);
+    pub fn statement_descriptor(mut self, statement_descriptor: impl Into<String>) -> Self {
+        self.inner.statement_descriptor = Some(statement_descriptor.into());
         self
     }
 }
-impl CreateTreasuryOutboundPayment<'_> {
+impl CreateTreasuryOutboundPayment {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -1043,41 +1067,41 @@ impl CreateTreasuryOutboundPayment<'_> {
     }
 }
 
-impl StripeRequest for CreateTreasuryOutboundPayment<'_> {
+impl StripeRequest for CreateTreasuryOutboundPayment {
     type Output = stripe_treasury::TreasuryOutboundPayment;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Post, "/treasury/outbound_payments").form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CancelTreasuryOutboundPaymentBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CancelTreasuryOutboundPaymentBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> CancelTreasuryOutboundPaymentBuilder<'a> {
+impl CancelTreasuryOutboundPaymentBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Cancel an OutboundPayment.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CancelTreasuryOutboundPayment<'a> {
-    inner: CancelTreasuryOutboundPaymentBuilder<'a>,
-    id: &'a stripe_treasury::TreasuryOutboundPaymentId,
+pub struct CancelTreasuryOutboundPayment {
+    inner: CancelTreasuryOutboundPaymentBuilder,
+    id: stripe_treasury::TreasuryOutboundPaymentId,
 }
-impl<'a> CancelTreasuryOutboundPayment<'a> {
+impl CancelTreasuryOutboundPayment {
     /// Construct a new `CancelTreasuryOutboundPayment`.
-    pub fn new(id: &'a stripe_treasury::TreasuryOutboundPaymentId) -> Self {
-        Self { id, inner: CancelTreasuryOutboundPaymentBuilder::new() }
+    pub fn new(id: impl Into<stripe_treasury::TreasuryOutboundPaymentId>) -> Self {
+        Self { id: id.into(), inner: CancelTreasuryOutboundPaymentBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl CancelTreasuryOutboundPayment<'_> {
+impl CancelTreasuryOutboundPayment {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -1095,11 +1119,11 @@ impl CancelTreasuryOutboundPayment<'_> {
     }
 }
 
-impl StripeRequest for CancelTreasuryOutboundPayment<'_> {
+impl StripeRequest for CancelTreasuryOutboundPayment {
     type Output = stripe_treasury::TreasuryOutboundPayment;
 
     fn build(&self) -> RequestBuilder {
-        let id = self.id;
+        let id = &self.id;
         RequestBuilder::new(StripeMethod::Post, format!("/treasury/outbound_payments/{id}/cancel"))
             .form(&self.inner)
     }

--- a/generated/async-stripe-treasury/src/treasury_outbound_transfer/requests.rs
+++ b/generated/async-stripe-treasury/src/treasury_outbound_transfer/requests.rs
@@ -2,26 +2,26 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListTreasuryOutboundTransferBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListTreasuryOutboundTransferBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
-    financial_account: &'a str,
+    expand: Option<Vec<String>>,
+    financial_account: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     status: Option<stripe_treasury::TreasuryOutboundTransferStatus>,
 }
-impl<'a> ListTreasuryOutboundTransferBuilder<'a> {
-    fn new(financial_account: &'a str) -> Self {
+impl ListTreasuryOutboundTransferBuilder {
+    fn new(financial_account: impl Into<String>) -> Self {
         Self {
             ending_before: None,
             expand: None,
-            financial_account,
+            financial_account: financial_account.into(),
             limit: None,
             starting_after: None,
             status: None,
@@ -30,46 +30,49 @@ impl<'a> ListTreasuryOutboundTransferBuilder<'a> {
 }
 /// Returns a list of OutboundTransfers sent from the specified FinancialAccount.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListTreasuryOutboundTransfer<'a> {
-    inner: ListTreasuryOutboundTransferBuilder<'a>,
+pub struct ListTreasuryOutboundTransfer {
+    inner: ListTreasuryOutboundTransferBuilder,
 }
-impl<'a> ListTreasuryOutboundTransfer<'a> {
+impl ListTreasuryOutboundTransfer {
     /// Construct a new `ListTreasuryOutboundTransfer`.
-    pub fn new(financial_account: &'a str) -> Self {
-        Self { inner: ListTreasuryOutboundTransferBuilder::new(financial_account) }
+    pub fn new(financial_account: impl Into<String>) -> Self {
+        Self { inner: ListTreasuryOutboundTransferBuilder::new(financial_account.into()) }
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
     /// Only return OutboundTransfers that have the given status: `processing`, `canceled`, `failed`, `posted`, or `returned`.
-    pub fn status(mut self, status: stripe_treasury::TreasuryOutboundTransferStatus) -> Self {
-        self.inner.status = Some(status);
+    pub fn status(
+        mut self,
+        status: impl Into<stripe_treasury::TreasuryOutboundTransferStatus>,
+    ) -> Self {
+        self.inner.status = Some(status.into());
         self
     }
 }
-impl ListTreasuryOutboundTransfer<'_> {
+impl ListTreasuryOutboundTransfer {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -91,45 +94,48 @@ impl ListTreasuryOutboundTransfer<'_> {
     ) -> stripe_client_core::ListPaginator<
         stripe_types::List<stripe_treasury::TreasuryOutboundTransfer>,
     > {
-        stripe_client_core::ListPaginator::new_list("/treasury/outbound_transfers", self.inner)
+        stripe_client_core::ListPaginator::new_list("/treasury/outbound_transfers", &self.inner)
     }
 }
 
-impl StripeRequest for ListTreasuryOutboundTransfer<'_> {
+impl StripeRequest for ListTreasuryOutboundTransfer {
     type Output = stripe_types::List<stripe_treasury::TreasuryOutboundTransfer>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/treasury/outbound_transfers").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveTreasuryOutboundTransferBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveTreasuryOutboundTransferBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveTreasuryOutboundTransferBuilder<'a> {
+impl RetrieveTreasuryOutboundTransferBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves the details of an existing OutboundTransfer by passing the unique OutboundTransfer ID from either the OutboundTransfer creation request or OutboundTransfer list.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveTreasuryOutboundTransfer<'a> {
-    inner: RetrieveTreasuryOutboundTransferBuilder<'a>,
-    outbound_transfer: &'a stripe_treasury::TreasuryOutboundTransferId,
+pub struct RetrieveTreasuryOutboundTransfer {
+    inner: RetrieveTreasuryOutboundTransferBuilder,
+    outbound_transfer: stripe_treasury::TreasuryOutboundTransferId,
 }
-impl<'a> RetrieveTreasuryOutboundTransfer<'a> {
+impl RetrieveTreasuryOutboundTransfer {
     /// Construct a new `RetrieveTreasuryOutboundTransfer`.
-    pub fn new(outbound_transfer: &'a stripe_treasury::TreasuryOutboundTransferId) -> Self {
-        Self { outbound_transfer, inner: RetrieveTreasuryOutboundTransferBuilder::new() }
+    pub fn new(outbound_transfer: impl Into<stripe_treasury::TreasuryOutboundTransferId>) -> Self {
+        Self {
+            outbound_transfer: outbound_transfer.into(),
+            inner: RetrieveTreasuryOutboundTransferBuilder::new(),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveTreasuryOutboundTransfer<'_> {
+impl RetrieveTreasuryOutboundTransfer {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -147,11 +153,11 @@ impl RetrieveTreasuryOutboundTransfer<'_> {
     }
 }
 
-impl StripeRequest for RetrieveTreasuryOutboundTransfer<'_> {
+impl StripeRequest for RetrieveTreasuryOutboundTransfer {
     type Output = stripe_treasury::TreasuryOutboundTransfer;
 
     fn build(&self) -> RequestBuilder {
-        let outbound_transfer = self.outbound_transfer;
+        let outbound_transfer = &self.outbound_transfer;
         RequestBuilder::new(
             StripeMethod::Get,
             format!("/treasury/outbound_transfers/{outbound_transfer}"),
@@ -159,12 +165,12 @@ impl StripeRequest for RetrieveTreasuryOutboundTransfer<'_> {
         .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct FailTreasuryOutboundTransferBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct FailTreasuryOutboundTransferBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> FailTreasuryOutboundTransferBuilder<'a> {
+impl FailTreasuryOutboundTransferBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
@@ -172,22 +178,25 @@ impl<'a> FailTreasuryOutboundTransferBuilder<'a> {
 /// Transitions a test mode created OutboundTransfer to the `failed` status.
 /// The OutboundTransfer must already be in the `processing` state.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct FailTreasuryOutboundTransfer<'a> {
-    inner: FailTreasuryOutboundTransferBuilder<'a>,
-    outbound_transfer: &'a str,
+pub struct FailTreasuryOutboundTransfer {
+    inner: FailTreasuryOutboundTransferBuilder,
+    outbound_transfer: String,
 }
-impl<'a> FailTreasuryOutboundTransfer<'a> {
+impl FailTreasuryOutboundTransfer {
     /// Construct a new `FailTreasuryOutboundTransfer`.
-    pub fn new(outbound_transfer: &'a str) -> Self {
-        Self { outbound_transfer, inner: FailTreasuryOutboundTransferBuilder::new() }
+    pub fn new(outbound_transfer: impl Into<String>) -> Self {
+        Self {
+            outbound_transfer: outbound_transfer.into(),
+            inner: FailTreasuryOutboundTransferBuilder::new(),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl FailTreasuryOutboundTransfer<'_> {
+impl FailTreasuryOutboundTransfer {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -205,11 +214,11 @@ impl FailTreasuryOutboundTransfer<'_> {
     }
 }
 
-impl StripeRequest for FailTreasuryOutboundTransfer<'_> {
+impl StripeRequest for FailTreasuryOutboundTransfer {
     type Output = stripe_treasury::TreasuryOutboundTransfer;
 
     fn build(&self) -> RequestBuilder {
-        let outbound_transfer = self.outbound_transfer;
+        let outbound_transfer = &self.outbound_transfer;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/test_helpers/treasury/outbound_transfers/{outbound_transfer}/fail"),
@@ -217,12 +226,12 @@ impl StripeRequest for FailTreasuryOutboundTransfer<'_> {
         .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct PostTreasuryOutboundTransferBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct PostTreasuryOutboundTransferBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> PostTreasuryOutboundTransferBuilder<'a> {
+impl PostTreasuryOutboundTransferBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
@@ -230,22 +239,25 @@ impl<'a> PostTreasuryOutboundTransferBuilder<'a> {
 /// Transitions a test mode created OutboundTransfer to the `posted` status.
 /// The OutboundTransfer must already be in the `processing` state.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct PostTreasuryOutboundTransfer<'a> {
-    inner: PostTreasuryOutboundTransferBuilder<'a>,
-    outbound_transfer: &'a str,
+pub struct PostTreasuryOutboundTransfer {
+    inner: PostTreasuryOutboundTransferBuilder,
+    outbound_transfer: String,
 }
-impl<'a> PostTreasuryOutboundTransfer<'a> {
+impl PostTreasuryOutboundTransfer {
     /// Construct a new `PostTreasuryOutboundTransfer`.
-    pub fn new(outbound_transfer: &'a str) -> Self {
-        Self { outbound_transfer, inner: PostTreasuryOutboundTransferBuilder::new() }
+    pub fn new(outbound_transfer: impl Into<String>) -> Self {
+        Self {
+            outbound_transfer: outbound_transfer.into(),
+            inner: PostTreasuryOutboundTransferBuilder::new(),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl PostTreasuryOutboundTransfer<'_> {
+impl PostTreasuryOutboundTransfer {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -263,11 +275,11 @@ impl PostTreasuryOutboundTransfer<'_> {
     }
 }
 
-impl StripeRequest for PostTreasuryOutboundTransfer<'_> {
+impl StripeRequest for PostTreasuryOutboundTransfer {
     type Output = stripe_treasury::TreasuryOutboundTransfer;
 
     fn build(&self) -> RequestBuilder {
-        let outbound_transfer = self.outbound_transfer;
+        let outbound_transfer = &self.outbound_transfer;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/test_helpers/treasury/outbound_transfers/{outbound_transfer}/post"),
@@ -275,14 +287,14 @@ impl StripeRequest for PostTreasuryOutboundTransfer<'_> {
         .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ReturnOutboundTransferTreasuryOutboundTransferBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ReturnOutboundTransferTreasuryOutboundTransferBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     returned_details: Option<ReturnOutboundTransferTreasuryOutboundTransferReturnedDetails>,
 }
-impl<'a> ReturnOutboundTransferTreasuryOutboundTransferBuilder<'a> {
+impl ReturnOutboundTransferTreasuryOutboundTransferBuilder {
     fn new() -> Self {
         Self { expand: None, returned_details: None }
     }
@@ -387,33 +399,33 @@ impl<'de> serde::Deserialize<'de>
 /// Transitions a test mode created OutboundTransfer to the `returned` status.
 /// The OutboundTransfer must already be in the `processing` state.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ReturnOutboundTransferTreasuryOutboundTransfer<'a> {
-    inner: ReturnOutboundTransferTreasuryOutboundTransferBuilder<'a>,
-    outbound_transfer: &'a str,
+pub struct ReturnOutboundTransferTreasuryOutboundTransfer {
+    inner: ReturnOutboundTransferTreasuryOutboundTransferBuilder,
+    outbound_transfer: String,
 }
-impl<'a> ReturnOutboundTransferTreasuryOutboundTransfer<'a> {
+impl ReturnOutboundTransferTreasuryOutboundTransfer {
     /// Construct a new `ReturnOutboundTransferTreasuryOutboundTransfer`.
-    pub fn new(outbound_transfer: &'a str) -> Self {
+    pub fn new(outbound_transfer: impl Into<String>) -> Self {
         Self {
-            outbound_transfer,
+            outbound_transfer: outbound_transfer.into(),
             inner: ReturnOutboundTransferTreasuryOutboundTransferBuilder::new(),
         }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Details about a returned OutboundTransfer.
     pub fn returned_details(
         mut self,
-        returned_details: ReturnOutboundTransferTreasuryOutboundTransferReturnedDetails,
+        returned_details: impl Into<ReturnOutboundTransferTreasuryOutboundTransferReturnedDetails>,
     ) -> Self {
-        self.inner.returned_details = Some(returned_details);
+        self.inner.returned_details = Some(returned_details.into());
         self
     }
 }
-impl ReturnOutboundTransferTreasuryOutboundTransfer<'_> {
+impl ReturnOutboundTransferTreasuryOutboundTransfer {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -431,11 +443,11 @@ impl ReturnOutboundTransferTreasuryOutboundTransfer<'_> {
     }
 }
 
-impl StripeRequest for ReturnOutboundTransferTreasuryOutboundTransfer<'_> {
+impl StripeRequest for ReturnOutboundTransferTreasuryOutboundTransfer {
     type Output = stripe_treasury::TreasuryOutboundTransfer;
 
     fn build(&self) -> RequestBuilder {
-        let outbound_transfer = self.outbound_transfer;
+        let outbound_transfer = &self.outbound_transfer;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/test_helpers/treasury/outbound_transfers/{outbound_transfer}/return"),
@@ -443,35 +455,39 @@ impl StripeRequest for ReturnOutboundTransferTreasuryOutboundTransfer<'_> {
         .form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateTreasuryOutboundTransferBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateTreasuryOutboundTransferBuilder {
     amount: i64,
     currency: stripe_types::Currency,
     #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<&'a str>,
+    description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    destination_payment_method: Option<&'a str>,
+    destination_payment_method: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     destination_payment_method_options:
         Option<CreateTreasuryOutboundTransferDestinationPaymentMethodOptions>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
-    financial_account: &'a str,
+    expand: Option<Vec<String>>,
+    financial_account: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    metadata: Option<&'a std::collections::HashMap<String, String>>,
+    metadata: Option<std::collections::HashMap<String, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    statement_descriptor: Option<&'a str>,
+    statement_descriptor: Option<String>,
 }
-impl<'a> CreateTreasuryOutboundTransferBuilder<'a> {
-    fn new(amount: i64, currency: stripe_types::Currency, financial_account: &'a str) -> Self {
+impl CreateTreasuryOutboundTransferBuilder {
+    fn new(
+        amount: impl Into<i64>,
+        currency: impl Into<stripe_types::Currency>,
+        financial_account: impl Into<String>,
+    ) -> Self {
         Self {
-            amount,
-            currency,
+            amount: amount.into(),
+            currency: currency.into(),
             description: None,
             destination_payment_method: None,
             destination_payment_method_options: None,
             expand: None,
-            financial_account,
+            financial_account: financial_account.into(),
             metadata: None,
             statement_descriptor: None,
         }
@@ -583,56 +599,73 @@ impl<'de> serde::Deserialize<'de>
 }
 /// Creates an OutboundTransfer.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateTreasuryOutboundTransfer<'a> {
-    inner: CreateTreasuryOutboundTransferBuilder<'a>,
+pub struct CreateTreasuryOutboundTransfer {
+    inner: CreateTreasuryOutboundTransferBuilder,
 }
-impl<'a> CreateTreasuryOutboundTransfer<'a> {
+impl CreateTreasuryOutboundTransfer {
     /// Construct a new `CreateTreasuryOutboundTransfer`.
-    pub fn new(amount: i64, currency: stripe_types::Currency, financial_account: &'a str) -> Self {
+    pub fn new(
+        amount: impl Into<i64>,
+        currency: impl Into<stripe_types::Currency>,
+        financial_account: impl Into<String>,
+    ) -> Self {
         Self {
-            inner: CreateTreasuryOutboundTransferBuilder::new(amount, currency, financial_account),
+            inner: CreateTreasuryOutboundTransferBuilder::new(
+                amount.into(),
+                currency.into(),
+                financial_account.into(),
+            ),
         }
     }
     /// An arbitrary string attached to the object. Often useful for displaying to users.
-    pub fn description(mut self, description: &'a str) -> Self {
-        self.inner.description = Some(description);
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.inner.description = Some(description.into());
         self
     }
     /// The PaymentMethod to use as the payment instrument for the OutboundTransfer.
-    pub fn destination_payment_method(mut self, destination_payment_method: &'a str) -> Self {
-        self.inner.destination_payment_method = Some(destination_payment_method);
+    pub fn destination_payment_method(
+        mut self,
+        destination_payment_method: impl Into<String>,
+    ) -> Self {
+        self.inner.destination_payment_method = Some(destination_payment_method.into());
         self
     }
     /// Hash describing payment method configuration details.
     pub fn destination_payment_method_options(
         mut self,
-        destination_payment_method_options: CreateTreasuryOutboundTransferDestinationPaymentMethodOptions,
+        destination_payment_method_options: impl Into<
+            CreateTreasuryOutboundTransferDestinationPaymentMethodOptions,
+        >,
     ) -> Self {
-        self.inner.destination_payment_method_options = Some(destination_payment_method_options);
+        self.inner.destination_payment_method_options =
+            Some(destination_payment_method_options.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object.
     /// This can be useful for storing additional information about the object in a structured format.
     /// Individual keys can be unset by posting an empty value to them.
     /// All keys can be unset by posting an empty value to `metadata`.
-    pub fn metadata(mut self, metadata: &'a std::collections::HashMap<String, String>) -> Self {
-        self.inner.metadata = Some(metadata);
+    pub fn metadata(
+        mut self,
+        metadata: impl Into<std::collections::HashMap<String, String>>,
+    ) -> Self {
+        self.inner.metadata = Some(metadata.into());
         self
     }
     /// Statement descriptor to be shown on the receiving end of an OutboundTransfer.
     /// Maximum 10 characters for `ach` transfers or 140 characters for `us_domestic_wire` transfers.
     /// The default value is "transfer".
-    pub fn statement_descriptor(mut self, statement_descriptor: &'a str) -> Self {
-        self.inner.statement_descriptor = Some(statement_descriptor);
+    pub fn statement_descriptor(mut self, statement_descriptor: impl Into<String>) -> Self {
+        self.inner.statement_descriptor = Some(statement_descriptor.into());
         self
     }
 }
-impl CreateTreasuryOutboundTransfer<'_> {
+impl CreateTreasuryOutboundTransfer {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -650,41 +683,44 @@ impl CreateTreasuryOutboundTransfer<'_> {
     }
 }
 
-impl StripeRequest for CreateTreasuryOutboundTransfer<'_> {
+impl StripeRequest for CreateTreasuryOutboundTransfer {
     type Output = stripe_treasury::TreasuryOutboundTransfer;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Post, "/treasury/outbound_transfers").form(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CancelTreasuryOutboundTransferBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CancelTreasuryOutboundTransferBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> CancelTreasuryOutboundTransferBuilder<'a> {
+impl CancelTreasuryOutboundTransferBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// An OutboundTransfer can be canceled if the funds have not yet been paid out.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CancelTreasuryOutboundTransfer<'a> {
-    inner: CancelTreasuryOutboundTransferBuilder<'a>,
-    outbound_transfer: &'a stripe_treasury::TreasuryOutboundTransferId,
+pub struct CancelTreasuryOutboundTransfer {
+    inner: CancelTreasuryOutboundTransferBuilder,
+    outbound_transfer: stripe_treasury::TreasuryOutboundTransferId,
 }
-impl<'a> CancelTreasuryOutboundTransfer<'a> {
+impl CancelTreasuryOutboundTransfer {
     /// Construct a new `CancelTreasuryOutboundTransfer`.
-    pub fn new(outbound_transfer: &'a stripe_treasury::TreasuryOutboundTransferId) -> Self {
-        Self { outbound_transfer, inner: CancelTreasuryOutboundTransferBuilder::new() }
+    pub fn new(outbound_transfer: impl Into<stripe_treasury::TreasuryOutboundTransferId>) -> Self {
+        Self {
+            outbound_transfer: outbound_transfer.into(),
+            inner: CancelTreasuryOutboundTransferBuilder::new(),
+        }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl CancelTreasuryOutboundTransfer<'_> {
+impl CancelTreasuryOutboundTransfer {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -702,11 +738,11 @@ impl CancelTreasuryOutboundTransfer<'_> {
     }
 }
 
-impl StripeRequest for CancelTreasuryOutboundTransfer<'_> {
+impl StripeRequest for CancelTreasuryOutboundTransfer {
     type Output = stripe_treasury::TreasuryOutboundTransfer;
 
     fn build(&self) -> RequestBuilder {
-        let outbound_transfer = self.outbound_transfer;
+        let outbound_transfer = &self.outbound_transfer;
         RequestBuilder::new(
             StripeMethod::Post,
             format!("/treasury/outbound_transfers/{outbound_transfer}/cancel"),

--- a/generated/async-stripe-treasury/src/treasury_received_credit/requests.rs
+++ b/generated/async-stripe-treasury/src/treasury_received_credit/requests.rs
@@ -2,28 +2,28 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListTreasuryReceivedCreditBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListTreasuryReceivedCreditBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
-    financial_account: &'a str,
+    expand: Option<Vec<String>>,
+    financial_account: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     linked_flows: Option<ListTreasuryReceivedCreditLinkedFlows>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     status: Option<stripe_treasury::TreasuryReceivedCreditStatus>,
 }
-impl<'a> ListTreasuryReceivedCreditBuilder<'a> {
-    fn new(financial_account: &'a str) -> Self {
+impl ListTreasuryReceivedCreditBuilder {
+    fn new(financial_account: impl Into<String>) -> Self {
         Self {
             ending_before: None,
             expand: None,
-            financial_account,
+            financial_account: financial_account.into(),
             limit: None,
             linked_flows: None,
             starting_after: None,
@@ -38,8 +38,10 @@ pub struct ListTreasuryReceivedCreditLinkedFlows {
     pub source_flow_type: ListTreasuryReceivedCreditLinkedFlowsSourceFlowType,
 }
 impl ListTreasuryReceivedCreditLinkedFlows {
-    pub fn new(source_flow_type: ListTreasuryReceivedCreditLinkedFlowsSourceFlowType) -> Self {
-        Self { source_flow_type }
+    pub fn new(
+        source_flow_type: impl Into<ListTreasuryReceivedCreditLinkedFlowsSourceFlowType>,
+    ) -> Self {
+        Self { source_flow_type: source_flow_type.into() }
     }
 }
 /// The source flow type.
@@ -108,51 +110,57 @@ impl<'de> serde::Deserialize<'de> for ListTreasuryReceivedCreditLinkedFlowsSourc
 }
 /// Returns a list of ReceivedCredits.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListTreasuryReceivedCredit<'a> {
-    inner: ListTreasuryReceivedCreditBuilder<'a>,
+pub struct ListTreasuryReceivedCredit {
+    inner: ListTreasuryReceivedCreditBuilder,
 }
-impl<'a> ListTreasuryReceivedCredit<'a> {
+impl ListTreasuryReceivedCredit {
     /// Construct a new `ListTreasuryReceivedCredit`.
-    pub fn new(financial_account: &'a str) -> Self {
-        Self { inner: ListTreasuryReceivedCreditBuilder::new(financial_account) }
+    pub fn new(financial_account: impl Into<String>) -> Self {
+        Self { inner: ListTreasuryReceivedCreditBuilder::new(financial_account.into()) }
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// Only return ReceivedCredits described by the flow.
-    pub fn linked_flows(mut self, linked_flows: ListTreasuryReceivedCreditLinkedFlows) -> Self {
-        self.inner.linked_flows = Some(linked_flows);
+    pub fn linked_flows(
+        mut self,
+        linked_flows: impl Into<ListTreasuryReceivedCreditLinkedFlows>,
+    ) -> Self {
+        self.inner.linked_flows = Some(linked_flows.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
     /// Only return ReceivedCredits that have the given status: `succeeded` or `failed`.
-    pub fn status(mut self, status: stripe_treasury::TreasuryReceivedCreditStatus) -> Self {
-        self.inner.status = Some(status);
+    pub fn status(
+        mut self,
+        status: impl Into<stripe_treasury::TreasuryReceivedCreditStatus>,
+    ) -> Self {
+        self.inner.status = Some(status.into());
         self
     }
 }
-impl ListTreasuryReceivedCredit<'_> {
+impl ListTreasuryReceivedCredit {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -174,45 +182,45 @@ impl ListTreasuryReceivedCredit<'_> {
     ) -> stripe_client_core::ListPaginator<
         stripe_types::List<stripe_treasury::TreasuryReceivedCredit>,
     > {
-        stripe_client_core::ListPaginator::new_list("/treasury/received_credits", self.inner)
+        stripe_client_core::ListPaginator::new_list("/treasury/received_credits", &self.inner)
     }
 }
 
-impl StripeRequest for ListTreasuryReceivedCredit<'_> {
+impl StripeRequest for ListTreasuryReceivedCredit {
     type Output = stripe_types::List<stripe_treasury::TreasuryReceivedCredit>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/treasury/received_credits").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveTreasuryReceivedCreditBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveTreasuryReceivedCreditBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveTreasuryReceivedCreditBuilder<'a> {
+impl RetrieveTreasuryReceivedCreditBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves the details of an existing ReceivedCredit by passing the unique ReceivedCredit ID from the ReceivedCredit list.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveTreasuryReceivedCredit<'a> {
-    inner: RetrieveTreasuryReceivedCreditBuilder<'a>,
-    id: &'a stripe_treasury::TreasuryReceivedCreditId,
+pub struct RetrieveTreasuryReceivedCredit {
+    inner: RetrieveTreasuryReceivedCreditBuilder,
+    id: stripe_treasury::TreasuryReceivedCreditId,
 }
-impl<'a> RetrieveTreasuryReceivedCredit<'a> {
+impl RetrieveTreasuryReceivedCredit {
     /// Construct a new `RetrieveTreasuryReceivedCredit`.
-    pub fn new(id: &'a stripe_treasury::TreasuryReceivedCreditId) -> Self {
-        Self { id, inner: RetrieveTreasuryReceivedCreditBuilder::new() }
+    pub fn new(id: impl Into<stripe_treasury::TreasuryReceivedCreditId>) -> Self {
+        Self { id: id.into(), inner: RetrieveTreasuryReceivedCreditBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveTreasuryReceivedCredit<'_> {
+impl RetrieveTreasuryReceivedCredit {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -230,61 +238,63 @@ impl RetrieveTreasuryReceivedCredit<'_> {
     }
 }
 
-impl StripeRequest for RetrieveTreasuryReceivedCredit<'_> {
+impl StripeRequest for RetrieveTreasuryReceivedCredit {
     type Output = stripe_treasury::TreasuryReceivedCredit;
 
     fn build(&self) -> RequestBuilder {
-        let id = self.id;
+        let id = &self.id;
         RequestBuilder::new(StripeMethod::Get, format!("/treasury/received_credits/{id}"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateTreasuryReceivedCreditBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateTreasuryReceivedCreditBuilder {
     amount: i64,
     currency: stripe_types::Currency,
     #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<&'a str>,
+    description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
-    financial_account: &'a str,
+    expand: Option<Vec<String>>,
+    financial_account: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     initiating_payment_method_details:
-        Option<CreateTreasuryReceivedCreditInitiatingPaymentMethodDetails<'a>>,
+        Option<CreateTreasuryReceivedCreditInitiatingPaymentMethodDetails>,
     network: CreateTreasuryReceivedCreditNetwork,
 }
-impl<'a> CreateTreasuryReceivedCreditBuilder<'a> {
+impl CreateTreasuryReceivedCreditBuilder {
     fn new(
-        amount: i64,
-        currency: stripe_types::Currency,
-        financial_account: &'a str,
-        network: CreateTreasuryReceivedCreditNetwork,
+        amount: impl Into<i64>,
+        currency: impl Into<stripe_types::Currency>,
+        financial_account: impl Into<String>,
+        network: impl Into<CreateTreasuryReceivedCreditNetwork>,
     ) -> Self {
         Self {
-            amount,
-            currency,
+            amount: amount.into(),
+            currency: currency.into(),
             description: None,
             expand: None,
-            financial_account,
+            financial_account: financial_account.into(),
             initiating_payment_method_details: None,
-            network,
+            network: network.into(),
         }
     }
 }
 /// Initiating payment method details for the object.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateTreasuryReceivedCreditInitiatingPaymentMethodDetails<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateTreasuryReceivedCreditInitiatingPaymentMethodDetails {
     /// The source type.
     #[serde(rename = "type")]
     pub type_: CreateTreasuryReceivedCreditInitiatingPaymentMethodDetailsType,
     /// Optional fields for `us_bank_account`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub us_bank_account:
-        Option<CreateTreasuryReceivedCreditInitiatingPaymentMethodDetailsUsBankAccount<'a>>,
+        Option<CreateTreasuryReceivedCreditInitiatingPaymentMethodDetailsUsBankAccount>,
 }
-impl<'a> CreateTreasuryReceivedCreditInitiatingPaymentMethodDetails<'a> {
-    pub fn new(type_: CreateTreasuryReceivedCreditInitiatingPaymentMethodDetailsType) -> Self {
-        Self { type_, us_bank_account: None }
+impl CreateTreasuryReceivedCreditInitiatingPaymentMethodDetails {
+    pub fn new(
+        type_: impl Into<CreateTreasuryReceivedCreditInitiatingPaymentMethodDetailsType>,
+    ) -> Self {
+        Self { type_: type_.into(), us_bank_account: None }
     }
 }
 /// The source type.
@@ -345,24 +355,24 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// Optional fields for `us_bank_account`.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateTreasuryReceivedCreditInitiatingPaymentMethodDetailsUsBankAccount<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateTreasuryReceivedCreditInitiatingPaymentMethodDetailsUsBankAccount {
     /// The bank account holder's name.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account_holder_name: Option<&'a str>,
+    pub account_holder_name: Option<String>,
     /// The bank account number.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account_number: Option<&'a str>,
+    pub account_number: Option<String>,
     /// The bank account's routing number.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub routing_number: Option<&'a str>,
+    pub routing_number: Option<String>,
 }
-impl<'a> CreateTreasuryReceivedCreditInitiatingPaymentMethodDetailsUsBankAccount<'a> {
+impl CreateTreasuryReceivedCreditInitiatingPaymentMethodDetailsUsBankAccount {
     pub fn new() -> Self {
         Self { account_holder_name: None, account_number: None, routing_number: None }
     }
 }
-impl<'a> Default for CreateTreasuryReceivedCreditInitiatingPaymentMethodDetailsUsBankAccount<'a> {
+impl Default for CreateTreasuryReceivedCreditInitiatingPaymentMethodDetailsUsBankAccount {
     fn default() -> Self {
         Self::new()
     }
@@ -428,46 +438,49 @@ impl<'de> serde::Deserialize<'de> for CreateTreasuryReceivedCreditNetwork {
 /// Use this endpoint to simulate a test mode ReceivedCredit initiated by a third party.
 /// In live mode, you can’t directly create ReceivedCredits initiated by third parties.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateTreasuryReceivedCredit<'a> {
-    inner: CreateTreasuryReceivedCreditBuilder<'a>,
+pub struct CreateTreasuryReceivedCredit {
+    inner: CreateTreasuryReceivedCreditBuilder,
 }
-impl<'a> CreateTreasuryReceivedCredit<'a> {
+impl CreateTreasuryReceivedCredit {
     /// Construct a new `CreateTreasuryReceivedCredit`.
     pub fn new(
-        amount: i64,
-        currency: stripe_types::Currency,
-        financial_account: &'a str,
-        network: CreateTreasuryReceivedCreditNetwork,
+        amount: impl Into<i64>,
+        currency: impl Into<stripe_types::Currency>,
+        financial_account: impl Into<String>,
+        network: impl Into<CreateTreasuryReceivedCreditNetwork>,
     ) -> Self {
         Self {
             inner: CreateTreasuryReceivedCreditBuilder::new(
-                amount,
-                currency,
-                financial_account,
-                network,
+                amount.into(),
+                currency.into(),
+                financial_account.into(),
+                network.into(),
             ),
         }
     }
     /// An arbitrary string attached to the object. Often useful for displaying to users.
-    pub fn description(mut self, description: &'a str) -> Self {
-        self.inner.description = Some(description);
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.inner.description = Some(description.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Initiating payment method details for the object.
     pub fn initiating_payment_method_details(
         mut self,
-        initiating_payment_method_details: CreateTreasuryReceivedCreditInitiatingPaymentMethodDetails<'a>,
+        initiating_payment_method_details: impl Into<
+            CreateTreasuryReceivedCreditInitiatingPaymentMethodDetails,
+        >,
     ) -> Self {
-        self.inner.initiating_payment_method_details = Some(initiating_payment_method_details);
+        self.inner.initiating_payment_method_details =
+            Some(initiating_payment_method_details.into());
         self
     }
 }
-impl CreateTreasuryReceivedCredit<'_> {
+impl CreateTreasuryReceivedCredit {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -485,7 +498,7 @@ impl CreateTreasuryReceivedCredit<'_> {
     }
 }
 
-impl StripeRequest for CreateTreasuryReceivedCredit<'_> {
+impl StripeRequest for CreateTreasuryReceivedCredit {
     type Output = stripe_treasury::TreasuryReceivedCredit;
 
     fn build(&self) -> RequestBuilder {

--- a/generated/async-stripe-treasury/src/treasury_received_debit/requests.rs
+++ b/generated/async-stripe-treasury/src/treasury_received_debit/requests.rs
@@ -2,26 +2,26 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListTreasuryReceivedDebitBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListTreasuryReceivedDebitBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
-    financial_account: &'a str,
+    expand: Option<Vec<String>>,
+    financial_account: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     status: Option<stripe_treasury::TreasuryReceivedDebitStatus>,
 }
-impl<'a> ListTreasuryReceivedDebitBuilder<'a> {
-    fn new(financial_account: &'a str) -> Self {
+impl ListTreasuryReceivedDebitBuilder {
+    fn new(financial_account: impl Into<String>) -> Self {
         Self {
             ending_before: None,
             expand: None,
-            financial_account,
+            financial_account: financial_account.into(),
             limit: None,
             starting_after: None,
             status: None,
@@ -30,46 +30,49 @@ impl<'a> ListTreasuryReceivedDebitBuilder<'a> {
 }
 /// Returns a list of ReceivedDebits.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListTreasuryReceivedDebit<'a> {
-    inner: ListTreasuryReceivedDebitBuilder<'a>,
+pub struct ListTreasuryReceivedDebit {
+    inner: ListTreasuryReceivedDebitBuilder,
 }
-impl<'a> ListTreasuryReceivedDebit<'a> {
+impl ListTreasuryReceivedDebit {
     /// Construct a new `ListTreasuryReceivedDebit`.
-    pub fn new(financial_account: &'a str) -> Self {
-        Self { inner: ListTreasuryReceivedDebitBuilder::new(financial_account) }
+    pub fn new(financial_account: impl Into<String>) -> Self {
+        Self { inner: ListTreasuryReceivedDebitBuilder::new(financial_account.into()) }
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
     /// Only return ReceivedDebits that have the given status: `succeeded` or `failed`.
-    pub fn status(mut self, status: stripe_treasury::TreasuryReceivedDebitStatus) -> Self {
-        self.inner.status = Some(status);
+    pub fn status(
+        mut self,
+        status: impl Into<stripe_treasury::TreasuryReceivedDebitStatus>,
+    ) -> Self {
+        self.inner.status = Some(status.into());
         self
     }
 }
-impl ListTreasuryReceivedDebit<'_> {
+impl ListTreasuryReceivedDebit {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -90,45 +93,45 @@ impl ListTreasuryReceivedDebit<'_> {
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_treasury::TreasuryReceivedDebit>>
     {
-        stripe_client_core::ListPaginator::new_list("/treasury/received_debits", self.inner)
+        stripe_client_core::ListPaginator::new_list("/treasury/received_debits", &self.inner)
     }
 }
 
-impl StripeRequest for ListTreasuryReceivedDebit<'_> {
+impl StripeRequest for ListTreasuryReceivedDebit {
     type Output = stripe_types::List<stripe_treasury::TreasuryReceivedDebit>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/treasury/received_debits").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveTreasuryReceivedDebitBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveTreasuryReceivedDebitBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveTreasuryReceivedDebitBuilder<'a> {
+impl RetrieveTreasuryReceivedDebitBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves the details of an existing ReceivedDebit by passing the unique ReceivedDebit ID from the ReceivedDebit list.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveTreasuryReceivedDebit<'a> {
-    inner: RetrieveTreasuryReceivedDebitBuilder<'a>,
-    id: &'a stripe_treasury::TreasuryReceivedDebitId,
+pub struct RetrieveTreasuryReceivedDebit {
+    inner: RetrieveTreasuryReceivedDebitBuilder,
+    id: stripe_treasury::TreasuryReceivedDebitId,
 }
-impl<'a> RetrieveTreasuryReceivedDebit<'a> {
+impl RetrieveTreasuryReceivedDebit {
     /// Construct a new `RetrieveTreasuryReceivedDebit`.
-    pub fn new(id: &'a stripe_treasury::TreasuryReceivedDebitId) -> Self {
-        Self { id, inner: RetrieveTreasuryReceivedDebitBuilder::new() }
+    pub fn new(id: impl Into<stripe_treasury::TreasuryReceivedDebitId>) -> Self {
+        Self { id: id.into(), inner: RetrieveTreasuryReceivedDebitBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveTreasuryReceivedDebit<'_> {
+impl RetrieveTreasuryReceivedDebit {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -146,61 +149,63 @@ impl RetrieveTreasuryReceivedDebit<'_> {
     }
 }
 
-impl StripeRequest for RetrieveTreasuryReceivedDebit<'_> {
+impl StripeRequest for RetrieveTreasuryReceivedDebit {
     type Output = stripe_treasury::TreasuryReceivedDebit;
 
     fn build(&self) -> RequestBuilder {
-        let id = self.id;
+        let id = &self.id;
         RequestBuilder::new(StripeMethod::Get, format!("/treasury/received_debits/{id}"))
             .query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct CreateTreasuryReceivedDebitBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct CreateTreasuryReceivedDebitBuilder {
     amount: i64,
     currency: stripe_types::Currency,
     #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<&'a str>,
+    description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
-    financial_account: &'a str,
+    expand: Option<Vec<String>>,
+    financial_account: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     initiating_payment_method_details:
-        Option<CreateTreasuryReceivedDebitInitiatingPaymentMethodDetails<'a>>,
+        Option<CreateTreasuryReceivedDebitInitiatingPaymentMethodDetails>,
     network: CreateTreasuryReceivedDebitNetwork,
 }
-impl<'a> CreateTreasuryReceivedDebitBuilder<'a> {
+impl CreateTreasuryReceivedDebitBuilder {
     fn new(
-        amount: i64,
-        currency: stripe_types::Currency,
-        financial_account: &'a str,
-        network: CreateTreasuryReceivedDebitNetwork,
+        amount: impl Into<i64>,
+        currency: impl Into<stripe_types::Currency>,
+        financial_account: impl Into<String>,
+        network: impl Into<CreateTreasuryReceivedDebitNetwork>,
     ) -> Self {
         Self {
-            amount,
-            currency,
+            amount: amount.into(),
+            currency: currency.into(),
             description: None,
             expand: None,
-            financial_account,
+            financial_account: financial_account.into(),
             initiating_payment_method_details: None,
-            network,
+            network: network.into(),
         }
     }
 }
 /// Initiating payment method details for the object.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateTreasuryReceivedDebitInitiatingPaymentMethodDetails<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateTreasuryReceivedDebitInitiatingPaymentMethodDetails {
     /// The source type.
     #[serde(rename = "type")]
     pub type_: CreateTreasuryReceivedDebitInitiatingPaymentMethodDetailsType,
     /// Optional fields for `us_bank_account`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub us_bank_account:
-        Option<CreateTreasuryReceivedDebitInitiatingPaymentMethodDetailsUsBankAccount<'a>>,
+        Option<CreateTreasuryReceivedDebitInitiatingPaymentMethodDetailsUsBankAccount>,
 }
-impl<'a> CreateTreasuryReceivedDebitInitiatingPaymentMethodDetails<'a> {
-    pub fn new(type_: CreateTreasuryReceivedDebitInitiatingPaymentMethodDetailsType) -> Self {
-        Self { type_, us_bank_account: None }
+impl CreateTreasuryReceivedDebitInitiatingPaymentMethodDetails {
+    pub fn new(
+        type_: impl Into<CreateTreasuryReceivedDebitInitiatingPaymentMethodDetailsType>,
+    ) -> Self {
+        Self { type_: type_.into(), us_bank_account: None }
     }
 }
 /// The source type.
@@ -261,24 +266,24 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// Optional fields for `us_bank_account`.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-pub struct CreateTreasuryReceivedDebitInitiatingPaymentMethodDetailsUsBankAccount<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+pub struct CreateTreasuryReceivedDebitInitiatingPaymentMethodDetailsUsBankAccount {
     /// The bank account holder's name.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account_holder_name: Option<&'a str>,
+    pub account_holder_name: Option<String>,
     /// The bank account number.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub account_number: Option<&'a str>,
+    pub account_number: Option<String>,
     /// The bank account's routing number.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub routing_number: Option<&'a str>,
+    pub routing_number: Option<String>,
 }
-impl<'a> CreateTreasuryReceivedDebitInitiatingPaymentMethodDetailsUsBankAccount<'a> {
+impl CreateTreasuryReceivedDebitInitiatingPaymentMethodDetailsUsBankAccount {
     pub fn new() -> Self {
         Self { account_holder_name: None, account_number: None, routing_number: None }
     }
 }
-impl<'a> Default for CreateTreasuryReceivedDebitInitiatingPaymentMethodDetailsUsBankAccount<'a> {
+impl Default for CreateTreasuryReceivedDebitInitiatingPaymentMethodDetailsUsBankAccount {
     fn default() -> Self {
         Self::new()
     }
@@ -341,46 +346,49 @@ impl<'de> serde::Deserialize<'de> for CreateTreasuryReceivedDebitNetwork {
 /// Use this endpoint to simulate a test mode ReceivedDebit initiated by a third party.
 /// In live mode, you can’t directly create ReceivedDebits initiated by third parties.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct CreateTreasuryReceivedDebit<'a> {
-    inner: CreateTreasuryReceivedDebitBuilder<'a>,
+pub struct CreateTreasuryReceivedDebit {
+    inner: CreateTreasuryReceivedDebitBuilder,
 }
-impl<'a> CreateTreasuryReceivedDebit<'a> {
+impl CreateTreasuryReceivedDebit {
     /// Construct a new `CreateTreasuryReceivedDebit`.
     pub fn new(
-        amount: i64,
-        currency: stripe_types::Currency,
-        financial_account: &'a str,
-        network: CreateTreasuryReceivedDebitNetwork,
+        amount: impl Into<i64>,
+        currency: impl Into<stripe_types::Currency>,
+        financial_account: impl Into<String>,
+        network: impl Into<CreateTreasuryReceivedDebitNetwork>,
     ) -> Self {
         Self {
             inner: CreateTreasuryReceivedDebitBuilder::new(
-                amount,
-                currency,
-                financial_account,
-                network,
+                amount.into(),
+                currency.into(),
+                financial_account.into(),
+                network.into(),
             ),
         }
     }
     /// An arbitrary string attached to the object. Often useful for displaying to users.
-    pub fn description(mut self, description: &'a str) -> Self {
-        self.inner.description = Some(description);
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.inner.description = Some(description.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// Initiating payment method details for the object.
     pub fn initiating_payment_method_details(
         mut self,
-        initiating_payment_method_details: CreateTreasuryReceivedDebitInitiatingPaymentMethodDetails<'a>,
+        initiating_payment_method_details: impl Into<
+            CreateTreasuryReceivedDebitInitiatingPaymentMethodDetails,
+        >,
     ) -> Self {
-        self.inner.initiating_payment_method_details = Some(initiating_payment_method_details);
+        self.inner.initiating_payment_method_details =
+            Some(initiating_payment_method_details.into());
         self
     }
 }
-impl CreateTreasuryReceivedDebit<'_> {
+impl CreateTreasuryReceivedDebit {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -398,7 +406,7 @@ impl CreateTreasuryReceivedDebit<'_> {
     }
 }
 
-impl StripeRequest for CreateTreasuryReceivedDebit<'_> {
+impl StripeRequest for CreateTreasuryReceivedDebit {
     type Output = stripe_treasury::TreasuryReceivedDebit;
 
     fn build(&self) -> RequestBuilder {

--- a/generated/async-stripe-treasury/src/treasury_transaction/requests.rs
+++ b/generated/async-stripe-treasury/src/treasury_transaction/requests.rs
@@ -2,33 +2,33 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListTreasuryTransactionBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListTreasuryTransactionBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     created: Option<stripe_types::RangeQueryTs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
-    financial_account: &'a str,
+    expand: Option<Vec<String>>,
+    financial_account: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     order_by: Option<ListTreasuryTransactionOrderBy>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     status: Option<stripe_treasury::TreasuryTransactionStatus>,
     #[serde(skip_serializing_if = "Option::is_none")]
     status_transitions: Option<ListTreasuryTransactionStatusTransitions>,
 }
-impl<'a> ListTreasuryTransactionBuilder<'a> {
-    fn new(financial_account: &'a str) -> Self {
+impl ListTreasuryTransactionBuilder {
+    fn new(financial_account: impl Into<String>) -> Self {
         Self {
             created: None,
             ending_before: None,
             expand: None,
-            financial_account,
+            financial_account: financial_account.into(),
             limit: None,
             order_by: None,
             starting_after: None,
@@ -114,66 +114,66 @@ impl Default for ListTreasuryTransactionStatusTransitions {
 }
 /// Retrieves a list of Transaction objects.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListTreasuryTransaction<'a> {
-    inner: ListTreasuryTransactionBuilder<'a>,
+pub struct ListTreasuryTransaction {
+    inner: ListTreasuryTransactionBuilder,
 }
-impl<'a> ListTreasuryTransaction<'a> {
+impl ListTreasuryTransaction {
     /// Construct a new `ListTreasuryTransaction`.
-    pub fn new(financial_account: &'a str) -> Self {
-        Self { inner: ListTreasuryTransactionBuilder::new(financial_account) }
+    pub fn new(financial_account: impl Into<String>) -> Self {
+        Self { inner: ListTreasuryTransactionBuilder::new(financial_account.into()) }
     }
     /// Only return Transactions that were created during the given date interval.
-    pub fn created(mut self, created: stripe_types::RangeQueryTs) -> Self {
-        self.inner.created = Some(created);
+    pub fn created(mut self, created: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.created = Some(created.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// The results are in reverse chronological order by `created` or `posted_at`.
     /// The default is `created`.
-    pub fn order_by(mut self, order_by: ListTreasuryTransactionOrderBy) -> Self {
-        self.inner.order_by = Some(order_by);
+    pub fn order_by(mut self, order_by: impl Into<ListTreasuryTransactionOrderBy>) -> Self {
+        self.inner.order_by = Some(order_by.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
     /// Only return Transactions that have the given status: `open`, `posted`, or `void`.
-    pub fn status(mut self, status: stripe_treasury::TreasuryTransactionStatus) -> Self {
-        self.inner.status = Some(status);
+    pub fn status(mut self, status: impl Into<stripe_treasury::TreasuryTransactionStatus>) -> Self {
+        self.inner.status = Some(status.into());
         self
     }
     /// A filter for the `status_transitions.posted_at` timestamp.
     /// When using this filter, `status=posted` and `order_by=posted_at` must also be specified.
     pub fn status_transitions(
         mut self,
-        status_transitions: ListTreasuryTransactionStatusTransitions,
+        status_transitions: impl Into<ListTreasuryTransactionStatusTransitions>,
     ) -> Self {
-        self.inner.status_transitions = Some(status_transitions);
+        self.inner.status_transitions = Some(status_transitions.into());
         self
     }
 }
-impl ListTreasuryTransaction<'_> {
+impl ListTreasuryTransaction {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -194,45 +194,45 @@ impl ListTreasuryTransaction<'_> {
         &self,
     ) -> stripe_client_core::ListPaginator<stripe_types::List<stripe_treasury::TreasuryTransaction>>
     {
-        stripe_client_core::ListPaginator::new_list("/treasury/transactions", self.inner)
+        stripe_client_core::ListPaginator::new_list("/treasury/transactions", &self.inner)
     }
 }
 
-impl StripeRequest for ListTreasuryTransaction<'_> {
+impl StripeRequest for ListTreasuryTransaction {
     type Output = stripe_types::List<stripe_treasury::TreasuryTransaction>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/treasury/transactions").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveTreasuryTransactionBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveTreasuryTransactionBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveTreasuryTransactionBuilder<'a> {
+impl RetrieveTreasuryTransactionBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves the details of an existing Transaction.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveTreasuryTransaction<'a> {
-    inner: RetrieveTreasuryTransactionBuilder<'a>,
-    id: &'a stripe_treasury::TreasuryTransactionId,
+pub struct RetrieveTreasuryTransaction {
+    inner: RetrieveTreasuryTransactionBuilder,
+    id: stripe_treasury::TreasuryTransactionId,
 }
-impl<'a> RetrieveTreasuryTransaction<'a> {
+impl RetrieveTreasuryTransaction {
     /// Construct a new `RetrieveTreasuryTransaction`.
-    pub fn new(id: &'a stripe_treasury::TreasuryTransactionId) -> Self {
-        Self { id, inner: RetrieveTreasuryTransactionBuilder::new() }
+    pub fn new(id: impl Into<stripe_treasury::TreasuryTransactionId>) -> Self {
+        Self { id: id.into(), inner: RetrieveTreasuryTransactionBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveTreasuryTransaction<'_> {
+impl RetrieveTreasuryTransaction {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -250,11 +250,11 @@ impl RetrieveTreasuryTransaction<'_> {
     }
 }
 
-impl StripeRequest for RetrieveTreasuryTransaction<'_> {
+impl StripeRequest for RetrieveTreasuryTransaction {
     type Output = stripe_treasury::TreasuryTransaction;
 
     fn build(&self) -> RequestBuilder {
-        let id = self.id;
+        let id = &self.id;
         RequestBuilder::new(StripeMethod::Get, format!("/treasury/transactions/{id}"))
             .query(&self.inner)
     }

--- a/generated/async-stripe-treasury/src/treasury_transaction_entry/requests.rs
+++ b/generated/async-stripe-treasury/src/treasury_transaction_entry/requests.rs
@@ -2,34 +2,34 @@ use stripe_client_core::{
     RequestBuilder, StripeBlockingClient, StripeClient, StripeMethod, StripeRequest,
 };
 
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct ListTreasuryTransactionEntryBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct ListTreasuryTransactionEntryBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
     created: Option<stripe_types::RangeQueryTs>,
     #[serde(skip_serializing_if = "Option::is_none")]
     effective_at: Option<stripe_types::RangeQueryTs>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    ending_before: Option<&'a str>,
+    ending_before: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
-    financial_account: &'a str,
+    expand: Option<Vec<String>>,
+    financial_account: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     limit: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     order_by: Option<ListTreasuryTransactionEntryOrderBy>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    starting_after: Option<&'a str>,
+    starting_after: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    transaction: Option<&'a str>,
+    transaction: Option<String>,
 }
-impl<'a> ListTreasuryTransactionEntryBuilder<'a> {
-    fn new(financial_account: &'a str) -> Self {
+impl ListTreasuryTransactionEntryBuilder {
+    fn new(financial_account: impl Into<String>) -> Self {
         Self {
             created: None,
             effective_at: None,
             ending_before: None,
             expand: None,
-            financial_account,
+            financial_account: financial_account.into(),
             limit: None,
             order_by: None,
             starting_after: None,
@@ -96,61 +96,61 @@ impl<'de> serde::Deserialize<'de> for ListTreasuryTransactionEntryOrderBy {
 }
 /// Retrieves a list of TransactionEntry objects.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct ListTreasuryTransactionEntry<'a> {
-    inner: ListTreasuryTransactionEntryBuilder<'a>,
+pub struct ListTreasuryTransactionEntry {
+    inner: ListTreasuryTransactionEntryBuilder,
 }
-impl<'a> ListTreasuryTransactionEntry<'a> {
+impl ListTreasuryTransactionEntry {
     /// Construct a new `ListTreasuryTransactionEntry`.
-    pub fn new(financial_account: &'a str) -> Self {
-        Self { inner: ListTreasuryTransactionEntryBuilder::new(financial_account) }
+    pub fn new(financial_account: impl Into<String>) -> Self {
+        Self { inner: ListTreasuryTransactionEntryBuilder::new(financial_account.into()) }
     }
     /// Only return TransactionEntries that were created during the given date interval.
-    pub fn created(mut self, created: stripe_types::RangeQueryTs) -> Self {
-        self.inner.created = Some(created);
+    pub fn created(mut self, created: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.created = Some(created.into());
         self
     }
-    pub fn effective_at(mut self, effective_at: stripe_types::RangeQueryTs) -> Self {
-        self.inner.effective_at = Some(effective_at);
+    pub fn effective_at(mut self, effective_at: impl Into<stripe_types::RangeQueryTs>) -> Self {
+        self.inner.effective_at = Some(effective_at.into());
         self
     }
     /// A cursor for use in pagination.
     /// `ending_before` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
-    pub fn ending_before(mut self, ending_before: &'a str) -> Self {
-        self.inner.ending_before = Some(ending_before);
+    pub fn ending_before(mut self, ending_before: impl Into<String>) -> Self {
+        self.inner.ending_before = Some(ending_before.into());
         self
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
     /// A limit on the number of objects to be returned.
     /// Limit can range between 1 and 100, and the default is 10.
-    pub fn limit(mut self, limit: i64) -> Self {
-        self.inner.limit = Some(limit);
+    pub fn limit(mut self, limit: impl Into<i64>) -> Self {
+        self.inner.limit = Some(limit.into());
         self
     }
     /// The results are in reverse chronological order by `created` or `effective_at`.
     /// The default is `created`.
-    pub fn order_by(mut self, order_by: ListTreasuryTransactionEntryOrderBy) -> Self {
-        self.inner.order_by = Some(order_by);
+    pub fn order_by(mut self, order_by: impl Into<ListTreasuryTransactionEntryOrderBy>) -> Self {
+        self.inner.order_by = Some(order_by.into());
         self
     }
     /// A cursor for use in pagination.
     /// `starting_after` is an object ID that defines your place in the list.
     /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
-    pub fn starting_after(mut self, starting_after: &'a str) -> Self {
-        self.inner.starting_after = Some(starting_after);
+    pub fn starting_after(mut self, starting_after: impl Into<String>) -> Self {
+        self.inner.starting_after = Some(starting_after.into());
         self
     }
     /// Only return TransactionEntries associated with this Transaction.
-    pub fn transaction(mut self, transaction: &'a str) -> Self {
-        self.inner.transaction = Some(transaction);
+    pub fn transaction(mut self, transaction: impl Into<String>) -> Self {
+        self.inner.transaction = Some(transaction.into());
         self
     }
 }
-impl ListTreasuryTransactionEntry<'_> {
+impl ListTreasuryTransactionEntry {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -172,45 +172,45 @@ impl ListTreasuryTransactionEntry<'_> {
     ) -> stripe_client_core::ListPaginator<
         stripe_types::List<stripe_treasury::TreasuryTransactionEntry>,
     > {
-        stripe_client_core::ListPaginator::new_list("/treasury/transaction_entries", self.inner)
+        stripe_client_core::ListPaginator::new_list("/treasury/transaction_entries", &self.inner)
     }
 }
 
-impl StripeRequest for ListTreasuryTransactionEntry<'_> {
+impl StripeRequest for ListTreasuryTransactionEntry {
     type Output = stripe_types::List<stripe_treasury::TreasuryTransactionEntry>;
 
     fn build(&self) -> RequestBuilder {
         RequestBuilder::new(StripeMethod::Get, "/treasury/transaction_entries").query(&self.inner)
     }
 }
-#[derive(Copy, Clone, Debug, serde::Serialize)]
-struct RetrieveTreasuryTransactionEntryBuilder<'a> {
+#[derive(Clone, Debug, serde::Serialize)]
+struct RetrieveTreasuryTransactionEntryBuilder {
     #[serde(skip_serializing_if = "Option::is_none")]
-    expand: Option<&'a [&'a str]>,
+    expand: Option<Vec<String>>,
 }
-impl<'a> RetrieveTreasuryTransactionEntryBuilder<'a> {
+impl RetrieveTreasuryTransactionEntryBuilder {
     fn new() -> Self {
         Self { expand: None }
     }
 }
 /// Retrieves a TransactionEntry object.
 #[derive(Clone, Debug, serde::Serialize)]
-pub struct RetrieveTreasuryTransactionEntry<'a> {
-    inner: RetrieveTreasuryTransactionEntryBuilder<'a>,
-    id: &'a stripe_treasury::TreasuryTransactionEntryId,
+pub struct RetrieveTreasuryTransactionEntry {
+    inner: RetrieveTreasuryTransactionEntryBuilder,
+    id: stripe_treasury::TreasuryTransactionEntryId,
 }
-impl<'a> RetrieveTreasuryTransactionEntry<'a> {
+impl RetrieveTreasuryTransactionEntry {
     /// Construct a new `RetrieveTreasuryTransactionEntry`.
-    pub fn new(id: &'a stripe_treasury::TreasuryTransactionEntryId) -> Self {
-        Self { id, inner: RetrieveTreasuryTransactionEntryBuilder::new() }
+    pub fn new(id: impl Into<stripe_treasury::TreasuryTransactionEntryId>) -> Self {
+        Self { id: id.into(), inner: RetrieveTreasuryTransactionEntryBuilder::new() }
     }
     /// Specifies which fields in the response should be expanded.
-    pub fn expand(mut self, expand: &'a [&'a str]) -> Self {
-        self.inner.expand = Some(expand);
+    pub fn expand(mut self, expand: impl Into<Vec<String>>) -> Self {
+        self.inner.expand = Some(expand.into());
         self
     }
 }
-impl RetrieveTreasuryTransactionEntry<'_> {
+impl RetrieveTreasuryTransactionEntry {
     /// Send the request and return the deserialized response.
     pub async fn send<C: StripeClient>(
         &self,
@@ -228,11 +228,11 @@ impl RetrieveTreasuryTransactionEntry<'_> {
     }
 }
 
-impl StripeRequest for RetrieveTreasuryTransactionEntry<'_> {
+impl StripeRequest for RetrieveTreasuryTransactionEntry {
     type Output = stripe_treasury::TreasuryTransactionEntry;
 
     fn build(&self) -> RequestBuilder {
-        let id = self.id;
+        let id = &self.id;
         RequestBuilder::new(StripeMethod::Get, format!("/treasury/transaction_entries/{id}"))
             .query(&self.inner)
     }

--- a/openapi/src/requests.rs
+++ b/openapi/src/requests.rs
@@ -196,7 +196,7 @@ fn build_request(
         Inference::new(&return_ident).required(true).infer_schema_or_ref_type(req.returned);
 
     let builder_ident = RustIdent::joined(&req_ident, "Builder");
-    let param_inference = Inference::new(&req_ident).can_borrow(true).required(true);
+    let param_inference = Inference::new(&req_ident).can_borrow(false).required(true);
 
     let param_typ = match &req.params {
         RequestParams::Form(schema) => {
@@ -255,21 +255,21 @@ fn build_request(
             bail!("Expected path parameter to follow schema format");
         };
         let base_param_typ = Inference::new(&req_ident)
-            .can_borrow(true)
+            .can_borrow(false)
             .required(param.required)
             .maybe_description(param.description.as_deref())
             .field_name(&param.name)
             .infer_schema_or_ref_type(schema);
 
-        if base_param_typ != RustType::Simple(SimpleType::Str) {
+        if base_param_typ != RustType::Simple(SimpleType::String) {
             bail!("Expected path parameter to be a string");
         }
 
         let rust_type = if let Some(id_typ) = infer_id_path(&param.name, req_path, path_id_map)? {
-            RustType::object_id(id_typ, true)
+            RustType::object_id(id_typ, false)
         } else {
             // NB: Assuming this is safe since we check earlier that this matches the path type.
-            RustType::Simple(SimpleType::Str)
+            RustType::Simple(SimpleType::String)
         };
 
         path_params.push(PathParam { name: param.name.clone(), rust_type })

--- a/openapi/src/stripe_object.rs
+++ b/openapi/src/stripe_object.rs
@@ -368,7 +368,7 @@ impl RequestSpec {
     }
 
     pub fn has_reference(&self, components: &Components) -> bool {
-        if !self.path_params.is_empty() {
+        if self.path_params.iter().any(|p| p.rust_type.has_reference(components)) {
             return true;
         }
         let Some(params) = &self.params else {

--- a/openapi/src/templates/structs.rs
+++ b/openapi/src/templates/structs.rs
@@ -62,7 +62,7 @@ impl<'a> ObjectWriter<'a> {
         let mut params = String::new();
         for field in fields.iter().filter(|f| f.required) {
             let printable = self.get_printable(&field.rust_type);
-            let typ = PrintableWithLifetime::new(&printable, self.lifetime);
+            let typ = PrintableWithLifetime::new(&printable, self.lifetime).impl_into();
             let _ = write!(params, "{}: {typ},", field.field_name);
         }
         params
@@ -76,7 +76,7 @@ impl<'a> ObjectWriter<'a> {
         for field in &struct_.fields {
             let f_name = &field.field_name;
             if field.required {
-                let _ = write!(cons_inner, "{f_name},");
+                let _ = write!(cons_inner, "{f_name}: {f_name}.into(),");
             } else {
                 // `Default::default()` would also work here, but nice to
                 // generate less code and maybe make things easier for the compiler since all

--- a/tests/tests/it/blocking/charge.rs
+++ b/tests/tests/it/blocking/charge.rs
@@ -1,11 +1,11 @@
-use stripe_core::charge::RetrieveCharge;
+use stripe_core::{charge::RetrieveCharge, ChargeId};
 
 #[test]
 fn is_charge_retrievable() {
     let client = super::get_client();
 
-    let id = "ch_123".parse().unwrap();
-    let charge = RetrieveCharge::new(&id).send_blocking(&client).unwrap();
+    let id = ChargeId::from("ch_123");
+    let charge = RetrieveCharge::new(id).send_blocking(&client).unwrap();
     assert_eq!(charge.id, "ch_123");
     assert!(charge.customer.is_none());
     assert!(charge.invoice.is_none());

--- a/tests/tests/it/blocking/checkout.rs
+++ b/tests/tests/it/blocking/checkout.rs
@@ -1,4 +1,4 @@
-use stripe_checkout::checkout_session::RetrieveCheckoutSession;
+use stripe_checkout::{checkout_session::RetrieveCheckoutSession, CheckoutSessionId};
 
 use super::get_client;
 
@@ -6,7 +6,7 @@ use super::get_client;
 fn is_checkout_session_retrievable() {
     let client = get_client();
 
-    let id = "cs_test_123".parse().unwrap();
-    let session = RetrieveCheckoutSession::new(&id).send_blocking(&client).unwrap();
+    let id = CheckoutSessionId::from("cs_test_123");
+    let session = RetrieveCheckoutSession::new(id).send_blocking(&client).unwrap();
     assert_eq!(session.id, "cs_test_123");
 }

--- a/tests/tests/it/blocking/customer.rs
+++ b/tests/tests/it/blocking/customer.rs
@@ -1,5 +1,6 @@
-use stripe_core::customer::{
-    CreateCustomer, DeleteCustomer, RetrieveCustomer, RetrieveCustomerReturned,
+use stripe_core::{
+    customer::{CreateCustomer, DeleteCustomer, RetrieveCustomer, RetrieveCustomerReturned},
+    CustomerId,
 };
 
 use super::{get_base_test_config, get_client};
@@ -30,7 +31,7 @@ fn customer_create_and_delete_with_account() {
 #[test]
 fn retrieve_customer() {
     let client = get_client();
-    let id = "cus_123".parse().unwrap();
+    let id = CustomerId::from("cus_123");
     let ret = RetrieveCustomer::new(&id).send_blocking(&client).unwrap();
     match ret {
         RetrieveCustomerReturned::Customer(cust) => {

--- a/tests/tests/it/blocking/invoice.rs
+++ b/tests/tests/it/blocking/invoice.rs
@@ -1,6 +1,9 @@
-use stripe_billing::invoice::{
-    FinalizeInvoiceInvoice, PayInvoice, RetrieveInvoice, UpcomingInvoice,
-    UpcomingInvoiceSubscriptionItems,
+use stripe_billing::{
+    invoice::{
+        FinalizeInvoiceInvoice, PayInvoice, RetrieveInvoice, UpcomingInvoice,
+        UpcomingInvoiceSubscriptionItems,
+    },
+    InvoiceId,
 };
 use stripe_core::ChargeId;
 
@@ -10,9 +13,9 @@ use super::get_client;
 #[test]
 fn is_invoice_retrievable() {
     let client = get_client();
-    let id = "in_123".parse().unwrap();
-    let result = RetrieveInvoice::new(&id)
-        .expand(&["charge.balance_transaction"])
+    let id = InvoiceId::from("in_123");
+    let result = RetrieveInvoice::new(id)
+        .expand([String::from("charge.balance_transaction")])
         .send_blocking(&client)
         .unwrap();
     let charge = result.charge.unwrap();
@@ -28,7 +31,7 @@ fn is_invoice_retrievable() {
 fn is_invoice_payable() {
     let client = get_client();
 
-    let id = "in_123".parse().unwrap();
+    let id = InvoiceId::from("in_123");
 
     let result = PayInvoice::new(&id)
         .forgive(true)

--- a/tests/tests/it/blocking/plan_interval.rs
+++ b/tests/tests/it/blocking/plan_interval.rs
@@ -6,7 +6,7 @@ use stripe_billing::subscription_item::{
     CreateSubscriptionItem, CreateSubscriptionItemPriceData,
     CreateSubscriptionItemPriceDataRecurring, CreateSubscriptionItemPriceDataRecurringInterval,
 };
-use stripe_billing::PlanInterval;
+use stripe_billing::{PlanId, PlanInterval};
 use stripe_types::Currency;
 
 use super::get_client;
@@ -15,8 +15,8 @@ use super::get_client;
 fn can_create_plan() {
     let client = get_client();
 
-    let id = "price_123".parse().unwrap();
-    let plan = RetrievePlan::new(&id).send_blocking(&client).unwrap();
+    let id = PlanId::from("price_123");
+    let plan = RetrievePlan::new(id).send_blocking(&client).unwrap();
     assert_eq!(plan.interval, PlanInterval::Month);
     assert_eq!(plan.amount, Some(2000));
 }

--- a/tests/tests/it/blocking/price.rs
+++ b/tests/tests/it/blocking/price.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use stripe_product::price::{UpdatePrice, UpdatePriceCurrencyOptions};
-use stripe_product::PriceTaxBehavior;
+use stripe_product::{PriceId, PriceTaxBehavior};
 use stripe_types::Currency;
 
 use super::get_client;
@@ -16,11 +16,9 @@ fn update_price() {
     opt.unit_amount = Some(4);
     currency_opts.insert(Currency::USD, opt);
 
-    let price_id = "price_123".parse().unwrap();
-    let price = UpdatePrice::new(&price_id)
-        .currency_options(&currency_opts)
-        .send_blocking(&client)
-        .unwrap();
+    let price_id = PriceId::from("price_123");
+    let price =
+        UpdatePrice::new(&price_id).currency_options(currency_opts).send_blocking(&client).unwrap();
 
     assert_eq!(price.id, price_id);
     assert_eq!(price.tax_behavior, Some(PriceTaxBehavior::Unspecified));

--- a/tests/tests/it/blocking/product.rs
+++ b/tests/tests/it/blocking/product.rs
@@ -9,9 +9,8 @@ use super::get_client;
 fn create_product() {
     let client = get_client();
 
-    let features = vec![Features::new("great feature")];
     let product = CreateProduct::new("my product")
-        .marketing_features(&features)
+        .marketing_features([Features::new("great feature")])
         .send_blocking(&client)
         .unwrap();
     assert_eq!(product.marketing_features.first().unwrap().name, Some("great feature".into()));

--- a/tests/tests/it/blocking/subscription.rs
+++ b/tests/tests/it/blocking/subscription.rs
@@ -1,5 +1,8 @@
-use stripe_billing::subscription::{
-    CancelSubscription, CancelSubscriptionCancellationDetails, RetrieveSubscription,
+use stripe_billing::{
+    subscription::{
+        CancelSubscription, CancelSubscriptionCancellationDetails, RetrieveSubscription,
+    },
+    SubscriptionId,
 };
 
 use super::get_client;
@@ -11,8 +14,8 @@ use super::get_client;
 fn is_subscription_retrievable() {
     let client = get_client();
 
-    let id = "sub_123".parse().unwrap();
-    let subscription = RetrieveSubscription::new(&id).send_blocking(&client).unwrap();
+    let id = SubscriptionId::from("sub_123");
+    let subscription = RetrieveSubscription::new(id).send_blocking(&client).unwrap();
     assert_eq!(subscription.id, "sub_123");
     assert!(!subscription.customer.is_object());
 }
@@ -22,9 +25,11 @@ fn is_subscription_retrievable() {
 fn is_subscription_expandable() {
     let client = get_client();
 
-    let id = "sub_123".parse().unwrap();
-    let subscription =
-        RetrieveSubscription::new(&id).expand(&["customer"]).send_blocking(&client).unwrap();
+    let id = SubscriptionId::from("sub_123");
+    let subscription = RetrieveSubscription::new(&id)
+        .expand([String::from("customer")])
+        .send_blocking(&client)
+        .unwrap();
     assert_eq!(subscription.id, "sub_123");
     assert!(subscription.customer.is_object());
 }
@@ -37,7 +42,7 @@ fn can_prorate_when_cancelling_subscription() {
     let client = get_client();
 
     let details = CancelSubscriptionCancellationDetails::new();
-    let id = "sub_123".parse().unwrap();
+    let id = SubscriptionId::from("sub_123");
     let result = CancelSubscription::new(&id)
         .prorate(true)
         .cancellation_details(details)

--- a/tests/tests/it/blocking/subscription_item.rs
+++ b/tests/tests/it/blocking/subscription_item.rs
@@ -1,7 +1,10 @@
 use chrono::Utc;
-use stripe_billing::usage_record::{
-    CreateSubscriptionItemUsageRecord, CreateSubscriptionItemUsageRecordAction,
-    CreateSubscriptionItemUsageRecordTimestamp,
+use stripe_billing::{
+    usage_record::{
+        CreateSubscriptionItemUsageRecord, CreateSubscriptionItemUsageRecordAction,
+        CreateSubscriptionItemUsageRecordTimestamp,
+    },
+    SubscriptionItemId,
 };
 
 use super::get_client;
@@ -10,8 +13,8 @@ use super::get_client;
 fn can_create_usage_record() {
     let client = get_client();
 
-    let subscription_item_id = "si_JVbsG8wiy20ycs".parse().unwrap();
-    let usage_record = CreateSubscriptionItemUsageRecord::new(&subscription_item_id, 42)
+    let subscription_item_id = SubscriptionItemId::from("si_JVbsG8wiy20ycs");
+    let usage_record = CreateSubscriptionItemUsageRecord::new(&subscription_item_id, 42u64)
         .action(CreateSubscriptionItemUsageRecordAction::Increment)
         .timestamp(CreateSubscriptionItemUsageRecordTimestamp::Timestamp(Utc::now().timestamp()))
         .send_blocking(&client)

--- a/tests/tests/it/blocking/transfer_reversal.rs
+++ b/tests/tests/it/blocking/transfer_reversal.rs
@@ -1,4 +1,4 @@
-use stripe_connect::transfer_reversal::CreateIdTransferReversal;
+use stripe_connect::{transfer_reversal::CreateIdTransferReversal, TransferId};
 
 use super::get_client;
 
@@ -7,8 +7,8 @@ use super::get_client;
 fn create_transfer_reversal() {
     let client = get_client();
 
-    let id = "tr_Ll53U0VONALFk36".parse().unwrap();
-    let created = CreateIdTransferReversal::new(&id)
+    let id = TransferId::from("tr_Ll53U0VONALFk36");
+    let created = CreateIdTransferReversal::new(id)
         .refund_application_fee(true)
         .amount(4)
         .send_blocking(&client)

--- a/tests/tests/it/enums.rs
+++ b/tests/tests/it/enums.rs
@@ -27,7 +27,7 @@ fn enums_requests() {
     assert_eq!(serde_json::to_string(&CreatePlanProduct::Id("id".into())).unwrap(), r#""id""#);
     assert_eq!(
         serde_json::to_string(&CreatePlanProduct::InlineProductParams(
-            CreatePlanInlineProductParams::new("my name".into())
+            CreatePlanInlineProductParams::new("my name")
         ))
         .unwrap(),
         r#"{"name":"my name"}"#


### PR DESCRIPTION
# Summary

This pull request closes #595 by removing borrow info from requests.

I'm not adding `Cow` because it would add unnecessary complexity, but I did add the `impl Into<{type}>` as it's convenient and it doesn't incur in performance penalty when both types are the same.

I didn't remove the lifetime code from the repo because I'm not sure if it might be useful somewhere else, I've just set `.can_borrow(false)` on the top-level inferences.

### Checklist

- [x] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features
 