### PR TITLE
fix: Re-export checkout_session_ext

### DIFF
--- a/src/resources.rs
+++ b/src/resources.rs
@@ -191,6 +191,9 @@ pub use {
         payment_link::*,
         item::*
     },
+    checkout::{
+        checkout_session_ext::*
+    }
 };
 
 #[rustfmt::skip]

--- a/tests/encoding.rs
+++ b/tests/encoding.rs
@@ -261,7 +261,7 @@ fn deserialize_customer_with_source() {
 }
 
 #[test]
-#[cfg(feature = "event")]
+#[cfg(feature = "events")]
 fn deserialize_checkout_event() {
     use stripe::Event;
 


### PR DESCRIPTION
# Summary

<!--
A quick summary of what this PR does, why is needs to be applied, what has changed, etc.
-->

checkout_session_ext.rs contains the RetrieveCheckoutSessionLineItems
struct. Without this re-export it is impossible to create an instance
and thus call CheckoutSession::retrieve_line_items.
There are other *_ext.rs files such as balance_ext.rs that are not
re-exported but they only contain trait implementations.

I assume the RetrieveCheckoutSessionLineItems struct got added to the
checkout_session_ext.rs file when it also contained just a trait
implementation but wasn't re-exported to reflect this addition.
Could be worth it to re-export everything on principle to avoid future
mistakes.

### Checklist

- [x] ran `cargo make fmt`
- [x] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features
  <!--
  EXAMPLES:
  feat: you can now add and remove principals from a project
  fix: fixes an issue where the combobox was displaying incorrect values
  -->
