### PR TITLE
fix: correct docs path for references

### DIFF
--- a/openapi/src/url_finder.rs
+++ b/openapi/src/url_finder.rs
@@ -42,7 +42,7 @@ impl UrlFinder {
         let object_names = [format!("{}_object", object_name), object_name];
         for name in object_names {
             if let Some(path) = self.url_lookup.get(&name) {
-                return Some(format!("https://stripe.com{}", path));
+                return Some(format!("https://stripe.com/docs{}", path));
             }
         }
 

--- a/src/resources/generated/payment_link.rs
+++ b/src/resources/generated/payment_link.rs
@@ -14,7 +14,7 @@ use crate::resources::{
 
 /// The resource representing a Stripe "PaymentLink".
 ///
-/// For more details see <https://stripe.com/docs/api/payment_links/payment_links/object>
+/// For more details see <https://stripe.com/docs/api/payment-link/object>
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct PaymentLink {
     /// Unique identifier for the object.


### PR DESCRIPTION
# Summary
The Stripe documentation now is hosted on `https://docs.stripe.com/api`. The old `https://stripe.com/docs/api` still works but gets redirected to the new one.
The issue is with how we use to generate documentation link on `url_finder.rs`. On that file, we look for the load the docs and find the `window.__INITIAL_STATE__`, which contains relative links to the resources.
We are using those relative links as if they were relative from `https://stripe.com`, but now they are relative from `https://docs.stripe.com ` which causes the links to not be correctly built.
This is the issue that is causing the `verify-codegen` CI job to fail.
By updating it to the right path, it should stop generating incorrect path to the docs.

### Checklist

- [x] ran `cargo make fmt`
- [x] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features

