### PR TITLE
feat(next): keep original string on unknown variants

### DIFF
--- a/async-stripe-webhook/src/webhook.rs
+++ b/async-stripe-webhook/src/webhook.rs
@@ -138,7 +138,7 @@ impl Webhook {
             account: base_evt.account,
             api_version: base_evt
                 .api_version
-                .map(|s| ApiVersion::from_str(&s).unwrap_or(ApiVersion::Unknown)),
+                .map(|s| ApiVersion::from_str(&s).unwrap_or(ApiVersion::Unknown(s))),
             created: base_evt.created,
             data: EventData {
                 object: event_obj,
@@ -222,7 +222,7 @@ mod tests {
         format!("t={timestamp},v1={v1}")
     }
 
-    fn mock_webhook_event(event_type: EventType, data: Value) -> Value {
+    fn mock_webhook_event(event_type: &EventType, data: Value) -> Value {
         json!({
             "id": "evt_123",
             "object": "event",
@@ -245,7 +245,7 @@ mod tests {
     #[track_caller]
     fn parse_mock_webhook_event(event_type: EventType, data: Value) -> EventObject {
         let now = Utc::now().timestamp();
-        let payload = mock_webhook_event(event_type, data).to_string();
+        let payload = mock_webhook_event(&event_type, data).to_string();
         let sig = get_mock_stripe_sig(&payload, now);
 
         let webhook = Webhook { current_timestamp: now };
@@ -275,7 +275,7 @@ mod tests {
             "proration": false,
             "quantity": 3
         });
-        let payload = mock_webhook_event(EventType::InvoiceitemCreated, object);
+        let payload = mock_webhook_event(&EventType::InvoiceitemCreated, object);
         let event_timestamp = 1533204620;
         let signature = format!("t={event_timestamp},v1=5a81ebe328da1df19581cbc6c7377920947ffd30b56eebcc7ba9a6938a090965,v0=63f3a72374a733066c4be69ed7f8e5ac85c22c9f0a6a612ab9a025a9e4ee7eef");
 

--- a/async-stripe/tests/it/hyper.rs
+++ b/async-stripe/tests/it/hyper.rs
@@ -227,7 +227,12 @@ async fn user_error_transfers() {
             // NB: `Unknown` here because the error code reported in the issue is not
             // present in the OpenAPI spec. Reporting unknown instead of an error seems
             // better regardless so that stripe adding new variants is not a breaking change
-            assert_eq!(err.code, Some(ApiErrorsCode::Unknown));
+            assert_eq!(
+                err.code,
+                Some(ApiErrorsCode::Unknown(String::from(
+                    "insufficient_capabilities_for_transfer"
+                )))
+            );
         }
         _ => panic!("Expected stripe error, got {:?}", res),
     }

--- a/generated/async-stripe-billing/src/billing_portal_session/types.rs
+++ b/generated/async-stripe-billing/src/billing_portal_session/types.rs
@@ -144,7 +144,7 @@ const _: () = {
                 self.flow.take(),
                 self.id.take(),
                 self.livemode,
-                self.locale,
+                self.locale.take(),
                 self.on_behalf_of.take(),
                 self.return_url.take(),
                 self.url.take(),
@@ -239,7 +239,7 @@ impl stripe_types::Object for BillingPortalSession {
     }
 }
 stripe_types::def_id!(BillingPortalSessionId);
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum BillingPortalSessionLocale {
     Auto,
@@ -290,10 +290,10 @@ pub enum BillingPortalSessionLocale {
     ZhMinusHk,
     ZhMinusTw,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl BillingPortalSessionLocale {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use BillingPortalSessionLocale::*;
         match self {
             Auto => "auto",
@@ -343,7 +343,7 @@ impl BillingPortalSessionLocale {
             Zh => "zh",
             ZhMinusHk => "zh-HK",
             ZhMinusTw => "zh-TW",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -400,7 +400,7 @@ impl std::str::FromStr for BillingPortalSessionLocale {
             "zh" => Ok(Zh),
             "zh-HK" => Ok(ZhMinusHk),
             "zh-TW" => Ok(ZhMinusTw),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-billing/src/invoice/requests.rs
+++ b/generated/async-stripe-billing/src/invoice/requests.rs
@@ -603,7 +603,7 @@ impl UpcomingInvoiceCustomerDetailsTaxIds {
     }
 }
 /// Type of the tax ID, one of `ad_nrt`, `ae_trn`, `ar_cuit`, `au_abn`, `au_arn`, `bg_uic`, `bh_vat`, `bo_tin`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `cn_tin`, `co_nit`, `cr_tin`, `do_rcn`, `ec_ruc`, `eg_tin`, `es_cif`, `eu_oss_vat`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `hu_tin`, `id_npwp`, `il_vat`, `in_gst`, `is_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `ke_pin`, `kr_brn`, `kz_bin`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `ng_tin`, `no_vat`, `no_voec`, `nz_gst`, `om_vat`, `pe_ruc`, `ph_tin`, `ro_tin`, `rs_pib`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `si_tin`, `sv_nit`, `th_vat`, `tr_tin`, `tw_vat`, `ua_vat`, `us_ein`, `uy_ruc`, `ve_rif`, `vn_tin`, or `za_vat`.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum UpcomingInvoiceCustomerDetailsTaxIdsType {
     AdNrt,
@@ -678,10 +678,10 @@ pub enum UpcomingInvoiceCustomerDetailsTaxIdsType {
     VnTin,
     ZaVat,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl UpcomingInvoiceCustomerDetailsTaxIdsType {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use UpcomingInvoiceCustomerDetailsTaxIdsType::*;
         match self {
             AdNrt => "ad_nrt",
@@ -755,7 +755,7 @@ impl UpcomingInvoiceCustomerDetailsTaxIdsType {
             VeRif => "ve_rif",
             VnTin => "vn_tin",
             ZaVat => "za_vat",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -836,7 +836,7 @@ impl std::str::FromStr for UpcomingInvoiceCustomerDetailsTaxIdsType {
             "ve_rif" => Ok(VeRif),
             "vn_tin" => Ok(VnTin),
             "za_vat" => Ok(ZaVat),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -3620,7 +3620,7 @@ impl UpcomingLinesInvoiceCustomerDetailsTaxIds {
     }
 }
 /// Type of the tax ID, one of `ad_nrt`, `ae_trn`, `ar_cuit`, `au_abn`, `au_arn`, `bg_uic`, `bh_vat`, `bo_tin`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `cn_tin`, `co_nit`, `cr_tin`, `do_rcn`, `ec_ruc`, `eg_tin`, `es_cif`, `eu_oss_vat`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `hu_tin`, `id_npwp`, `il_vat`, `in_gst`, `is_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `ke_pin`, `kr_brn`, `kz_bin`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `ng_tin`, `no_vat`, `no_voec`, `nz_gst`, `om_vat`, `pe_ruc`, `ph_tin`, `ro_tin`, `rs_pib`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `si_tin`, `sv_nit`, `th_vat`, `tr_tin`, `tw_vat`, `ua_vat`, `us_ein`, `uy_ruc`, `ve_rif`, `vn_tin`, or `za_vat`.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum UpcomingLinesInvoiceCustomerDetailsTaxIdsType {
     AdNrt,
@@ -3695,10 +3695,10 @@ pub enum UpcomingLinesInvoiceCustomerDetailsTaxIdsType {
     VnTin,
     ZaVat,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl UpcomingLinesInvoiceCustomerDetailsTaxIdsType {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use UpcomingLinesInvoiceCustomerDetailsTaxIdsType::*;
         match self {
             AdNrt => "ad_nrt",
@@ -3772,7 +3772,7 @@ impl UpcomingLinesInvoiceCustomerDetailsTaxIdsType {
             VeRif => "ve_rif",
             VnTin => "vn_tin",
             ZaVat => "za_vat",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -3853,7 +3853,7 @@ impl std::str::FromStr for UpcomingLinesInvoiceCustomerDetailsTaxIdsType {
             "ve_rif" => Ok(VeRif),
             "vn_tin" => Ok(VnTin),
             "za_vat" => Ok(ZaVat),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -7540,7 +7540,7 @@ impl<'de> serde::Deserialize<'de>
 /// The list of payment method types (e.g.
 /// card) to provide to the invoice’s PaymentIntent.
 /// If not set, Stripe attempts to automatically determine the types to use by looking at the invoice’s default payment method, the subscription’s default payment method, the customer’s default payment method, and your [invoice template settings](https://dashboard.stripe.com/settings/billing/invoice).
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CreateInvoicePaymentSettingsPaymentMethodTypes {
     AchCreditTransfer,
@@ -7572,10 +7572,10 @@ pub enum CreateInvoicePaymentSettingsPaymentMethodTypes {
     UsBankAccount,
     WechatPay,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl CreateInvoicePaymentSettingsPaymentMethodTypes {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use CreateInvoicePaymentSettingsPaymentMethodTypes::*;
         match self {
             AchCreditTransfer => "ach_credit_transfer",
@@ -7606,7 +7606,7 @@ impl CreateInvoicePaymentSettingsPaymentMethodTypes {
             Sofort => "sofort",
             UsBankAccount => "us_bank_account",
             WechatPay => "wechat_pay",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -7644,7 +7644,7 @@ impl std::str::FromStr for CreateInvoicePaymentSettingsPaymentMethodTypes {
             "sofort" => Ok(Sofort),
             "us_bank_account" => Ok(UsBankAccount),
             "wechat_pay" => Ok(WechatPay),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -9715,7 +9715,7 @@ impl<'de> serde::Deserialize<'de>
 /// The list of payment method types (e.g.
 /// card) to provide to the invoice’s PaymentIntent.
 /// If not set, Stripe attempts to automatically determine the types to use by looking at the invoice’s default payment method, the subscription’s default payment method, the customer’s default payment method, and your [invoice template settings](https://dashboard.stripe.com/settings/billing/invoice).
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum UpdateInvoicePaymentSettingsPaymentMethodTypes {
     AchCreditTransfer,
@@ -9747,10 +9747,10 @@ pub enum UpdateInvoicePaymentSettingsPaymentMethodTypes {
     UsBankAccount,
     WechatPay,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl UpdateInvoicePaymentSettingsPaymentMethodTypes {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use UpdateInvoicePaymentSettingsPaymentMethodTypes::*;
         match self {
             AchCreditTransfer => "ach_credit_transfer",
@@ -9781,7 +9781,7 @@ impl UpdateInvoicePaymentSettingsPaymentMethodTypes {
             Sofort => "sofort",
             UsBankAccount => "us_bank_account",
             WechatPay => "wechat_pay",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -9819,7 +9819,7 @@ impl std::str::FromStr for UpdateInvoicePaymentSettingsPaymentMethodTypes {
             "sofort" => Ok(Sofort),
             "us_bank_account" => Ok(UsBankAccount),
             "wechat_pay" => Ok(WechatPay),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -11324,7 +11324,7 @@ impl CreatePreviewInvoiceCustomerDetailsTaxIds {
     }
 }
 /// Type of the tax ID, one of `ad_nrt`, `ae_trn`, `ar_cuit`, `au_abn`, `au_arn`, `bg_uic`, `bh_vat`, `bo_tin`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `cn_tin`, `co_nit`, `cr_tin`, `do_rcn`, `ec_ruc`, `eg_tin`, `es_cif`, `eu_oss_vat`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `hu_tin`, `id_npwp`, `il_vat`, `in_gst`, `is_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `ke_pin`, `kr_brn`, `kz_bin`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `ng_tin`, `no_vat`, `no_voec`, `nz_gst`, `om_vat`, `pe_ruc`, `ph_tin`, `ro_tin`, `rs_pib`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `si_tin`, `sv_nit`, `th_vat`, `tr_tin`, `tw_vat`, `ua_vat`, `us_ein`, `uy_ruc`, `ve_rif`, `vn_tin`, or `za_vat`.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CreatePreviewInvoiceCustomerDetailsTaxIdsType {
     AdNrt,
@@ -11399,10 +11399,10 @@ pub enum CreatePreviewInvoiceCustomerDetailsTaxIdsType {
     VnTin,
     ZaVat,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl CreatePreviewInvoiceCustomerDetailsTaxIdsType {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use CreatePreviewInvoiceCustomerDetailsTaxIdsType::*;
         match self {
             AdNrt => "ad_nrt",
@@ -11476,7 +11476,7 @@ impl CreatePreviewInvoiceCustomerDetailsTaxIdsType {
             VeRif => "ve_rif",
             VnTin => "vn_tin",
             ZaVat => "za_vat",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -11557,7 +11557,7 @@ impl std::str::FromStr for CreatePreviewInvoiceCustomerDetailsTaxIdsType {
             "ve_rif" => Ok(VeRif),
             "vn_tin" => Ok(VnTin),
             "za_vat" => Ok(ZaVat),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-billing/src/subscription/requests.rs
+++ b/generated/async-stripe-billing/src/subscription/requests.rs
@@ -2279,7 +2279,7 @@ impl<'de> serde::Deserialize<'de>
 /// The list of payment method types (e.g.
 /// card) to provide to the invoice’s PaymentIntent.
 /// If not set, Stripe attempts to automatically determine the types to use by looking at the invoice’s default payment method, the subscription’s default payment method, the customer’s default payment method, and your [invoice template settings](https://dashboard.stripe.com/settings/billing/invoice).
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CreateSubscriptionPaymentSettingsPaymentMethodTypes {
     AchCreditTransfer,
@@ -2311,10 +2311,10 @@ pub enum CreateSubscriptionPaymentSettingsPaymentMethodTypes {
     UsBankAccount,
     WechatPay,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl CreateSubscriptionPaymentSettingsPaymentMethodTypes {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use CreateSubscriptionPaymentSettingsPaymentMethodTypes::*;
         match self {
             AchCreditTransfer => "ach_credit_transfer",
@@ -2345,7 +2345,7 @@ impl CreateSubscriptionPaymentSettingsPaymentMethodTypes {
             Sofort => "sofort",
             UsBankAccount => "us_bank_account",
             WechatPay => "wechat_pay",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -2383,7 +2383,7 @@ impl std::str::FromStr for CreateSubscriptionPaymentSettingsPaymentMethodTypes {
             "sofort" => Ok(Sofort),
             "us_bank_account" => Ok(UsBankAccount),
             "wechat_pay" => Ok(WechatPay),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -5084,7 +5084,7 @@ impl<'de> serde::Deserialize<'de>
 /// The list of payment method types (e.g.
 /// card) to provide to the invoice’s PaymentIntent.
 /// If not set, Stripe attempts to automatically determine the types to use by looking at the invoice’s default payment method, the subscription’s default payment method, the customer’s default payment method, and your [invoice template settings](https://dashboard.stripe.com/settings/billing/invoice).
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum UpdateSubscriptionPaymentSettingsPaymentMethodTypes {
     AchCreditTransfer,
@@ -5116,10 +5116,10 @@ pub enum UpdateSubscriptionPaymentSettingsPaymentMethodTypes {
     UsBankAccount,
     WechatPay,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl UpdateSubscriptionPaymentSettingsPaymentMethodTypes {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use UpdateSubscriptionPaymentSettingsPaymentMethodTypes::*;
         match self {
             AchCreditTransfer => "ach_credit_transfer",
@@ -5150,7 +5150,7 @@ impl UpdateSubscriptionPaymentSettingsPaymentMethodTypes {
             Sofort => "sofort",
             UsBankAccount => "us_bank_account",
             WechatPay => "wechat_pay",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -5188,7 +5188,7 @@ impl std::str::FromStr for UpdateSubscriptionPaymentSettingsPaymentMethodTypes {
             "sofort" => Ok(Sofort),
             "us_bank_account" => Ok(UsBankAccount),
             "wechat_pay" => Ok(WechatPay),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-billing/src/tax_id/requests.rs
+++ b/generated/async-stripe-billing/src/tax_id/requests.rs
@@ -470,7 +470,7 @@ impl CreateCustomerTaxIdBuilder {
     }
 }
 /// Type of the tax ID, one of `ad_nrt`, `ae_trn`, `ar_cuit`, `au_abn`, `au_arn`, `bg_uic`, `bh_vat`, `bo_tin`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `cn_tin`, `co_nit`, `cr_tin`, `do_rcn`, `ec_ruc`, `eg_tin`, `es_cif`, `eu_oss_vat`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `hu_tin`, `id_npwp`, `il_vat`, `in_gst`, `is_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `ke_pin`, `kr_brn`, `kz_bin`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `ng_tin`, `no_vat`, `no_voec`, `nz_gst`, `om_vat`, `pe_ruc`, `ph_tin`, `ro_tin`, `rs_pib`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `si_tin`, `sv_nit`, `th_vat`, `tr_tin`, `tw_vat`, `ua_vat`, `us_ein`, `uy_ruc`, `ve_rif`, `vn_tin`, or `za_vat`.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CreateCustomerTaxIdType {
     AdNrt,
@@ -545,10 +545,10 @@ pub enum CreateCustomerTaxIdType {
     VnTin,
     ZaVat,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl CreateCustomerTaxIdType {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use CreateCustomerTaxIdType::*;
         match self {
             AdNrt => "ad_nrt",
@@ -622,7 +622,7 @@ impl CreateCustomerTaxIdType {
             VeRif => "ve_rif",
             VnTin => "vn_tin",
             ZaVat => "za_vat",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -703,7 +703,7 @@ impl std::str::FromStr for CreateCustomerTaxIdType {
             "ve_rif" => Ok(VeRif),
             "vn_tin" => Ok(VnTin),
             "za_vat" => Ok(ZaVat),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -880,7 +880,7 @@ impl<'de> serde::Deserialize<'de> for CreateTaxIdOwnerType {
     }
 }
 /// Type of the tax ID, one of `ad_nrt`, `ae_trn`, `ar_cuit`, `au_abn`, `au_arn`, `bg_uic`, `bh_vat`, `bo_tin`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `cn_tin`, `co_nit`, `cr_tin`, `do_rcn`, `ec_ruc`, `eg_tin`, `es_cif`, `eu_oss_vat`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `hu_tin`, `id_npwp`, `il_vat`, `in_gst`, `is_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `ke_pin`, `kr_brn`, `kz_bin`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `ng_tin`, `no_vat`, `no_voec`, `nz_gst`, `om_vat`, `pe_ruc`, `ph_tin`, `ro_tin`, `rs_pib`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `si_tin`, `sv_nit`, `th_vat`, `tr_tin`, `tw_vat`, `ua_vat`, `us_ein`, `uy_ruc`, `ve_rif`, `vn_tin`, or `za_vat`.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CreateTaxIdType {
     AdNrt,
@@ -955,10 +955,10 @@ pub enum CreateTaxIdType {
     VnTin,
     ZaVat,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl CreateTaxIdType {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use CreateTaxIdType::*;
         match self {
             AdNrt => "ad_nrt",
@@ -1032,7 +1032,7 @@ impl CreateTaxIdType {
             VeRif => "ve_rif",
             VnTin => "vn_tin",
             ZaVat => "za_vat",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -1113,7 +1113,7 @@ impl std::str::FromStr for CreateTaxIdType {
             "ve_rif" => Ok(VeRif),
             "vn_tin" => Ok(VnTin),
             "za_vat" => Ok(ZaVat),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-checkout/src/checkout_session/requests.rs
+++ b/generated/async-stripe-checkout/src/checkout_session/requests.rs
@@ -5339,7 +5339,7 @@ impl<'de> serde::Deserialize<'de> for CreateCheckoutSessionPaymentMethodOptionsP
     }
 }
 /// [Preferred locale](https://stripe.com/docs/payments/paypal/supported-locales) of the PayPal checkout page that the customer is redirected to.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CreateCheckoutSessionPaymentMethodOptionsPaypalPreferredLocale {
     CsMinusCz,
@@ -5364,10 +5364,10 @@ pub enum CreateCheckoutSessionPaymentMethodOptionsPaypalPreferredLocale {
     SkMinusSk,
     SvMinusSe,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl CreateCheckoutSessionPaymentMethodOptionsPaypalPreferredLocale {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use CreateCheckoutSessionPaymentMethodOptionsPaypalPreferredLocale::*;
         match self {
             CsMinusCz => "cs-CZ",
@@ -5391,7 +5391,7 @@ impl CreateCheckoutSessionPaymentMethodOptionsPaypalPreferredLocale {
             PtMinusPt => "pt-PT",
             SkMinusSk => "sk-SK",
             SvMinusSe => "sv-SE",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -5422,7 +5422,7 @@ impl std::str::FromStr for CreateCheckoutSessionPaymentMethodOptionsPaypalPrefer
             "pt-PT" => Ok(PtMinusPt),
             "sk-SK" => Ok(SkMinusSk),
             "sv-SE" => Ok(SvMinusSe),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -6288,7 +6288,7 @@ impl<'de> serde::Deserialize<'de>
 /// If multiple payment methods are passed, Checkout will dynamically reorder them to
 /// prioritize the most relevant payment methods based on the customer's location and
 /// other characteristics.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CreateCheckoutSessionPaymentMethodTypes {
     AcssDebit,
@@ -6327,10 +6327,10 @@ pub enum CreateCheckoutSessionPaymentMethodTypes {
     WechatPay,
     Zip,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl CreateCheckoutSessionPaymentMethodTypes {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use CreateCheckoutSessionPaymentMethodTypes::*;
         match self {
             AcssDebit => "acss_debit",
@@ -6368,7 +6368,7 @@ impl CreateCheckoutSessionPaymentMethodTypes {
             UsBankAccount => "us_bank_account",
             WechatPay => "wechat_pay",
             Zip => "zip",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -6413,7 +6413,7 @@ impl std::str::FromStr for CreateCheckoutSessionPaymentMethodTypes {
             "us_bank_account" => Ok(UsBankAccount),
             "wechat_pay" => Ok(WechatPay),
             "zip" => Ok(Zip),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -6649,7 +6649,7 @@ impl CreateCheckoutSessionShippingAddressCollection {
 /// An array of two-letter ISO country codes representing which countries Checkout should provide as options for.
 /// shipping locations.
 /// Unsupported country codes: `AS, CX, CC, CU, HM, IR, KP, MH, FM, NF, MP, PW, SD, SY, UM, VI`.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CreateCheckoutSessionShippingAddressCollectionAllowedCountries {
     Ac,
@@ -6890,10 +6890,10 @@ pub enum CreateCheckoutSessionShippingAddressCollectionAllowedCountries {
     Zw,
     Zz,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl CreateCheckoutSessionShippingAddressCollectionAllowedCountries {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use CreateCheckoutSessionShippingAddressCollectionAllowedCountries::*;
         match self {
             Ac => "AC",
@@ -7133,7 +7133,7 @@ impl CreateCheckoutSessionShippingAddressCollectionAllowedCountries {
             Zm => "ZM",
             Zw => "ZW",
             Zz => "ZZ",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -7380,7 +7380,7 @@ impl std::str::FromStr for CreateCheckoutSessionShippingAddressCollectionAllowed
             "ZM" => Ok(Zm),
             "ZW" => Ok(Zw),
             "ZZ" => Ok(Zz),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-checkout/src/checkout_session/types.rs
+++ b/generated/async-stripe-checkout/src/checkout_session/types.rs
@@ -471,7 +471,7 @@ const _: () = {
                 self.invoice_creation.take(),
                 self.line_items.take(),
                 self.livemode,
-                self.locale,
+                self.locale.take(),
                 self.metadata.take(),
                 self.mode,
                 self.payment_intent.take(),
@@ -1037,7 +1037,7 @@ impl<'de> serde::Deserialize<'de> for CheckoutSessionBillingAddressCollection {
         })
     }
 }
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CheckoutSessionLocale {
     Auto,
@@ -1082,10 +1082,10 @@ pub enum CheckoutSessionLocale {
     ZhMinusHk,
     ZhMinusTw,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl CheckoutSessionLocale {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use CheckoutSessionLocale::*;
         match self {
             Auto => "auto",
@@ -1129,7 +1129,7 @@ impl CheckoutSessionLocale {
             Zh => "zh",
             ZhMinusHk => "zh-HK",
             ZhMinusTw => "zh-TW",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -1180,7 +1180,7 @@ impl std::str::FromStr for CheckoutSessionLocale {
             "zh" => Ok(Zh),
             "zh-HK" => Ok(ZhMinusHk),
             "zh-TW" => Ok(ZhMinusTw),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-checkout/src/payment_pages_checkout_session_shipping_address_collection.rs
+++ b/generated/async-stripe-checkout/src/payment_pages_checkout_session_shipping_address_collection.rs
@@ -109,7 +109,7 @@ const _: () = {
 /// An array of two-letter ISO country codes representing which countries Checkout should provide as options for.
 /// shipping locations.
 /// Unsupported country codes: `AS, CX, CC, CU, HM, IR, KP, MH, FM, NF, MP, PW, SD, SY, UM, VI`.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum PaymentPagesCheckoutSessionShippingAddressCollectionAllowedCountries {
     Ac,
@@ -350,10 +350,10 @@ pub enum PaymentPagesCheckoutSessionShippingAddressCollectionAllowedCountries {
     Zw,
     Zz,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl PaymentPagesCheckoutSessionShippingAddressCollectionAllowedCountries {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use PaymentPagesCheckoutSessionShippingAddressCollectionAllowedCountries::*;
         match self {
             Ac => "AC",
@@ -593,7 +593,7 @@ impl PaymentPagesCheckoutSessionShippingAddressCollectionAllowedCountries {
             Zm => "ZM",
             Zw => "ZW",
             Zz => "ZZ",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -840,7 +840,7 @@ impl std::str::FromStr for PaymentPagesCheckoutSessionShippingAddressCollectionA
             "ZM" => Ok(Zm),
             "ZW" => Ok(Zw),
             "ZZ" => Ok(Zz),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-connect/src/account/requests.rs
+++ b/generated/async-stripe-connect/src/account/requests.rs
@@ -708,7 +708,7 @@ impl Default for CreateAccountCompanyAddressKanji {
 /// The category identifying the legal structure of the company or legal entity.
 /// See [Business structure](https://docs.stripe.com/connect/identity-verification#business-structure) for more details.
 /// Pass an empty string to unset this value.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CreateAccountCompanyStructure {
     FreeZoneEstablishment,
@@ -735,10 +735,10 @@ pub enum CreateAccountCompanyStructure {
     UnincorporatedNonProfit,
     UnincorporatedPartnership,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl CreateAccountCompanyStructure {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use CreateAccountCompanyStructure::*;
         match self {
             FreeZoneEstablishment => "free_zone_establishment",
@@ -764,7 +764,7 @@ impl CreateAccountCompanyStructure {
             UnincorporatedAssociation => "unincorporated_association",
             UnincorporatedNonProfit => "unincorporated_non_profit",
             UnincorporatedPartnership => "unincorporated_partnership",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -797,7 +797,7 @@ impl std::str::FromStr for CreateAccountCompanyStructure {
             "unincorporated_association" => Ok(UnincorporatedAssociation),
             "unincorporated_non_profit" => Ok(UnincorporatedNonProfit),
             "unincorporated_partnership" => Ok(UnincorporatedPartnership),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -2125,7 +2125,7 @@ impl Default for UpdateAccountCompanyAddressKanji {
 /// The category identifying the legal structure of the company or legal entity.
 /// See [Business structure](https://docs.stripe.com/connect/identity-verification#business-structure) for more details.
 /// Pass an empty string to unset this value.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum UpdateAccountCompanyStructure {
     FreeZoneEstablishment,
@@ -2152,10 +2152,10 @@ pub enum UpdateAccountCompanyStructure {
     UnincorporatedNonProfit,
     UnincorporatedPartnership,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl UpdateAccountCompanyStructure {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use UpdateAccountCompanyStructure::*;
         match self {
             FreeZoneEstablishment => "free_zone_establishment",
@@ -2181,7 +2181,7 @@ impl UpdateAccountCompanyStructure {
             UnincorporatedAssociation => "unincorporated_association",
             UnincorporatedNonProfit => "unincorporated_non_profit",
             UnincorporatedPartnership => "unincorporated_partnership",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -2214,7 +2214,7 @@ impl std::str::FromStr for UpdateAccountCompanyStructure {
             "unincorporated_association" => Ok(UnincorporatedAssociation),
             "unincorporated_non_profit" => Ok(UnincorporatedNonProfit),
             "unincorporated_partnership" => Ok(UnincorporatedPartnership),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-core/src/customer/requests.rs
+++ b/generated/async-stripe-core/src/customer/requests.rs
@@ -519,7 +519,7 @@ impl<'de> serde::Deserialize<'de> for ListPaymentMethodsCustomerAllowRedisplay {
 /// An optional filter on the list, based on the object `type` field.
 /// Without the filter, the list includes all current and future payment method types.
 /// If your integration expects only one type of payment method in the response, make sure to provide a type value in the request.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum ListPaymentMethodsCustomerType {
     AcssDebit,
@@ -558,10 +558,10 @@ pub enum ListPaymentMethodsCustomerType {
     WechatPay,
     Zip,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl ListPaymentMethodsCustomerType {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use ListPaymentMethodsCustomerType::*;
         match self {
             AcssDebit => "acss_debit",
@@ -599,7 +599,7 @@ impl ListPaymentMethodsCustomerType {
             UsBankAccount => "us_bank_account",
             WechatPay => "wechat_pay",
             Zip => "zip",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -644,7 +644,7 @@ impl std::str::FromStr for ListPaymentMethodsCustomerType {
             "us_bank_account" => Ok(UsBankAccount),
             "wechat_pay" => Ok(WechatPay),
             "zip" => Ok(Zip),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -1302,7 +1302,7 @@ impl CreateCustomerTaxIdData {
     }
 }
 /// Type of the tax ID, one of `ad_nrt`, `ae_trn`, `ar_cuit`, `au_abn`, `au_arn`, `bg_uic`, `bh_vat`, `bo_tin`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `cn_tin`, `co_nit`, `cr_tin`, `do_rcn`, `ec_ruc`, `eg_tin`, `es_cif`, `eu_oss_vat`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `hu_tin`, `id_npwp`, `il_vat`, `in_gst`, `is_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `ke_pin`, `kr_brn`, `kz_bin`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `ng_tin`, `no_vat`, `no_voec`, `nz_gst`, `om_vat`, `pe_ruc`, `ph_tin`, `ro_tin`, `rs_pib`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `si_tin`, `sv_nit`, `th_vat`, `tr_tin`, `tw_vat`, `ua_vat`, `us_ein`, `uy_ruc`, `ve_rif`, `vn_tin`, or `za_vat`.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CreateCustomerTaxIdDataType {
     AdNrt,
@@ -1377,10 +1377,10 @@ pub enum CreateCustomerTaxIdDataType {
     VnTin,
     ZaVat,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl CreateCustomerTaxIdDataType {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use CreateCustomerTaxIdDataType::*;
         match self {
             AdNrt => "ad_nrt",
@@ -1454,7 +1454,7 @@ impl CreateCustomerTaxIdDataType {
             VeRif => "ve_rif",
             VnTin => "vn_tin",
             ZaVat => "za_vat",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -1535,7 +1535,7 @@ impl std::str::FromStr for CreateCustomerTaxIdDataType {
             "ve_rif" => Ok(VeRif),
             "vn_tin" => Ok(VnTin),
             "za_vat" => Ok(ZaVat),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-core/src/payment_intent/requests.rs
+++ b/generated/async-stripe-core/src/payment_intent/requests.rs
@@ -918,7 +918,7 @@ impl CreatePaymentIntentPaymentMethodDataBoleto {
     }
 }
 /// If this is an `eps` PaymentMethod, this hash contains details about the EPS payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, serde::Serialize)]
 pub struct CreatePaymentIntentPaymentMethodDataEps {
     /// The customer's bank.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -935,7 +935,7 @@ impl Default for CreatePaymentIntentPaymentMethodDataEps {
     }
 }
 /// The customer's bank.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CreatePaymentIntentPaymentMethodDataEpsBank {
     ArzteUndApothekerBank,
@@ -967,10 +967,10 @@ pub enum CreatePaymentIntentPaymentMethodDataEpsBank {
     VolkskreditbankAg,
     VrBankBraunau,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl CreatePaymentIntentPaymentMethodDataEpsBank {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use CreatePaymentIntentPaymentMethodDataEpsBank::*;
         match self {
             ArzteUndApothekerBank => "arzte_und_apotheker_bank",
@@ -1001,7 +1001,7 @@ impl CreatePaymentIntentPaymentMethodDataEpsBank {
             VolksbankGruppe => "volksbank_gruppe",
             VolkskreditbankAg => "volkskreditbank_ag",
             VrBankBraunau => "vr_bank_braunau",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -1039,7 +1039,7 @@ impl std::str::FromStr for CreatePaymentIntentPaymentMethodDataEpsBank {
             "volksbank_gruppe" => Ok(VolksbankGruppe),
             "volkskreditbank_ag" => Ok(VolkskreditbankAg),
             "vr_bank_braunau" => Ok(VrBankBraunau),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -1071,7 +1071,7 @@ impl<'de> serde::Deserialize<'de> for CreatePaymentIntentPaymentMethodDataEpsBan
     }
 }
 /// If this is an `fpx` PaymentMethod, this hash contains details about the FPX payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, serde::Serialize)]
 pub struct CreatePaymentIntentPaymentMethodDataFpx {
     /// Account holder type for FPX transaction
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1143,7 +1143,7 @@ impl<'de> serde::Deserialize<'de> for CreatePaymentIntentPaymentMethodDataFpxAcc
     }
 }
 /// The customer's bank.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CreatePaymentIntentPaymentMethodDataFpxBank {
     AffinBank,
@@ -1169,10 +1169,10 @@ pub enum CreatePaymentIntentPaymentMethodDataFpxBank {
     StandardChartered,
     Uob,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl CreatePaymentIntentPaymentMethodDataFpxBank {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use CreatePaymentIntentPaymentMethodDataFpxBank::*;
         match self {
             AffinBank => "affin_bank",
@@ -1197,7 +1197,7 @@ impl CreatePaymentIntentPaymentMethodDataFpxBank {
             Rhb => "rhb",
             StandardChartered => "standard_chartered",
             Uob => "uob",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -1229,7 +1229,7 @@ impl std::str::FromStr for CreatePaymentIntentPaymentMethodDataFpxBank {
             "rhb" => Ok(Rhb),
             "standard_chartered" => Ok(StandardChartered),
             "uob" => Ok(Uob),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -1261,7 +1261,7 @@ impl<'de> serde::Deserialize<'de> for CreatePaymentIntentPaymentMethodDataFpxBan
     }
 }
 /// If this is an `ideal` PaymentMethod, this hash contains details about the iDEAL payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, serde::Serialize)]
 pub struct CreatePaymentIntentPaymentMethodDataIdeal {
     /// The customer's bank.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1278,7 +1278,7 @@ impl Default for CreatePaymentIntentPaymentMethodDataIdeal {
     }
 }
 /// The customer's bank.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CreatePaymentIntentPaymentMethodDataIdealBank {
     AbnAmro,
@@ -1298,10 +1298,10 @@ pub enum CreatePaymentIntentPaymentMethodDataIdealBank {
     VanLanschot,
     Yoursafe,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl CreatePaymentIntentPaymentMethodDataIdealBank {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use CreatePaymentIntentPaymentMethodDataIdealBank::*;
         match self {
             AbnAmro => "abn_amro",
@@ -1320,7 +1320,7 @@ impl CreatePaymentIntentPaymentMethodDataIdealBank {
             TriodosBank => "triodos_bank",
             VanLanschot => "van_lanschot",
             Yoursafe => "yoursafe",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -1346,7 +1346,7 @@ impl std::str::FromStr for CreatePaymentIntentPaymentMethodDataIdealBank {
             "triodos_bank" => Ok(TriodosBank),
             "van_lanschot" => Ok(VanLanschot),
             "yoursafe" => Ok(Yoursafe),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -1395,7 +1395,7 @@ impl Default for CreatePaymentIntentPaymentMethodDataKlarna {
     }
 }
 /// If this is a `p24` PaymentMethod, this hash contains details about the P24 payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, serde::Serialize)]
 pub struct CreatePaymentIntentPaymentMethodDataP24 {
     /// The customer's bank.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1412,7 +1412,7 @@ impl Default for CreatePaymentIntentPaymentMethodDataP24 {
     }
 }
 /// The customer's bank.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CreatePaymentIntentPaymentMethodDataP24Bank {
     AliorBank,
@@ -1442,10 +1442,10 @@ pub enum CreatePaymentIntentPaymentMethodDataP24Bank {
     Velobank,
     VolkswagenBank,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl CreatePaymentIntentPaymentMethodDataP24Bank {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use CreatePaymentIntentPaymentMethodDataP24Bank::*;
         match self {
             AliorBank => "alior_bank",
@@ -1474,7 +1474,7 @@ impl CreatePaymentIntentPaymentMethodDataP24Bank {
             ToyotaBank => "toyota_bank",
             Velobank => "velobank",
             VolkswagenBank => "volkswagen_bank",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -1510,7 +1510,7 @@ impl std::str::FromStr for CreatePaymentIntentPaymentMethodDataP24Bank {
             "toyota_bank" => Ok(ToyotaBank),
             "velobank" => Ok(Velobank),
             "volkswagen_bank" => Ok(VolkswagenBank),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -1636,7 +1636,7 @@ impl<'de> serde::Deserialize<'de> for CreatePaymentIntentPaymentMethodDataSofort
 /// The type of the PaymentMethod.
 /// An additional hash is included on the PaymentMethod with a name matching this value.
 /// It contains additional information specific to the PaymentMethod type.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CreatePaymentIntentPaymentMethodDataType {
     AcssDebit,
@@ -1674,10 +1674,10 @@ pub enum CreatePaymentIntentPaymentMethodDataType {
     WechatPay,
     Zip,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl CreatePaymentIntentPaymentMethodDataType {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use CreatePaymentIntentPaymentMethodDataType::*;
         match self {
             AcssDebit => "acss_debit",
@@ -1714,7 +1714,7 @@ impl CreatePaymentIntentPaymentMethodDataType {
             UsBankAccount => "us_bank_account",
             WechatPay => "wechat_pay",
             Zip => "zip",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -1758,7 +1758,7 @@ impl std::str::FromStr for CreatePaymentIntentPaymentMethodDataType {
             "us_bank_account" => Ok(UsBankAccount),
             "wechat_pay" => Ok(WechatPay),
             "zip" => Ok(Zip),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -5898,7 +5898,7 @@ impl<'de> serde::Deserialize<'de> for CreatePaymentIntentPaymentMethodOptionsIde
     }
 }
 /// If this is a `klarna` PaymentMethod, this sub-hash contains details about the Klarna payment method options.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, serde::Serialize)]
 pub struct CreatePaymentIntentPaymentMethodOptionsKlarna {
     /// Controls when the funds will be captured from the customer's account.
     ///
@@ -5991,7 +5991,7 @@ impl<'de> serde::Deserialize<'de> for CreatePaymentIntentPaymentMethodOptionsKla
     }
 }
 /// Preferred language of the Klarna authorization page that the customer is redirected to
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CreatePaymentIntentPaymentMethodOptionsKlarnaPreferredLocale {
     CsMinusCz,
@@ -6039,10 +6039,10 @@ pub enum CreatePaymentIntentPaymentMethodOptionsKlarnaPreferredLocale {
     SvMinusFi,
     SvMinusSe,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl CreatePaymentIntentPaymentMethodOptionsKlarnaPreferredLocale {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use CreatePaymentIntentPaymentMethodOptionsKlarnaPreferredLocale::*;
         match self {
             CsMinusCz => "cs-CZ",
@@ -6089,7 +6089,7 @@ impl CreatePaymentIntentPaymentMethodOptionsKlarnaPreferredLocale {
             PtMinusPt => "pt-PT",
             SvMinusFi => "sv-FI",
             SvMinusSe => "sv-SE",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -6143,7 +6143,7 @@ impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsKlarnaPreferre
             "pt-PT" => Ok(PtMinusPt),
             "sv-FI" => Ok(SvMinusFi),
             "sv-SE" => Ok(SvMinusSe),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -7026,7 +7026,7 @@ impl<'de> serde::Deserialize<'de> for CreatePaymentIntentPaymentMethodOptionsPay
     }
 }
 /// [Preferred locale](https://stripe.com/docs/payments/paypal/supported-locales) of the PayPal checkout page that the customer is redirected to.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CreatePaymentIntentPaymentMethodOptionsPaypalPreferredLocale {
     CsMinusCz,
@@ -7051,10 +7051,10 @@ pub enum CreatePaymentIntentPaymentMethodOptionsPaypalPreferredLocale {
     SkMinusSk,
     SvMinusSe,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl CreatePaymentIntentPaymentMethodOptionsPaypalPreferredLocale {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use CreatePaymentIntentPaymentMethodOptionsPaypalPreferredLocale::*;
         match self {
             CsMinusCz => "cs-CZ",
@@ -7078,7 +7078,7 @@ impl CreatePaymentIntentPaymentMethodOptionsPaypalPreferredLocale {
             PtMinusPt => "pt-PT",
             SkMinusSk => "sk-SK",
             SvMinusSe => "sv-SE",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -7109,7 +7109,7 @@ impl std::str::FromStr for CreatePaymentIntentPaymentMethodOptionsPaypalPreferre
             "pt-PT" => Ok(PtMinusPt),
             "sk-SK" => Ok(SkMinusSk),
             "sv-SE" => Ok(SvMinusSe),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -9480,7 +9480,7 @@ impl UpdatePaymentIntentPaymentMethodDataBoleto {
     }
 }
 /// If this is an `eps` PaymentMethod, this hash contains details about the EPS payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, serde::Serialize)]
 pub struct UpdatePaymentIntentPaymentMethodDataEps {
     /// The customer's bank.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -9497,7 +9497,7 @@ impl Default for UpdatePaymentIntentPaymentMethodDataEps {
     }
 }
 /// The customer's bank.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum UpdatePaymentIntentPaymentMethodDataEpsBank {
     ArzteUndApothekerBank,
@@ -9529,10 +9529,10 @@ pub enum UpdatePaymentIntentPaymentMethodDataEpsBank {
     VolkskreditbankAg,
     VrBankBraunau,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl UpdatePaymentIntentPaymentMethodDataEpsBank {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use UpdatePaymentIntentPaymentMethodDataEpsBank::*;
         match self {
             ArzteUndApothekerBank => "arzte_und_apotheker_bank",
@@ -9563,7 +9563,7 @@ impl UpdatePaymentIntentPaymentMethodDataEpsBank {
             VolksbankGruppe => "volksbank_gruppe",
             VolkskreditbankAg => "volkskreditbank_ag",
             VrBankBraunau => "vr_bank_braunau",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -9601,7 +9601,7 @@ impl std::str::FromStr for UpdatePaymentIntentPaymentMethodDataEpsBank {
             "volksbank_gruppe" => Ok(VolksbankGruppe),
             "volkskreditbank_ag" => Ok(VolkskreditbankAg),
             "vr_bank_braunau" => Ok(VrBankBraunau),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -9633,7 +9633,7 @@ impl<'de> serde::Deserialize<'de> for UpdatePaymentIntentPaymentMethodDataEpsBan
     }
 }
 /// If this is an `fpx` PaymentMethod, this hash contains details about the FPX payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, serde::Serialize)]
 pub struct UpdatePaymentIntentPaymentMethodDataFpx {
     /// Account holder type for FPX transaction
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -9705,7 +9705,7 @@ impl<'de> serde::Deserialize<'de> for UpdatePaymentIntentPaymentMethodDataFpxAcc
     }
 }
 /// The customer's bank.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum UpdatePaymentIntentPaymentMethodDataFpxBank {
     AffinBank,
@@ -9731,10 +9731,10 @@ pub enum UpdatePaymentIntentPaymentMethodDataFpxBank {
     StandardChartered,
     Uob,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl UpdatePaymentIntentPaymentMethodDataFpxBank {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use UpdatePaymentIntentPaymentMethodDataFpxBank::*;
         match self {
             AffinBank => "affin_bank",
@@ -9759,7 +9759,7 @@ impl UpdatePaymentIntentPaymentMethodDataFpxBank {
             Rhb => "rhb",
             StandardChartered => "standard_chartered",
             Uob => "uob",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -9791,7 +9791,7 @@ impl std::str::FromStr for UpdatePaymentIntentPaymentMethodDataFpxBank {
             "rhb" => Ok(Rhb),
             "standard_chartered" => Ok(StandardChartered),
             "uob" => Ok(Uob),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -9823,7 +9823,7 @@ impl<'de> serde::Deserialize<'de> for UpdatePaymentIntentPaymentMethodDataFpxBan
     }
 }
 /// If this is an `ideal` PaymentMethod, this hash contains details about the iDEAL payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, serde::Serialize)]
 pub struct UpdatePaymentIntentPaymentMethodDataIdeal {
     /// The customer's bank.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -9840,7 +9840,7 @@ impl Default for UpdatePaymentIntentPaymentMethodDataIdeal {
     }
 }
 /// The customer's bank.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum UpdatePaymentIntentPaymentMethodDataIdealBank {
     AbnAmro,
@@ -9860,10 +9860,10 @@ pub enum UpdatePaymentIntentPaymentMethodDataIdealBank {
     VanLanschot,
     Yoursafe,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl UpdatePaymentIntentPaymentMethodDataIdealBank {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use UpdatePaymentIntentPaymentMethodDataIdealBank::*;
         match self {
             AbnAmro => "abn_amro",
@@ -9882,7 +9882,7 @@ impl UpdatePaymentIntentPaymentMethodDataIdealBank {
             TriodosBank => "triodos_bank",
             VanLanschot => "van_lanschot",
             Yoursafe => "yoursafe",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -9908,7 +9908,7 @@ impl std::str::FromStr for UpdatePaymentIntentPaymentMethodDataIdealBank {
             "triodos_bank" => Ok(TriodosBank),
             "van_lanschot" => Ok(VanLanschot),
             "yoursafe" => Ok(Yoursafe),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -9957,7 +9957,7 @@ impl Default for UpdatePaymentIntentPaymentMethodDataKlarna {
     }
 }
 /// If this is a `p24` PaymentMethod, this hash contains details about the P24 payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, serde::Serialize)]
 pub struct UpdatePaymentIntentPaymentMethodDataP24 {
     /// The customer's bank.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -9974,7 +9974,7 @@ impl Default for UpdatePaymentIntentPaymentMethodDataP24 {
     }
 }
 /// The customer's bank.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum UpdatePaymentIntentPaymentMethodDataP24Bank {
     AliorBank,
@@ -10004,10 +10004,10 @@ pub enum UpdatePaymentIntentPaymentMethodDataP24Bank {
     Velobank,
     VolkswagenBank,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl UpdatePaymentIntentPaymentMethodDataP24Bank {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use UpdatePaymentIntentPaymentMethodDataP24Bank::*;
         match self {
             AliorBank => "alior_bank",
@@ -10036,7 +10036,7 @@ impl UpdatePaymentIntentPaymentMethodDataP24Bank {
             ToyotaBank => "toyota_bank",
             Velobank => "velobank",
             VolkswagenBank => "volkswagen_bank",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -10072,7 +10072,7 @@ impl std::str::FromStr for UpdatePaymentIntentPaymentMethodDataP24Bank {
             "toyota_bank" => Ok(ToyotaBank),
             "velobank" => Ok(Velobank),
             "volkswagen_bank" => Ok(VolkswagenBank),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -10198,7 +10198,7 @@ impl<'de> serde::Deserialize<'de> for UpdatePaymentIntentPaymentMethodDataSofort
 /// The type of the PaymentMethod.
 /// An additional hash is included on the PaymentMethod with a name matching this value.
 /// It contains additional information specific to the PaymentMethod type.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum UpdatePaymentIntentPaymentMethodDataType {
     AcssDebit,
@@ -10236,10 +10236,10 @@ pub enum UpdatePaymentIntentPaymentMethodDataType {
     WechatPay,
     Zip,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl UpdatePaymentIntentPaymentMethodDataType {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use UpdatePaymentIntentPaymentMethodDataType::*;
         match self {
             AcssDebit => "acss_debit",
@@ -10276,7 +10276,7 @@ impl UpdatePaymentIntentPaymentMethodDataType {
             UsBankAccount => "us_bank_account",
             WechatPay => "wechat_pay",
             Zip => "zip",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -10320,7 +10320,7 @@ impl std::str::FromStr for UpdatePaymentIntentPaymentMethodDataType {
             "us_bank_account" => Ok(UsBankAccount),
             "wechat_pay" => Ok(WechatPay),
             "zip" => Ok(Zip),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -14460,7 +14460,7 @@ impl<'de> serde::Deserialize<'de> for UpdatePaymentIntentPaymentMethodOptionsIde
     }
 }
 /// If this is a `klarna` PaymentMethod, this sub-hash contains details about the Klarna payment method options.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, serde::Serialize)]
 pub struct UpdatePaymentIntentPaymentMethodOptionsKlarna {
     /// Controls when the funds will be captured from the customer's account.
     ///
@@ -14553,7 +14553,7 @@ impl<'de> serde::Deserialize<'de> for UpdatePaymentIntentPaymentMethodOptionsKla
     }
 }
 /// Preferred language of the Klarna authorization page that the customer is redirected to
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum UpdatePaymentIntentPaymentMethodOptionsKlarnaPreferredLocale {
     CsMinusCz,
@@ -14601,10 +14601,10 @@ pub enum UpdatePaymentIntentPaymentMethodOptionsKlarnaPreferredLocale {
     SvMinusFi,
     SvMinusSe,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl UpdatePaymentIntentPaymentMethodOptionsKlarnaPreferredLocale {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use UpdatePaymentIntentPaymentMethodOptionsKlarnaPreferredLocale::*;
         match self {
             CsMinusCz => "cs-CZ",
@@ -14651,7 +14651,7 @@ impl UpdatePaymentIntentPaymentMethodOptionsKlarnaPreferredLocale {
             PtMinusPt => "pt-PT",
             SvMinusFi => "sv-FI",
             SvMinusSe => "sv-SE",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -14705,7 +14705,7 @@ impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsKlarnaPreferre
             "pt-PT" => Ok(PtMinusPt),
             "sv-FI" => Ok(SvMinusFi),
             "sv-SE" => Ok(SvMinusSe),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -15588,7 +15588,7 @@ impl<'de> serde::Deserialize<'de> for UpdatePaymentIntentPaymentMethodOptionsPay
     }
 }
 /// [Preferred locale](https://stripe.com/docs/payments/paypal/supported-locales) of the PayPal checkout page that the customer is redirected to.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum UpdatePaymentIntentPaymentMethodOptionsPaypalPreferredLocale {
     CsMinusCz,
@@ -15613,10 +15613,10 @@ pub enum UpdatePaymentIntentPaymentMethodOptionsPaypalPreferredLocale {
     SkMinusSk,
     SvMinusSe,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl UpdatePaymentIntentPaymentMethodOptionsPaypalPreferredLocale {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use UpdatePaymentIntentPaymentMethodOptionsPaypalPreferredLocale::*;
         match self {
             CsMinusCz => "cs-CZ",
@@ -15640,7 +15640,7 @@ impl UpdatePaymentIntentPaymentMethodOptionsPaypalPreferredLocale {
             PtMinusPt => "pt-PT",
             SkMinusSk => "sk-SK",
             SvMinusSe => "sv-SE",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -15671,7 +15671,7 @@ impl std::str::FromStr for UpdatePaymentIntentPaymentMethodOptionsPaypalPreferre
             "pt-PT" => Ok(PtMinusPt),
             "sk-SK" => Ok(SkMinusSk),
             "sv-SE" => Ok(SvMinusSe),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -18503,7 +18503,7 @@ impl ConfirmPaymentIntentPaymentMethodDataBoleto {
     }
 }
 /// If this is an `eps` PaymentMethod, this hash contains details about the EPS payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, serde::Serialize)]
 pub struct ConfirmPaymentIntentPaymentMethodDataEps {
     /// The customer's bank.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -18520,7 +18520,7 @@ impl Default for ConfirmPaymentIntentPaymentMethodDataEps {
     }
 }
 /// The customer's bank.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum ConfirmPaymentIntentPaymentMethodDataEpsBank {
     ArzteUndApothekerBank,
@@ -18552,10 +18552,10 @@ pub enum ConfirmPaymentIntentPaymentMethodDataEpsBank {
     VolkskreditbankAg,
     VrBankBraunau,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl ConfirmPaymentIntentPaymentMethodDataEpsBank {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use ConfirmPaymentIntentPaymentMethodDataEpsBank::*;
         match self {
             ArzteUndApothekerBank => "arzte_und_apotheker_bank",
@@ -18586,7 +18586,7 @@ impl ConfirmPaymentIntentPaymentMethodDataEpsBank {
             VolksbankGruppe => "volksbank_gruppe",
             VolkskreditbankAg => "volkskreditbank_ag",
             VrBankBraunau => "vr_bank_braunau",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -18624,7 +18624,7 @@ impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodDataEpsBank {
             "volksbank_gruppe" => Ok(VolksbankGruppe),
             "volkskreditbank_ag" => Ok(VolkskreditbankAg),
             "vr_bank_braunau" => Ok(VrBankBraunau),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -18656,7 +18656,7 @@ impl<'de> serde::Deserialize<'de> for ConfirmPaymentIntentPaymentMethodDataEpsBa
     }
 }
 /// If this is an `fpx` PaymentMethod, this hash contains details about the FPX payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, serde::Serialize)]
 pub struct ConfirmPaymentIntentPaymentMethodDataFpx {
     /// Account holder type for FPX transaction
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -18728,7 +18728,7 @@ impl<'de> serde::Deserialize<'de> for ConfirmPaymentIntentPaymentMethodDataFpxAc
     }
 }
 /// The customer's bank.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum ConfirmPaymentIntentPaymentMethodDataFpxBank {
     AffinBank,
@@ -18754,10 +18754,10 @@ pub enum ConfirmPaymentIntentPaymentMethodDataFpxBank {
     StandardChartered,
     Uob,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl ConfirmPaymentIntentPaymentMethodDataFpxBank {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use ConfirmPaymentIntentPaymentMethodDataFpxBank::*;
         match self {
             AffinBank => "affin_bank",
@@ -18782,7 +18782,7 @@ impl ConfirmPaymentIntentPaymentMethodDataFpxBank {
             Rhb => "rhb",
             StandardChartered => "standard_chartered",
             Uob => "uob",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -18814,7 +18814,7 @@ impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodDataFpxBank {
             "rhb" => Ok(Rhb),
             "standard_chartered" => Ok(StandardChartered),
             "uob" => Ok(Uob),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -18846,7 +18846,7 @@ impl<'de> serde::Deserialize<'de> for ConfirmPaymentIntentPaymentMethodDataFpxBa
     }
 }
 /// If this is an `ideal` PaymentMethod, this hash contains details about the iDEAL payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, serde::Serialize)]
 pub struct ConfirmPaymentIntentPaymentMethodDataIdeal {
     /// The customer's bank.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -18863,7 +18863,7 @@ impl Default for ConfirmPaymentIntentPaymentMethodDataIdeal {
     }
 }
 /// The customer's bank.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum ConfirmPaymentIntentPaymentMethodDataIdealBank {
     AbnAmro,
@@ -18883,10 +18883,10 @@ pub enum ConfirmPaymentIntentPaymentMethodDataIdealBank {
     VanLanschot,
     Yoursafe,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl ConfirmPaymentIntentPaymentMethodDataIdealBank {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use ConfirmPaymentIntentPaymentMethodDataIdealBank::*;
         match self {
             AbnAmro => "abn_amro",
@@ -18905,7 +18905,7 @@ impl ConfirmPaymentIntentPaymentMethodDataIdealBank {
             TriodosBank => "triodos_bank",
             VanLanschot => "van_lanschot",
             Yoursafe => "yoursafe",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -18931,7 +18931,7 @@ impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodDataIdealBank {
             "triodos_bank" => Ok(TriodosBank),
             "van_lanschot" => Ok(VanLanschot),
             "yoursafe" => Ok(Yoursafe),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -18980,7 +18980,7 @@ impl Default for ConfirmPaymentIntentPaymentMethodDataKlarna {
     }
 }
 /// If this is a `p24` PaymentMethod, this hash contains details about the P24 payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, serde::Serialize)]
 pub struct ConfirmPaymentIntentPaymentMethodDataP24 {
     /// The customer's bank.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -18997,7 +18997,7 @@ impl Default for ConfirmPaymentIntentPaymentMethodDataP24 {
     }
 }
 /// The customer's bank.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum ConfirmPaymentIntentPaymentMethodDataP24Bank {
     AliorBank,
@@ -19027,10 +19027,10 @@ pub enum ConfirmPaymentIntentPaymentMethodDataP24Bank {
     Velobank,
     VolkswagenBank,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl ConfirmPaymentIntentPaymentMethodDataP24Bank {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use ConfirmPaymentIntentPaymentMethodDataP24Bank::*;
         match self {
             AliorBank => "alior_bank",
@@ -19059,7 +19059,7 @@ impl ConfirmPaymentIntentPaymentMethodDataP24Bank {
             ToyotaBank => "toyota_bank",
             Velobank => "velobank",
             VolkswagenBank => "volkswagen_bank",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -19095,7 +19095,7 @@ impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodDataP24Bank {
             "toyota_bank" => Ok(ToyotaBank),
             "velobank" => Ok(Velobank),
             "volkswagen_bank" => Ok(VolkswagenBank),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -19221,7 +19221,7 @@ impl<'de> serde::Deserialize<'de> for ConfirmPaymentIntentPaymentMethodDataSofor
 /// The type of the PaymentMethod.
 /// An additional hash is included on the PaymentMethod with a name matching this value.
 /// It contains additional information specific to the PaymentMethod type.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum ConfirmPaymentIntentPaymentMethodDataType {
     AcssDebit,
@@ -19259,10 +19259,10 @@ pub enum ConfirmPaymentIntentPaymentMethodDataType {
     WechatPay,
     Zip,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl ConfirmPaymentIntentPaymentMethodDataType {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use ConfirmPaymentIntentPaymentMethodDataType::*;
         match self {
             AcssDebit => "acss_debit",
@@ -19299,7 +19299,7 @@ impl ConfirmPaymentIntentPaymentMethodDataType {
             UsBankAccount => "us_bank_account",
             WechatPay => "wechat_pay",
             Zip => "zip",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -19343,7 +19343,7 @@ impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodDataType {
             "us_bank_account" => Ok(UsBankAccount),
             "wechat_pay" => Ok(WechatPay),
             "zip" => Ok(Zip),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -23482,7 +23482,7 @@ impl<'de> serde::Deserialize<'de>
     }
 }
 /// If this is a `klarna` PaymentMethod, this sub-hash contains details about the Klarna payment method options.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, serde::Serialize)]
 pub struct ConfirmPaymentIntentPaymentMethodOptionsKlarna {
     /// Controls when the funds will be captured from the customer's account.
     ///
@@ -23575,7 +23575,7 @@ impl<'de> serde::Deserialize<'de> for ConfirmPaymentIntentPaymentMethodOptionsKl
     }
 }
 /// Preferred language of the Klarna authorization page that the customer is redirected to
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum ConfirmPaymentIntentPaymentMethodOptionsKlarnaPreferredLocale {
     CsMinusCz,
@@ -23623,10 +23623,10 @@ pub enum ConfirmPaymentIntentPaymentMethodOptionsKlarnaPreferredLocale {
     SvMinusFi,
     SvMinusSe,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl ConfirmPaymentIntentPaymentMethodOptionsKlarnaPreferredLocale {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use ConfirmPaymentIntentPaymentMethodOptionsKlarnaPreferredLocale::*;
         match self {
             CsMinusCz => "cs-CZ",
@@ -23673,7 +23673,7 @@ impl ConfirmPaymentIntentPaymentMethodOptionsKlarnaPreferredLocale {
             PtMinusPt => "pt-PT",
             SvMinusFi => "sv-FI",
             SvMinusSe => "sv-SE",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -23727,7 +23727,7 @@ impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsKlarnaPreferr
             "pt-PT" => Ok(PtMinusPt),
             "sv-FI" => Ok(SvMinusFi),
             "sv-SE" => Ok(SvMinusSe),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -24612,7 +24612,7 @@ impl<'de> serde::Deserialize<'de> for ConfirmPaymentIntentPaymentMethodOptionsPa
     }
 }
 /// [Preferred locale](https://stripe.com/docs/payments/paypal/supported-locales) of the PayPal checkout page that the customer is redirected to.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum ConfirmPaymentIntentPaymentMethodOptionsPaypalPreferredLocale {
     CsMinusCz,
@@ -24637,10 +24637,10 @@ pub enum ConfirmPaymentIntentPaymentMethodOptionsPaypalPreferredLocale {
     SkMinusSk,
     SvMinusSe,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl ConfirmPaymentIntentPaymentMethodOptionsPaypalPreferredLocale {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use ConfirmPaymentIntentPaymentMethodOptionsPaypalPreferredLocale::*;
         match self {
             CsMinusCz => "cs-CZ",
@@ -24664,7 +24664,7 @@ impl ConfirmPaymentIntentPaymentMethodOptionsPaypalPreferredLocale {
             PtMinusPt => "pt-PT",
             SkMinusSk => "sk-SK",
             SvMinusSe => "sv-SE",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -24695,7 +24695,7 @@ impl std::str::FromStr for ConfirmPaymentIntentPaymentMethodOptionsPaypalPreferr
             "pt-PT" => Ok(PtMinusPt),
             "sk-SK" => Ok(SkMinusSk),
             "sv-SE" => Ok(SvMinusSe),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-core/src/setup_intent/requests.rs
+++ b/generated/async-stripe-core/src/setup_intent/requests.rs
@@ -752,7 +752,7 @@ impl CreateSetupIntentPaymentMethodDataBoleto {
     }
 }
 /// If this is an `eps` PaymentMethod, this hash contains details about the EPS payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, serde::Serialize)]
 pub struct CreateSetupIntentPaymentMethodDataEps {
     /// The customer's bank.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -769,7 +769,7 @@ impl Default for CreateSetupIntentPaymentMethodDataEps {
     }
 }
 /// The customer's bank.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CreateSetupIntentPaymentMethodDataEpsBank {
     ArzteUndApothekerBank,
@@ -801,10 +801,10 @@ pub enum CreateSetupIntentPaymentMethodDataEpsBank {
     VolkskreditbankAg,
     VrBankBraunau,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl CreateSetupIntentPaymentMethodDataEpsBank {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use CreateSetupIntentPaymentMethodDataEpsBank::*;
         match self {
             ArzteUndApothekerBank => "arzte_und_apotheker_bank",
@@ -835,7 +835,7 @@ impl CreateSetupIntentPaymentMethodDataEpsBank {
             VolksbankGruppe => "volksbank_gruppe",
             VolkskreditbankAg => "volkskreditbank_ag",
             VrBankBraunau => "vr_bank_braunau",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -873,7 +873,7 @@ impl std::str::FromStr for CreateSetupIntentPaymentMethodDataEpsBank {
             "volksbank_gruppe" => Ok(VolksbankGruppe),
             "volkskreditbank_ag" => Ok(VolkskreditbankAg),
             "vr_bank_braunau" => Ok(VrBankBraunau),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -905,7 +905,7 @@ impl<'de> serde::Deserialize<'de> for CreateSetupIntentPaymentMethodDataEpsBank 
     }
 }
 /// If this is an `fpx` PaymentMethod, this hash contains details about the FPX payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, serde::Serialize)]
 pub struct CreateSetupIntentPaymentMethodDataFpx {
     /// Account holder type for FPX transaction
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -977,7 +977,7 @@ impl<'de> serde::Deserialize<'de> for CreateSetupIntentPaymentMethodDataFpxAccou
     }
 }
 /// The customer's bank.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CreateSetupIntentPaymentMethodDataFpxBank {
     AffinBank,
@@ -1003,10 +1003,10 @@ pub enum CreateSetupIntentPaymentMethodDataFpxBank {
     StandardChartered,
     Uob,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl CreateSetupIntentPaymentMethodDataFpxBank {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use CreateSetupIntentPaymentMethodDataFpxBank::*;
         match self {
             AffinBank => "affin_bank",
@@ -1031,7 +1031,7 @@ impl CreateSetupIntentPaymentMethodDataFpxBank {
             Rhb => "rhb",
             StandardChartered => "standard_chartered",
             Uob => "uob",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -1063,7 +1063,7 @@ impl std::str::FromStr for CreateSetupIntentPaymentMethodDataFpxBank {
             "rhb" => Ok(Rhb),
             "standard_chartered" => Ok(StandardChartered),
             "uob" => Ok(Uob),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -1095,7 +1095,7 @@ impl<'de> serde::Deserialize<'de> for CreateSetupIntentPaymentMethodDataFpxBank 
     }
 }
 /// If this is an `ideal` PaymentMethod, this hash contains details about the iDEAL payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, serde::Serialize)]
 pub struct CreateSetupIntentPaymentMethodDataIdeal {
     /// The customer's bank.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1112,7 +1112,7 @@ impl Default for CreateSetupIntentPaymentMethodDataIdeal {
     }
 }
 /// The customer's bank.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CreateSetupIntentPaymentMethodDataIdealBank {
     AbnAmro,
@@ -1132,10 +1132,10 @@ pub enum CreateSetupIntentPaymentMethodDataIdealBank {
     VanLanschot,
     Yoursafe,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl CreateSetupIntentPaymentMethodDataIdealBank {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use CreateSetupIntentPaymentMethodDataIdealBank::*;
         match self {
             AbnAmro => "abn_amro",
@@ -1154,7 +1154,7 @@ impl CreateSetupIntentPaymentMethodDataIdealBank {
             TriodosBank => "triodos_bank",
             VanLanschot => "van_lanschot",
             Yoursafe => "yoursafe",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -1180,7 +1180,7 @@ impl std::str::FromStr for CreateSetupIntentPaymentMethodDataIdealBank {
             "triodos_bank" => Ok(TriodosBank),
             "van_lanschot" => Ok(VanLanschot),
             "yoursafe" => Ok(Yoursafe),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -1229,7 +1229,7 @@ impl Default for CreateSetupIntentPaymentMethodDataKlarna {
     }
 }
 /// If this is a `p24` PaymentMethod, this hash contains details about the P24 payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, serde::Serialize)]
 pub struct CreateSetupIntentPaymentMethodDataP24 {
     /// The customer's bank.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1246,7 +1246,7 @@ impl Default for CreateSetupIntentPaymentMethodDataP24 {
     }
 }
 /// The customer's bank.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CreateSetupIntentPaymentMethodDataP24Bank {
     AliorBank,
@@ -1276,10 +1276,10 @@ pub enum CreateSetupIntentPaymentMethodDataP24Bank {
     Velobank,
     VolkswagenBank,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl CreateSetupIntentPaymentMethodDataP24Bank {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use CreateSetupIntentPaymentMethodDataP24Bank::*;
         match self {
             AliorBank => "alior_bank",
@@ -1308,7 +1308,7 @@ impl CreateSetupIntentPaymentMethodDataP24Bank {
             ToyotaBank => "toyota_bank",
             Velobank => "velobank",
             VolkswagenBank => "volkswagen_bank",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -1344,7 +1344,7 @@ impl std::str::FromStr for CreateSetupIntentPaymentMethodDataP24Bank {
             "toyota_bank" => Ok(ToyotaBank),
             "velobank" => Ok(Velobank),
             "volkswagen_bank" => Ok(VolkswagenBank),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -1470,7 +1470,7 @@ impl<'de> serde::Deserialize<'de> for CreateSetupIntentPaymentMethodDataSofortCo
 /// The type of the PaymentMethod.
 /// An additional hash is included on the PaymentMethod with a name matching this value.
 /// It contains additional information specific to the PaymentMethod type.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CreateSetupIntentPaymentMethodDataType {
     AcssDebit,
@@ -1508,10 +1508,10 @@ pub enum CreateSetupIntentPaymentMethodDataType {
     WechatPay,
     Zip,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl CreateSetupIntentPaymentMethodDataType {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use CreateSetupIntentPaymentMethodDataType::*;
         match self {
             AcssDebit => "acss_debit",
@@ -1548,7 +1548,7 @@ impl CreateSetupIntentPaymentMethodDataType {
             UsBankAccount => "us_bank_account",
             WechatPay => "wechat_pay",
             Zip => "zip",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -1592,7 +1592,7 @@ impl std::str::FromStr for CreateSetupIntentPaymentMethodDataType {
             "us_bank_account" => Ok(UsBankAccount),
             "wechat_pay" => Ok(WechatPay),
             "zip" => Ok(Zip),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -4055,7 +4055,7 @@ impl UpdateSetupIntentPaymentMethodDataBoleto {
     }
 }
 /// If this is an `eps` PaymentMethod, this hash contains details about the EPS payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, serde::Serialize)]
 pub struct UpdateSetupIntentPaymentMethodDataEps {
     /// The customer's bank.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -4072,7 +4072,7 @@ impl Default for UpdateSetupIntentPaymentMethodDataEps {
     }
 }
 /// The customer's bank.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum UpdateSetupIntentPaymentMethodDataEpsBank {
     ArzteUndApothekerBank,
@@ -4104,10 +4104,10 @@ pub enum UpdateSetupIntentPaymentMethodDataEpsBank {
     VolkskreditbankAg,
     VrBankBraunau,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl UpdateSetupIntentPaymentMethodDataEpsBank {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use UpdateSetupIntentPaymentMethodDataEpsBank::*;
         match self {
             ArzteUndApothekerBank => "arzte_und_apotheker_bank",
@@ -4138,7 +4138,7 @@ impl UpdateSetupIntentPaymentMethodDataEpsBank {
             VolksbankGruppe => "volksbank_gruppe",
             VolkskreditbankAg => "volkskreditbank_ag",
             VrBankBraunau => "vr_bank_braunau",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -4176,7 +4176,7 @@ impl std::str::FromStr for UpdateSetupIntentPaymentMethodDataEpsBank {
             "volksbank_gruppe" => Ok(VolksbankGruppe),
             "volkskreditbank_ag" => Ok(VolkskreditbankAg),
             "vr_bank_braunau" => Ok(VrBankBraunau),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -4208,7 +4208,7 @@ impl<'de> serde::Deserialize<'de> for UpdateSetupIntentPaymentMethodDataEpsBank 
     }
 }
 /// If this is an `fpx` PaymentMethod, this hash contains details about the FPX payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, serde::Serialize)]
 pub struct UpdateSetupIntentPaymentMethodDataFpx {
     /// Account holder type for FPX transaction
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -4280,7 +4280,7 @@ impl<'de> serde::Deserialize<'de> for UpdateSetupIntentPaymentMethodDataFpxAccou
     }
 }
 /// The customer's bank.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum UpdateSetupIntentPaymentMethodDataFpxBank {
     AffinBank,
@@ -4306,10 +4306,10 @@ pub enum UpdateSetupIntentPaymentMethodDataFpxBank {
     StandardChartered,
     Uob,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl UpdateSetupIntentPaymentMethodDataFpxBank {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use UpdateSetupIntentPaymentMethodDataFpxBank::*;
         match self {
             AffinBank => "affin_bank",
@@ -4334,7 +4334,7 @@ impl UpdateSetupIntentPaymentMethodDataFpxBank {
             Rhb => "rhb",
             StandardChartered => "standard_chartered",
             Uob => "uob",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -4366,7 +4366,7 @@ impl std::str::FromStr for UpdateSetupIntentPaymentMethodDataFpxBank {
             "rhb" => Ok(Rhb),
             "standard_chartered" => Ok(StandardChartered),
             "uob" => Ok(Uob),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -4398,7 +4398,7 @@ impl<'de> serde::Deserialize<'de> for UpdateSetupIntentPaymentMethodDataFpxBank 
     }
 }
 /// If this is an `ideal` PaymentMethod, this hash contains details about the iDEAL payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, serde::Serialize)]
 pub struct UpdateSetupIntentPaymentMethodDataIdeal {
     /// The customer's bank.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -4415,7 +4415,7 @@ impl Default for UpdateSetupIntentPaymentMethodDataIdeal {
     }
 }
 /// The customer's bank.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum UpdateSetupIntentPaymentMethodDataIdealBank {
     AbnAmro,
@@ -4435,10 +4435,10 @@ pub enum UpdateSetupIntentPaymentMethodDataIdealBank {
     VanLanschot,
     Yoursafe,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl UpdateSetupIntentPaymentMethodDataIdealBank {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use UpdateSetupIntentPaymentMethodDataIdealBank::*;
         match self {
             AbnAmro => "abn_amro",
@@ -4457,7 +4457,7 @@ impl UpdateSetupIntentPaymentMethodDataIdealBank {
             TriodosBank => "triodos_bank",
             VanLanschot => "van_lanschot",
             Yoursafe => "yoursafe",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -4483,7 +4483,7 @@ impl std::str::FromStr for UpdateSetupIntentPaymentMethodDataIdealBank {
             "triodos_bank" => Ok(TriodosBank),
             "van_lanschot" => Ok(VanLanschot),
             "yoursafe" => Ok(Yoursafe),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -4532,7 +4532,7 @@ impl Default for UpdateSetupIntentPaymentMethodDataKlarna {
     }
 }
 /// If this is a `p24` PaymentMethod, this hash contains details about the P24 payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, serde::Serialize)]
 pub struct UpdateSetupIntentPaymentMethodDataP24 {
     /// The customer's bank.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -4549,7 +4549,7 @@ impl Default for UpdateSetupIntentPaymentMethodDataP24 {
     }
 }
 /// The customer's bank.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum UpdateSetupIntentPaymentMethodDataP24Bank {
     AliorBank,
@@ -4579,10 +4579,10 @@ pub enum UpdateSetupIntentPaymentMethodDataP24Bank {
     Velobank,
     VolkswagenBank,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl UpdateSetupIntentPaymentMethodDataP24Bank {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use UpdateSetupIntentPaymentMethodDataP24Bank::*;
         match self {
             AliorBank => "alior_bank",
@@ -4611,7 +4611,7 @@ impl UpdateSetupIntentPaymentMethodDataP24Bank {
             ToyotaBank => "toyota_bank",
             Velobank => "velobank",
             VolkswagenBank => "volkswagen_bank",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -4647,7 +4647,7 @@ impl std::str::FromStr for UpdateSetupIntentPaymentMethodDataP24Bank {
             "toyota_bank" => Ok(ToyotaBank),
             "velobank" => Ok(Velobank),
             "volkswagen_bank" => Ok(VolkswagenBank),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -4773,7 +4773,7 @@ impl<'de> serde::Deserialize<'de> for UpdateSetupIntentPaymentMethodDataSofortCo
 /// The type of the PaymentMethod.
 /// An additional hash is included on the PaymentMethod with a name matching this value.
 /// It contains additional information specific to the PaymentMethod type.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum UpdateSetupIntentPaymentMethodDataType {
     AcssDebit,
@@ -4811,10 +4811,10 @@ pub enum UpdateSetupIntentPaymentMethodDataType {
     WechatPay,
     Zip,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl UpdateSetupIntentPaymentMethodDataType {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use UpdateSetupIntentPaymentMethodDataType::*;
         match self {
             AcssDebit => "acss_debit",
@@ -4851,7 +4851,7 @@ impl UpdateSetupIntentPaymentMethodDataType {
             UsBankAccount => "us_bank_account",
             WechatPay => "wechat_pay",
             Zip => "zip",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -4895,7 +4895,7 @@ impl std::str::FromStr for UpdateSetupIntentPaymentMethodDataType {
             "us_bank_account" => Ok(UsBankAccount),
             "wechat_pay" => Ok(WechatPay),
             "zip" => Ok(Zip),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -7489,7 +7489,7 @@ impl ConfirmSetupIntentPaymentMethodDataBoleto {
     }
 }
 /// If this is an `eps` PaymentMethod, this hash contains details about the EPS payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, serde::Serialize)]
 pub struct ConfirmSetupIntentPaymentMethodDataEps {
     /// The customer's bank.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -7506,7 +7506,7 @@ impl Default for ConfirmSetupIntentPaymentMethodDataEps {
     }
 }
 /// The customer's bank.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum ConfirmSetupIntentPaymentMethodDataEpsBank {
     ArzteUndApothekerBank,
@@ -7538,10 +7538,10 @@ pub enum ConfirmSetupIntentPaymentMethodDataEpsBank {
     VolkskreditbankAg,
     VrBankBraunau,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl ConfirmSetupIntentPaymentMethodDataEpsBank {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use ConfirmSetupIntentPaymentMethodDataEpsBank::*;
         match self {
             ArzteUndApothekerBank => "arzte_und_apotheker_bank",
@@ -7572,7 +7572,7 @@ impl ConfirmSetupIntentPaymentMethodDataEpsBank {
             VolksbankGruppe => "volksbank_gruppe",
             VolkskreditbankAg => "volkskreditbank_ag",
             VrBankBraunau => "vr_bank_braunau",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -7610,7 +7610,7 @@ impl std::str::FromStr for ConfirmSetupIntentPaymentMethodDataEpsBank {
             "volksbank_gruppe" => Ok(VolksbankGruppe),
             "volkskreditbank_ag" => Ok(VolkskreditbankAg),
             "vr_bank_braunau" => Ok(VrBankBraunau),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -7642,7 +7642,7 @@ impl<'de> serde::Deserialize<'de> for ConfirmSetupIntentPaymentMethodDataEpsBank
     }
 }
 /// If this is an `fpx` PaymentMethod, this hash contains details about the FPX payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, serde::Serialize)]
 pub struct ConfirmSetupIntentPaymentMethodDataFpx {
     /// Account holder type for FPX transaction
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -7714,7 +7714,7 @@ impl<'de> serde::Deserialize<'de> for ConfirmSetupIntentPaymentMethodDataFpxAcco
     }
 }
 /// The customer's bank.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum ConfirmSetupIntentPaymentMethodDataFpxBank {
     AffinBank,
@@ -7740,10 +7740,10 @@ pub enum ConfirmSetupIntentPaymentMethodDataFpxBank {
     StandardChartered,
     Uob,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl ConfirmSetupIntentPaymentMethodDataFpxBank {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use ConfirmSetupIntentPaymentMethodDataFpxBank::*;
         match self {
             AffinBank => "affin_bank",
@@ -7768,7 +7768,7 @@ impl ConfirmSetupIntentPaymentMethodDataFpxBank {
             Rhb => "rhb",
             StandardChartered => "standard_chartered",
             Uob => "uob",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -7800,7 +7800,7 @@ impl std::str::FromStr for ConfirmSetupIntentPaymentMethodDataFpxBank {
             "rhb" => Ok(Rhb),
             "standard_chartered" => Ok(StandardChartered),
             "uob" => Ok(Uob),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -7832,7 +7832,7 @@ impl<'de> serde::Deserialize<'de> for ConfirmSetupIntentPaymentMethodDataFpxBank
     }
 }
 /// If this is an `ideal` PaymentMethod, this hash contains details about the iDEAL payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, serde::Serialize)]
 pub struct ConfirmSetupIntentPaymentMethodDataIdeal {
     /// The customer's bank.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -7849,7 +7849,7 @@ impl Default for ConfirmSetupIntentPaymentMethodDataIdeal {
     }
 }
 /// The customer's bank.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum ConfirmSetupIntentPaymentMethodDataIdealBank {
     AbnAmro,
@@ -7869,10 +7869,10 @@ pub enum ConfirmSetupIntentPaymentMethodDataIdealBank {
     VanLanschot,
     Yoursafe,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl ConfirmSetupIntentPaymentMethodDataIdealBank {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use ConfirmSetupIntentPaymentMethodDataIdealBank::*;
         match self {
             AbnAmro => "abn_amro",
@@ -7891,7 +7891,7 @@ impl ConfirmSetupIntentPaymentMethodDataIdealBank {
             TriodosBank => "triodos_bank",
             VanLanschot => "van_lanschot",
             Yoursafe => "yoursafe",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -7917,7 +7917,7 @@ impl std::str::FromStr for ConfirmSetupIntentPaymentMethodDataIdealBank {
             "triodos_bank" => Ok(TriodosBank),
             "van_lanschot" => Ok(VanLanschot),
             "yoursafe" => Ok(Yoursafe),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -7966,7 +7966,7 @@ impl Default for ConfirmSetupIntentPaymentMethodDataKlarna {
     }
 }
 /// If this is a `p24` PaymentMethod, this hash contains details about the P24 payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, serde::Serialize)]
 pub struct ConfirmSetupIntentPaymentMethodDataP24 {
     /// The customer's bank.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -7983,7 +7983,7 @@ impl Default for ConfirmSetupIntentPaymentMethodDataP24 {
     }
 }
 /// The customer's bank.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum ConfirmSetupIntentPaymentMethodDataP24Bank {
     AliorBank,
@@ -8013,10 +8013,10 @@ pub enum ConfirmSetupIntentPaymentMethodDataP24Bank {
     Velobank,
     VolkswagenBank,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl ConfirmSetupIntentPaymentMethodDataP24Bank {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use ConfirmSetupIntentPaymentMethodDataP24Bank::*;
         match self {
             AliorBank => "alior_bank",
@@ -8045,7 +8045,7 @@ impl ConfirmSetupIntentPaymentMethodDataP24Bank {
             ToyotaBank => "toyota_bank",
             Velobank => "velobank",
             VolkswagenBank => "volkswagen_bank",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -8081,7 +8081,7 @@ impl std::str::FromStr for ConfirmSetupIntentPaymentMethodDataP24Bank {
             "toyota_bank" => Ok(ToyotaBank),
             "velobank" => Ok(Velobank),
             "volkswagen_bank" => Ok(VolkswagenBank),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -8207,7 +8207,7 @@ impl<'de> serde::Deserialize<'de> for ConfirmSetupIntentPaymentMethodDataSofortC
 /// The type of the PaymentMethod.
 /// An additional hash is included on the PaymentMethod with a name matching this value.
 /// It contains additional information specific to the PaymentMethod type.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum ConfirmSetupIntentPaymentMethodDataType {
     AcssDebit,
@@ -8245,10 +8245,10 @@ pub enum ConfirmSetupIntentPaymentMethodDataType {
     WechatPay,
     Zip,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl ConfirmSetupIntentPaymentMethodDataType {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use ConfirmSetupIntentPaymentMethodDataType::*;
         match self {
             AcssDebit => "acss_debit",
@@ -8285,7 +8285,7 @@ impl ConfirmSetupIntentPaymentMethodDataType {
             UsBankAccount => "us_bank_account",
             WechatPay => "wechat_pay",
             Zip => "zip",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -8329,7 +8329,7 @@ impl std::str::FromStr for ConfirmSetupIntentPaymentMethodDataType {
             "us_bank_account" => Ok(UsBankAccount),
             "wechat_pay" => Ok(WechatPay),
             "zip" => Ok(Zip),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-core/src/token/requests.rs
+++ b/generated/async-stripe-core/src/token/requests.rs
@@ -392,7 +392,7 @@ impl Default for CreateTokenAccountCompanyOwnershipDeclaration {
 /// The category identifying the legal structure of the company or legal entity.
 /// See [Business structure](https://docs.stripe.com/connect/identity-verification#business-structure) for more details.
 /// Pass an empty string to unset this value.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CreateTokenAccountCompanyStructure {
     FreeZoneEstablishment,
@@ -419,10 +419,10 @@ pub enum CreateTokenAccountCompanyStructure {
     UnincorporatedNonProfit,
     UnincorporatedPartnership,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl CreateTokenAccountCompanyStructure {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use CreateTokenAccountCompanyStructure::*;
         match self {
             FreeZoneEstablishment => "free_zone_establishment",
@@ -448,7 +448,7 @@ impl CreateTokenAccountCompanyStructure {
             UnincorporatedAssociation => "unincorporated_association",
             UnincorporatedNonProfit => "unincorporated_non_profit",
             UnincorporatedPartnership => "unincorporated_partnership",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -481,7 +481,7 @@ impl std::str::FromStr for CreateTokenAccountCompanyStructure {
             "unincorporated_association" => Ok(UnincorporatedAssociation),
             "unincorporated_non_profit" => Ok(UnincorporatedNonProfit),
             "unincorporated_partnership" => Ok(UnincorporatedPartnership),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-issuing/src/issuing_authorization/requests.rs
+++ b/generated/async-stripe-issuing/src/issuing_authorization/requests.rs
@@ -534,7 +534,7 @@ impl Default for CreateIssuingAuthorizationMerchantData {
 }
 /// A categorization of the seller's type of business.
 /// See our [merchant categories guide](https://stripe.com/docs/issuing/merchant-categories) for a list of possible values.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CreateIssuingAuthorizationMerchantDataCategory {
     AcRefrigerationRepair,
@@ -832,10 +832,10 @@ pub enum CreateIssuingAuthorizationMerchantDataCategory {
     WomensReadyToWearStores,
     WreckingAndSalvageYards,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl CreateIssuingAuthorizationMerchantDataCategory {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use CreateIssuingAuthorizationMerchantDataCategory::*;
         match self {
             AcRefrigerationRepair => "ac_refrigeration_repair",
@@ -1176,7 +1176,7 @@ impl CreateIssuingAuthorizationMerchantDataCategory {
             WomensAccessoryAndSpecialtyShops => "womens_accessory_and_specialty_shops",
             WomensReadyToWearStores => "womens_ready_to_wear_stores",
             WreckingAndSalvageYards => "wrecking_and_salvage_yards",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -1528,7 +1528,7 @@ impl std::str::FromStr for CreateIssuingAuthorizationMerchantDataCategory {
             "womens_accessory_and_specialty_shops" => Ok(WomensAccessoryAndSpecialtyShops),
             "womens_ready_to_wear_stores" => Ok(WomensReadyToWearStores),
             "wrecking_and_salvage_yards" => Ok(WreckingAndSalvageYards),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-issuing/src/issuing_card/requests.rs
+++ b/generated/async-stripe-issuing/src/issuing_card/requests.rs
@@ -526,7 +526,7 @@ impl Default for CreateIssuingCardSpendingControls {
 /// Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to allow.
 /// All other categories will be blocked.
 /// Cannot be set with `blocked_categories`.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CreateIssuingCardSpendingControlsAllowedCategories {
     AcRefrigerationRepair,
@@ -825,10 +825,10 @@ pub enum CreateIssuingCardSpendingControlsAllowedCategories {
     WomensReadyToWearStores,
     WreckingAndSalvageYards,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl CreateIssuingCardSpendingControlsAllowedCategories {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use CreateIssuingCardSpendingControlsAllowedCategories::*;
         match self {
             AcRefrigerationRepair => "ac_refrigeration_repair",
@@ -1170,7 +1170,7 @@ impl CreateIssuingCardSpendingControlsAllowedCategories {
             WomensAccessoryAndSpecialtyShops => "womens_accessory_and_specialty_shops",
             WomensReadyToWearStores => "womens_ready_to_wear_stores",
             WreckingAndSalvageYards => "wrecking_and_salvage_yards",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -1523,7 +1523,7 @@ impl std::str::FromStr for CreateIssuingCardSpendingControlsAllowedCategories {
             "womens_accessory_and_specialty_shops" => Ok(WomensAccessoryAndSpecialtyShops),
             "womens_ready_to_wear_stores" => Ok(WomensReadyToWearStores),
             "wrecking_and_salvage_yards" => Ok(WreckingAndSalvageYards),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -1557,7 +1557,7 @@ impl<'de> serde::Deserialize<'de> for CreateIssuingCardSpendingControlsAllowedCa
 /// Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to decline.
 /// All other categories will be allowed.
 /// Cannot be set with `allowed_categories`.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CreateIssuingCardSpendingControlsBlockedCategories {
     AcRefrigerationRepair,
@@ -1856,10 +1856,10 @@ pub enum CreateIssuingCardSpendingControlsBlockedCategories {
     WomensReadyToWearStores,
     WreckingAndSalvageYards,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl CreateIssuingCardSpendingControlsBlockedCategories {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use CreateIssuingCardSpendingControlsBlockedCategories::*;
         match self {
             AcRefrigerationRepair => "ac_refrigeration_repair",
@@ -2201,7 +2201,7 @@ impl CreateIssuingCardSpendingControlsBlockedCategories {
             WomensAccessoryAndSpecialtyShops => "womens_accessory_and_specialty_shops",
             WomensReadyToWearStores => "womens_ready_to_wear_stores",
             WreckingAndSalvageYards => "wrecking_and_salvage_yards",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -2554,7 +2554,7 @@ impl std::str::FromStr for CreateIssuingCardSpendingControlsBlockedCategories {
             "womens_accessory_and_specialty_shops" => Ok(WomensAccessoryAndSpecialtyShops),
             "womens_ready_to_wear_stores" => Ok(WomensReadyToWearStores),
             "wrecking_and_salvage_yards" => Ok(WreckingAndSalvageYards),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -2607,7 +2607,7 @@ impl CreateIssuingCardSpendingControlsSpendingLimits {
 }
 /// Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) this limit applies to.
 /// Omitting this field will apply the limit to all categories.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CreateIssuingCardSpendingControlsSpendingLimitsCategories {
     AcRefrigerationRepair,
@@ -2906,10 +2906,10 @@ pub enum CreateIssuingCardSpendingControlsSpendingLimitsCategories {
     WomensReadyToWearStores,
     WreckingAndSalvageYards,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl CreateIssuingCardSpendingControlsSpendingLimitsCategories {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use CreateIssuingCardSpendingControlsSpendingLimitsCategories::*;
         match self {
             AcRefrigerationRepair => "ac_refrigeration_repair",
@@ -3251,7 +3251,7 @@ impl CreateIssuingCardSpendingControlsSpendingLimitsCategories {
             WomensAccessoryAndSpecialtyShops => "womens_accessory_and_specialty_shops",
             WomensReadyToWearStores => "womens_ready_to_wear_stores",
             WreckingAndSalvageYards => "wrecking_and_salvage_yards",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -3604,7 +3604,7 @@ impl std::str::FromStr for CreateIssuingCardSpendingControlsSpendingLimitsCatego
             "womens_accessory_and_specialty_shops" => Ok(WomensAccessoryAndSpecialtyShops),
             "womens_ready_to_wear_stores" => Ok(WomensReadyToWearStores),
             "wrecking_and_salvage_yards" => Ok(WreckingAndSalvageYards),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -4013,7 +4013,7 @@ impl Default for UpdateIssuingCardSpendingControls {
 /// Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to allow.
 /// All other categories will be blocked.
 /// Cannot be set with `blocked_categories`.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum UpdateIssuingCardSpendingControlsAllowedCategories {
     AcRefrigerationRepair,
@@ -4312,10 +4312,10 @@ pub enum UpdateIssuingCardSpendingControlsAllowedCategories {
     WomensReadyToWearStores,
     WreckingAndSalvageYards,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl UpdateIssuingCardSpendingControlsAllowedCategories {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use UpdateIssuingCardSpendingControlsAllowedCategories::*;
         match self {
             AcRefrigerationRepair => "ac_refrigeration_repair",
@@ -4657,7 +4657,7 @@ impl UpdateIssuingCardSpendingControlsAllowedCategories {
             WomensAccessoryAndSpecialtyShops => "womens_accessory_and_specialty_shops",
             WomensReadyToWearStores => "womens_ready_to_wear_stores",
             WreckingAndSalvageYards => "wrecking_and_salvage_yards",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -5010,7 +5010,7 @@ impl std::str::FromStr for UpdateIssuingCardSpendingControlsAllowedCategories {
             "womens_accessory_and_specialty_shops" => Ok(WomensAccessoryAndSpecialtyShops),
             "womens_ready_to_wear_stores" => Ok(WomensReadyToWearStores),
             "wrecking_and_salvage_yards" => Ok(WreckingAndSalvageYards),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -5044,7 +5044,7 @@ impl<'de> serde::Deserialize<'de> for UpdateIssuingCardSpendingControlsAllowedCa
 /// Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to decline.
 /// All other categories will be allowed.
 /// Cannot be set with `allowed_categories`.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum UpdateIssuingCardSpendingControlsBlockedCategories {
     AcRefrigerationRepair,
@@ -5343,10 +5343,10 @@ pub enum UpdateIssuingCardSpendingControlsBlockedCategories {
     WomensReadyToWearStores,
     WreckingAndSalvageYards,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl UpdateIssuingCardSpendingControlsBlockedCategories {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use UpdateIssuingCardSpendingControlsBlockedCategories::*;
         match self {
             AcRefrigerationRepair => "ac_refrigeration_repair",
@@ -5688,7 +5688,7 @@ impl UpdateIssuingCardSpendingControlsBlockedCategories {
             WomensAccessoryAndSpecialtyShops => "womens_accessory_and_specialty_shops",
             WomensReadyToWearStores => "womens_ready_to_wear_stores",
             WreckingAndSalvageYards => "wrecking_and_salvage_yards",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -6041,7 +6041,7 @@ impl std::str::FromStr for UpdateIssuingCardSpendingControlsBlockedCategories {
             "womens_accessory_and_specialty_shops" => Ok(WomensAccessoryAndSpecialtyShops),
             "womens_ready_to_wear_stores" => Ok(WomensReadyToWearStores),
             "wrecking_and_salvage_yards" => Ok(WreckingAndSalvageYards),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -6094,7 +6094,7 @@ impl UpdateIssuingCardSpendingControlsSpendingLimits {
 }
 /// Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) this limit applies to.
 /// Omitting this field will apply the limit to all categories.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum UpdateIssuingCardSpendingControlsSpendingLimitsCategories {
     AcRefrigerationRepair,
@@ -6393,10 +6393,10 @@ pub enum UpdateIssuingCardSpendingControlsSpendingLimitsCategories {
     WomensReadyToWearStores,
     WreckingAndSalvageYards,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl UpdateIssuingCardSpendingControlsSpendingLimitsCategories {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use UpdateIssuingCardSpendingControlsSpendingLimitsCategories::*;
         match self {
             AcRefrigerationRepair => "ac_refrigeration_repair",
@@ -6738,7 +6738,7 @@ impl UpdateIssuingCardSpendingControlsSpendingLimitsCategories {
             WomensAccessoryAndSpecialtyShops => "womens_accessory_and_specialty_shops",
             WomensReadyToWearStores => "womens_ready_to_wear_stores",
             WreckingAndSalvageYards => "wrecking_and_salvage_yards",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -7091,7 +7091,7 @@ impl std::str::FromStr for UpdateIssuingCardSpendingControlsSpendingLimitsCatego
             "womens_accessory_and_specialty_shops" => Ok(WomensAccessoryAndSpecialtyShops),
             "womens_ready_to_wear_stores" => Ok(WomensReadyToWearStores),
             "wrecking_and_salvage_yards" => Ok(WreckingAndSalvageYards),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-issuing/src/issuing_cardholder/requests.rs
+++ b/generated/async-stripe-issuing/src/issuing_cardholder/requests.rs
@@ -292,7 +292,7 @@ impl Default for CreateIssuingCardholderSpendingControls {
 /// Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to allow.
 /// All other categories will be blocked.
 /// Cannot be set with `blocked_categories`.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CreateIssuingCardholderSpendingControlsAllowedCategories {
     AcRefrigerationRepair,
@@ -591,10 +591,10 @@ pub enum CreateIssuingCardholderSpendingControlsAllowedCategories {
     WomensReadyToWearStores,
     WreckingAndSalvageYards,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl CreateIssuingCardholderSpendingControlsAllowedCategories {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use CreateIssuingCardholderSpendingControlsAllowedCategories::*;
         match self {
             AcRefrigerationRepair => "ac_refrigeration_repair",
@@ -936,7 +936,7 @@ impl CreateIssuingCardholderSpendingControlsAllowedCategories {
             WomensAccessoryAndSpecialtyShops => "womens_accessory_and_specialty_shops",
             WomensReadyToWearStores => "womens_ready_to_wear_stores",
             WreckingAndSalvageYards => "wrecking_and_salvage_yards",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -1289,7 +1289,7 @@ impl std::str::FromStr for CreateIssuingCardholderSpendingControlsAllowedCategor
             "womens_accessory_and_specialty_shops" => Ok(WomensAccessoryAndSpecialtyShops),
             "womens_ready_to_wear_stores" => Ok(WomensReadyToWearStores),
             "wrecking_and_salvage_yards" => Ok(WreckingAndSalvageYards),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -1323,7 +1323,7 @@ impl<'de> serde::Deserialize<'de> for CreateIssuingCardholderSpendingControlsAll
 /// Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to decline.
 /// All other categories will be allowed.
 /// Cannot be set with `allowed_categories`.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CreateIssuingCardholderSpendingControlsBlockedCategories {
     AcRefrigerationRepair,
@@ -1622,10 +1622,10 @@ pub enum CreateIssuingCardholderSpendingControlsBlockedCategories {
     WomensReadyToWearStores,
     WreckingAndSalvageYards,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl CreateIssuingCardholderSpendingControlsBlockedCategories {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use CreateIssuingCardholderSpendingControlsBlockedCategories::*;
         match self {
             AcRefrigerationRepair => "ac_refrigeration_repair",
@@ -1967,7 +1967,7 @@ impl CreateIssuingCardholderSpendingControlsBlockedCategories {
             WomensAccessoryAndSpecialtyShops => "womens_accessory_and_specialty_shops",
             WomensReadyToWearStores => "womens_ready_to_wear_stores",
             WreckingAndSalvageYards => "wrecking_and_salvage_yards",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -2320,7 +2320,7 @@ impl std::str::FromStr for CreateIssuingCardholderSpendingControlsBlockedCategor
             "womens_accessory_and_specialty_shops" => Ok(WomensAccessoryAndSpecialtyShops),
             "womens_ready_to_wear_stores" => Ok(WomensReadyToWearStores),
             "wrecking_and_salvage_yards" => Ok(WreckingAndSalvageYards),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -2373,7 +2373,7 @@ impl CreateIssuingCardholderSpendingControlsSpendingLimits {
 }
 /// Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) this limit applies to.
 /// Omitting this field will apply the limit to all categories.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CreateIssuingCardholderSpendingControlsSpendingLimitsCategories {
     AcRefrigerationRepair,
@@ -2672,10 +2672,10 @@ pub enum CreateIssuingCardholderSpendingControlsSpendingLimitsCategories {
     WomensReadyToWearStores,
     WreckingAndSalvageYards,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl CreateIssuingCardholderSpendingControlsSpendingLimitsCategories {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use CreateIssuingCardholderSpendingControlsSpendingLimitsCategories::*;
         match self {
             AcRefrigerationRepair => "ac_refrigeration_repair",
@@ -3017,7 +3017,7 @@ impl CreateIssuingCardholderSpendingControlsSpendingLimitsCategories {
             WomensAccessoryAndSpecialtyShops => "womens_accessory_and_specialty_shops",
             WomensReadyToWearStores => "womens_ready_to_wear_stores",
             WreckingAndSalvageYards => "wrecking_and_salvage_yards",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -3370,7 +3370,7 @@ impl std::str::FromStr for CreateIssuingCardholderSpendingControlsSpendingLimits
             "womens_accessory_and_specialty_shops" => Ok(WomensAccessoryAndSpecialtyShops),
             "womens_ready_to_wear_stores" => Ok(WomensReadyToWearStores),
             "wrecking_and_salvage_yards" => Ok(WreckingAndSalvageYards),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -3731,7 +3731,7 @@ impl Default for UpdateIssuingCardholderSpendingControls {
 /// Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to allow.
 /// All other categories will be blocked.
 /// Cannot be set with `blocked_categories`.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum UpdateIssuingCardholderSpendingControlsAllowedCategories {
     AcRefrigerationRepair,
@@ -4030,10 +4030,10 @@ pub enum UpdateIssuingCardholderSpendingControlsAllowedCategories {
     WomensReadyToWearStores,
     WreckingAndSalvageYards,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl UpdateIssuingCardholderSpendingControlsAllowedCategories {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use UpdateIssuingCardholderSpendingControlsAllowedCategories::*;
         match self {
             AcRefrigerationRepair => "ac_refrigeration_repair",
@@ -4375,7 +4375,7 @@ impl UpdateIssuingCardholderSpendingControlsAllowedCategories {
             WomensAccessoryAndSpecialtyShops => "womens_accessory_and_specialty_shops",
             WomensReadyToWearStores => "womens_ready_to_wear_stores",
             WreckingAndSalvageYards => "wrecking_and_salvage_yards",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -4728,7 +4728,7 @@ impl std::str::FromStr for UpdateIssuingCardholderSpendingControlsAllowedCategor
             "womens_accessory_and_specialty_shops" => Ok(WomensAccessoryAndSpecialtyShops),
             "womens_ready_to_wear_stores" => Ok(WomensReadyToWearStores),
             "wrecking_and_salvage_yards" => Ok(WreckingAndSalvageYards),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -4762,7 +4762,7 @@ impl<'de> serde::Deserialize<'de> for UpdateIssuingCardholderSpendingControlsAll
 /// Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to decline.
 /// All other categories will be allowed.
 /// Cannot be set with `allowed_categories`.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum UpdateIssuingCardholderSpendingControlsBlockedCategories {
     AcRefrigerationRepair,
@@ -5061,10 +5061,10 @@ pub enum UpdateIssuingCardholderSpendingControlsBlockedCategories {
     WomensReadyToWearStores,
     WreckingAndSalvageYards,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl UpdateIssuingCardholderSpendingControlsBlockedCategories {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use UpdateIssuingCardholderSpendingControlsBlockedCategories::*;
         match self {
             AcRefrigerationRepair => "ac_refrigeration_repair",
@@ -5406,7 +5406,7 @@ impl UpdateIssuingCardholderSpendingControlsBlockedCategories {
             WomensAccessoryAndSpecialtyShops => "womens_accessory_and_specialty_shops",
             WomensReadyToWearStores => "womens_ready_to_wear_stores",
             WreckingAndSalvageYards => "wrecking_and_salvage_yards",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -5759,7 +5759,7 @@ impl std::str::FromStr for UpdateIssuingCardholderSpendingControlsBlockedCategor
             "womens_accessory_and_specialty_shops" => Ok(WomensAccessoryAndSpecialtyShops),
             "womens_ready_to_wear_stores" => Ok(WomensReadyToWearStores),
             "wrecking_and_salvage_yards" => Ok(WreckingAndSalvageYards),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -5812,7 +5812,7 @@ impl UpdateIssuingCardholderSpendingControlsSpendingLimits {
 }
 /// Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) this limit applies to.
 /// Omitting this field will apply the limit to all categories.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum UpdateIssuingCardholderSpendingControlsSpendingLimitsCategories {
     AcRefrigerationRepair,
@@ -6111,10 +6111,10 @@ pub enum UpdateIssuingCardholderSpendingControlsSpendingLimitsCategories {
     WomensReadyToWearStores,
     WreckingAndSalvageYards,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl UpdateIssuingCardholderSpendingControlsSpendingLimitsCategories {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use UpdateIssuingCardholderSpendingControlsSpendingLimitsCategories::*;
         match self {
             AcRefrigerationRepair => "ac_refrigeration_repair",
@@ -6456,7 +6456,7 @@ impl UpdateIssuingCardholderSpendingControlsSpendingLimitsCategories {
             WomensAccessoryAndSpecialtyShops => "womens_accessory_and_specialty_shops",
             WomensReadyToWearStores => "womens_ready_to_wear_stores",
             WreckingAndSalvageYards => "wrecking_and_salvage_yards",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -6809,7 +6809,7 @@ impl std::str::FromStr for UpdateIssuingCardholderSpendingControlsSpendingLimits
             "womens_accessory_and_specialty_shops" => Ok(WomensAccessoryAndSpecialtyShops),
             "womens_ready_to_wear_stores" => Ok(WomensReadyToWearStores),
             "wrecking_and_salvage_yards" => Ok(WreckingAndSalvageYards),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-issuing/src/issuing_transaction/requests.rs
+++ b/generated/async-stripe-issuing/src/issuing_transaction/requests.rs
@@ -397,7 +397,7 @@ impl Default for CreateForceCaptureIssuingTransactionMerchantData {
 }
 /// A categorization of the seller's type of business.
 /// See our [merchant categories guide](https://stripe.com/docs/issuing/merchant-categories) for a list of possible values.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CreateForceCaptureIssuingTransactionMerchantDataCategory {
     AcRefrigerationRepair,
@@ -695,10 +695,10 @@ pub enum CreateForceCaptureIssuingTransactionMerchantDataCategory {
     WomensReadyToWearStores,
     WreckingAndSalvageYards,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl CreateForceCaptureIssuingTransactionMerchantDataCategory {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use CreateForceCaptureIssuingTransactionMerchantDataCategory::*;
         match self {
             AcRefrigerationRepair => "ac_refrigeration_repair",
@@ -1039,7 +1039,7 @@ impl CreateForceCaptureIssuingTransactionMerchantDataCategory {
             WomensAccessoryAndSpecialtyShops => "womens_accessory_and_specialty_shops",
             WomensReadyToWearStores => "womens_ready_to_wear_stores",
             WreckingAndSalvageYards => "wrecking_and_salvage_yards",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -1391,7 +1391,7 @@ impl std::str::FromStr for CreateForceCaptureIssuingTransactionMerchantDataCateg
             "womens_accessory_and_specialty_shops" => Ok(WomensAccessoryAndSpecialtyShops),
             "womens_ready_to_wear_stores" => Ok(WomensReadyToWearStores),
             "wrecking_and_salvage_yards" => Ok(WreckingAndSalvageYards),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -1757,7 +1757,7 @@ impl Default for CreateUnlinkedRefundIssuingTransactionMerchantData {
 }
 /// A categorization of the seller's type of business.
 /// See our [merchant categories guide](https://stripe.com/docs/issuing/merchant-categories) for a list of possible values.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CreateUnlinkedRefundIssuingTransactionMerchantDataCategory {
     AcRefrigerationRepair,
@@ -2055,10 +2055,10 @@ pub enum CreateUnlinkedRefundIssuingTransactionMerchantDataCategory {
     WomensReadyToWearStores,
     WreckingAndSalvageYards,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl CreateUnlinkedRefundIssuingTransactionMerchantDataCategory {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use CreateUnlinkedRefundIssuingTransactionMerchantDataCategory::*;
         match self {
             AcRefrigerationRepair => "ac_refrigeration_repair",
@@ -2399,7 +2399,7 @@ impl CreateUnlinkedRefundIssuingTransactionMerchantDataCategory {
             WomensAccessoryAndSpecialtyShops => "womens_accessory_and_specialty_shops",
             WomensReadyToWearStores => "womens_ready_to_wear_stores",
             WreckingAndSalvageYards => "wrecking_and_salvage_yards",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -2751,7 +2751,7 @@ impl std::str::FromStr for CreateUnlinkedRefundIssuingTransactionMerchantDataCat
             "womens_accessory_and_specialty_shops" => Ok(WomensAccessoryAndSpecialtyShops),
             "womens_ready_to_wear_stores" => Ok(WomensReadyToWearStores),
             "wrecking_and_salvage_yards" => Ok(WreckingAndSalvageYards),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-misc/src/gelato_session_last_error.rs
+++ b/generated/async-stripe-misc/src/gelato_session_last_error.rs
@@ -66,7 +66,7 @@ const _: () = {
         }
 
         fn take_out(&mut self) -> Option<Self::Out> {
-            let (Some(code), Some(reason)) = (self.code, self.reason.take()) else {
+            let (Some(code), Some(reason)) = (self.code.take(), self.reason.take()) else {
                 return None;
             };
             Some(Self::Out { code, reason })
@@ -107,7 +107,7 @@ const _: () = {
     }
 };
 /// A short machine-readable string giving the reason for the verification or user-session failure.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum GelatoSessionLastErrorCode {
     Abandoned,
@@ -130,10 +130,10 @@ pub enum GelatoSessionLastErrorCode {
     SelfieUnverifiedOther,
     UnderSupportedAge,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl GelatoSessionLastErrorCode {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use GelatoSessionLastErrorCode::*;
         match self {
             Abandoned => "abandoned",
@@ -155,7 +155,7 @@ impl GelatoSessionLastErrorCode {
             SelfieManipulated => "selfie_manipulated",
             SelfieUnverifiedOther => "selfie_unverified_other",
             UnderSupportedAge => "under_supported_age",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -184,7 +184,7 @@ impl std::str::FromStr for GelatoSessionLastErrorCode {
             "selfie_manipulated" => Ok(SelfieManipulated),
             "selfie_unverified_other" => Ok(SelfieUnverifiedOther),
             "under_supported_age" => Ok(UnderSupportedAge),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-misc/src/reporting_report_run/requests.rs
+++ b/generated/async-stripe-misc/src/reporting_report_run/requests.rs
@@ -218,7 +218,7 @@ impl Default for CreateReportingReportRunParameters {
     }
 }
 /// Category of balance transactions to be included in the report run.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CreateReportingReportRunParametersReportingCategory {
     Advance,
@@ -259,10 +259,10 @@ pub enum CreateReportingReportRunParametersReportingCategory {
     TransferReversal,
     UnreconciledCustomerFunds,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl CreateReportingReportRunParametersReportingCategory {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use CreateReportingReportRunParametersReportingCategory::*;
         match self {
             Advance => "advance",
@@ -302,7 +302,7 @@ impl CreateReportingReportRunParametersReportingCategory {
             Transfer => "transfer",
             TransferReversal => "transfer_reversal",
             UnreconciledCustomerFunds => "unreconciled_customer_funds",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -349,7 +349,7 @@ impl std::str::FromStr for CreateReportingReportRunParametersReportingCategory {
             "transfer" => Ok(Transfer),
             "transfer_reversal" => Ok(TransferReversal),
             "unreconciled_customer_funds" => Ok(UnreconciledCustomerFunds),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -384,7 +384,7 @@ impl<'de> serde::Deserialize<'de> for CreateReportingReportRunParametersReportin
 /// The output timezone for all timestamps in the report.
 /// A list of possible time zone values is maintained at the [IANA Time Zone Database](http://www.iana.org/time-zones).
 /// Has no effect on `interval_start` or `interval_end`.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CreateReportingReportRunParametersTimezone {
     AfricaAbidjan,
@@ -986,10 +986,10 @@ pub enum CreateReportingReportRunParametersTimezone {
     Wet,
     Zulu,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl CreateReportingReportRunParametersTimezone {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use CreateReportingReportRunParametersTimezone::*;
         match self {
             AfricaAbidjan => "Africa/Abidjan",
@@ -1590,7 +1590,7 @@ impl CreateReportingReportRunParametersTimezone {
             WMinusSu => "W-SU",
             Wet => "WET",
             Zulu => "Zulu",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -2198,7 +2198,7 @@ impl std::str::FromStr for CreateReportingReportRunParametersTimezone {
             "W-SU" => Ok(WMinusSu),
             "WET" => Ok(Wet),
             "Zulu" => Ok(Zulu),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-misc/src/tax_calculation/requests.rs
+++ b/generated/async-stripe-misc/src/tax_calculation/requests.rs
@@ -282,7 +282,7 @@ impl CreateTaxCalculationCustomerDetailsTaxIds {
     }
 }
 /// Type of the tax ID, one of `ad_nrt`, `ae_trn`, `ar_cuit`, `au_abn`, `au_arn`, `bg_uic`, `bh_vat`, `bo_tin`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `cn_tin`, `co_nit`, `cr_tin`, `do_rcn`, `ec_ruc`, `eg_tin`, `es_cif`, `eu_oss_vat`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `hu_tin`, `id_npwp`, `il_vat`, `in_gst`, `is_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `ke_pin`, `kr_brn`, `kz_bin`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `ng_tin`, `no_vat`, `no_voec`, `nz_gst`, `om_vat`, `pe_ruc`, `ph_tin`, `ro_tin`, `rs_pib`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `si_tin`, `sv_nit`, `th_vat`, `tr_tin`, `tw_vat`, `ua_vat`, `us_ein`, `uy_ruc`, `ve_rif`, `vn_tin`, or `za_vat`.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CreateTaxCalculationCustomerDetailsTaxIdsType {
     AdNrt,
@@ -357,10 +357,10 @@ pub enum CreateTaxCalculationCustomerDetailsTaxIdsType {
     VnTin,
     ZaVat,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl CreateTaxCalculationCustomerDetailsTaxIdsType {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use CreateTaxCalculationCustomerDetailsTaxIdsType::*;
         match self {
             AdNrt => "ad_nrt",
@@ -434,7 +434,7 @@ impl CreateTaxCalculationCustomerDetailsTaxIdsType {
             VeRif => "ve_rif",
             VnTin => "vn_tin",
             ZaVat => "za_vat",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -515,7 +515,7 @@ impl std::str::FromStr for CreateTaxCalculationCustomerDetailsTaxIdsType {
             "ve_rif" => Ok(VeRif),
             "vn_tin" => Ok(VnTin),
             "za_vat" => Ok(ZaVat),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-misc/src/tax_product_resource_line_item_tax_breakdown.rs
+++ b/generated/async-stripe-misc/src/tax_product_resource_line_item_tax_breakdown.rs
@@ -101,7 +101,7 @@ const _: () = {
                 self.jurisdiction.take(),
                 self.sourcing,
                 self.tax_rate_details.take(),
-                self.taxability_reason,
+                self.taxability_reason.take(),
                 self.taxable_amount,
             )
             else {
@@ -234,7 +234,7 @@ impl<'de> serde::Deserialize<'de> for TaxProductResourceLineItemTaxBreakdownSour
 }
 /// The reasoning behind this tax, for example, if the product is tax exempt.
 /// The possible values for this field may be extended as new tax rules are supported.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum TaxProductResourceLineItemTaxBreakdownTaxabilityReason {
     CustomerExempt,
@@ -253,10 +253,10 @@ pub enum TaxProductResourceLineItemTaxBreakdownTaxabilityReason {
     TaxableBasisReduced,
     ZeroRated,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl TaxProductResourceLineItemTaxBreakdownTaxabilityReason {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use TaxProductResourceLineItemTaxBreakdownTaxabilityReason::*;
         match self {
             CustomerExempt => "customer_exempt",
@@ -274,7 +274,7 @@ impl TaxProductResourceLineItemTaxBreakdownTaxabilityReason {
             StandardRated => "standard_rated",
             TaxableBasisReduced => "taxable_basis_reduced",
             ZeroRated => "zero_rated",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -299,7 +299,7 @@ impl std::str::FromStr for TaxProductResourceLineItemTaxBreakdownTaxabilityReaso
             "standard_rated" => Ok(StandardRated),
             "taxable_basis_reduced" => Ok(TaxableBasisReduced),
             "zero_rated" => Ok(ZeroRated),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-misc/src/tax_product_resource_tax_breakdown.rs
+++ b/generated/async-stripe-misc/src/tax_product_resource_tax_breakdown.rs
@@ -93,7 +93,7 @@ const _: () = {
                 self.amount,
                 self.inclusive,
                 self.tax_rate_details.take(),
-                self.taxability_reason,
+                self.taxability_reason.take(),
                 self.taxable_amount,
             )
             else {
@@ -147,7 +147,7 @@ const _: () = {
 };
 /// The reasoning behind this tax, for example, if the product is tax exempt.
 /// We might extend the possible values for this field to support new tax rules.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum TaxProductResourceTaxBreakdownTaxabilityReason {
     CustomerExempt,
@@ -166,10 +166,10 @@ pub enum TaxProductResourceTaxBreakdownTaxabilityReason {
     TaxableBasisReduced,
     ZeroRated,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl TaxProductResourceTaxBreakdownTaxabilityReason {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use TaxProductResourceTaxBreakdownTaxabilityReason::*;
         match self {
             CustomerExempt => "customer_exempt",
@@ -187,7 +187,7 @@ impl TaxProductResourceTaxBreakdownTaxabilityReason {
             StandardRated => "standard_rated",
             TaxableBasisReduced => "taxable_basis_reduced",
             ZeroRated => "zero_rated",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -212,7 +212,7 @@ impl std::str::FromStr for TaxProductResourceTaxBreakdownTaxabilityReason {
             "standard_rated" => Ok(StandardRated),
             "taxable_basis_reduced" => Ok(TaxableBasisReduced),
             "zero_rated" => Ok(ZeroRated),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-misc/src/webhook_endpoint/requests.rs
+++ b/generated/async-stripe-misc/src/webhook_endpoint/requests.rs
@@ -217,7 +217,7 @@ impl CreateWebhookEndpointBuilder {
 }
 /// The list of events to enable for this endpoint.
 /// You may specify `['*']` to enable all events, except those that require explicit selection.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CreateWebhookEndpointEnabledEvents {
     All,
@@ -449,10 +449,10 @@ pub enum CreateWebhookEndpointEnabledEvents {
     TreasuryReceivedCreditSucceeded,
     TreasuryReceivedDebitCreated,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl CreateWebhookEndpointEnabledEvents {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use CreateWebhookEndpointEnabledEvents::*;
         match self {
             All => "*",
@@ -705,7 +705,7 @@ impl CreateWebhookEndpointEnabledEvents {
             TreasuryReceivedCreditFailed => "treasury.received_credit.failed",
             TreasuryReceivedCreditSucceeded => "treasury.received_credit.succeeded",
             TreasuryReceivedDebitCreated => "treasury.received_debit.created",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -973,7 +973,7 @@ impl std::str::FromStr for CreateWebhookEndpointEnabledEvents {
             "treasury.received_credit.failed" => Ok(TreasuryReceivedCreditFailed),
             "treasury.received_credit.succeeded" => Ok(TreasuryReceivedCreditSucceeded),
             "treasury.received_debit.created" => Ok(TreasuryReceivedDebitCreated),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -1107,7 +1107,7 @@ impl UpdateWebhookEndpointBuilder {
 }
 /// The list of events to enable for this endpoint.
 /// You may specify `['*']` to enable all events, except those that require explicit selection.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum UpdateWebhookEndpointEnabledEvents {
     All,
@@ -1339,10 +1339,10 @@ pub enum UpdateWebhookEndpointEnabledEvents {
     TreasuryReceivedCreditSucceeded,
     TreasuryReceivedDebitCreated,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl UpdateWebhookEndpointEnabledEvents {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use UpdateWebhookEndpointEnabledEvents::*;
         match self {
             All => "*",
@@ -1595,7 +1595,7 @@ impl UpdateWebhookEndpointEnabledEvents {
             TreasuryReceivedCreditFailed => "treasury.received_credit.failed",
             TreasuryReceivedCreditSucceeded => "treasury.received_credit.succeeded",
             TreasuryReceivedDebitCreated => "treasury.received_debit.created",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -1863,7 +1863,7 @@ impl std::str::FromStr for UpdateWebhookEndpointEnabledEvents {
             "treasury.received_credit.failed" => Ok(TreasuryReceivedCreditFailed),
             "treasury.received_credit.succeeded" => Ok(TreasuryReceivedCreditSucceeded),
             "treasury.received_debit.created" => Ok(TreasuryReceivedDebitCreated),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-payment/src/confirmation_token/requests.rs
+++ b/generated/async-stripe-payment/src/confirmation_token/requests.rs
@@ -476,7 +476,7 @@ impl CreateConfirmationTokenPaymentMethodDataBoleto {
     }
 }
 /// If this is an `eps` PaymentMethod, this hash contains details about the EPS payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, serde::Serialize)]
 pub struct CreateConfirmationTokenPaymentMethodDataEps {
     /// The customer's bank.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -493,7 +493,7 @@ impl Default for CreateConfirmationTokenPaymentMethodDataEps {
     }
 }
 /// The customer's bank.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CreateConfirmationTokenPaymentMethodDataEpsBank {
     ArzteUndApothekerBank,
@@ -525,10 +525,10 @@ pub enum CreateConfirmationTokenPaymentMethodDataEpsBank {
     VolkskreditbankAg,
     VrBankBraunau,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl CreateConfirmationTokenPaymentMethodDataEpsBank {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use CreateConfirmationTokenPaymentMethodDataEpsBank::*;
         match self {
             ArzteUndApothekerBank => "arzte_und_apotheker_bank",
@@ -559,7 +559,7 @@ impl CreateConfirmationTokenPaymentMethodDataEpsBank {
             VolksbankGruppe => "volksbank_gruppe",
             VolkskreditbankAg => "volkskreditbank_ag",
             VrBankBraunau => "vr_bank_braunau",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -597,7 +597,7 @@ impl std::str::FromStr for CreateConfirmationTokenPaymentMethodDataEpsBank {
             "volksbank_gruppe" => Ok(VolksbankGruppe),
             "volkskreditbank_ag" => Ok(VolkskreditbankAg),
             "vr_bank_braunau" => Ok(VrBankBraunau),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -629,7 +629,7 @@ impl<'de> serde::Deserialize<'de> for CreateConfirmationTokenPaymentMethodDataEp
     }
 }
 /// If this is an `fpx` PaymentMethod, this hash contains details about the FPX payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, serde::Serialize)]
 pub struct CreateConfirmationTokenPaymentMethodDataFpx {
     /// Account holder type for FPX transaction
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -701,7 +701,7 @@ impl<'de> serde::Deserialize<'de> for CreateConfirmationTokenPaymentMethodDataFp
     }
 }
 /// The customer's bank.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CreateConfirmationTokenPaymentMethodDataFpxBank {
     AffinBank,
@@ -727,10 +727,10 @@ pub enum CreateConfirmationTokenPaymentMethodDataFpxBank {
     StandardChartered,
     Uob,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl CreateConfirmationTokenPaymentMethodDataFpxBank {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use CreateConfirmationTokenPaymentMethodDataFpxBank::*;
         match self {
             AffinBank => "affin_bank",
@@ -755,7 +755,7 @@ impl CreateConfirmationTokenPaymentMethodDataFpxBank {
             Rhb => "rhb",
             StandardChartered => "standard_chartered",
             Uob => "uob",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -787,7 +787,7 @@ impl std::str::FromStr for CreateConfirmationTokenPaymentMethodDataFpxBank {
             "rhb" => Ok(Rhb),
             "standard_chartered" => Ok(StandardChartered),
             "uob" => Ok(Uob),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -819,7 +819,7 @@ impl<'de> serde::Deserialize<'de> for CreateConfirmationTokenPaymentMethodDataFp
     }
 }
 /// If this is an `ideal` PaymentMethod, this hash contains details about the iDEAL payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, serde::Serialize)]
 pub struct CreateConfirmationTokenPaymentMethodDataIdeal {
     /// The customer's bank.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -836,7 +836,7 @@ impl Default for CreateConfirmationTokenPaymentMethodDataIdeal {
     }
 }
 /// The customer's bank.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CreateConfirmationTokenPaymentMethodDataIdealBank {
     AbnAmro,
@@ -856,10 +856,10 @@ pub enum CreateConfirmationTokenPaymentMethodDataIdealBank {
     VanLanschot,
     Yoursafe,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl CreateConfirmationTokenPaymentMethodDataIdealBank {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use CreateConfirmationTokenPaymentMethodDataIdealBank::*;
         match self {
             AbnAmro => "abn_amro",
@@ -878,7 +878,7 @@ impl CreateConfirmationTokenPaymentMethodDataIdealBank {
             TriodosBank => "triodos_bank",
             VanLanschot => "van_lanschot",
             Yoursafe => "yoursafe",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -904,7 +904,7 @@ impl std::str::FromStr for CreateConfirmationTokenPaymentMethodDataIdealBank {
             "triodos_bank" => Ok(TriodosBank),
             "van_lanschot" => Ok(VanLanschot),
             "yoursafe" => Ok(Yoursafe),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -968,7 +968,7 @@ impl CreateConfirmationTokenPaymentMethodDataKlarnaDob {
     }
 }
 /// If this is a `p24` PaymentMethod, this hash contains details about the P24 payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, serde::Serialize)]
 pub struct CreateConfirmationTokenPaymentMethodDataP24 {
     /// The customer's bank.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -985,7 +985,7 @@ impl Default for CreateConfirmationTokenPaymentMethodDataP24 {
     }
 }
 /// The customer's bank.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CreateConfirmationTokenPaymentMethodDataP24Bank {
     AliorBank,
@@ -1015,10 +1015,10 @@ pub enum CreateConfirmationTokenPaymentMethodDataP24Bank {
     Velobank,
     VolkswagenBank,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl CreateConfirmationTokenPaymentMethodDataP24Bank {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use CreateConfirmationTokenPaymentMethodDataP24Bank::*;
         match self {
             AliorBank => "alior_bank",
@@ -1047,7 +1047,7 @@ impl CreateConfirmationTokenPaymentMethodDataP24Bank {
             ToyotaBank => "toyota_bank",
             Velobank => "velobank",
             VolkswagenBank => "volkswagen_bank",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -1083,7 +1083,7 @@ impl std::str::FromStr for CreateConfirmationTokenPaymentMethodDataP24Bank {
             "toyota_bank" => Ok(ToyotaBank),
             "velobank" => Ok(Velobank),
             "volkswagen_bank" => Ok(VolkswagenBank),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -1227,7 +1227,7 @@ impl<'de> serde::Deserialize<'de> for CreateConfirmationTokenPaymentMethodDataSo
 /// The type of the PaymentMethod.
 /// An additional hash is included on the PaymentMethod with a name matching this value.
 /// It contains additional information specific to the PaymentMethod type.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CreateConfirmationTokenPaymentMethodDataType {
     AcssDebit,
@@ -1265,10 +1265,10 @@ pub enum CreateConfirmationTokenPaymentMethodDataType {
     WechatPay,
     Zip,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl CreateConfirmationTokenPaymentMethodDataType {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use CreateConfirmationTokenPaymentMethodDataType::*;
         match self {
             AcssDebit => "acss_debit",
@@ -1305,7 +1305,7 @@ impl CreateConfirmationTokenPaymentMethodDataType {
             UsBankAccount => "us_bank_account",
             WechatPay => "wechat_pay",
             Zip => "zip",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -1349,7 +1349,7 @@ impl std::str::FromStr for CreateConfirmationTokenPaymentMethodDataType {
             "us_bank_account" => Ok(UsBankAccount),
             "wechat_pay" => Ok(WechatPay),
             "zip" => Ok(Zip),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-payment/src/confirmation_tokens_resource_payment_method_preview.rs
+++ b/generated/async-stripe-payment/src/confirmation_tokens_resource_payment_method_preview.rs
@@ -275,18 +275,18 @@ const _: () = {
                 self.card_present.take(),
                 self.cashapp.take(),
                 self.customer_balance,
-                self.eps,
-                self.fpx,
+                self.eps.take(),
+                self.fpx.take(),
                 self.giropay,
                 self.grabpay,
-                self.ideal,
+                self.ideal.take(),
                 self.interac_present.take(),
                 self.klarna,
                 self.konbini,
                 self.link.take(),
                 self.mobilepay,
                 self.oxxo,
-                self.p24,
+                self.p24.take(),
                 self.paynow,
                 self.paypal.take(),
                 self.pix,
@@ -295,7 +295,7 @@ const _: () = {
                 self.sepa_debit.take(),
                 self.sofort.take(),
                 self.swish,
-                self.type_,
+                self.type_.take(),
                 self.us_bank_account.take(),
                 self.wechat_pay,
                 self.zip,
@@ -420,7 +420,7 @@ const _: () = {
 /// The type of the PaymentMethod.
 /// An additional hash is included on the PaymentMethod with a name matching this value.
 /// It contains additional information specific to the PaymentMethod type.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum ConfirmationTokensResourcePaymentMethodPreviewType {
     AcssDebit,
@@ -461,10 +461,10 @@ pub enum ConfirmationTokensResourcePaymentMethodPreviewType {
     WechatPay,
     Zip,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl ConfirmationTokensResourcePaymentMethodPreviewType {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use ConfirmationTokensResourcePaymentMethodPreviewType::*;
         match self {
             AcssDebit => "acss_debit",
@@ -504,7 +504,7 @@ impl ConfirmationTokensResourcePaymentMethodPreviewType {
             UsBankAccount => "us_bank_account",
             WechatPay => "wechat_pay",
             Zip => "zip",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -551,7 +551,7 @@ impl std::str::FromStr for ConfirmationTokensResourcePaymentMethodPreviewType {
             "us_bank_account" => Ok(UsBankAccount),
             "wechat_pay" => Ok(WechatPay),
             "zip" => Ok(Zip),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-payment/src/payment_link/requests.rs
+++ b/generated/async-stripe-payment/src/payment_link/requests.rs
@@ -1515,7 +1515,7 @@ impl CreatePaymentLinkShippingAddressCollection {
 /// An array of two-letter ISO country codes representing which countries Checkout should provide as options for.
 /// shipping locations.
 /// Unsupported country codes: `AS, CX, CC, CU, HM, IR, KP, MH, FM, NF, MP, PW, SD, SY, UM, VI`.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CreatePaymentLinkShippingAddressCollectionAllowedCountries {
     Ac,
@@ -1756,10 +1756,10 @@ pub enum CreatePaymentLinkShippingAddressCollectionAllowedCountries {
     Zw,
     Zz,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl CreatePaymentLinkShippingAddressCollectionAllowedCountries {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use CreatePaymentLinkShippingAddressCollectionAllowedCountries::*;
         match self {
             Ac => "AC",
@@ -1999,7 +1999,7 @@ impl CreatePaymentLinkShippingAddressCollectionAllowedCountries {
             Zm => "ZM",
             Zw => "ZW",
             Zz => "ZZ",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -2246,7 +2246,7 @@ impl std::str::FromStr for CreatePaymentLinkShippingAddressCollectionAllowedCoun
             "ZM" => Ok(Zm),
             "ZW" => Ok(Zw),
             "ZZ" => Ok(Zz),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -3655,7 +3655,7 @@ impl UpdatePaymentLinkShippingAddressCollection {
 /// An array of two-letter ISO country codes representing which countries Checkout should provide as options for.
 /// shipping locations.
 /// Unsupported country codes: `AS, CX, CC, CU, HM, IR, KP, MH, FM, NF, MP, PW, SD, SY, UM, VI`.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum UpdatePaymentLinkShippingAddressCollectionAllowedCountries {
     Ac,
@@ -3896,10 +3896,10 @@ pub enum UpdatePaymentLinkShippingAddressCollectionAllowedCountries {
     Zw,
     Zz,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl UpdatePaymentLinkShippingAddressCollectionAllowedCountries {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use UpdatePaymentLinkShippingAddressCollectionAllowedCountries::*;
         match self {
             Ac => "AC",
@@ -4139,7 +4139,7 @@ impl UpdatePaymentLinkShippingAddressCollectionAllowedCountries {
             Zm => "ZM",
             Zw => "ZW",
             Zz => "ZZ",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -4386,7 +4386,7 @@ impl std::str::FromStr for UpdatePaymentLinkShippingAddressCollectionAllowedCoun
             "ZM" => Ok(Zm),
             "ZW" => Ok(Zw),
             "ZZ" => Ok(Zz),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-payment/src/payment_method/requests.rs
+++ b/generated/async-stripe-payment/src/payment_method/requests.rs
@@ -33,7 +33,7 @@ impl ListPaymentMethodBuilder {
 /// An optional filter on the list, based on the object `type` field.
 /// Without the filter, the list includes all current and future payment method types.
 /// If your integration expects only one type of payment method in the response, make sure to provide a type value in the request.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum ListPaymentMethodType {
     AcssDebit,
@@ -72,10 +72,10 @@ pub enum ListPaymentMethodType {
     WechatPay,
     Zip,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl ListPaymentMethodType {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use ListPaymentMethodType::*;
         match self {
             AcssDebit => "acss_debit",
@@ -113,7 +113,7 @@ impl ListPaymentMethodType {
             UsBankAccount => "us_bank_account",
             WechatPay => "wechat_pay",
             Zip => "zip",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -158,7 +158,7 @@ impl std::str::FromStr for ListPaymentMethodType {
             "us_bank_account" => Ok(UsBankAccount),
             "wechat_pay" => Ok(WechatPay),
             "zip" => Ok(Zip),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -765,7 +765,7 @@ impl CreatePaymentMethodTokenParams {
     }
 }
 /// If this is an `eps` PaymentMethod, this hash contains details about the EPS payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, serde::Serialize)]
 pub struct CreatePaymentMethodEps {
     /// The customer's bank.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -782,7 +782,7 @@ impl Default for CreatePaymentMethodEps {
     }
 }
 /// The customer's bank.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CreatePaymentMethodEpsBank {
     ArzteUndApothekerBank,
@@ -814,10 +814,10 @@ pub enum CreatePaymentMethodEpsBank {
     VolkskreditbankAg,
     VrBankBraunau,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl CreatePaymentMethodEpsBank {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use CreatePaymentMethodEpsBank::*;
         match self {
             ArzteUndApothekerBank => "arzte_und_apotheker_bank",
@@ -848,7 +848,7 @@ impl CreatePaymentMethodEpsBank {
             VolksbankGruppe => "volksbank_gruppe",
             VolkskreditbankAg => "volkskreditbank_ag",
             VrBankBraunau => "vr_bank_braunau",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -886,7 +886,7 @@ impl std::str::FromStr for CreatePaymentMethodEpsBank {
             "volksbank_gruppe" => Ok(VolksbankGruppe),
             "volkskreditbank_ag" => Ok(VolkskreditbankAg),
             "vr_bank_braunau" => Ok(VrBankBraunau),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -918,7 +918,7 @@ impl<'de> serde::Deserialize<'de> for CreatePaymentMethodEpsBank {
     }
 }
 /// If this is an `fpx` PaymentMethod, this hash contains details about the FPX payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, serde::Serialize)]
 pub struct CreatePaymentMethodFpx {
     /// Account holder type for FPX transaction
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -988,7 +988,7 @@ impl<'de> serde::Deserialize<'de> for CreatePaymentMethodFpxAccountHolderType {
     }
 }
 /// The customer's bank.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CreatePaymentMethodFpxBank {
     AffinBank,
@@ -1014,10 +1014,10 @@ pub enum CreatePaymentMethodFpxBank {
     StandardChartered,
     Uob,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl CreatePaymentMethodFpxBank {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use CreatePaymentMethodFpxBank::*;
         match self {
             AffinBank => "affin_bank",
@@ -1042,7 +1042,7 @@ impl CreatePaymentMethodFpxBank {
             Rhb => "rhb",
             StandardChartered => "standard_chartered",
             Uob => "uob",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -1074,7 +1074,7 @@ impl std::str::FromStr for CreatePaymentMethodFpxBank {
             "rhb" => Ok(Rhb),
             "standard_chartered" => Ok(StandardChartered),
             "uob" => Ok(Uob),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -1106,7 +1106,7 @@ impl<'de> serde::Deserialize<'de> for CreatePaymentMethodFpxBank {
     }
 }
 /// If this is an `ideal` PaymentMethod, this hash contains details about the iDEAL payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, serde::Serialize)]
 pub struct CreatePaymentMethodIdeal {
     /// The customer's bank.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1123,7 +1123,7 @@ impl Default for CreatePaymentMethodIdeal {
     }
 }
 /// The customer's bank.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CreatePaymentMethodIdealBank {
     AbnAmro,
@@ -1143,10 +1143,10 @@ pub enum CreatePaymentMethodIdealBank {
     VanLanschot,
     Yoursafe,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl CreatePaymentMethodIdealBank {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use CreatePaymentMethodIdealBank::*;
         match self {
             AbnAmro => "abn_amro",
@@ -1165,7 +1165,7 @@ impl CreatePaymentMethodIdealBank {
             TriodosBank => "triodos_bank",
             VanLanschot => "van_lanschot",
             Yoursafe => "yoursafe",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -1191,7 +1191,7 @@ impl std::str::FromStr for CreatePaymentMethodIdealBank {
             "triodos_bank" => Ok(TriodosBank),
             "van_lanschot" => Ok(VanLanschot),
             "yoursafe" => Ok(Yoursafe),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -1255,7 +1255,7 @@ impl CreatePaymentMethodKlarnaDob {
     }
 }
 /// If this is a `p24` PaymentMethod, this hash contains details about the P24 payment method.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, serde::Serialize)]
 pub struct CreatePaymentMethodP24 {
     /// The customer's bank.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1272,7 +1272,7 @@ impl Default for CreatePaymentMethodP24 {
     }
 }
 /// The customer's bank.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CreatePaymentMethodP24Bank {
     AliorBank,
@@ -1302,10 +1302,10 @@ pub enum CreatePaymentMethodP24Bank {
     Velobank,
     VolkswagenBank,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl CreatePaymentMethodP24Bank {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use CreatePaymentMethodP24Bank::*;
         match self {
             AliorBank => "alior_bank",
@@ -1334,7 +1334,7 @@ impl CreatePaymentMethodP24Bank {
             ToyotaBank => "toyota_bank",
             Velobank => "velobank",
             VolkswagenBank => "volkswagen_bank",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -1370,7 +1370,7 @@ impl std::str::FromStr for CreatePaymentMethodP24Bank {
             "toyota_bank" => Ok(ToyotaBank),
             "velobank" => Ok(Velobank),
             "volkswagen_bank" => Ok(VolkswagenBank),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -1512,7 +1512,7 @@ impl<'de> serde::Deserialize<'de> for CreatePaymentMethodSofortCountry {
 /// The type of the PaymentMethod.
 /// An additional hash is included on the PaymentMethod with a name matching this value.
 /// It contains additional information specific to the PaymentMethod type.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CreatePaymentMethodType {
     AcssDebit,
@@ -1551,10 +1551,10 @@ pub enum CreatePaymentMethodType {
     WechatPay,
     Zip,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl CreatePaymentMethodType {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use CreatePaymentMethodType::*;
         match self {
             AcssDebit => "acss_debit",
@@ -1592,7 +1592,7 @@ impl CreatePaymentMethodType {
             UsBankAccount => "us_bank_account",
             WechatPay => "wechat_pay",
             Zip => "zip",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -1637,7 +1637,7 @@ impl std::str::FromStr for CreatePaymentMethodType {
             "us_bank_account" => Ok(UsBankAccount),
             "wechat_pay" => Ok(WechatPay),
             "zip" => Ok(Zip),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-shared/src/account_requirements_error.rs
+++ b/generated/async-stripe-shared/src/account_requirements_error.rs
@@ -74,7 +74,7 @@ const _: () = {
 
         fn take_out(&mut self) -> Option<Self::Out> {
             let (Some(code), Some(reason), Some(requirement)) =
-                (self.code, self.reason.take(), self.requirement.take())
+                (self.code.take(), self.reason.take(), self.requirement.take())
             else {
                 return None;
             };
@@ -117,7 +117,7 @@ const _: () = {
     }
 };
 /// The code for the type of error.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum AccountRequirementsErrorCode {
     InvalidAddressCityStatePostalCode,
@@ -209,10 +209,10 @@ pub enum AccountRequirementsErrorCode {
     VerificationMissingOwners,
     VerificationRequiresAdditionalMemorandumOfAssociations,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl AccountRequirementsErrorCode {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use AccountRequirementsErrorCode::*;
         match self {
             InvalidAddressCityStatePostalCode => "invalid_address_city_state_postal_code",
@@ -337,7 +337,7 @@ impl AccountRequirementsErrorCode {
             VerificationRequiresAdditionalMemorandumOfAssociations => {
                 "verification_requires_additional_memorandum_of_associations"
             }
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -471,7 +471,7 @@ impl std::str::FromStr for AccountRequirementsErrorCode {
             "verification_requires_additional_memorandum_of_associations" => {
                 Ok(VerificationRequiresAdditionalMemorandumOfAssociations)
             }
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-shared/src/api_errors.rs
+++ b/generated/async-stripe-shared/src/api_errors.rs
@@ -137,7 +137,7 @@ const _: () = {
                 Some(type_),
             ) = (
                 self.charge.take(),
-                self.code,
+                self.code.take(),
                 self.decline_code.take(),
                 self.doc_url.take(),
                 self.message.take(),
@@ -216,7 +216,7 @@ const _: () = {
     }
 };
 /// For some errors that could be handled programmatically, a short string indicating the [error code](https://stripe.com/docs/error-codes) reported.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum ApiErrorsCode {
     AccountClosed,
@@ -392,10 +392,10 @@ pub enum ApiErrorsCode {
     TransfersNotAllowed,
     UrlInvalid,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl ApiErrorsCode {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use ApiErrorsCode::*;
         match self {
             AccountClosed => "account_closed",
@@ -596,7 +596,7 @@ impl ApiErrorsCode {
             }
             TransfersNotAllowed => "transfers_not_allowed",
             UrlInvalid => "url_invalid",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -812,7 +812,7 @@ impl std::str::FromStr for ApiErrorsCode {
             }
             "transfers_not_allowed" => Ok(TransfersNotAllowed),
             "url_invalid" => Ok(UrlInvalid),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-shared/src/api_version.rs
+++ b/generated/async-stripe-shared/src/api_version.rs
@@ -1,4 +1,4 @@
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum ApiVersion {
     V2011_01_01,
@@ -103,10 +103,10 @@ pub enum ApiVersion {
     V2023_10_16,
     V2024_04_10,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl ApiVersion {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use ApiVersion::*;
         match self {
             V2011_01_01 => "2011-01-01",
@@ -210,7 +210,7 @@ impl ApiVersion {
             V2023_08_16 => "2023-08-16",
             V2023_10_16 => "2023-10-16",
             V2024_04_10 => "2024-04-10",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -321,7 +321,7 @@ impl std::str::FromStr for ApiVersion {
             "2023-08-16" => Ok(V2023_08_16),
             "2023-10-16" => Ok(V2023_10_16),
             "2024-04-10" => Ok(V2024_04_10),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-shared/src/balance_transaction.rs
+++ b/generated/async-stripe-shared/src/balance_transaction.rs
@@ -173,7 +173,7 @@ const _: () = {
                 self.reporting_category.take(),
                 self.source.take(),
                 self.status.take(),
-                self.type_,
+                self.type_.take(),
             )
             else {
                 return None;
@@ -269,7 +269,7 @@ impl serde::Serialize for BalanceTransaction {
 /// Transaction type: `adjustment`, `advance`, `advance_funding`, `anticipation_repayment`, `application_fee`, `application_fee_refund`, `charge`, `climate_order_purchase`, `climate_order_refund`, `connect_collection_transfer`, `contribution`, `issuing_authorization_hold`, `issuing_authorization_release`, `issuing_dispute`, `issuing_transaction`, `obligation_outbound`, `obligation_reversal_inbound`, `payment`, `payment_failure_refund`, `payment_network_reserve_hold`, `payment_network_reserve_release`, `payment_refund`, `payment_reversal`, `payment_unreconciled`, `payout`, `payout_cancel`, `payout_failure`, `refund`, `refund_failure`, `reserve_transaction`, `reserved_funds`, `stripe_fee`, `stripe_fx_fee`, `tax_fee`, `topup`, `topup_reversal`, `transfer`, `transfer_cancel`, `transfer_failure`, or `transfer_refund`.
 /// Learn more about [balance transaction types and what they represent](https://stripe.com/docs/reports/balance-transaction-types).
 /// To classify transactions for accounting purposes, consider `reporting_category` instead.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum BalanceTransactionType {
     Adjustment,
@@ -313,10 +313,10 @@ pub enum BalanceTransactionType {
     TransferFailure,
     TransferRefund,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl BalanceTransactionType {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use BalanceTransactionType::*;
         match self {
             Adjustment => "adjustment",
@@ -359,7 +359,7 @@ impl BalanceTransactionType {
             TransferCancel => "transfer_cancel",
             TransferFailure => "transfer_failure",
             TransferRefund => "transfer_refund",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -409,7 +409,7 @@ impl std::str::FromStr for BalanceTransactionType {
             "transfer_cancel" => Ok(TransferCancel),
             "transfer_failure" => Ok(TransferFailure),
             "transfer_refund" => Ok(TransferRefund),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-shared/src/credit_note_tax_amount.rs
+++ b/generated/async-stripe-shared/src/credit_note_tax_amount.rs
@@ -94,7 +94,7 @@ const _: () = {
                 self.amount,
                 self.inclusive,
                 self.tax_rate.take(),
-                self.taxability_reason,
+                self.taxability_reason.take(),
                 self.taxable_amount,
             )
             else {
@@ -142,7 +142,7 @@ const _: () = {
 };
 /// The reasoning behind this tax, for example, if the product is tax exempt.
 /// The possible values for this field may be extended as new tax rules are supported.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum CreditNoteTaxAmountTaxabilityReason {
     CustomerExempt,
@@ -161,10 +161,10 @@ pub enum CreditNoteTaxAmountTaxabilityReason {
     TaxableBasisReduced,
     ZeroRated,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl CreditNoteTaxAmountTaxabilityReason {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use CreditNoteTaxAmountTaxabilityReason::*;
         match self {
             CustomerExempt => "customer_exempt",
@@ -182,7 +182,7 @@ impl CreditNoteTaxAmountTaxabilityReason {
             StandardRated => "standard_rated",
             TaxableBasisReduced => "taxable_basis_reduced",
             ZeroRated => "zero_rated",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -207,7 +207,7 @@ impl std::str::FromStr for CreditNoteTaxAmountTaxabilityReason {
             "standard_rated" => Ok(StandardRated),
             "taxable_basis_reduced" => Ok(TaxableBasisReduced),
             "zero_rated" => Ok(ZeroRated),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-shared/src/event.rs
+++ b/generated/async-stripe-shared/src/event.rs
@@ -151,7 +151,7 @@ const _: () = {
                 self.livemode,
                 self.pending_webhooks,
                 self.request.take(),
-                self.type_,
+                self.type_.take(),
             )
             else {
                 return None;
@@ -230,7 +230,7 @@ impl serde::Serialize for Event {
     }
 }
 /// Description of the event (for example, `invoice.created` or `charge.refunded`).
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum EventType {
     AccountApplicationAuthorized,
@@ -461,10 +461,10 @@ pub enum EventType {
     TreasuryReceivedCreditSucceeded,
     TreasuryReceivedDebitCreated,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl EventType {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use EventType::*;
         match self {
             AccountApplicationAuthorized => "account.application.authorized",
@@ -716,7 +716,7 @@ impl EventType {
             TreasuryReceivedCreditFailed => "treasury.received_credit.failed",
             TreasuryReceivedCreditSucceeded => "treasury.received_credit.succeeded",
             TreasuryReceivedDebitCreated => "treasury.received_debit.created",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -983,7 +983,7 @@ impl std::str::FromStr for EventType {
             "treasury.received_credit.failed" => Ok(TreasuryReceivedCreditFailed),
             "treasury.received_credit.succeeded" => Ok(TreasuryReceivedCreditSucceeded),
             "treasury.received_debit.created" => Ok(TreasuryReceivedDebitCreated),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-shared/src/file.rs
+++ b/generated/async-stripe-shared/src/file.rs
@@ -131,7 +131,7 @@ const _: () = {
                 self.filename.take(),
                 self.id.take(),
                 self.links.take(),
-                self.purpose,
+                self.purpose.take(),
                 self.size,
                 self.title.take(),
                 self.type_.take(),
@@ -227,7 +227,7 @@ impl stripe_types::Object for File {
     }
 }
 stripe_types::def_id!(FileId);
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum FilePurpose {
     AccountRequirement,
@@ -246,10 +246,10 @@ pub enum FilePurpose {
     TaxDocumentUserUpload,
     TerminalReaderSplashscreen,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl FilePurpose {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use FilePurpose::*;
         match self {
             AccountRequirement => "account_requirement",
@@ -267,7 +267,7 @@ impl FilePurpose {
             SigmaScheduledQuery => "sigma_scheduled_query",
             TaxDocumentUserUpload => "tax_document_user_upload",
             TerminalReaderSplashscreen => "terminal_reader_splashscreen",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -292,7 +292,7 @@ impl std::str::FromStr for FilePurpose {
             "sigma_scheduled_query" => Ok(SigmaScheduledQuery),
             "tax_document_user_upload" => Ok(TaxDocumentUserUpload),
             "terminal_reader_splashscreen" => Ok(TerminalReaderSplashscreen),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-shared/src/invoice_tax_amount.rs
+++ b/generated/async-stripe-shared/src/invoice_tax_amount.rs
@@ -94,7 +94,7 @@ const _: () = {
                 self.amount,
                 self.inclusive,
                 self.tax_rate.take(),
-                self.taxability_reason,
+                self.taxability_reason.take(),
                 self.taxable_amount,
             )
             else {
@@ -142,7 +142,7 @@ const _: () = {
 };
 /// The reasoning behind this tax, for example, if the product is tax exempt.
 /// The possible values for this field may be extended as new tax rules are supported.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum InvoiceTaxAmountTaxabilityReason {
     CustomerExempt,
@@ -161,10 +161,10 @@ pub enum InvoiceTaxAmountTaxabilityReason {
     TaxableBasisReduced,
     ZeroRated,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl InvoiceTaxAmountTaxabilityReason {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use InvoiceTaxAmountTaxabilityReason::*;
         match self {
             CustomerExempt => "customer_exempt",
@@ -182,7 +182,7 @@ impl InvoiceTaxAmountTaxabilityReason {
             StandardRated => "standard_rated",
             TaxableBasisReduced => "taxable_basis_reduced",
             ZeroRated => "zero_rated",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -207,7 +207,7 @@ impl std::str::FromStr for InvoiceTaxAmountTaxabilityReason {
             "standard_rated" => Ok(StandardRated),
             "taxable_basis_reduced" => Ok(TaxableBasisReduced),
             "zero_rated" => Ok(ZeroRated),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-shared/src/invoices_payment_settings.rs
+++ b/generated/async-stripe-shared/src/invoices_payment_settings.rs
@@ -126,7 +126,7 @@ const _: () = {
 /// The list of payment method types (e.g.
 /// card) to provide to the invoice’s PaymentIntent.
 /// If not set, Stripe attempts to automatically determine the types to use by looking at the invoice’s default payment method, the subscription’s default payment method, the customer’s default payment method, and your [invoice template settings](https://dashboard.stripe.com/settings/billing/invoice).
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum InvoicesPaymentSettingsPaymentMethodTypes {
     AchCreditTransfer,
@@ -158,10 +158,10 @@ pub enum InvoicesPaymentSettingsPaymentMethodTypes {
     UsBankAccount,
     WechatPay,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl InvoicesPaymentSettingsPaymentMethodTypes {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use InvoicesPaymentSettingsPaymentMethodTypes::*;
         match self {
             AchCreditTransfer => "ach_credit_transfer",
@@ -192,7 +192,7 @@ impl InvoicesPaymentSettingsPaymentMethodTypes {
             Sofort => "sofort",
             UsBankAccount => "us_bank_account",
             WechatPay => "wechat_pay",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -230,7 +230,7 @@ impl std::str::FromStr for InvoicesPaymentSettingsPaymentMethodTypes {
             "sofort" => Ok(Sofort),
             "us_bank_account" => Ok(UsBankAccount),
             "wechat_pay" => Ok(WechatPay),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-shared/src/issuing_authorization_request.rs
+++ b/generated/async-stripe-shared/src/issuing_authorization_request.rs
@@ -152,7 +152,7 @@ const _: () = {
                 self.merchant_amount,
                 self.merchant_currency,
                 self.network_risk_score,
-                self.reason,
+                self.reason.take(),
                 self.reason_message.take(),
                 self.requested_at,
             )
@@ -220,7 +220,7 @@ const _: () = {
     }
 };
 /// When an authorization is approved or declined by you or by Stripe, this field provides additional detail on the reason for the outcome.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum IssuingAuthorizationRequestReason {
     AccountDisabled,
@@ -238,10 +238,10 @@ pub enum IssuingAuthorizationRequestReason {
     WebhookError,
     WebhookTimeout,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl IssuingAuthorizationRequestReason {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use IssuingAuthorizationRequestReason::*;
         match self {
             AccountDisabled => "account_disabled",
@@ -258,7 +258,7 @@ impl IssuingAuthorizationRequestReason {
             WebhookDeclined => "webhook_declined",
             WebhookError => "webhook_error",
             WebhookTimeout => "webhook_timeout",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -282,7 +282,7 @@ impl std::str::FromStr for IssuingAuthorizationRequestReason {
             "webhook_declined" => Ok(WebhookDeclined),
             "webhook_error" => Ok(WebhookError),
             "webhook_timeout" => Ok(WebhookTimeout),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-shared/src/issuing_card_authorization_controls.rs
+++ b/generated/async-stripe-shared/src/issuing_card_authorization_controls.rs
@@ -182,7 +182,7 @@ const _: () = {
 /// Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to allow.
 /// All other categories will be blocked.
 /// Cannot be set with `blocked_categories`.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum IssuingCardAuthorizationControlsAllowedCategories {
     AcRefrigerationRepair,
@@ -481,10 +481,10 @@ pub enum IssuingCardAuthorizationControlsAllowedCategories {
     WomensReadyToWearStores,
     WreckingAndSalvageYards,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl IssuingCardAuthorizationControlsAllowedCategories {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use IssuingCardAuthorizationControlsAllowedCategories::*;
         match self {
             AcRefrigerationRepair => "ac_refrigeration_repair",
@@ -826,7 +826,7 @@ impl IssuingCardAuthorizationControlsAllowedCategories {
             WomensAccessoryAndSpecialtyShops => "womens_accessory_and_specialty_shops",
             WomensReadyToWearStores => "womens_ready_to_wear_stores",
             WreckingAndSalvageYards => "wrecking_and_salvage_yards",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -1179,7 +1179,7 @@ impl std::str::FromStr for IssuingCardAuthorizationControlsAllowedCategories {
             "womens_accessory_and_specialty_shops" => Ok(WomensAccessoryAndSpecialtyShops),
             "womens_ready_to_wear_stores" => Ok(WomensReadyToWearStores),
             "wrecking_and_salvage_yards" => Ok(WreckingAndSalvageYards),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -1229,7 +1229,7 @@ impl<'de> serde::Deserialize<'de> for IssuingCardAuthorizationControlsAllowedCat
 /// Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to decline.
 /// All other categories will be allowed.
 /// Cannot be set with `allowed_categories`.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum IssuingCardAuthorizationControlsBlockedCategories {
     AcRefrigerationRepair,
@@ -1528,10 +1528,10 @@ pub enum IssuingCardAuthorizationControlsBlockedCategories {
     WomensReadyToWearStores,
     WreckingAndSalvageYards,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl IssuingCardAuthorizationControlsBlockedCategories {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use IssuingCardAuthorizationControlsBlockedCategories::*;
         match self {
             AcRefrigerationRepair => "ac_refrigeration_repair",
@@ -1873,7 +1873,7 @@ impl IssuingCardAuthorizationControlsBlockedCategories {
             WomensAccessoryAndSpecialtyShops => "womens_accessory_and_specialty_shops",
             WomensReadyToWearStores => "womens_ready_to_wear_stores",
             WreckingAndSalvageYards => "wrecking_and_salvage_yards",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -2226,7 +2226,7 @@ impl std::str::FromStr for IssuingCardAuthorizationControlsBlockedCategories {
             "womens_accessory_and_specialty_shops" => Ok(WomensAccessoryAndSpecialtyShops),
             "womens_ready_to_wear_stores" => Ok(WomensReadyToWearStores),
             "wrecking_and_salvage_yards" => Ok(WreckingAndSalvageYards),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-shared/src/issuing_card_spending_limit.rs
+++ b/generated/async-stripe-shared/src/issuing_card_spending_limit.rs
@@ -120,7 +120,7 @@ const _: () = {
 };
 /// Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) this limit applies to.
 /// Omitting this field will apply the limit to all categories.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum IssuingCardSpendingLimitCategories {
     AcRefrigerationRepair,
@@ -419,10 +419,10 @@ pub enum IssuingCardSpendingLimitCategories {
     WomensReadyToWearStores,
     WreckingAndSalvageYards,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl IssuingCardSpendingLimitCategories {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use IssuingCardSpendingLimitCategories::*;
         match self {
             AcRefrigerationRepair => "ac_refrigeration_repair",
@@ -764,7 +764,7 @@ impl IssuingCardSpendingLimitCategories {
             WomensAccessoryAndSpecialtyShops => "womens_accessory_and_specialty_shops",
             WomensReadyToWearStores => "womens_ready_to_wear_stores",
             WreckingAndSalvageYards => "wrecking_and_salvage_yards",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -1117,7 +1117,7 @@ impl std::str::FromStr for IssuingCardSpendingLimitCategories {
             "womens_accessory_and_specialty_shops" => Ok(WomensAccessoryAndSpecialtyShops),
             "womens_ready_to_wear_stores" => Ok(WomensReadyToWearStores),
             "wrecking_and_salvage_yards" => Ok(WreckingAndSalvageYards),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-shared/src/issuing_cardholder_authorization_controls.rs
+++ b/generated/async-stripe-shared/src/issuing_cardholder_authorization_controls.rs
@@ -184,7 +184,7 @@ const _: () = {
 /// Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to allow.
 /// All other categories will be blocked.
 /// Cannot be set with `blocked_categories`.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum IssuingCardholderAuthorizationControlsAllowedCategories {
     AcRefrigerationRepair,
@@ -483,10 +483,10 @@ pub enum IssuingCardholderAuthorizationControlsAllowedCategories {
     WomensReadyToWearStores,
     WreckingAndSalvageYards,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl IssuingCardholderAuthorizationControlsAllowedCategories {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use IssuingCardholderAuthorizationControlsAllowedCategories::*;
         match self {
             AcRefrigerationRepair => "ac_refrigeration_repair",
@@ -828,7 +828,7 @@ impl IssuingCardholderAuthorizationControlsAllowedCategories {
             WomensAccessoryAndSpecialtyShops => "womens_accessory_and_specialty_shops",
             WomensReadyToWearStores => "womens_ready_to_wear_stores",
             WreckingAndSalvageYards => "wrecking_and_salvage_yards",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -1181,7 +1181,7 @@ impl std::str::FromStr for IssuingCardholderAuthorizationControlsAllowedCategori
             "womens_accessory_and_specialty_shops" => Ok(WomensAccessoryAndSpecialtyShops),
             "womens_ready_to_wear_stores" => Ok(WomensReadyToWearStores),
             "wrecking_and_salvage_yards" => Ok(WreckingAndSalvageYards),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -1234,7 +1234,7 @@ impl<'de> serde::Deserialize<'de> for IssuingCardholderAuthorizationControlsAllo
 /// Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to decline.
 /// All other categories will be allowed.
 /// Cannot be set with `allowed_categories`.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum IssuingCardholderAuthorizationControlsBlockedCategories {
     AcRefrigerationRepair,
@@ -1533,10 +1533,10 @@ pub enum IssuingCardholderAuthorizationControlsBlockedCategories {
     WomensReadyToWearStores,
     WreckingAndSalvageYards,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl IssuingCardholderAuthorizationControlsBlockedCategories {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use IssuingCardholderAuthorizationControlsBlockedCategories::*;
         match self {
             AcRefrigerationRepair => "ac_refrigeration_repair",
@@ -1878,7 +1878,7 @@ impl IssuingCardholderAuthorizationControlsBlockedCategories {
             WomensAccessoryAndSpecialtyShops => "womens_accessory_and_specialty_shops",
             WomensReadyToWearStores => "womens_ready_to_wear_stores",
             WreckingAndSalvageYards => "wrecking_and_salvage_yards",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -2231,7 +2231,7 @@ impl std::str::FromStr for IssuingCardholderAuthorizationControlsBlockedCategori
             "womens_accessory_and_specialty_shops" => Ok(WomensAccessoryAndSpecialtyShops),
             "womens_ready_to_wear_stores" => Ok(WomensReadyToWearStores),
             "wrecking_and_salvage_yards" => Ok(WreckingAndSalvageYards),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-shared/src/issuing_cardholder_spending_limit.rs
+++ b/generated/async-stripe-shared/src/issuing_cardholder_spending_limit.rs
@@ -120,7 +120,7 @@ const _: () = {
 };
 /// Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) this limit applies to.
 /// Omitting this field will apply the limit to all categories.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum IssuingCardholderSpendingLimitCategories {
     AcRefrigerationRepair,
@@ -419,10 +419,10 @@ pub enum IssuingCardholderSpendingLimitCategories {
     WomensReadyToWearStores,
     WreckingAndSalvageYards,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl IssuingCardholderSpendingLimitCategories {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use IssuingCardholderSpendingLimitCategories::*;
         match self {
             AcRefrigerationRepair => "ac_refrigeration_repair",
@@ -764,7 +764,7 @@ impl IssuingCardholderSpendingLimitCategories {
             WomensAccessoryAndSpecialtyShops => "womens_accessory_and_specialty_shops",
             WomensReadyToWearStores => "womens_ready_to_wear_stores",
             WreckingAndSalvageYards => "wrecking_and_salvage_yards",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -1117,7 +1117,7 @@ impl std::str::FromStr for IssuingCardholderSpendingLimitCategories {
             "womens_accessory_and_specialty_shops" => Ok(WomensAccessoryAndSpecialtyShops),
             "womens_ready_to_wear_stores" => Ok(WomensReadyToWearStores),
             "wrecking_and_salvage_yards" => Ok(WreckingAndSalvageYards),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-shared/src/issuing_network_token_wallet_provider.rs
+++ b/generated/async-stripe-shared/src/issuing_network_token_wallet_provider.rs
@@ -282,7 +282,7 @@ impl<'de> serde::Deserialize<'de> for IssuingNetworkTokenWalletProviderCardNumbe
     }
 }
 /// The reasons for suggested tokenization given by the card network.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum IssuingNetworkTokenWalletProviderReasonCodes {
     AccountCardTooNew,
@@ -314,10 +314,10 @@ pub enum IssuingNetworkTokenWalletProviderReasonCodes {
     TooManyRecentAttempts,
     TooManyRecentTokens,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl IssuingNetworkTokenWalletProviderReasonCodes {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use IssuingNetworkTokenWalletProviderReasonCodes::*;
         match self {
             AccountCardTooNew => "account_card_too_new",
@@ -352,7 +352,7 @@ impl IssuingNetworkTokenWalletProviderReasonCodes {
             TooManyDifferentCardholders => "too_many_different_cardholders",
             TooManyRecentAttempts => "too_many_recent_attempts",
             TooManyRecentTokens => "too_many_recent_tokens",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -394,7 +394,7 @@ impl std::str::FromStr for IssuingNetworkTokenWalletProviderReasonCodes {
             "too_many_different_cardholders" => Ok(TooManyDifferentCardholders),
             "too_many_recent_attempts" => Ok(TooManyRecentAttempts),
             "too_many_recent_tokens" => Ok(TooManyRecentTokens),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-shared/src/legal_entity_company.rs
+++ b/generated/async-stripe-shared/src/legal_entity_company.rs
@@ -185,7 +185,7 @@ const _: () = {
                 self.owners_provided,
                 self.ownership_declaration.take(),
                 self.phone.take(),
-                self.structure,
+                self.structure.take(),
                 self.tax_id_provided,
                 self.tax_id_registrar.take(),
                 self.vat_id_provided,
@@ -270,7 +270,7 @@ const _: () = {
 };
 /// The category identifying the legal structure of the company or legal entity.
 /// See [Business structure](https://stripe.com/docs/connect/identity-verification#business-structure) for more details.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum LegalEntityCompanyStructure {
     FreeZoneEstablishment,
@@ -297,10 +297,10 @@ pub enum LegalEntityCompanyStructure {
     UnincorporatedNonProfit,
     UnincorporatedPartnership,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl LegalEntityCompanyStructure {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use LegalEntityCompanyStructure::*;
         match self {
             FreeZoneEstablishment => "free_zone_establishment",
@@ -326,7 +326,7 @@ impl LegalEntityCompanyStructure {
             UnincorporatedAssociation => "unincorporated_association",
             UnincorporatedNonProfit => "unincorporated_non_profit",
             UnincorporatedPartnership => "unincorporated_partnership",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -359,7 +359,7 @@ impl std::str::FromStr for LegalEntityCompanyStructure {
             "unincorporated_association" => Ok(UnincorporatedAssociation),
             "unincorporated_non_profit" => Ok(UnincorporatedNonProfit),
             "unincorporated_partnership" => Ok(UnincorporatedPartnership),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-shared/src/line_items_tax_amount.rs
+++ b/generated/async-stripe-shared/src/line_items_tax_amount.rs
@@ -79,7 +79,7 @@ const _: () = {
 
         fn take_out(&mut self) -> Option<Self::Out> {
             let (Some(amount), Some(rate), Some(taxability_reason), Some(taxable_amount)) =
-                (self.amount, self.rate.take(), self.taxability_reason, self.taxable_amount)
+                (self.amount, self.rate.take(), self.taxability_reason.take(), self.taxable_amount)
             else {
                 return None;
             };
@@ -124,7 +124,7 @@ const _: () = {
 };
 /// The reasoning behind this tax, for example, if the product is tax exempt.
 /// The possible values for this field may be extended as new tax rules are supported.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum LineItemsTaxAmountTaxabilityReason {
     CustomerExempt,
@@ -143,10 +143,10 @@ pub enum LineItemsTaxAmountTaxabilityReason {
     TaxableBasisReduced,
     ZeroRated,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl LineItemsTaxAmountTaxabilityReason {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use LineItemsTaxAmountTaxabilityReason::*;
         match self {
             CustomerExempt => "customer_exempt",
@@ -164,7 +164,7 @@ impl LineItemsTaxAmountTaxabilityReason {
             StandardRated => "standard_rated",
             TaxableBasisReduced => "taxable_basis_reduced",
             ZeroRated => "zero_rated",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -189,7 +189,7 @@ impl std::str::FromStr for LineItemsTaxAmountTaxabilityReason {
             "standard_rated" => Ok(StandardRated),
             "taxable_basis_reduced" => Ok(TaxableBasisReduced),
             "zero_rated" => Ok(ZeroRated),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-shared/src/payment_link.rs
+++ b/generated/async-stripe-shared/src/payment_link.rs
@@ -688,7 +688,7 @@ impl<'de> serde::Deserialize<'de> for PaymentLinkBillingAddressCollection {
         })
     }
 }
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum PaymentLinkPaymentMethodTypes {
     Affirm,
@@ -721,10 +721,10 @@ pub enum PaymentLinkPaymentMethodTypes {
     UsBankAccount,
     WechatPay,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl PaymentLinkPaymentMethodTypes {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use PaymentLinkPaymentMethodTypes::*;
         match self {
             Affirm => "affirm",
@@ -756,7 +756,7 @@ impl PaymentLinkPaymentMethodTypes {
             Swish => "swish",
             UsBankAccount => "us_bank_account",
             WechatPay => "wechat_pay",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -795,7 +795,7 @@ impl std::str::FromStr for PaymentLinkPaymentMethodTypes {
             "swish" => Ok(Swish),
             "us_bank_account" => Ok(UsBankAccount),
             "wechat_pay" => Ok(WechatPay),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-shared/src/payment_links_resource_shipping_address_collection.rs
+++ b/generated/async-stripe-shared/src/payment_links_resource_shipping_address_collection.rs
@@ -103,7 +103,7 @@ const _: () = {
 };
 /// An array of two-letter ISO country codes representing which countries Checkout should provide as options for shipping locations.
 /// Unsupported country codes: `AS, CX, CC, CU, HM, IR, KP, MH, FM, NF, MP, PW, SD, SY, UM, VI`.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum PaymentLinksResourceShippingAddressCollectionAllowedCountries {
     Ac,
@@ -344,10 +344,10 @@ pub enum PaymentLinksResourceShippingAddressCollectionAllowedCountries {
     Zw,
     Zz,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl PaymentLinksResourceShippingAddressCollectionAllowedCountries {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use PaymentLinksResourceShippingAddressCollectionAllowedCountries::*;
         match self {
             Ac => "AC",
@@ -587,7 +587,7 @@ impl PaymentLinksResourceShippingAddressCollectionAllowedCountries {
             Zm => "ZM",
             Zw => "ZW",
             Zz => "ZZ",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -834,7 +834,7 @@ impl std::str::FromStr for PaymentLinksResourceShippingAddressCollectionAllowedC
             "ZM" => Ok(Zm),
             "ZW" => Ok(Zw),
             "ZZ" => Ok(Zz),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-shared/src/payment_method.rs
+++ b/generated/async-stripe-shared/src/payment_method.rs
@@ -319,12 +319,12 @@ const _: () = {
                 self.created,
                 self.customer.take(),
                 self.customer_balance,
-                self.eps,
-                self.fpx,
+                self.eps.take(),
+                self.fpx.take(),
                 self.giropay,
                 self.grabpay,
                 self.id.take(),
-                self.ideal,
+                self.ideal.take(),
                 self.interac_present.take(),
                 self.klarna,
                 self.konbini,
@@ -333,7 +333,7 @@ const _: () = {
                 self.metadata.take(),
                 self.mobilepay,
                 self.oxxo,
-                self.p24,
+                self.p24.take(),
                 self.paynow,
                 self.paypal.take(),
                 self.pix,
@@ -343,7 +343,7 @@ const _: () = {
                 self.sepa_debit.take(),
                 self.sofort.take(),
                 self.swish,
-                self.type_,
+                self.type_.take(),
                 self.us_bank_account.take(),
                 self.wechat_pay,
                 self.zip,
@@ -535,7 +535,7 @@ impl serde::Serialize for PaymentMethod {
 /// The type of the PaymentMethod.
 /// An additional hash is included on the PaymentMethod with a name matching this value.
 /// It contains additional information specific to the PaymentMethod type.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum PaymentMethodType {
     AcssDebit,
@@ -576,10 +576,10 @@ pub enum PaymentMethodType {
     WechatPay,
     Zip,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl PaymentMethodType {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use PaymentMethodType::*;
         match self {
             AcssDebit => "acss_debit",
@@ -619,7 +619,7 @@ impl PaymentMethodType {
             UsBankAccount => "us_bank_account",
             WechatPay => "wechat_pay",
             Zip => "zip",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -666,7 +666,7 @@ impl std::str::FromStr for PaymentMethodType {
             "us_bank_account" => Ok(UsBankAccount),
             "wechat_pay" => Ok(WechatPay),
             "zip" => Ok(Zip),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-shared/src/payment_method_details_eps.rs
+++ b/generated/async-stripe-shared/src/payment_method_details_eps.rs
@@ -68,7 +68,8 @@ const _: () = {
         }
 
         fn take_out(&mut self) -> Option<Self::Out> {
-            let (Some(bank), Some(verified_name)) = (self.bank, self.verified_name.take()) else {
+            let (Some(bank), Some(verified_name)) = (self.bank.take(), self.verified_name.take())
+            else {
                 return None;
             };
             Some(Self::Out { bank, verified_name })
@@ -110,7 +111,7 @@ const _: () = {
 };
 /// The customer's bank.
 /// Should be one of `arzte_und_apotheker_bank`, `austrian_anadi_bank_ag`, `bank_austria`, `bankhaus_carl_spangler`, `bankhaus_schelhammer_und_schattera_ag`, `bawag_psk_ag`, `bks_bank_ag`, `brull_kallmus_bank_ag`, `btv_vier_lander_bank`, `capital_bank_grawe_gruppe_ag`, `deutsche_bank_ag`, `dolomitenbank`, `easybank_ag`, `erste_bank_und_sparkassen`, `hypo_alpeadriabank_international_ag`, `hypo_noe_lb_fur_niederosterreich_u_wien`, `hypo_oberosterreich_salzburg_steiermark`, `hypo_tirol_bank_ag`, `hypo_vorarlberg_bank_ag`, `hypo_bank_burgenland_aktiengesellschaft`, `marchfelder_bank`, `oberbank_ag`, `raiffeisen_bankengruppe_osterreich`, `schoellerbank_ag`, `sparda_bank_wien`, `volksbank_gruppe`, `volkskreditbank_ag`, or `vr_bank_braunau`.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum PaymentMethodDetailsEpsBank {
     ArzteUndApothekerBank,
@@ -142,10 +143,10 @@ pub enum PaymentMethodDetailsEpsBank {
     VolkskreditbankAg,
     VrBankBraunau,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl PaymentMethodDetailsEpsBank {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use PaymentMethodDetailsEpsBank::*;
         match self {
             ArzteUndApothekerBank => "arzte_und_apotheker_bank",
@@ -176,7 +177,7 @@ impl PaymentMethodDetailsEpsBank {
             VolksbankGruppe => "volksbank_gruppe",
             VolkskreditbankAg => "volkskreditbank_ag",
             VrBankBraunau => "vr_bank_braunau",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -214,7 +215,7 @@ impl std::str::FromStr for PaymentMethodDetailsEpsBank {
             "volksbank_gruppe" => Ok(VolksbankGruppe),
             "volkskreditbank_ag" => Ok(VolkskreditbankAg),
             "vr_bank_braunau" => Ok(VrBankBraunau),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-shared/src/payment_method_details_fpx.rs
+++ b/generated/async-stripe-shared/src/payment_method_details_fpx.rs
@@ -75,7 +75,7 @@ const _: () = {
 
         fn take_out(&mut self) -> Option<Self::Out> {
             let (Some(account_holder_type), Some(bank), Some(transaction_id)) =
-                (self.account_holder_type, self.bank, self.transaction_id.take())
+                (self.account_holder_type, self.bank.take(), self.transaction_id.take())
             else {
                 return None;
             };
@@ -193,7 +193,7 @@ impl<'de> serde::Deserialize<'de> for PaymentMethodDetailsFpxAccountHolderType {
 }
 /// The customer's bank.
 /// Can be one of `affin_bank`, `agrobank`, `alliance_bank`, `ambank`, `bank_islam`, `bank_muamalat`, `bank_rakyat`, `bsn`, `cimb`, `hong_leong_bank`, `hsbc`, `kfh`, `maybank2u`, `ocbc`, `public_bank`, `rhb`, `standard_chartered`, `uob`, `deutsche_bank`, `maybank2e`, `pb_enterprise`, or `bank_of_china`.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum PaymentMethodDetailsFpxBank {
     AffinBank,
@@ -219,10 +219,10 @@ pub enum PaymentMethodDetailsFpxBank {
     StandardChartered,
     Uob,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl PaymentMethodDetailsFpxBank {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use PaymentMethodDetailsFpxBank::*;
         match self {
             AffinBank => "affin_bank",
@@ -247,7 +247,7 @@ impl PaymentMethodDetailsFpxBank {
             Rhb => "rhb",
             StandardChartered => "standard_chartered",
             Uob => "uob",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -279,7 +279,7 @@ impl std::str::FromStr for PaymentMethodDetailsFpxBank {
             "rhb" => Ok(Rhb),
             "standard_chartered" => Ok(StandardChartered),
             "uob" => Ok(Uob),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-shared/src/payment_method_details_ideal.rs
+++ b/generated/async-stripe-shared/src/payment_method_details_ideal.rs
@@ -100,8 +100,8 @@ const _: () = {
                 Some(iban_last4),
                 Some(verified_name),
             ) = (
-                self.bank,
-                self.bic,
+                self.bank.take(),
+                self.bic.take(),
                 self.generated_sepa_debit.take(),
                 self.generated_sepa_debit_mandate.take(),
                 self.iban_last4.take(),
@@ -162,7 +162,7 @@ const _: () = {
 };
 /// The customer's bank.
 /// Can be one of `abn_amro`, `asn_bank`, `bunq`, `handelsbanken`, `ing`, `knab`, `moneyou`, `n26`, `nn`, `rabobank`, `regiobank`, `revolut`, `sns_bank`, `triodos_bank`, `van_lanschot`, or `yoursafe`.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum PaymentMethodDetailsIdealBank {
     AbnAmro,
@@ -182,10 +182,10 @@ pub enum PaymentMethodDetailsIdealBank {
     VanLanschot,
     Yoursafe,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl PaymentMethodDetailsIdealBank {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use PaymentMethodDetailsIdealBank::*;
         match self {
             AbnAmro => "abn_amro",
@@ -204,7 +204,7 @@ impl PaymentMethodDetailsIdealBank {
             TriodosBank => "triodos_bank",
             VanLanschot => "van_lanschot",
             Yoursafe => "yoursafe",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -230,7 +230,7 @@ impl std::str::FromStr for PaymentMethodDetailsIdealBank {
             "triodos_bank" => Ok(TriodosBank),
             "van_lanschot" => Ok(VanLanschot),
             "yoursafe" => Ok(Yoursafe),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -278,7 +278,7 @@ impl<'de> serde::Deserialize<'de> for PaymentMethodDetailsIdealBank {
     }
 }
 /// The Bank Identifier Code of the customer's bank.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum PaymentMethodDetailsIdealBic {
     Abnanl2a,
@@ -299,10 +299,10 @@ pub enum PaymentMethodDetailsIdealBic {
     Snsbnl2a,
     Trionl2u,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl PaymentMethodDetailsIdealBic {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use PaymentMethodDetailsIdealBic::*;
         match self {
             Abnanl2a => "ABNANL2A",
@@ -322,7 +322,7 @@ impl PaymentMethodDetailsIdealBic {
             Revolt21 => "REVOLT21",
             Snsbnl2a => "SNSBNL2A",
             Trionl2u => "TRIONL2U",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -349,7 +349,7 @@ impl std::str::FromStr for PaymentMethodDetailsIdealBic {
             "REVOLT21" => Ok(Revolt21),
             "SNSBNL2A" => Ok(Snsbnl2a),
             "TRIONL2U" => Ok(Trionl2u),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-shared/src/payment_method_details_p24.rs
+++ b/generated/async-stripe-shared/src/payment_method_details_p24.rs
@@ -77,7 +77,7 @@ const _: () = {
 
         fn take_out(&mut self) -> Option<Self::Out> {
             let (Some(bank), Some(reference), Some(verified_name)) =
-                (self.bank, self.reference.take(), self.verified_name.take())
+                (self.bank.take(), self.reference.take(), self.verified_name.take())
             else {
                 return None;
             };
@@ -121,7 +121,7 @@ const _: () = {
 };
 /// The customer's bank.
 /// Can be one of `ing`, `citi_handlowy`, `tmobile_usbugi_bankowe`, `plus_bank`, `etransfer_pocztowy24`, `banki_spbdzielcze`, `bank_nowy_bfg_sa`, `getin_bank`, `velobank`, `blik`, `noble_pay`, `ideabank`, `envelobank`, `santander_przelew24`, `nest_przelew`, `mbank_mtransfer`, `inteligo`, `pbac_z_ipko`, `bnp_paribas`, `credit_agricole`, `toyota_bank`, `bank_pekao_sa`, `volkswagen_bank`, `bank_millennium`, `alior_bank`, or `boz`.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum PaymentMethodDetailsP24Bank {
     AliorBank,
@@ -151,10 +151,10 @@ pub enum PaymentMethodDetailsP24Bank {
     Velobank,
     VolkswagenBank,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl PaymentMethodDetailsP24Bank {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use PaymentMethodDetailsP24Bank::*;
         match self {
             AliorBank => "alior_bank",
@@ -183,7 +183,7 @@ impl PaymentMethodDetailsP24Bank {
             ToyotaBank => "toyota_bank",
             Velobank => "velobank",
             VolkswagenBank => "volkswagen_bank",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -219,7 +219,7 @@ impl std::str::FromStr for PaymentMethodDetailsP24Bank {
             "toyota_bank" => Ok(ToyotaBank),
             "velobank" => Ok(Velobank),
             "volkswagen_bank" => Ok(VolkswagenBank),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-shared/src/payment_method_eps.rs
+++ b/generated/async-stripe-shared/src/payment_method_eps.rs
@@ -1,4 +1,4 @@
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 pub struct PaymentMethodEps {
@@ -62,7 +62,7 @@ const _: () = {
         }
 
         fn take_out(&mut self) -> Option<Self::Out> {
-            let (Some(bank),) = (self.bank,) else {
+            let (Some(bank),) = (self.bank.take(),) else {
                 return None;
             };
             Some(Self::Out { bank })
@@ -103,7 +103,7 @@ const _: () = {
 };
 /// The customer's bank.
 /// Should be one of `arzte_und_apotheker_bank`, `austrian_anadi_bank_ag`, `bank_austria`, `bankhaus_carl_spangler`, `bankhaus_schelhammer_und_schattera_ag`, `bawag_psk_ag`, `bks_bank_ag`, `brull_kallmus_bank_ag`, `btv_vier_lander_bank`, `capital_bank_grawe_gruppe_ag`, `deutsche_bank_ag`, `dolomitenbank`, `easybank_ag`, `erste_bank_und_sparkassen`, `hypo_alpeadriabank_international_ag`, `hypo_noe_lb_fur_niederosterreich_u_wien`, `hypo_oberosterreich_salzburg_steiermark`, `hypo_tirol_bank_ag`, `hypo_vorarlberg_bank_ag`, `hypo_bank_burgenland_aktiengesellschaft`, `marchfelder_bank`, `oberbank_ag`, `raiffeisen_bankengruppe_osterreich`, `schoellerbank_ag`, `sparda_bank_wien`, `volksbank_gruppe`, `volkskreditbank_ag`, or `vr_bank_braunau`.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum PaymentMethodEpsBank {
     ArzteUndApothekerBank,
@@ -135,10 +135,10 @@ pub enum PaymentMethodEpsBank {
     VolkskreditbankAg,
     VrBankBraunau,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl PaymentMethodEpsBank {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use PaymentMethodEpsBank::*;
         match self {
             ArzteUndApothekerBank => "arzte_und_apotheker_bank",
@@ -169,7 +169,7 @@ impl PaymentMethodEpsBank {
             VolksbankGruppe => "volksbank_gruppe",
             VolkskreditbankAg => "volkskreditbank_ag",
             VrBankBraunau => "vr_bank_braunau",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -207,7 +207,7 @@ impl std::str::FromStr for PaymentMethodEpsBank {
             "volksbank_gruppe" => Ok(VolksbankGruppe),
             "volkskreditbank_ag" => Ok(VolkskreditbankAg),
             "vr_bank_braunau" => Ok(VrBankBraunau),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-shared/src/payment_method_fpx.rs
+++ b/generated/async-stripe-shared/src/payment_method_fpx.rs
@@ -1,4 +1,4 @@
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 pub struct PaymentMethodFpx {
@@ -66,7 +66,8 @@ const _: () = {
         }
 
         fn take_out(&mut self) -> Option<Self::Out> {
-            let (Some(account_holder_type), Some(bank)) = (self.account_holder_type, self.bank)
+            let (Some(account_holder_type), Some(bank)) =
+                (self.account_holder_type, self.bank.take())
             else {
                 return None;
             };
@@ -182,7 +183,7 @@ impl<'de> serde::Deserialize<'de> for PaymentMethodFpxAccountHolderType {
 }
 /// The customer's bank, if provided.
 /// Can be one of `affin_bank`, `agrobank`, `alliance_bank`, `ambank`, `bank_islam`, `bank_muamalat`, `bank_rakyat`, `bsn`, `cimb`, `hong_leong_bank`, `hsbc`, `kfh`, `maybank2u`, `ocbc`, `public_bank`, `rhb`, `standard_chartered`, `uob`, `deutsche_bank`, `maybank2e`, `pb_enterprise`, or `bank_of_china`.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum PaymentMethodFpxBank {
     AffinBank,
@@ -208,10 +209,10 @@ pub enum PaymentMethodFpxBank {
     StandardChartered,
     Uob,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl PaymentMethodFpxBank {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use PaymentMethodFpxBank::*;
         match self {
             AffinBank => "affin_bank",
@@ -236,7 +237,7 @@ impl PaymentMethodFpxBank {
             Rhb => "rhb",
             StandardChartered => "standard_chartered",
             Uob => "uob",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -268,7 +269,7 @@ impl std::str::FromStr for PaymentMethodFpxBank {
             "rhb" => Ok(Rhb),
             "standard_chartered" => Ok(StandardChartered),
             "uob" => Ok(Uob),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-shared/src/payment_method_ideal.rs
+++ b/generated/async-stripe-shared/src/payment_method_ideal.rs
@@ -1,4 +1,4 @@
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 pub struct PaymentMethodIdeal {
@@ -66,7 +66,7 @@ const _: () = {
         }
 
         fn take_out(&mut self) -> Option<Self::Out> {
-            let (Some(bank), Some(bic)) = (self.bank, self.bic) else {
+            let (Some(bank), Some(bic)) = (self.bank.take(), self.bic.take()) else {
                 return None;
             };
             Some(Self::Out { bank, bic })
@@ -108,7 +108,7 @@ const _: () = {
 };
 /// The customer's bank, if provided.
 /// Can be one of `abn_amro`, `asn_bank`, `bunq`, `handelsbanken`, `ing`, `knab`, `moneyou`, `n26`, `nn`, `rabobank`, `regiobank`, `revolut`, `sns_bank`, `triodos_bank`, `van_lanschot`, or `yoursafe`.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum PaymentMethodIdealBank {
     AbnAmro,
@@ -128,10 +128,10 @@ pub enum PaymentMethodIdealBank {
     VanLanschot,
     Yoursafe,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl PaymentMethodIdealBank {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use PaymentMethodIdealBank::*;
         match self {
             AbnAmro => "abn_amro",
@@ -150,7 +150,7 @@ impl PaymentMethodIdealBank {
             TriodosBank => "triodos_bank",
             VanLanschot => "van_lanschot",
             Yoursafe => "yoursafe",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -176,7 +176,7 @@ impl std::str::FromStr for PaymentMethodIdealBank {
             "triodos_bank" => Ok(TriodosBank),
             "van_lanschot" => Ok(VanLanschot),
             "yoursafe" => Ok(Yoursafe),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -224,7 +224,7 @@ impl<'de> serde::Deserialize<'de> for PaymentMethodIdealBank {
     }
 }
 /// The Bank Identifier Code of the customer's bank, if the bank was provided.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum PaymentMethodIdealBic {
     Abnanl2a,
@@ -245,10 +245,10 @@ pub enum PaymentMethodIdealBic {
     Snsbnl2a,
     Trionl2u,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl PaymentMethodIdealBic {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use PaymentMethodIdealBic::*;
         match self {
             Abnanl2a => "ABNANL2A",
@@ -268,7 +268,7 @@ impl PaymentMethodIdealBic {
             Revolt21 => "REVOLT21",
             Snsbnl2a => "SNSBNL2A",
             Trionl2u => "TRIONL2U",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -295,7 +295,7 @@ impl std::str::FromStr for PaymentMethodIdealBic {
             "REVOLT21" => Ok(Revolt21),
             "SNSBNL2A" => Ok(Snsbnl2a),
             "TRIONL2U" => Ok(Trionl2u),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-shared/src/payment_method_p24.rs
+++ b/generated/async-stripe-shared/src/payment_method_p24.rs
@@ -1,4 +1,4 @@
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 pub struct PaymentMethodP24 {
@@ -61,7 +61,7 @@ const _: () = {
         }
 
         fn take_out(&mut self) -> Option<Self::Out> {
-            let (Some(bank),) = (self.bank,) else {
+            let (Some(bank),) = (self.bank.take(),) else {
                 return None;
             };
             Some(Self::Out { bank })
@@ -101,7 +101,7 @@ const _: () = {
     }
 };
 /// The customer's bank, if provided.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum PaymentMethodP24Bank {
     AliorBank,
@@ -131,10 +131,10 @@ pub enum PaymentMethodP24Bank {
     Velobank,
     VolkswagenBank,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl PaymentMethodP24Bank {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use PaymentMethodP24Bank::*;
         match self {
             AliorBank => "alior_bank",
@@ -163,7 +163,7 @@ impl PaymentMethodP24Bank {
             ToyotaBank => "toyota_bank",
             Velobank => "velobank",
             VolkswagenBank => "volkswagen_bank",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -199,7 +199,7 @@ impl std::str::FromStr for PaymentMethodP24Bank {
             "toyota_bank" => Ok(ToyotaBank),
             "velobank" => Ok(Velobank),
             "volkswagen_bank" => Ok(VolkswagenBank),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-shared/src/setup_attempt_payment_method_details_ideal.rs
+++ b/generated/async-stripe-shared/src/setup_attempt_payment_method_details_ideal.rs
@@ -100,8 +100,8 @@ const _: () = {
                 Some(iban_last4),
                 Some(verified_name),
             ) = (
-                self.bank,
-                self.bic,
+                self.bank.take(),
+                self.bic.take(),
                 self.generated_sepa_debit.take(),
                 self.generated_sepa_debit_mandate.take(),
                 self.iban_last4.take(),
@@ -162,7 +162,7 @@ const _: () = {
 };
 /// The customer's bank.
 /// Can be one of `abn_amro`, `asn_bank`, `bunq`, `handelsbanken`, `ing`, `knab`, `moneyou`, `n26`, `nn`, `rabobank`, `regiobank`, `revolut`, `sns_bank`, `triodos_bank`, `van_lanschot`, or `yoursafe`.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum SetupAttemptPaymentMethodDetailsIdealBank {
     AbnAmro,
@@ -182,10 +182,10 @@ pub enum SetupAttemptPaymentMethodDetailsIdealBank {
     VanLanschot,
     Yoursafe,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl SetupAttemptPaymentMethodDetailsIdealBank {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use SetupAttemptPaymentMethodDetailsIdealBank::*;
         match self {
             AbnAmro => "abn_amro",
@@ -204,7 +204,7 @@ impl SetupAttemptPaymentMethodDetailsIdealBank {
             TriodosBank => "triodos_bank",
             VanLanschot => "van_lanschot",
             Yoursafe => "yoursafe",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -230,7 +230,7 @@ impl std::str::FromStr for SetupAttemptPaymentMethodDetailsIdealBank {
             "triodos_bank" => Ok(TriodosBank),
             "van_lanschot" => Ok(VanLanschot),
             "yoursafe" => Ok(Yoursafe),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }
@@ -278,7 +278,7 @@ impl<'de> serde::Deserialize<'de> for SetupAttemptPaymentMethodDetailsIdealBank 
     }
 }
 /// The Bank Identifier Code of the customer's bank.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum SetupAttemptPaymentMethodDetailsIdealBic {
     Abnanl2a,
@@ -299,10 +299,10 @@ pub enum SetupAttemptPaymentMethodDetailsIdealBic {
     Snsbnl2a,
     Trionl2u,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl SetupAttemptPaymentMethodDetailsIdealBic {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use SetupAttemptPaymentMethodDetailsIdealBic::*;
         match self {
             Abnanl2a => "ABNANL2A",
@@ -322,7 +322,7 @@ impl SetupAttemptPaymentMethodDetailsIdealBic {
             Revolt21 => "REVOLT21",
             Snsbnl2a => "SNSBNL2A",
             Trionl2u => "TRIONL2U",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -349,7 +349,7 @@ impl std::str::FromStr for SetupAttemptPaymentMethodDetailsIdealBic {
             "REVOLT21" => Ok(Revolt21),
             "SNSBNL2A" => Ok(Snsbnl2a),
             "TRIONL2U" => Ok(Trionl2u),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-shared/src/source.rs
+++ b/generated/async-stripe-shared/src/source.rs
@@ -317,7 +317,7 @@ const _: () = {
                 self.statement_descriptor.take(),
                 self.status.take(),
                 self.three_d_secure.take(),
-                self.type_,
+                self.type_.take(),
                 self.usage.take(),
                 self.wechat.take(),
             )
@@ -485,7 +485,7 @@ impl serde::Serialize for Source {
 /// The `type` is a payment method, one of `ach_credit_transfer`, `ach_debit`, `alipay`, `bancontact`, `card`, `card_present`, `eps`, `giropay`, `ideal`, `multibanco`, `klarna`, `p24`, `sepa_debit`, `sofort`, `three_d_secure`, or `wechat`.
 /// An additional hash is included on the source with a name matching this value.
 /// It contains additional information specific to the [payment method](https://stripe.com/docs/sources) used.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum SourceType {
     AchCreditTransfer,
@@ -508,10 +508,10 @@ pub enum SourceType {
     ThreeDSecure,
     Wechat,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl SourceType {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use SourceType::*;
         match self {
             AchCreditTransfer => "ach_credit_transfer",
@@ -533,7 +533,7 @@ impl SourceType {
             Sofort => "sofort",
             ThreeDSecure => "three_d_secure",
             Wechat => "wechat",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -562,7 +562,7 @@ impl std::str::FromStr for SourceType {
             "sofort" => Ok(Sofort),
             "three_d_secure" => Ok(ThreeDSecure),
             "wechat" => Ok(Wechat),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-shared/src/source_transaction.rs
+++ b/generated/async-stripe-shared/src/source_transaction.rs
@@ -150,7 +150,7 @@ const _: () = {
                 self.sepa_credit_transfer.take(),
                 self.source.take(),
                 self.status.take(),
-                self.type_,
+                self.type_.take(),
             )
             else {
                 return None;
@@ -241,7 +241,7 @@ impl serde::Serialize for SourceTransaction {
     }
 }
 /// The type of source this transaction is attached to.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum SourceTransactionType {
     AchCreditTransfer,
@@ -261,10 +261,10 @@ pub enum SourceTransactionType {
     ThreeDSecure,
     Wechat,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl SourceTransactionType {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use SourceTransactionType::*;
         match self {
             AchCreditTransfer => "ach_credit_transfer",
@@ -283,7 +283,7 @@ impl SourceTransactionType {
             Sofort => "sofort",
             ThreeDSecure => "three_d_secure",
             Wechat => "wechat",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -309,7 +309,7 @@ impl std::str::FromStr for SourceTransactionType {
             "sofort" => Ok(Sofort),
             "three_d_secure" => Ok(ThreeDSecure),
             "wechat" => Ok(Wechat),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-shared/src/subscriptions_resource_payment_settings.rs
+++ b/generated/async-stripe-shared/src/subscriptions_resource_payment_settings.rs
@@ -141,7 +141,7 @@ const _: () = {
 };
 /// The list of payment method types to provide to every invoice created by the subscription.
 /// If not set, Stripe attempts to automatically determine the types to use by looking at the invoice’s default payment method, the subscription’s default payment method, the customer’s default payment method, and your [invoice template settings](https://dashboard.stripe.com/settings/billing/invoice).
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum SubscriptionsResourcePaymentSettingsPaymentMethodTypes {
     AchCreditTransfer,
@@ -173,10 +173,10 @@ pub enum SubscriptionsResourcePaymentSettingsPaymentMethodTypes {
     UsBankAccount,
     WechatPay,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl SubscriptionsResourcePaymentSettingsPaymentMethodTypes {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use SubscriptionsResourcePaymentSettingsPaymentMethodTypes::*;
         match self {
             AchCreditTransfer => "ach_credit_transfer",
@@ -207,7 +207,7 @@ impl SubscriptionsResourcePaymentSettingsPaymentMethodTypes {
             Sofort => "sofort",
             UsBankAccount => "us_bank_account",
             WechatPay => "wechat_pay",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -245,7 +245,7 @@ impl std::str::FromStr for SubscriptionsResourcePaymentSettingsPaymentMethodType
             "sofort" => Ok(Sofort),
             "us_bank_account" => Ok(UsBankAccount),
             "wechat_pay" => Ok(WechatPay),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-treasury/src/treasury_inbound_transfer/requests.rs
+++ b/generated/async-stripe-treasury/src/treasury_inbound_transfer/requests.rs
@@ -172,7 +172,7 @@ impl FailTreasuryInboundTransferBuilder {
     }
 }
 /// Details about a failed InboundTransfer.
-#[derive(Copy, Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, serde::Serialize)]
 pub struct FailTreasuryInboundTransferFailureDetails {
     /// Reason for the failure.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -189,7 +189,7 @@ impl Default for FailTreasuryInboundTransferFailureDetails {
     }
 }
 /// Reason for the failure.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum FailTreasuryInboundTransferFailureDetailsCode {
     AccountClosed,
@@ -206,10 +206,10 @@ pub enum FailTreasuryInboundTransferFailureDetailsCode {
     NoAccount,
     Other,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl FailTreasuryInboundTransferFailureDetailsCode {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use FailTreasuryInboundTransferFailureDetailsCode::*;
         match self {
             AccountClosed => "account_closed",
@@ -225,7 +225,7 @@ impl FailTreasuryInboundTransferFailureDetailsCode {
             InvalidCurrency => "invalid_currency",
             NoAccount => "no_account",
             Other => "other",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -248,7 +248,7 @@ impl std::str::FromStr for FailTreasuryInboundTransferFailureDetailsCode {
             "invalid_currency" => Ok(InvalidCurrency),
             "no_account" => Ok(NoAccount),
             "other" => Ok(Other),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-treasury/src/treasury_inbound_transfer/types.rs
+++ b/generated/async-stripe-treasury/src/treasury_inbound_transfer/types.rs
@@ -194,7 +194,7 @@ const _: () = {
                 self.created,
                 self.currency,
                 self.description.take(),
-                self.failure_details,
+                self.failure_details.take(),
                 self.financial_account.take(),
                 self.hosted_regulatory_receipt_url.take(),
                 self.id.take(),

--- a/generated/async-stripe-treasury/src/treasury_inbound_transfers_resource_failure_details.rs
+++ b/generated/async-stripe-treasury/src/treasury_inbound_transfers_resource_failure_details.rs
@@ -1,4 +1,4 @@
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 pub struct TreasuryInboundTransfersResourceFailureDetails {
@@ -61,7 +61,7 @@ const _: () = {
         }
 
         fn take_out(&mut self) -> Option<Self::Out> {
-            let (Some(code),) = (self.code,) else {
+            let (Some(code),) = (self.code.take(),) else {
                 return None;
             };
             Some(Self::Out { code })
@@ -101,7 +101,7 @@ const _: () = {
     }
 };
 /// Reason for the failure.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum TreasuryInboundTransfersResourceFailureDetailsCode {
     AccountClosed,
@@ -118,10 +118,10 @@ pub enum TreasuryInboundTransfersResourceFailureDetailsCode {
     NoAccount,
     Other,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl TreasuryInboundTransfersResourceFailureDetailsCode {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use TreasuryInboundTransfersResourceFailureDetailsCode::*;
         match self {
             AccountClosed => "account_closed",
@@ -137,7 +137,7 @@ impl TreasuryInboundTransfersResourceFailureDetailsCode {
             InvalidCurrency => "invalid_currency",
             NoAccount => "no_account",
             Other => "other",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -160,7 +160,7 @@ impl std::str::FromStr for TreasuryInboundTransfersResourceFailureDetailsCode {
             "invalid_currency" => Ok(InvalidCurrency),
             "no_account" => Ok(NoAccount),
             "other" => Ok(Other),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/generated/async-stripe-treasury/src/treasury_transaction_entry/types.rs
+++ b/generated/async-stripe-treasury/src/treasury_transaction_entry/types.rs
@@ -144,7 +144,7 @@ const _: () = {
                 self.id.take(),
                 self.livemode,
                 self.transaction.take(),
-                self.type_,
+                self.type_.take(),
             )
             else {
                 return None;
@@ -326,7 +326,7 @@ impl<'de> serde::Deserialize<'de> for TreasuryTransactionEntryFlowType {
     }
 }
 /// The specific money movement that generated the TransactionEntry.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum TreasuryTransactionEntryType {
     CreditReversal,
@@ -350,10 +350,10 @@ pub enum TreasuryTransactionEntryType {
     ReceivedCredit,
     ReceivedDebit,
     /// An unrecognized value from Stripe. Should not be used as a request parameter.
-    Unknown,
+    Unknown(String),
 }
 impl TreasuryTransactionEntryType {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(&self) -> &str {
         use TreasuryTransactionEntryType::*;
         match self {
             CreditReversal => "credit_reversal",
@@ -376,7 +376,7 @@ impl TreasuryTransactionEntryType {
             OutboundTransferReturn => "outbound_transfer_return",
             ReceivedCredit => "received_credit",
             ReceivedDebit => "received_debit",
-            Unknown => "unknown",
+            Unknown(v) => v,
         }
     }
 }
@@ -406,7 +406,7 @@ impl std::str::FromStr for TreasuryTransactionEntryType {
             "outbound_transfer_return" => Ok(OutboundTransferReturn),
             "received_credit" => Ok(ReceivedCredit),
             "received_debit" => Ok(ReceivedDebit),
-            _ => Ok(Self::Unknown),
+            v => Ok(Unknown(v.to_owned())),
         }
     }
 }

--- a/openapi/src/object_writing.rs
+++ b/openapi/src/object_writing.rs
@@ -11,8 +11,6 @@ use crate::templates::utils::write_doc_comment;
 use crate::templates::ObjectWriter;
 use crate::STRIPE_TYPES;
 
-const ADD_UNKNOWN_VARIANT_THRESHOLD: usize = 12;
-
 impl Components {
     fn write_rust_type_objs(&self, typ: &RustType, out: &mut String, usage: ObjectUsage) {
         let Some((obj, meta)) = typ.extract_object() else {
@@ -55,9 +53,7 @@ impl Components {
                 }
             }
             RustObject::FieldlessEnum(variants) => {
-                let provide_unknown_variant = variants.len() > ADD_UNKNOWN_VARIANT_THRESHOLD
-                    && !variants.iter().any(|v| v.variant_name.as_ref() == "Unknown");
-                writer.provide_unknown_variant(provide_unknown_variant);
+                writer.provide_unknown_variant(obj.provide_unknown_variant());
                 writer.write_fieldless_enum_variants(out, variants);
             }
             RustObject::Enum(variants) => {

--- a/tests/tests/it/enums.rs
+++ b/tests/tests/it/enums.rs
@@ -43,7 +43,13 @@ fn from_str_and_deser_behavior_match_on_unknown_variant() {
     );
     assert_eq!(EventType::AccountApplicationAuthorized.as_str(), acct_authorized);
 
-    assert_eq!(EventType::Unknown, EventType::from_str("acct").unwrap());
-    assert_eq!(miniserde::json::from_str::<EventType>(r#""acct""#).unwrap(), EventType::Unknown);
-    assert_eq!(serde_json::from_str::<EventType>(r#""acct""#).unwrap(), EventType::Unknown);
+    assert_eq!(EventType::Unknown(String::from("acct")), EventType::from_str("acct").unwrap());
+    assert_eq!(
+        miniserde::json::from_str::<EventType>(r#""acct""#).unwrap(),
+        EventType::Unknown(String::from("acct"))
+    );
+    assert_eq!(
+        serde_json::from_str::<EventType>(r#""acct""#).unwrap(),
+        EventType::Unknown(String::from("acct"))
+    );
 }


### PR DESCRIPTION
# Summary

This PR aims to keep the original values for unknown variants, if they are generated.

This allows downstream crates to act on them, for example logging the unexpected value. This is useful for example on the `ApiVersion` for the [webhook versioning](https://docs.stripe.com/webhooks/versioning), in order to be able to properly determine if the event comes from a newer api version.

### Checklist

- [x] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features