### PR TITLE
feat: export checkout_session_ext

### DIFF
--- a/src/resources.rs
+++ b/src/resources.rs
@@ -187,6 +187,7 @@ pub use {
 #[rustfmt::skip]
 #[cfg(feature = "checkout")]
 pub use {
+    checkout::checkout_session_ext::*,
     generated::checkout::{
         checkout_session::*,
         payment_link::*,


### PR DESCRIPTION
### Description
Currently, the `checkout_session_ext` is not being exported, which makes the `RetrieveCheckoutSessionLineItems` not being able to be used.

With this change, the following should now be possible:
```rust
use std::str::FromStr;

use stripe::{CheckoutSession, CheckoutSessionId, Client, RetrieveCheckoutSessionLineItems};

#[tokio::main]
async fn main() {
    let secret_key = std::env::var("STRIPE_SECRET_KEY").expect("Missing STRIPE_SECRET_KEY in env");
    let client = Client::new(secret_key);

    let _line_items = CheckoutSession::retrieve_line_items(
        &client,
        &CheckoutSessionId::from_str("").unwrap(),
        &RetrieveCheckoutSessionLineItems::default(),
    )
    .await
    .unwrap();
}
```

Closes #614

# Summary

<!--
A quick summary of what this PR does, why is needs to be applied, what has changed, etc.
-->

### Checklist

- [x] ran `cargo make fmt`
- [x] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features
  <!--
  EXAMPLES:
  feat: you can now add and remove principals from a project
  fix: fixes an issue where the combobox was displaying incorrect values
  -->
