### PR TITLE
bump msrv since openssl fails to compile

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -51,7 +51,7 @@ body:
     id: language-version
     attributes:
       label: Rust version
-      placeholder: Our MSRV is 1.74.0
+      placeholder: Our MSRV is 1.78.0
     validations:
       required: true
   - type: input

--- a/.github/workflows/async-stripe.yml
+++ b/.github/workflows/async-stripe.yml
@@ -123,7 +123,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: "1.74.0"
+          toolchain: "1.78.0"
       - uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
           token: ${{ secrets.REPO_SCOPED_TOKEN }}
       - uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: "1.74.0"
+          toolchain: "1.78.0"
       - uses: cycjimmy/semantic-release-action@v4
         with:
           extra_plugins: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 name = "async-stripe"
 version = "0.39.1"
 description = "API bindings for the Stripe HTTP API"
-rust-version = "1.74.0"
+rust-version = "1.78.0"
 authors = [
   "Anna Baldwin <abaldwin@developers.wyyerd.com>",
   "Kevin Stenerson <kestred@users.noreply.github.com>",

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ If you don't see the specific version you are on, prefer the next available vers
 
 ## MSRV
 
-We currently have `1.74.0` pinned in CI, so any version of rustc newer than that should work.
+We currently have `1.78.0` pinned in CI, so any version of rustc newer than that should work.
 If this is not the case, please open an issue. As a policy, we permit MSRV increases in non-breaking releases.
 If you have a compelling usecase for bumping it, we are usually open to do so, as long as
 the rust version is not too new (generally 3 releases).

--- a/src/client/stripe.rs
+++ b/src/client/stripe.rs
@@ -179,7 +179,7 @@ impl Client {
 
     fn create_request(&self, method: Method, url: Url) -> Request {
         let mut req = Request::new(method, url);
-        req.insert_header("authorization", &format!("Bearer {}", self.secret_key));
+        req.insert_header("authorization", format!("Bearer {}", self.secret_key));
 
         for (key, value) in self.headers.to_array().iter().filter_map(|(k, v)| v.map(|v| (*k, v))) {
             req.insert_header(key, value);

--- a/src/resources/payment_source.rs
+++ b/src/resources/payment_source.rs
@@ -6,9 +6,10 @@ use crate::params::Object;
 use crate::resources::{Account, BankAccount, Card, Currency, Source};
 
 /// A PaymentSourceParams represents all of the supported ways that can
-/// be used to creating a new customer with a payment method or creating
-/// a payment method directly for a customer via `Customer::attach_source`.
+/// be used.
 ///
+/// This includes creating a new customer with a payment method or creating
+/// a payment method directly for a customer via `Customer::attach_source`.
 /// Not to be confused with `SourceParams` which is used by `Source::create`
 /// to create a source that is not necessarily attached to a customer.
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/tests/encoding.rs
+++ b/tests/encoding.rs
@@ -261,7 +261,7 @@ fn deserialize_customer_with_source() {
 }
 
 #[test]
-#[cfg(feature = "event")]
+#[cfg(feature = "events")]
 fn deserialize_checkout_event() {
     use stripe::Event;
 
@@ -277,6 +277,15 @@ fn deserialize_checkout_event() {
       "data": {
         "object": {
           "id": "cs_00000000000000",
+          "created": 1649316731,
+          "expires_at": 1649316731,
+          "shipping_options": [],
+          "custom_fields": [],
+          "custom_text": {},
+          "automatic_tax": {
+              "enabled": false,
+              "created": 1649316731,
+          },
           "object": "checkout.session",
           "billing_address_collection": null,
           "cancel_url": "https://example.com/cancel",


### PR DESCRIPTION
# Summary

Also fixes some new lints from new rust compiler versions and re-enables a test that was accidentally not being run.

### Checklist

- [x] ran `cargo make fmt`
- [x] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features
  <!--
  EXAMPLES:
  feat: you can now add and remove principals from a project
  fix: fixes an issue where the combobox was displaying incorrect values
  -->
