### PR TITLE
feat(next): Serialize and deserialize webhook events

### DIFF
--- a/async-stripe-webhook/src/generated/mod.rs
+++ b/async-stripe-webhook/src/generated/mod.rs
@@ -686,6 +686,8 @@ const _: () = {
 };
 
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 #[non_exhaustive]
 /// The event data for a webhook event.
 pub enum EventObject {
@@ -1227,6 +1229,10 @@ pub enum EventObject {
     /// Occurs whenever a received_debit is created as a result of funds being pulled by another account.
     #[cfg(feature = "async-stripe-treasury")]
     TreasuryReceivedDebitCreated(stripe_treasury::TreasuryReceivedDebit),
+    #[cfg_attr(
+        any(feature = "deserialize", feature = "serialize"),
+        serde(with = "stripe_types::with_serde_json")
+    )]
     Unknown(miniserde::json::Value),
 }
 impl EventObject {

--- a/async-stripe-webhook/src/webhook.rs
+++ b/async-stripe-webhook/src/webhook.rs
@@ -9,6 +9,8 @@ use stripe_shared::ApiVersion;
 use crate::{EventObject, WebhookError};
 
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 pub struct Event {
     /// The connected account that originated the event.
     pub account: Option<String>,
@@ -34,6 +36,8 @@ pub struct Event {
 }
 
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+#[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
 pub struct EventData {
     /// Object containing the API resource relevant to the event.
     ///
@@ -43,6 +47,10 @@ pub struct EventData {
     ///
     /// If an array attribute has any updated elements, this object contains the entire array.
     /// In Stripe API versions 2017-04-06 or earlier, an updated array attribute in this object includes only the updated array elements.
+    #[cfg_attr(
+        any(feature = "deserialize", feature = "serialize"),
+        serde(with = "stripe_types::with_serde_json_opt")
+    )]
     pub previous_attributes: Option<miniserde::json::Value>,
 }
 

--- a/openapi/src/webhook.rs
+++ b/openapi/src/webhook.rs
@@ -77,10 +77,18 @@ fn write_event_object(components: &Components, out_path: &Path) -> anyhow::Resul
             r#""{evt_type}" => Self::{ident}(FromValueOpt::from_value(data)?),"#
         );
     }
-    let _ = writeln!(enum_body, "Unknown(miniserde::json::Value),");
+    let _ = writedoc! {enum_body, r#"
+    #[cfg_attr(
+        any(feature = "deserialize", feature = "serialize"),
+        serde(with = "stripe_types::with_serde_json")
+    )]
+    Unknown(miniserde::json::Value),
+    "#};
 
     write_derives_line(&mut out, Default::default());
     let _ = writedoc! {out, r#"
+    #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
+    #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
     #[non_exhaustive]
     /// The event data for a webhook event.
     pub enum EventObject {{


### PR DESCRIPTION
# Summary

It's recommended to process stripe webhook events asynchronously ([doc](https://docs.stripe.com/webhooks#handle-events-asynchronously)), so it will be common to write those events to some kind of pub/pub like kafka.

This PR derives the serialize and deserialize traits on the webhook event when the feature flags are enabled.

### Checklist

- [x] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features
