### PR TITLE
fix(transfer): add `ErrorCode::InsufficientCapabilitiesForTransfer`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -100,6 +100,7 @@ pub enum ErrorCode {
     IncorrectNumber,
     IncorrectZip,
     InstantPayoutsUnsupported,
+    InsufficientCapabilitiesForTransfer,
     InvalidCardType,
     InvalidChargeAmount,
     InvalidCvc,


### PR DESCRIPTION
# Summary

fixes #636

<!--
A quick summary of what this PR does, why is needs to be applied, what has changed, etc.
-->

This simply adds a new variant for ErrorCode to make the deserialization of the response in #636 not fail.

### Checklist

- [x] ran `cargo make fmt`
- [x] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features
  <!--
  EXAMPLES:
  feat: you can now add and remove principals from a project
  fix: fixes an issue where the combobox was displaying incorrect values
  -->
