### PR TITLE
feat: Adding UsageRecordSummary::list function

### DIFF
--- a/src/resources/usage_record_ext.rs
+++ b/src/resources/usage_record_ext.rs
@@ -1,6 +1,10 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{Client, Response, SubscriptionItemId, Timestamp, UsageRecord};
+use crate::params::{List, Object, Paginable};
+use crate::{
+    Client, Response, SubscriptionItemId, Timestamp, UsageRecord, UsageRecordSummary,
+    UsageRecordSummaryId,
+};
 
 impl UsageRecord {
     pub fn create(
@@ -42,4 +46,54 @@ pub struct CreateUsageRecord {
 pub enum UsageRecordAction {
     Increment,
     Set,
+}
+
+impl UsageRecordSummary {
+    /// For the specified subscription item, returns a list of summary objects. Each object in the list provides usage information that’s been summarized from multiple usage records and over a subscription billing period (e.g., 15 usage records in the month of September).
+    ///
+    /// The list is sorted in reverse-chronological order (newest first). The first list item represents the most current usage period that hasn’t ended yet. Since new usage records can still be added, the returned summary information for the subscription item’s ID should be seen as unstable until the subscription billing period ends.
+    pub fn list(
+        client: &Client,
+        subscription_item_id: &SubscriptionItemId,
+        params: ListUsageRecordSummaries,
+    ) -> Response<List<UsageRecordSummary>> {
+        client.get_query(
+            &format!("/subscription_items/{}/usage_record_summaries", subscription_item_id),
+            &params,
+        )
+    }
+}
+
+/// For the specified subscription item, returns a list of summary objects. Each object in the list provides usage information that’s been summarized from multiple usage records and over a subscription billing period (e.g., 15 usage records in the month of September).
+///
+/// The list is sorted in reverse-chronological order (newest first). The first list item represents the most current usage period that hasn’t ended yet. Since new usage records can still be added, the returned summary information for the subscription item’s ID should be seen as unstable until the subscription billing period ends.
+/// For more details see [https://stripe.com/docs/api/usage_records/subscription_item_summary_list](https://stripe.com/docs/api/usage_records/subscription_item_summary_list).
+#[derive(Clone, Debug, Serialize)]
+pub struct ListUsageRecordSummaries {
+    /// A cursor for use in pagination.
+    ///
+    /// `ending_before` is an object ID that defines your place in the list.
+    /// For instance, if you make a list request and receive 100 objects, starting with `obj_bar`, your subsequent call can include `ending_before=obj_bar` in order to fetch the previous page of the list.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ending_before: Option<UsageRecordSummaryId>,
+
+    /// A cursor for use in pagination.
+    ///
+    /// `starting_after` is an object ID that defines your place in the list.
+    /// For instance, if you make a list request and receive 100 objects, ending with `obj_foo`, your subsequent call can include `starting_after=obj_foo` in order to fetch the next page of the list.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub starting_after: Option<UsageRecordSummaryId>,
+
+    /// A limit on the number of objects to be returned.
+    ///
+    /// Limit can range between 1 and 100, and the default is 10.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u64>,
+}
+
+impl Paginable for ListUsageRecordSummaries {
+    type O = UsageRecordSummary;
+    fn set_last(&mut self, item: Self::O) {
+        self.starting_after = Some(item.id());
+    }
 }


### PR DESCRIPTION
This adds the `list()` function to `UsageRecordSummary`

Stripe API: https://docs.stripe.com/api/usage-record-summary/list

### Checklist

- [X] ran `cargo make fmt`
- [X] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features
