### PR TITLE
chore: align differently used Rust versions

### DIFF
--- a/.github/workflows/async-stripe.yml
+++ b/.github/workflows/async-stripe.yml
@@ -11,9 +11,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@v1
+      - uses: dtolnay/rust-toolchain@1.82.0
         with:
-          toolchain: nightly
           components: rustfmt
       - uses: davidB/rust-cargo-make@v1
       - name: regenerate openapi
@@ -26,9 +25,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@v1
+      - uses: dtolnay/rust-toolchain@1.82.0
         with:
-          toolchain: nightly
           components: rustfmt
       - uses: davidB/rust-cargo-make@v1
       - name: regenerate openapi
@@ -56,9 +54,8 @@ jobs:
       RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@v1
+      - uses: dtolnay/rust-toolchain@1.82.0
         with:
-          toolchain: stable
           components: clippy
       - run: cargo clippy -p stripe-openapi-codegen --tests
 
@@ -80,9 +77,8 @@ jobs:
           ]
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@v1
+      - uses: dtolnay/rust-toolchain@1.82.0
         with:
-          toolchain: stable
           components: clippy
       - uses: actions/cache@v4
         with:
@@ -121,9 +117,7 @@ jobs:
           - 12112:12112
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@v1
-        with:
-          toolchain: "1.78.0"
+      - uses: dtolnay/rust-toolchain@1.78.0
       - uses: actions/cache@v4
         with:
           path: |
@@ -152,12 +146,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly
-      - uses: dtolnay/rust-toolchain@v1
-        with:
-          toolchain: stable
+          toolchain: "nightly-2024-10-18"
       - name: Install cargo-public-api
         uses: baptiste0928/cargo-install@v3
         with:

--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -8,10 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install minimal nightly with rustfmt
-        uses: dtolnay/rust-toolchain@v1
+      - name: Install toolchain 1.82.0 with rustfmt
+        uses: dtolnay/rust-toolchain@1.82.0
         with:
-          toolchain: nightly
           components: rustfmt
       - uses: davidB/rust-cargo-make@v1
       - name: regenerate openapi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.REPO_SCOPED_TOKEN }}
-      - uses: dtolnay/rust-toolchain@v1
-        with:
-          toolchain: "1.78.0"
+      - uses: dtolnay/rust-toolchain@1.78.0
       - uses: cycjimmy/semantic-release-action@v4
         with:
           extra_plugins: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 1. Fork it!
 2. Create your feature branch: `git checkout -b my-new-feature`
 3. Test it: `cargo test --features runtime-blocking`
-4. Lint it: `cargo +nightly clippy --all --all-targets -- -D warnings`
+4. Lint it: `cargo +1.82.0 clippy --all --all-targets -- -D warnings`
 5. Commit your changes: `git commit -am 'Add some feature'`
 6. Push to the branch: `git push origin my-new-feature`
 7. Submit a pull request :D
@@ -89,4 +89,3 @@ In some cases, it is helpful to have additional logic associated with a datatype
 capture a create `Charge` object. This additional impl goes in the `charge_ext.rs` file in the
 `resources` folder, to provide a clean seperation between generated and hand maintained files.
 If you notice that logic is missing, please add it to (or create) the appropriate `ext` file.
- 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -33,18 +33,21 @@ rg -N --no-filename -i '^pub (struct|enum) ([A-Z][a-zA-z0-9]+).*?$'  src/resourc
 [tasks.openapi-generate-no-fetch]
 cwd = "openapi"
 command = "cargo"
+toolchain = "1.82.0"
 args = ["run", "spec3.sdk.json"]
 dependencies = ["openapi-delete-out"]
 
 [tasks.openapi-generate]
 cwd = "openapi"
 command = "cargo"
+toolchain = "1.82.0"
 args = ["run", "spec3.sdk.json", "--fetch", "current"]
 dependencies = ["openapi-delete-out"]
 
 [tasks.openapi-generate-latest]
 cwd = "openapi"
 command = "cargo"
+toolchain = "1.82.0"
 args = ["run", "spec3.sdk.json", "--fetch", "latest"]
 dependencies = ["openapi-delete-out"]
 
@@ -57,16 +60,16 @@ args = ["-a", "--delete-during", "out/", "../src/resources/generated"]
 
 [tasks.fmt]
 command = "cargo"
-toolchain = "nightly"
+toolchain = "1.82.0"
 install_crate = "rustfmt"
 # we set this to true because missing files currently cause rustfmt to fail
 # which impacts our weekly CI job 
-ignore_errors = true 
+ignore_errors = true
 args = ["fmt"]
 
 [tasks.check]
 command = "cargo"
-toolchain = "nightly"
+toolchain = "1.82.0"
 install_crate = "rustfmt"
 args = ["fmt", "--", "--check"]
 

--- a/src/resources/generated/account.rs
+++ b/src/resources/generated/account.rs
@@ -2,8 +2,6 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::client::{Client, Response};
 use crate::ids::AccountId;
 use crate::params::{
@@ -13,6 +11,7 @@ use crate::resources::{
     Address, Currency, DelayDays, ExternalAccount, File, Person, PersonVerificationParams, TaxId,
     VerificationDocumentParams,
 };
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "Account".
 ///

--- a/src/resources/generated/account_link.rs
+++ b/src/resources/generated/account_link.rs
@@ -2,11 +2,10 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::client::{Client, Response};
 use crate::ids::AccountId;
 use crate::params::{Expand, Object, Timestamp};
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "AccountLink".
 ///

--- a/src/resources/generated/api_errors.rs
+++ b/src/resources/generated/api_errors.rs
@@ -2,9 +2,8 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::resources::{PaymentIntent, PaymentMethod, PaymentSource, SetupIntent};
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "APIErrors".
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]

--- a/src/resources/generated/application.rs
+++ b/src/resources/generated/application.rs
@@ -2,10 +2,9 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::ids::ApplicationId;
 use crate::params::Object;
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "Application".
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]

--- a/src/resources/generated/application_fee.rs
+++ b/src/resources/generated/application_fee.rs
@@ -2,14 +2,13 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::client::{Client, Response};
 use crate::ids::{ApplicationFeeId, ChargeId};
 use crate::params::{Expand, Expandable, List, Object, Paginable, RangeQuery, Timestamp};
 use crate::resources::{
     Account, Application, ApplicationFeeRefund, BalanceTransaction, Charge, Currency,
 };
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "PlatformFee".
 ///

--- a/src/resources/generated/balance.rs
+++ b/src/resources/generated/balance.rs
@@ -2,10 +2,9 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::params::Object;
 use crate::resources::{BalanceAmountBySourceType, Currency};
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "Balance".
 ///

--- a/src/resources/generated/balance_transaction.rs
+++ b/src/resources/generated/balance_transaction.rs
@@ -2,14 +2,13 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::client::{Client, Response};
 use crate::ids::{BalanceTransactionId, PayoutId, SourceId};
 use crate::params::{Expand, Expandable, List, Object, Paginable, RangeQuery, Timestamp};
 use crate::resources::{
     BalanceTransactionSourceUnion, BalanceTransactionStatus, Currency, FeeType,
 };
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "BalanceTransaction".
 ///

--- a/src/resources/generated/bank_account.rs
+++ b/src/resources/generated/bank_account.rs
@@ -2,11 +2,10 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::ids::BankAccountId;
 use crate::params::{Expandable, Metadata, Object};
 use crate::resources::{Account, BankAccountStatus, Currency, Customer};
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "BankAccount".
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]

--- a/src/resources/generated/billing_details.rs
+++ b/src/resources/generated/billing_details.rs
@@ -2,9 +2,8 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::resources::Address;
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "billing_details".
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]

--- a/src/resources/generated/billing_portal_configuration.rs
+++ b/src/resources/generated/billing_portal_configuration.rs
@@ -2,11 +2,10 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::ids::BillingPortalConfigurationId;
 use crate::params::{Expandable, Metadata, Object, Timestamp};
 use crate::resources::Application;
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "PortalConfiguration".
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]

--- a/src/resources/generated/billing_portal_session.rs
+++ b/src/resources/generated/billing_portal_session.rs
@@ -2,12 +2,11 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::client::{Client, Response};
 use crate::ids::{BillingPortalSessionId, CustomerId};
 use crate::params::{Expand, Expandable, Object, Timestamp};
 use crate::resources::BillingPortalConfiguration;
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "PortalSession".
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]

--- a/src/resources/generated/card.rs
+++ b/src/resources/generated/card.rs
@@ -2,11 +2,10 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::ids::CardId;
 use crate::params::{Expandable, Metadata, Object};
 use crate::resources::{Account, Currency, Customer};
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "Card".
 ///

--- a/src/resources/generated/cash_balance.rs
+++ b/src/resources/generated/cash_balance.rs
@@ -2,9 +2,8 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::params::Object;
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "cash_balance".
 ///

--- a/src/resources/generated/charge.rs
+++ b/src/resources/generated/charge.rs
@@ -2,8 +2,6 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::client::{Client, Response};
 use crate::ids::{ChargeId, CustomerId, PaymentIntentId};
 use crate::params::{Expand, Expandable, List, Metadata, Object, Paginable, RangeQuery, Timestamp};
@@ -14,6 +12,7 @@ use crate::resources::{
     PaymentMethodDetailsCardWalletGooglePay, PaymentSource, RadarRadarOptions, Refund, Review,
     Shipping, Transfer,
 };
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "Charge".
 ///

--- a/src/resources/generated/checkout_session.rs
+++ b/src/resources/generated/checkout_session.rs
@@ -2,8 +2,6 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::client::{Client, Response};
 use crate::ids::{
     CheckoutSessionId, CustomerId, PaymentIntentId, PaymentLinkId, PaymentMethodConfigurationId,
@@ -19,6 +17,7 @@ use crate::resources::{
     PaymentMethodOptionsCustomerBalanceEuBankAccount, SetupIntent, Shipping, ShippingRate,
     Subscription, TaxId, TaxRate,
 };
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "Session".
 ///

--- a/src/resources/generated/connect_account_reference.rs
+++ b/src/resources/generated/connect_account_reference.rs
@@ -2,10 +2,9 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::params::Expandable;
 use crate::resources::Account;
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "ConnectAccountReference".
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]

--- a/src/resources/generated/connect_collection_transfer.rs
+++ b/src/resources/generated/connect_collection_transfer.rs
@@ -2,11 +2,10 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::ids::ConnectCollectionTransferId;
 use crate::params::{Expandable, Object};
 use crate::resources::{Account, Currency};
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "ConnectCollectionTransfer".
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]

--- a/src/resources/generated/coupon.rs
+++ b/src/resources/generated/coupon.rs
@@ -2,14 +2,13 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::client::{Client, Response};
 use crate::ids::CouponId;
 use crate::params::{
     CurrencyMap, Deleted, Expand, List, Metadata, Object, Paginable, RangeQuery, Timestamp,
 };
 use crate::resources::Currency;
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "Coupon".
 ///

--- a/src/resources/generated/credit_note.rs
+++ b/src/resources/generated/credit_note.rs
@@ -2,8 +2,6 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::client::{Client, Response};
 use crate::ids::{CreditNoteId, CustomerId, InvoiceId, RefundId};
 use crate::params::{Expand, Expandable, List, Metadata, Object, Paginable, Timestamp};
@@ -11,6 +9,7 @@ use crate::resources::{
     CreditNoteLineItem, Currency, Customer, CustomerBalanceTransaction, Discount, Invoice,
     InvoicesShippingCost, Refund, TaxRate,
 };
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "CreditNote".
 ///

--- a/src/resources/generated/credit_note_line_item.rs
+++ b/src/resources/generated/credit_note_line_item.rs
@@ -2,11 +2,10 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::ids::CreditNoteLineItemId;
 use crate::params::{Expandable, Object};
 use crate::resources::{Discount, TaxRate};
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "CreditNoteLineItem".
 ///

--- a/src/resources/generated/customer.rs
+++ b/src/resources/generated/customer.rs
@@ -2,8 +2,6 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::client::{Client, Response};
 use crate::ids::{CouponId, CustomerId, PaymentMethodId, PaymentSourceId, PromotionCodeId};
 use crate::params::{
@@ -13,6 +11,7 @@ use crate::resources::{
     Address, CashBalance, Currency, Discount, InvoiceSettingRenderingOptions, PaymentMethod,
     PaymentSource, PaymentSourceParams, Shipping, Subscription, TaxId, TestHelpersTestClock,
 };
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "Customer".
 ///

--- a/src/resources/generated/customer_balance_transaction.rs
+++ b/src/resources/generated/customer_balance_transaction.rs
@@ -2,11 +2,10 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::ids::CustomerBalanceTransactionId;
 use crate::params::{Expandable, Metadata, Object, Timestamp};
 use crate::resources::{CreditNote, Currency, Customer, Invoice};
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "CustomerBalanceTransaction".
 ///

--- a/src/resources/generated/discount.rs
+++ b/src/resources/generated/discount.rs
@@ -2,11 +2,10 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::ids::DiscountId;
 use crate::params::{Expandable, Object, Timestamp};
 use crate::resources::{Coupon, Customer, PromotionCode};
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "Discount".
 ///

--- a/src/resources/generated/dispute.rs
+++ b/src/resources/generated/dispute.rs
@@ -2,12 +2,11 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::client::{Client, Response};
 use crate::ids::{ChargeId, DisputeId, PaymentIntentId};
 use crate::params::{Expand, Expandable, List, Metadata, Object, Paginable, RangeQuery, Timestamp};
 use crate::resources::{BalanceTransaction, Charge, Currency, File, PaymentIntent};
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "Dispute".
 ///

--- a/src/resources/generated/ephemeral_key.rs
+++ b/src/resources/generated/ephemeral_key.rs
@@ -2,11 +2,10 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::client::{Client, Response};
 use crate::ids::{CustomerId, EphemeralKeyId, IssuingCardId};
 use crate::params::{Deleted, Expand, Object, Timestamp};
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "EphemeralKey".
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]

--- a/src/resources/generated/event.rs
+++ b/src/resources/generated/event.rs
@@ -2,12 +2,11 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::client::{Client, Response};
 use crate::ids::EventId;
 use crate::params::{Expand, List, Object, Paginable, RangeQuery, Timestamp};
 use crate::resources::{EventType, NotificationEventData};
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "NotificationEvent".
 ///

--- a/src/resources/generated/fee_refund.rs
+++ b/src/resources/generated/fee_refund.rs
@@ -2,11 +2,10 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::ids::ApplicationFeeRefundId;
 use crate::params::{Expandable, Metadata, Object, Timestamp};
 use crate::resources::{ApplicationFee, BalanceTransaction, Currency};
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "FeeRefund".
 ///

--- a/src/resources/generated/file.rs
+++ b/src/resources/generated/file.rs
@@ -2,12 +2,11 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::client::{Client, Response};
 use crate::ids::FileId;
 use crate::params::{Expand, List, Object, Paginable, RangeQuery, Timestamp};
 use crate::resources::FileLink;
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "File".
 ///

--- a/src/resources/generated/file_link.rs
+++ b/src/resources/generated/file_link.rs
@@ -2,12 +2,11 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::client::{Client, Response};
 use crate::ids::{FileId, FileLinkId};
 use crate::params::{Expand, Expandable, List, Metadata, Object, Paginable, RangeQuery, Timestamp};
 use crate::resources::{File, Scheduled};
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "FileLink".
 ///

--- a/src/resources/generated/invoice.rs
+++ b/src/resources/generated/invoice.rs
@@ -2,8 +2,6 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::client::{Client, Response};
 use crate::ids::{CustomerId, InvoiceId, SubscriptionId};
 use crate::params::{
@@ -18,6 +16,7 @@ use crate::resources::{
     InvoiceSettingRenderingOptions, InvoicesShippingCost, PaymentIntent, PaymentMethod,
     PaymentSource, Quote, Shipping, Subscription, TaxId, TaxRate, TestHelpersTestClock,
 };
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "Invoice".
 ///

--- a/src/resources/generated/invoiceitem.rs
+++ b/src/resources/generated/invoiceitem.rs
@@ -2,8 +2,6 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::client::{Client, Response};
 use crate::ids::{CustomerId, InvoiceId, InvoiceItemId, PriceId, SubscriptionId};
 use crate::params::{
@@ -13,6 +11,7 @@ use crate::resources::{
     Currency, Customer, Discount, Invoice, Period, Plan, Price, Subscription, TaxRate,
     TestHelpersTestClock,
 };
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "InvoiceItem".
 ///

--- a/src/resources/generated/invoices_shipping_cost.rs
+++ b/src/resources/generated/invoices_shipping_cost.rs
@@ -2,10 +2,9 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::params::Expandable;
 use crate::resources::{ShippingRate, TaxRate};
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "InvoicesShippingCost".
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]

--- a/src/resources/generated/issuing_authorization.rs
+++ b/src/resources/generated/issuing_authorization.rs
@@ -2,8 +2,6 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::ids::IssuingAuthorizationId;
 use crate::params::{Expandable, Metadata, Object, Timestamp};
 use crate::resources::{
@@ -11,6 +9,7 @@ use crate::resources::{
     IssuingAuthorizationMethod, IssuingAuthorizationReason, IssuingCard, IssuingCardholder,
     IssuingToken, IssuingTransaction, MerchantData,
 };
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "IssuingAuthorization".
 ///

--- a/src/resources/generated/issuing_card.rs
+++ b/src/resources/generated/issuing_card.rs
@@ -2,14 +2,13 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::ids::IssuingCardId;
 use crate::params::{Expandable, Metadata, Object, Timestamp};
 use crate::resources::{
     Address, CardBrand, Currency, IssuingCardShippingStatus, IssuingCardShippingType,
     IssuingCardType, IssuingCardholder, MerchantCategory,
 };
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "IssuingCard".
 ///

--- a/src/resources/generated/issuing_cardholder.rs
+++ b/src/resources/generated/issuing_cardholder.rs
@@ -2,11 +2,10 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::ids::IssuingCardholderId;
 use crate::params::{Expandable, Metadata, Object, Timestamp};
 use crate::resources::{Address, Currency, File, MerchantCategory};
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "IssuingCardholder".
 ///

--- a/src/resources/generated/issuing_dispute.rs
+++ b/src/resources/generated/issuing_dispute.rs
@@ -2,13 +2,12 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::ids::IssuingDisputeId;
 use crate::params::{Expandable, Metadata, Object, Timestamp};
 use crate::resources::{
     BalanceTransaction, Currency, File, IssuingDisputeStatus, IssuingTransaction,
 };
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "IssuingDispute".
 ///

--- a/src/resources/generated/issuing_token.rs
+++ b/src/resources/generated/issuing_token.rs
@@ -2,11 +2,10 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::ids::IssuingTokenId;
 use crate::params::{Expandable, Object, Timestamp};
 use crate::resources::IssuingCard;
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "IssuingNetworkToken".
 ///

--- a/src/resources/generated/issuing_transaction.rs
+++ b/src/resources/generated/issuing_transaction.rs
@@ -2,14 +2,13 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::ids::IssuingTransactionId;
 use crate::params::{Expandable, Metadata, Object, Timestamp};
 use crate::resources::{
     BalanceTransaction, Currency, IssuingAuthorization, IssuingCard, IssuingCardholder,
     IssuingDispute, IssuingToken, IssuingTransactionType, MerchantData,
 };
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "IssuingTransaction".
 ///

--- a/src/resources/generated/item.rs
+++ b/src/resources/generated/item.rs
@@ -2,11 +2,10 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::ids::CheckoutSessionItemId;
 use crate::params::Object;
 use crate::resources::{Currency, Discount, Price, TaxRate};
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "LineItem".
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]

--- a/src/resources/generated/line_item.rs
+++ b/src/resources/generated/line_item.rs
@@ -2,13 +2,12 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::ids::InvoiceLineItemId;
 use crate::params::{Expandable, Metadata, Object};
 use crate::resources::{
     Currency, Discount, InvoiceItem, Period, Plan, Price, Subscription, SubscriptionItem, TaxRate,
 };
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "InvoiceLineItem".
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]

--- a/src/resources/generated/login_link.rs
+++ b/src/resources/generated/login_link.rs
@@ -2,9 +2,8 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::params::{Object, Timestamp};
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "LoginLink".
 ///

--- a/src/resources/generated/mandate.rs
+++ b/src/resources/generated/mandate.rs
@@ -2,12 +2,11 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::client::{Client, Response};
 use crate::ids::MandateId;
 use crate::params::{Expand, Expandable, Object, Timestamp};
 use crate::resources::{Currency, PaymentMethod};
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "Mandate".
 ///

--- a/src/resources/generated/payment_intent.rs
+++ b/src/resources/generated/payment_intent.rs
@@ -2,8 +2,6 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::client::{Client, Response};
 use crate::ids::{
     CustomerId, MandateId, PaymentIntentId, PaymentMethodConfigurationId, PaymentMethodId,
@@ -17,6 +15,7 @@ use crate::resources::{
     PaymentMethodDetailsCardInstallmentsPlan, PaymentMethodOptionsCustomerBalanceEuBankAccount,
     PaymentMethodOptionsUsBankAccountMandateOptions, PaymentSource, Review, Shipping,
 };
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "PaymentIntent".
 ///

--- a/src/resources/generated/payment_intent_next_action_cashapp_handle_redirect_or_display_qr_code.rs
+++ b/src/resources/generated/payment_intent_next_action_cashapp_handle_redirect_or_display_qr_code.rs
@@ -2,9 +2,8 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::params::Timestamp;
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "PaymentIntentNextActionCashappHandleRedirectOrDisplayQrCode".
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]

--- a/src/resources/generated/payment_link.rs
+++ b/src/resources/generated/payment_link.rs
@@ -2,8 +2,6 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::client::{Client, Response};
 use crate::ids::PaymentLinkId;
 use crate::params::{Expand, Expandable, List, Metadata, Object, Paginable};
@@ -11,6 +9,7 @@ use crate::resources::{
     Account, Application, CheckoutSessionItem, ConnectAccountReference, Currency,
     InvoiceSettingRenderingOptions, ShippingRate, SubscriptionsTrialsResourceTrialSettings, TaxId,
 };
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "PaymentLink".
 ///

--- a/src/resources/generated/payment_method.rs
+++ b/src/resources/generated/payment_method.rs
@@ -2,8 +2,6 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::client::{Client, Response};
 use crate::ids::{CustomerId, PaymentMethodId};
 use crate::params::{Expand, Expandable, List, Metadata, Object, Paginable, Timestamp};
@@ -11,6 +9,7 @@ use crate::resources::{
     Address, BillingDetails, Charge, Customer, PaymentMethodCardPresentNetworks, RadarRadarOptions,
     SetupAttempt,
 };
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "PaymentMethod".
 ///

--- a/src/resources/generated/payout.rs
+++ b/src/resources/generated/payout.rs
@@ -2,12 +2,11 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::client::{Client, Response};
 use crate::ids::PayoutId;
 use crate::params::{Expand, Expandable, List, Metadata, Object, Paginable, RangeQuery, Timestamp};
 use crate::resources::{BalanceTransaction, Currency, PayoutDestinationUnion};
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "Payout".
 ///

--- a/src/resources/generated/person.rs
+++ b/src/resources/generated/person.rs
@@ -2,11 +2,10 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::ids::PersonId;
 use crate::params::{Expandable, Metadata, Object, Timestamp};
 use crate::resources::{Address, File};
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "Person".
 ///

--- a/src/resources/generated/placeholders.rs
+++ b/src/resources/generated/placeholders.rs
@@ -1,7 +1,6 @@
-use serde::{Deserialize, Serialize};
-
 use crate::ids::*;
 use crate::params::Object;
+use serde::{Deserialize, Serialize};
 
 #[cfg(not(feature = "connect"))]
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]

--- a/src/resources/generated/plan.rs
+++ b/src/resources/generated/plan.rs
@@ -2,8 +2,6 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::client::{Client, Response};
 use crate::ids::PlanId;
 use crate::params::{
@@ -11,6 +9,7 @@ use crate::params::{
     Timestamp,
 };
 use crate::resources::{CreateProduct, Currency, Product};
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "Plan".
 ///

--- a/src/resources/generated/platform_tax_fee.rs
+++ b/src/resources/generated/platform_tax_fee.rs
@@ -2,10 +2,9 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::ids::PlatformTaxFeeId;
 use crate::params::Object;
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "PlatformTax".
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]

--- a/src/resources/generated/price.rs
+++ b/src/resources/generated/price.rs
@@ -2,8 +2,6 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::client::{Client, Response};
 use crate::ids::PriceId;
 use crate::params::{
@@ -11,6 +9,7 @@ use crate::params::{
     Timestamp,
 };
 use crate::resources::{CreateProduct, Currency, CustomUnitAmount, Product, UpTo};
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "Price".
 ///

--- a/src/resources/generated/product.rs
+++ b/src/resources/generated/product.rs
@@ -2,8 +2,6 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::client::{Client, Response};
 use crate::ids::{ProductId, TaxCodeId};
 use crate::params::{
@@ -11,6 +9,7 @@ use crate::params::{
     Timestamp,
 };
 use crate::resources::{Currency, Price, TaxCode, UpTo};
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "Product".
 ///

--- a/src/resources/generated/promotion_code.rs
+++ b/src/resources/generated/promotion_code.rs
@@ -2,14 +2,13 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::client::{Client, Response};
 use crate::ids::{CouponId, CustomerId, PromotionCodeId};
 use crate::params::{
     CurrencyMap, Expand, Expandable, List, Metadata, Object, Paginable, RangeQuery, Timestamp,
 };
 use crate::resources::{Coupon, Currency, Customer};
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "PromotionCode".
 ///

--- a/src/resources/generated/quote.rs
+++ b/src/resources/generated/quote.rs
@@ -2,8 +2,6 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::client::{Client, Response};
 use crate::ids::{CustomerId, QuoteId};
 use crate::params::{Expand, Expandable, List, Metadata, Object, Paginable, Timestamp};
@@ -12,6 +10,7 @@ use crate::resources::{
     Discount, Invoice, QuotesResourceTotalDetails, Subscription, SubscriptionSchedule, TaxRate,
     TestHelpersTestClock,
 };
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "Quote".
 ///

--- a/src/resources/generated/quotes_resource_total_details.rs
+++ b/src/resources/generated/quotes_resource_total_details.rs
@@ -2,9 +2,8 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::resources::{Discount, TaxRate};
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "QuotesResourceTotalDetails".
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]

--- a/src/resources/generated/refund.rs
+++ b/src/resources/generated/refund.rs
@@ -2,12 +2,11 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::client::{Client, Response};
 use crate::ids::{ChargeId, CustomerId, PaymentIntentId, RefundId};
 use crate::params::{Expand, Expandable, List, Metadata, Object, Paginable, RangeQuery, Timestamp};
 use crate::resources::{BalanceTransaction, Charge, Currency, PaymentIntent, TransferReversal};
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "Refund".
 ///

--- a/src/resources/generated/reserve_transaction.rs
+++ b/src/resources/generated/reserve_transaction.rs
@@ -2,11 +2,10 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::ids::ReserveTransactionId;
 use crate::params::Object;
 use crate::resources::Currency;
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "ReserveTransaction".
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]

--- a/src/resources/generated/review.rs
+++ b/src/resources/generated/review.rs
@@ -2,12 +2,11 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::client::{Client, Response};
 use crate::ids::ReviewId;
 use crate::params::{Expand, Expandable, List, Object, Paginable, RangeQuery, Timestamp};
 use crate::resources::{Charge, PaymentIntent, ReviewReason};
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "RadarReview".
 ///

--- a/src/resources/generated/scheduled_query_run.rs
+++ b/src/resources/generated/scheduled_query_run.rs
@@ -2,11 +2,10 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::ids::ScheduledQueryRunId;
 use crate::params::{Object, Timestamp};
 use crate::resources::File;
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "ScheduledQueryRun".
 ///

--- a/src/resources/generated/setup_attempt.rs
+++ b/src/resources/generated/setup_attempt.rs
@@ -2,8 +2,6 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::client::{Client, Response};
 use crate::ids::{SetupAttemptId, SetupIntentId};
 use crate::params::{Expand, Expandable, List, Object, Paginable, RangeQuery, Timestamp};
@@ -11,6 +9,7 @@ use crate::resources::{
     Account, ApiErrors, Application, Customer, Mandate, PaymentMethod,
     PaymentMethodDetailsCardWalletApplePay, PaymentMethodDetailsCardWalletGooglePay, SetupIntent,
 };
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "PaymentFlowsSetupIntentSetupAttempt".
 ///

--- a/src/resources/generated/setup_intent.rs
+++ b/src/resources/generated/setup_intent.rs
@@ -2,8 +2,6 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::client::{Client, Response};
 use crate::ids::{CustomerId, PaymentMethodConfigurationId, PaymentMethodId, SetupIntentId};
 use crate::params::{Expand, Expandable, List, Metadata, Object, Paginable, RangeQuery, Timestamp};
@@ -13,6 +11,7 @@ use crate::resources::{
     PaymentMethodConfigBizPaymentMethodConfigurationDetails,
     PaymentMethodOptionsUsBankAccountMandateOptions, SetupAttempt,
 };
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "SetupIntent".
 ///

--- a/src/resources/generated/shipping.rs
+++ b/src/resources/generated/shipping.rs
@@ -2,9 +2,8 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::resources::Address;
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "Shipping".
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]

--- a/src/resources/generated/shipping_rate.rs
+++ b/src/resources/generated/shipping_rate.rs
@@ -2,14 +2,13 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::client::{Client, Response};
 use crate::ids::{ShippingRateId, TaxCodeId};
 use crate::params::{
     CurrencyMap, Expand, Expandable, List, Metadata, Object, Paginable, RangeQuery, Timestamp,
 };
 use crate::resources::{Currency, TaxCode};
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "ShippingRate".
 ///

--- a/src/resources/generated/source.rs
+++ b/src/resources/generated/source.rs
@@ -2,8 +2,6 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::client::{Client, Response};
 use crate::ids::{CustomerId, SourceId, TokenId};
 use crate::params::{Expand, List, Metadata, Object, Paginable, Timestamp};
@@ -11,6 +9,7 @@ use crate::resources::{
     Address, BillingDetails, Currency, Shipping, SourceRedirectFlowFailureReason,
     SourceRedirectFlowStatus, SourceStatus, SourceUsage,
 };
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "Source".
 ///

--- a/src/resources/generated/subscription.rs
+++ b/src/resources/generated/subscription.rs
@@ -2,8 +2,6 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::client::{Client, Response};
 use crate::ids::{CouponId, CustomerId, PlanId, PriceId, PromotionCodeId, SubscriptionId};
 use crate::params::{
@@ -18,6 +16,7 @@ use crate::resources::{
     SubscriptionSchedule, SubscriptionTransferData, SubscriptionsTrialsResourceTrialSettings,
     TaxRate, TestHelpersTestClock,
 };
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "Subscription".
 ///

--- a/src/resources/generated/subscription_item.rs
+++ b/src/resources/generated/subscription_item.rs
@@ -2,12 +2,11 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::client::{Client, Response};
 use crate::ids::{PlanId, PriceId, SubscriptionId, SubscriptionItemId};
 use crate::params::{Deleted, Expand, List, Metadata, Object, Paginable, Timestamp};
 use crate::resources::{Currency, Plan, Price, SubscriptionItemBillingThresholds, TaxRate};
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "SubscriptionItem".
 ///

--- a/src/resources/generated/subscription_schedule.rs
+++ b/src/resources/generated/subscription_schedule.rs
@@ -2,8 +2,6 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::client::{Client, Response};
 use crate::ids::{CustomerId, SubscriptionScheduleId};
 use crate::params::{Expand, Expandable, List, Metadata, Object, Paginable, RangeQuery, Timestamp};
@@ -13,6 +11,7 @@ use crate::resources::{
     SubscriptionItemBillingThresholds, SubscriptionTransferData, TaxId, TaxRate,
     TestHelpersTestClock,
 };
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "SubscriptionSchedule".
 ///

--- a/src/resources/generated/tax_calculation.rs
+++ b/src/resources/generated/tax_calculation.rs
@@ -2,11 +2,10 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::ids::TaxCalculationId;
 use crate::params::{List, Object, Timestamp};
 use crate::resources::{Currency, TaxCalculationLineItem, TaxProductResourceCustomerDetails};
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "TaxProductResourceTaxCalculation".
 ///

--- a/src/resources/generated/tax_calculation_line_item.rs
+++ b/src/resources/generated/tax_calculation_line_item.rs
@@ -2,10 +2,9 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::ids::TaxCalculationLineItemId;
 use crate::params::Object;
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "TaxProductResourceTaxCalculationLineItem".
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]

--- a/src/resources/generated/tax_code.rs
+++ b/src/resources/generated/tax_code.rs
@@ -2,11 +2,10 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::client::{Client, Response};
 use crate::ids::TaxCodeId;
 use crate::params::{Expand, List, Object, Paginable};
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "TaxProductResourceTaxCode".
 ///

--- a/src/resources/generated/tax_deducted_at_source.rs
+++ b/src/resources/generated/tax_deducted_at_source.rs
@@ -2,10 +2,9 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::ids::TaxDeductedAtSourceId;
 use crate::params::{Object, Timestamp};
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "TaxDeductedAtSource".
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]

--- a/src/resources/generated/tax_id.rs
+++ b/src/resources/generated/tax_id.rs
@@ -2,12 +2,11 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::client::{Client, Response};
 use crate::ids::TaxIdId;
 use crate::params::{Deleted, Expand, Expandable, List, Object, Paginable, Timestamp};
 use crate::resources::{Account, Application, Customer};
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "tax_id".
 ///

--- a/src/resources/generated/tax_rate.rs
+++ b/src/resources/generated/tax_rate.rs
@@ -2,11 +2,10 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::client::{Client, Response};
 use crate::ids::TaxRateId;
 use crate::params::{Expand, List, Metadata, Object, Paginable, RangeQuery, Timestamp};
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "TaxRate".
 ///

--- a/src/resources/generated/terminal_configuration.rs
+++ b/src/resources/generated/terminal_configuration.rs
@@ -2,12 +2,11 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::client::{Client, Response};
 use crate::ids::TerminalConfigurationId;
 use crate::params::{Expand, Expandable, List, Object, Paginable};
 use crate::resources::File;
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "TerminalConfigurationConfiguration".
 ///

--- a/src/resources/generated/terminal_connection_token.rs
+++ b/src/resources/generated/terminal_connection_token.rs
@@ -2,10 +2,9 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::client::{Client, Response};
 use crate::params::{Expand, Object};
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "TerminalConnectionToken".
 ///

--- a/src/resources/generated/terminal_location.rs
+++ b/src/resources/generated/terminal_location.rs
@@ -2,12 +2,11 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::client::{Client, Response};
 use crate::ids::TerminalLocationId;
 use crate::params::{Expand, List, Metadata, Object, Paginable};
 use crate::resources::Address;
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "TerminalLocationLocation".
 ///

--- a/src/resources/generated/terminal_reader.rs
+++ b/src/resources/generated/terminal_reader.rs
@@ -2,12 +2,11 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::client::{Client, Response};
 use crate::ids::TerminalReaderId;
 use crate::params::{Expand, Expandable, List, Metadata, Object, Paginable};
 use crate::resources::{Charge, Currency, PaymentIntent, Refund, SetupIntent, TerminalLocation};
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "TerminalReaderReader".
 ///

--- a/src/resources/generated/test_helpers_test_clock.rs
+++ b/src/resources/generated/test_helpers_test_clock.rs
@@ -2,10 +2,9 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::ids::TestHelpersTestClockId;
 use crate::params::{Object, Timestamp};
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "TestClock".
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]

--- a/src/resources/generated/token.rs
+++ b/src/resources/generated/token.rs
@@ -2,12 +2,11 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::client::{Client, Response};
 use crate::ids::{CustomerId, TokenId};
 use crate::params::{Expand, Metadata, Object, Timestamp};
 use crate::resources::{Address, BankAccount, Card, CompanyParams, PersonParams, TokenType};
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "Token".
 ///

--- a/src/resources/generated/topup.rs
+++ b/src/resources/generated/topup.rs
@@ -2,12 +2,11 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::client::{Client, Response};
 use crate::ids::TopupId;
 use crate::params::{Expand, Expandable, List, Metadata, Object, Paginable, RangeQuery, Timestamp};
 use crate::resources::{BalanceTransaction, Currency, Source};
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "Topup".
 ///

--- a/src/resources/generated/transfer.rs
+++ b/src/resources/generated/transfer.rs
@@ -2,12 +2,11 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::client::{Client, Response};
 use crate::ids::{ChargeId, TransferId};
 use crate::params::{Expand, Expandable, List, Metadata, Object, Paginable, RangeQuery, Timestamp};
 use crate::resources::{Account, BalanceTransaction, Charge, Currency, TransferReversal};
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "Transfer".
 ///

--- a/src/resources/generated/transfer_reversal.rs
+++ b/src/resources/generated/transfer_reversal.rs
@@ -2,11 +2,10 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::ids::TransferReversalId;
 use crate::params::{Expandable, Metadata, Object, Timestamp};
 use crate::resources::{BalanceTransaction, Currency, Refund, Transfer};
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "TransferReversal".
 ///

--- a/src/resources/generated/usage_record.rs
+++ b/src/resources/generated/usage_record.rs
@@ -2,10 +2,9 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::ids::UsageRecordId;
 use crate::params::{Object, Timestamp};
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "UsageRecord".
 ///

--- a/src/resources/generated/usage_record_summary.rs
+++ b/src/resources/generated/usage_record_summary.rs
@@ -2,12 +2,13 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::ids::UsageRecordSummaryId;
 use crate::params::{Object, Timestamp};
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "UsageRecordSummary".
+///
+/// For more details see <https://stripe.com/docs/api/usage-record-summary/object>
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct UsageRecordSummary {
     /// Unique identifier for the object.

--- a/src/resources/generated/webhook_endpoint.rs
+++ b/src/resources/generated/webhook_endpoint.rs
@@ -2,12 +2,11 @@
 // This file was automatically generated.
 // ======================================
 
-use serde::{Deserialize, Serialize};
-
 use crate::client::{Client, Response};
 use crate::ids::WebhookEndpointId;
 use crate::params::{Deleted, Expand, List, Metadata, Object, Paginable, Timestamp};
 use crate::resources::{ApiVersion, WebhookEndpointStatus};
+use serde::{Deserialize, Serialize};
 
 /// The resource representing a Stripe "NotificationWebhookEndpoint".
 ///


### PR DESCRIPTION
# Summary

In an attempt to fix that, instead of relying on stable and nightly, we can
instead make it explicit which versions of Rust we want to use.

The proposed solution here is:
- Use `1.82` for formatting, Clippy and for running cargo make binaries.
- Use `1.78` as the MSRV, running tests and build.
- `nightly-2024-10-18` for cargo-public-api (as per recommended [on docs](https://github.com/cargo-public-api/cargo-public-api))

Why 1.82.0? Just because an arbitrary `latest version - 2` (latest 1.84). But we can choose another one
if we prefer.

With this bump to the rustfmt, the generated files need to be update as well. But the only change is the order
of the import to Serde Serialize/Deserialize.

Hopefully this should stop workflows from failing when a new version of stable/nightly comes out, like on #656

### Checklist

- [x] ran `cargo make fmt`
- [x] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features
  <!--
  EXAMPLES:
  feat: you can now add and remove principals from a project
  fix: fixes an issue where the combobox was displaying incorrect values
  -->
