### PR TITLE
chore: bump upload-artifact to v4

### DIFF
--- a/.github/workflows/async-stripe.yml
+++ b/.github/workflows/async-stripe.yml
@@ -136,7 +136,7 @@ jobs:
       #     token: ${{secrets.CODECOV_TOKEN}}
       #     files: lcov.info
       # - name: Archive code coverage results
-      #   uses: actions/upload-artifact@v1
+      #   uses: actions/upload-artifact@v4
       #   with:
       #     name: code-coverage-report
       #     path: lcov.info
@@ -148,7 +148,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "nightly-2024-10-18"
+          toolchain: "nightly-2025-01-25"
       - name: Install cargo-public-api
         uses: baptiste0928/cargo-install@v3
         with:
@@ -167,7 +167,7 @@ jobs:
             fs.writeFileSync("./public-api/pr_number", text);
       - name: Compare with latest version published on crates.io
         run: cargo public-api diff latest --features runtime-tokio-hyper >> "public-api/diff"
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: public-api
           path: public-api/


### PR DESCRIPTION
# Summary
[actions/upload-artifact](https://github.com/actions/upload-artifact) v3 has been deprecated on November 30, 2024 and is [causing `generate-public-api` to break](https://github.com/arlyon/async-stripe/actions/runs/13416807888/job/37479514754).

> Breaking Changes
>
>    1. On self hosted runners, additional firewall rules may be required.
>
>    2. Uploading to the same named Artifact multiple times.
>
>    3. Due to how Artifacts are created in this new version, it is no longer possible to upload to the same named Artifact multiple times. You must either split the uploads into multiple Artifacts with different names, or only upload once. Otherwise you will encounter an error.
>
>    4. Limit of Artifacts for an individual job. Each job in a workflow run now has a limit of 500 artifacts.
>
>    5. With v4.4 and later, hidden files are excluded by default.

### Checklist

- [x] ran `cargo make fmt`
- [x] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features
