### PR TITLE
fix: pin native-tls to <= 0.2.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,6 +163,7 @@ actix-web = "4.2.1"
 # We have a few deps that have MSRVs that are higher than our own. 
 # We pin them here to ensure that we can run tests on the MSRV
 bumpalo = ">=3.0.0, <= 3.15.0"
+native-tls = ">= 0.2.0, <= 0.2.13"
 
 [[example]]
 name = "checkout"


### PR DESCRIPTION
# Summary

[native-tls 0.2.14 bumped their MSRV from 1.53.0 to 1.80.0](https://github.com/sfackler/rust-native-tls/compare/v0.2.12...v0.2.14), which we don't support. Since [tokio-native-tls has dependency to `native-tls = "0.2"`](https://github.com/tokio-rs/tls/blob/02c1aeb7001525f4aa71e07312f8519872dc638a/tokio-native-tls/Cargo.toml#L25), is causing the tests to break.

This pins the `native-tls` to `<= 0.2.13`.

### Checklist

- [x] ran `cargo make fmt`
- [x] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features