### PR TITLE
fix: Remove quotes from EventType display 

### DIFF
--- a/src/resources/webhook_events.rs
+++ b/src/resources/webhook_events.rs
@@ -405,7 +405,7 @@ pub enum EventType {
 
 impl std::fmt::Display for EventType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&serde_json::to_string(self).expect("serializing EventType should not fail"))
+        self.serialize(f)
     }
 }
 
@@ -586,6 +586,18 @@ impl<'r> Signature<'r> {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "webhook-events")]
+    #[test]
+    fn test_event_type_display() {
+        use super::EventType;
+
+        // Can catch issues like quotes being added to the string
+        assert_eq!(
+            EventType::CustomerSubscriptionCreated.to_string(),
+            "customer.subscription.created"
+        );
+    }
+
     #[cfg(feature = "webhook-events")]
     #[test]
     fn test_signature_parse() {


### PR DESCRIPTION
# Summary
Using `EventType::to_string` was returning a string that started and ended with quotation marks due to how it was using serde_json to generate the string.

This tripped me up because I was using `.starts_with("customer.subscription")` for handling subscription events which failed until I changed it to `.starts_with("\"customer.subscription")`

This PR changes the Display implementation to use the [serde::Serializer implementation for std::fmt::Formatter](https://docs.rs/serde/1.0.219/serde/trait.Serializer.html#impl-Serializer-for-%26mut+Formatter%3C'a%3E)
instead of involving serde_json. This makes it not have the quotes (see the included test) and has the added benefit of removing a possible panic since the error returned by the formatter's serializer can be returned directly.
<!--
A quick summary of what this PR does, why is needs to be applied, what has changed, etc.
-->

### Checklist

- [X] ran `cargo make fmt` 
    Note that it spammed warnings about a groups_import feature that needs nightly even when I run `cargo +nightly make fmt` even tried overriding the toolchain with nightly :shrug: 
- [X] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features
  <!--
  EXAMPLES:
  feat: you can now add and remove principals from a project
  fix: fixes an issue where the combobox was displaying incorrect values
  -->
