### PR TITLE
fix: Support sole_prop in account.business_type

### DIFF
--- a/src/resources/generated/account.rs
+++ b/src/resources/generated/account.rs
@@ -2942,6 +2942,7 @@ pub enum AccountBusinessType {
     GovernmentEntity,
     Individual,
     NonProfit,
+    SoleProp,
 }
 
 impl AccountBusinessType {
@@ -2951,6 +2952,7 @@ impl AccountBusinessType {
             AccountBusinessType::GovernmentEntity => "government_entity",
             AccountBusinessType::Individual => "individual",
             AccountBusinessType::NonProfit => "non_profit",
+            AccountBusinessType::SoleProp => "sole_prop",
         }
     }
 }


### PR DESCRIPTION
# Summary

Hi.
Recently, In my Stripe webhook, sometimes "sole_prop" is set for `account.business_type`.
It's [undocumented](https://docs.stripe.com/api/accounts/object#account_object-business_type) but may be a change in Stripe's specifications.

### Checklist

- [x] ran `cargo make fmt`
- [x] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features
