### PR TITLE
chore(webhook-axum): bump Axum to 0.8.4

### DIFF
--- a/examples/webhook-axum/Cargo.toml
+++ b/examples/webhook-axum/Cargo.toml
@@ -6,6 +6,7 @@ publish = false
 
 [dependencies]
 tokio = { version = "1.24.1", features = ["rt-multi-thread", "macros"] }
-axum = { version = "0.7.4", features = ["macros"] }
-async-stripe-webhook = { path = "../../async-stripe-webhook", features = ["async-stripe-checkout"] }
-async-trait = "0.1"
+axum = { version = "0.8.4", features = ["macros"] }
+async-stripe-webhook = { path = "../../async-stripe-webhook", features = [
+    "async-stripe-checkout",
+] }

--- a/examples/webhook-axum/src/main.rs
+++ b/examples/webhook-axum/src/main.rs
@@ -13,7 +13,6 @@
 //! ```
 
 use axum::{
-    async_trait,
     body::Body,
     extract::FromRequest,
     http::{Request, StatusCode},
@@ -39,7 +38,6 @@ async fn main() {
 
 struct StripeEvent(Event);
 
-#[async_trait]
 impl<S> FromRequest<S> for StripeEvent
 where
     String: FromRequest<S>,


### PR DESCRIPTION
# Summary
Bumps Axum to 0.8 on the `webhook-axum` example. This bump requires the removal of #[async_trait] as pointed out on #712.

Close #712 

### Checklist

- [x] ran `cargo make fmt`
- [x] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features
