### PR TITLE
fix: wrong comment on example

### DIFF
--- a/examples/checkout.rs
+++ b/examples/checkout.rs
@@ -41,7 +41,7 @@ async fn main() {
 
     println!("created a customer at https://dashboard.stripe.com/test/customers/{}", customer.id);
 
-    // create a new example project
+    // create a new example product
     let product = {
         let mut create_product = CreateProduct::new("T-Shirt");
         create_product.metadata = Some(std::collections::HashMap::from([(

--- a/examples/payment-link.rs
+++ b/examples/payment-link.rs
@@ -17,7 +17,7 @@ async fn main() {
     let secret_key = std::env::var("STRIPE_SECRET_KEY").expect("Missing STRIPE_SECRET_KEY in env");
     let client = Client::new(secret_key);
 
-    // create a new example project
+    // create a new example product
     let product = {
         let mut create_product = CreateProduct::new("T-Shirt");
         create_product.metadata = Some(std::collections::HashMap::from([(


### PR DESCRIPTION
# Summary

Just correction of wrong comment on examples: `project` -> `product`


### Checklist

- [ ] ran `cargo make fmt`
- [x] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features
  <!--
  EXAMPLES:
  feat: you can now add and remove principals from a project
  fix: fixes an issue where the combobox was displaying incorrect values
  -->
