### PR TITLE
add From<Uuid> implementation for IdempotencyKey

### DIFF
--- a/async-stripe-client-core/src/request_strategy.rs
+++ b/async-stripe-client-core/src/request_strategy.rs
@@ -143,6 +143,14 @@ impl TryFrom<String> for IdempotencyKey {
     }
 }
 
+#[cfg(feature = "uuid")]
+impl From<uuid::Uuid> for IdempotencyKey {
+    #[inline]
+    fn from(value: uuid::Uuid) -> Self {
+        Self(value.to_string())
+    }
+}
+
 fn calculate_backoff(retry_count: u32) -> Duration {
     Duration::from_secs(2_u64.pow(retry_count))
 }


### PR DESCRIPTION
# Summary

I started using the `next` branch and whilst migrating my code I found myself writing a lot of the following:
```rust
let customer = CreateCustomer::new()
    .email(user.email)
    .name(user.name)
    .customize()
    .request_strategy(RequestStrategy::Idempotent(
        IdempotencyKey::try_from(user_id.to_string())
            .expect("Uuid is always valid IdempotencyKey"),
    ))
    .send(stripe_client)
    .await?;
```
Due to the `IdempotencyKey` not being just a `String` anymore but a newtype with length validation in its `TryFrom<String>` implementation. 

The new `From<Uuid>` impl will allow just writing:

```rust
let customer = CreateCustomer::new()
    .email(user.email)
    .name(user.name)
    .customize()
    .request_strategy(RequestStrategy::Idempotent(user_id.into()))
    .send(stripe_client)
    .await?;
```

### Checklist

- [ x] ran `cargo make fmt`
- [x ] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and 
