### PR TITLE
Remove unused `total_count` field from `List`

### DIFF
--- a/async-stripe-client-core/src/pagination.rs
+++ b/async-stripe-client-core/src/pagination.rs
@@ -53,7 +53,9 @@ where
 
     fn into_parts(self) -> ListParts<Self::Data> {
         ListParts {
-            total_count: self.total_count,
+            // total_count is not present in `List`, but still present in `ListParts` because the stripe API
+            // claims search pagination can still include `total_count` if requested
+            total_count: None,
             url: self.url,
             data: self.data,
             has_more: self.has_more,
@@ -61,12 +63,7 @@ where
     }
 
     fn from_parts(parts: ListParts<Self::Data>) -> Self {
-        Self {
-            data: parts.data,
-            has_more: parts.has_more,
-            total_count: parts.total_count,
-            url: parts.url,
-        }
+        Self { data: parts.data, has_more: parts.has_more, url: parts.url }
     }
 
     fn update_params(&mut self, params: &mut Value) {
@@ -186,7 +183,7 @@ impl<T> ListPaginator<List<T>> {
     /// to implement `PaginationExt`. Not part of the public API.
     #[doc(hidden)]
     pub fn new_list(url: impl Into<String>, params: impl Serialize) -> Self {
-        let page = List { data: vec![], has_more: true, total_count: None, url: url.into() };
+        let page = List { data: vec![], has_more: true, url: url.into() };
         Self {
             page,
             params: serde_json::to_value(params)

--- a/async-stripe-types/src/pagination.rs
+++ b/async-stripe-types/src/pagination.rs
@@ -72,8 +72,6 @@ pub struct List<T> {
     pub data: Vec<T>,
     /// If true, making another request with our new url will yield more data.
     pub has_more: bool,
-    /// The total number of results.
-    pub total_count: Option<u64>,
     /// The base endpoint we're targeting.
     pub url: String,
 }
@@ -91,7 +89,6 @@ impl<T: Serialize> Serialize for List<T> {
         let mut ser = serializer.serialize_struct("List", 5)?;
         ser.serialize_field("data", &self.data)?;
         ser.serialize_field("has_more", &self.has_more)?;
-        ser.serialize_field("total_count", &self.total_count)?;
         ser.serialize_field("url", &self.url)?;
         ser.serialize_field("object", "list")?;
         ser.end()
@@ -100,12 +97,7 @@ impl<T: Serialize> Serialize for List<T> {
 
 impl<T: Clone> Clone for List<T> {
     fn clone(&self) -> Self {
-        List {
-            data: self.data.clone(),
-            has_more: self.has_more,
-            total_count: self.total_count,
-            url: self.url.clone(),
-        }
+        List { data: self.data.clone(), has_more: self.has_more, url: self.url.clone() }
     }
 }
 
@@ -161,7 +153,6 @@ mod impl_deserialize {
                 out: &mut self.out,
                 data: Deserialize::default(),
                 has_more: Deserialize::default(),
-                total_count: Deserialize::default(),
                 url: Deserialize::default(),
             }))
         }
@@ -171,7 +162,6 @@ mod impl_deserialize {
         out: &'a mut Option<List<T>>,
         data: Option<Vec<T>>,
         has_more: Option<bool>,
-        total_count: Option<Option<u64>>,
         url: Option<String>,
     }
 
@@ -181,7 +171,6 @@ mod impl_deserialize {
                 "url" => Ok(Deserialize::begin(&mut self.url)),
                 "data" => Ok(Deserialize::begin(&mut self.data)),
                 "has_more" => Ok(Deserialize::begin(&mut self.has_more)),
-                "total_count" => Ok(Deserialize::begin(&mut self.total_count)),
                 _ => Ok(<dyn Visitor>::ignore()),
             }
         }
@@ -190,8 +179,7 @@ mod impl_deserialize {
             let url = self.url.take().ok_or(Error)?;
             let data = self.data.take().ok_or(Error)?;
             let has_more = self.has_more.ok_or(Error)?;
-            let total_count = self.total_count.ok_or(Error)?;
-            *self.out = Some(List { data, has_more, total_count, url });
+            *self.out = Some(List { data, has_more, url });
             Ok(())
         }
     }
@@ -200,7 +188,6 @@ mod impl_deserialize {
         fn from_value(v: Value) -> Option<Self> {
             let mut data: Option<Vec<T>> = None;
             let mut has_more: Option<bool> = None;
-            let mut total_count: Option<Option<u64>> = Some(None);
             let mut url: Option<String> = None;
             let Value::Object(obj) = v else {
                 return None;
@@ -210,11 +197,10 @@ mod impl_deserialize {
                     "has_more" => has_more = Some(bool::from_value(v)?),
                     "data" => data = Some(FromValueOpt::from_value(v)?),
                     "url" => url = Some(FromValueOpt::from_value(v)?),
-                    "total_count" => total_count = Some(FromValueOpt::from_value(v)?),
                     _ => {}
                 }
             }
-            Some(Self { data: data?, has_more: has_more?, total_count: total_count?, url: url? })
+            Some(Self { data: data?, has_more: has_more?, url: url? })
         }
     }
 


### PR DESCRIPTION
Replacing #709, rebased on latest API changes