### PR TITLE
chore: release v1.0.0-alpha.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,9 +21,9 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.11.1"
+version = "3.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44cceded2fb55f3c4b67068fa64962e2ca59614edc5b03167de9ff82ae803da0"
+checksum = "7926860314cbe2fb5d1f13731e387ab43bd32bca224e82e6e2db85de0a3dba49"
 dependencies = [
  "actix-codec",
  "actix-rt",
@@ -65,7 +65,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.106",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -182,16 +182,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
-]
-
-[[package]]
-name = "addr2line"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
-dependencies = [
- "gimli",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -256,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
@@ -380,7 +371,7 @@ dependencies = [
  "polling",
  "rustix",
  "slab",
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -436,7 +427,7 @@ dependencies = [
  "rustix",
  "signal-hook-registry",
  "slab",
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -486,12 +477,12 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.108",
 ]
 
 [[package]]
 name = "async-stripe"
-version = "1.0.0-alpha.4"
+version = "1.0.0-alpha.5"
 dependencies = [
  "async-std",
  "async-stripe-client-core",
@@ -514,7 +505,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-billing"
-version = "1.0.0-alpha.4"
+version = "1.0.0-alpha.5"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -527,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-checkout"
-version = "1.0.0-alpha.4"
+version = "1.0.0-alpha.5"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -540,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-client-core"
-version = "1.0.0-alpha.4"
+version = "1.0.0-alpha.5"
 dependencies = [
  "async-stripe-shared",
  "async-stripe-types",
@@ -557,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-connect"
-version = "1.0.0-alpha.4"
+version = "1.0.0-alpha.5"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -570,7 +561,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-core"
-version = "1.0.0-alpha.4"
+version = "1.0.0-alpha.5"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -583,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-fraud"
-version = "1.0.0-alpha.4"
+version = "1.0.0-alpha.5"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -596,7 +587,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-issuing"
-version = "1.0.0-alpha.4"
+version = "1.0.0-alpha.5"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -609,7 +600,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-misc"
-version = "1.0.0-alpha.4"
+version = "1.0.0-alpha.5"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -622,7 +613,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-payment"
-version = "1.0.0-alpha.4"
+version = "1.0.0-alpha.5"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -635,7 +626,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-product"
-version = "1.0.0-alpha.4"
+version = "1.0.0-alpha.5"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -648,7 +639,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-shared"
-version = "1.0.0-alpha.4"
+version = "1.0.0-alpha.5"
 dependencies = [
  "async-stripe-types",
  "miniserde",
@@ -659,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-terminal"
-version = "1.0.0-alpha.4"
+version = "1.0.0-alpha.5"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -702,7 +693,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-treasury"
-version = "1.0.0-alpha.4"
+version = "1.0.0-alpha.5"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -715,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-types"
-version = "1.0.0-alpha.4"
+version = "1.0.0-alpha.5"
 dependencies = [
  "miniserde",
  "serde",
@@ -726,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-webhook"
-version = "1.0.0-alpha.4"
+version = "1.0.0-alpha.5"
 dependencies = [
  "async-stripe-billing",
  "async-stripe-checkout",
@@ -762,7 +753,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -853,22 +844,7 @@ checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
-]
-
-[[package]]
-name = "backtrace"
-version = "0.3.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-link",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -903,9 +879,9 @@ checksum = "383d29d513d8764dcdc42ea295d979eb99c3c9f00607b3692cf68a431f7dca72"
 
 [[package]]
 name = "bitflags"
-version = "2.9.4"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "block-buffer"
@@ -976,9 +952,9 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytemuck"
-version = "1.23.2"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
+checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
 
 [[package]]
 name = "bytes"
@@ -1003,9 +979,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.39"
+version = "1.2.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1354349954c6fc9cb0deab020f27f783cf0b604e8bb754dc4658ecf0d29c35f"
+checksum = "739eb0f94557554b3ca9a86d2d37bebd49c5e6d0c1d2bda35ba5bdac830befc2"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1015,9 +991,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
@@ -1197,7 +1173,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "socket2 0.6.0",
+ "socket2 0.6.1",
  "windows-sys 0.59.0",
 ]
 
@@ -1237,9 +1213,9 @@ checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "deranged"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a41953f86f8a05768a6cda24def994fd2f424b04ec5c719cf89989779f199071"
+checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
 ]
@@ -1261,7 +1237,7 @@ checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.108",
  "unicode-xid",
 ]
 
@@ -1295,7 +1271,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -1332,7 +1308,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -1379,7 +1355,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1440,15 +1416,15 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
+checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
 
 [[package]]
 name = "flate2"
-version = "1.1.2"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1585,7 +1561,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -1633,9 +1609,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.7"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
@@ -1665,14 +1641,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.7+wasi-0.2.4",
+ "wasip2",
 ]
 
 [[package]]
@@ -1684,12 +1660,6 @@ dependencies = [
  "opaque-debug",
  "polyval",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "glob"
@@ -2022,7 +1992,7 @@ dependencies = [
  "hyper 1.7.0",
  "libc",
  "pin-project-lite",
- "socket2 0.6.0",
+ "socket2 0.6.1",
  "tokio",
  "tower-service",
  "tracing",
@@ -2054,9 +2024,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -2067,9 +2037,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -2080,11 +2050,10 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
@@ -2095,42 +2064,38 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "2.0.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+checksum = "e93fcd3157766c0c8da2f8cff6ce651a31f0810eaa1c51ec363ef790bbb5fb99"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "potential_utf",
  "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "2.0.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+checksum = "02845b3647bb045f1100ecd6480ff52f34c35f82d9880e029d329c21d1054899"
 
 [[package]]
 name = "icu_provider"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
- "stable_deref_trait",
- "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
@@ -2167,9 +2132,9 @@ checksum = "e8a5a9a0ff0086c7a148acb942baaabeadf9504d10400b5a05645853729b9cd2"
 
 [[package]]
 name = "indexmap"
-version = "2.11.4"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
+checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -2199,25 +2164,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-uring"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
-dependencies = [
- "bitflags",
- "cfg-if",
- "libc",
-]
-
-[[package]]
 name = "is-terminal"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2255,15 +2209,15 @@ version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.81"
+version = "0.3.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
+checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2298,9 +2252,9 @@ checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
-version = "0.2.176"
+version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
+checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "libnghttp2-sys"
@@ -2332,9 +2286,9 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "local-channel"
@@ -2355,11 +2309,10 @@ checksum = "4d873d7c67ce09b42110d801813efbc9364414e356be9935700d368351657487"
 
 [[package]]
 name = "lock_api"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
@@ -2432,7 +2385,7 @@ checksum = "560f32b6891d8d9bade8942c45a27694f16d789d3b4b8e6b7135a5240de0a8af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -2453,18 +2406,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
 name = "mio"
-version = "1.0.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2505,11 +2459,11 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.50.1"
+version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2538,15 +2492,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.37.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2560,9 +2505,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.73"
+version = "0.10.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
+checksum = "24ad14dd45412269e1a30f52ad8f0664f0f4f4a89ee8fe28c3b3527021ebb654"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -2581,7 +2526,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -2592,9 +2537,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.109"
+version = "0.9.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+checksum = "0a9f0075ba3c21b09f8e8b2026584b1d18d49388648f2fbbf3c97ea8deced8e2"
 dependencies = [
  "cc",
  "libc",
@@ -2620,9 +2565,9 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -2630,15 +2575,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.11"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -2661,7 +2606,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -2687,7 +2632,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -2730,7 +2675,7 @@ dependencies = [
  "hermit-abi",
  "pin-project-lite",
  "rustix",
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2746,9 +2691,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
@@ -2776,9 +2721,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.101"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]
@@ -2791,7 +2736,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.108",
  "version_check",
  "yansi",
 ]
@@ -2899,7 +2844,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2913,9 +2858,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.17"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
 ]
@@ -2937,14 +2882,14 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.108",
 ]
 
 [[package]]
 name = "regex"
-version = "1.11.3"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2954,9 +2899,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2965,15 +2910,15 @@ dependencies = [
 
 [[package]]
 name = "regex-lite"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943f41321c63ef1c92fd763bfe054d2668f7f225a5c29f0105903dc2fc04ba30"
+checksum = "8d942b98df5e658f56f20d592c7f868833fe38115e65c33003d8cd224b0155da"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "ring"
@@ -3038,7 +2983,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rocket_http",
- "syn 2.0.106",
+ "syn 2.0.108",
  "unicode-xid",
  "version_check",
 ]
@@ -3071,12 +3016,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
-
-[[package]]
 name = "rustc_version"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3095,14 +3034,14 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.32"
+version = "0.23.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3c25631629d034ce7cd9940adc9d45762d46de2b0f57193c4443b92c6d4d40"
+checksum = "6a9586e9ee2b4f8fab52a0048ca7334d7024eef48e2cb9407e3497bb7cab7fa7"
 dependencies = [
  "log",
  "once_cell",
@@ -3115,9 +3054,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
+checksum = "9980d917ebb0c0536119ba501e90834767bffc3d60641457fd84a1f3fd337923"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -3127,18 +3066,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+checksum = "94182ad936a0c91c324cd46c6511b9510ed16af436d7b5bab34beab0afd55f7a"
 dependencies = [
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.7"
+version = "0.103.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10b3f4191e8a80e6b43eebabfac91e5dcecebb27a71f04e820c47ec41d314bf"
+checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3163,7 +3102,7 @@ version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3256,7 +3195,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -3411,6 +3350,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3461,12 +3406,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3495,9 +3440,9 @@ dependencies = [
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "standback"
@@ -3608,9 +3553,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.106"
+version = "2.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+checksum = "da58917d35242480a05c2897064da0a80589a2a0476c9a3f2fdc83b53502e917"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3631,7 +3576,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -3641,10 +3586,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand 2.3.0",
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3673,7 +3618,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -3684,7 +3629,7 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -3767,9 +3712,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3777,33 +3722,30 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.47.1"
+version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
+checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
 dependencies = [
- "backtrace",
  "bytes 1.10.1",
- "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "slab",
- "socket2 0.6.0",
+ "socket2 0.6.1",
  "tokio-macros",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -3939,7 +3881,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -4030,9 +3972,9 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.19"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "unicode-xid"
@@ -4080,7 +4022,7 @@ version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -4137,15 +4079,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasi"
-version = "0.14.7+wasi-0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
-dependencies = [
- "wasip2",
-]
-
-[[package]]
 name = "wasip2"
 version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4156,9 +4089,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.104"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
+checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4168,24 +4101,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn 2.0.106",
- "wasm-bindgen-shared",
-]
-
-[[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.54"
+version = "0.4.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e038d41e478cc73bae0ff9b36c60cff1c98b8f38f8d7e8061e79ee63608ac5c"
+checksum = "551f88106c6d5e7ccc7cd9a16f312dd3b5d36ea8b4954304657d5dfba115d4a0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -4196,9 +4115,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.104"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
+checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4206,31 +4125,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.104"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
+checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.106",
- "wasm-bindgen-backend",
+ "syn 2.0.108",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.104"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
+checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.81"
+version = "0.3.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9367c417a924a74cae129e6a2ae3b47fabb1f8995595ab474029da749a8be120"
+checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4266,9 +4185,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
+checksum = "32b130c0d2d49f8b6889abc456e795e82525204f27c42cf767cf0d7734e089b8"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4306,9 +4225,9 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.62.1"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6844ee5416b285084d3d3fffd743b925a6c9385455f64f6d4fa3031c4c2749a9"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
@@ -4319,46 +4238,46 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
-version = "0.60.1"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edb307e42a74fb6de9bf3a02d9712678b22399c87e6fa869d6dfcd8c1b7754e0"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.108",
 ]
 
 [[package]]
 name = "windows-interface"
-version = "0.59.2"
+version = "0.59.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0abd1ddbc6964ac14db11c7213d6532ef34bd9aa042c2e5935f59d7908b46a5"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.108",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-result"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
  "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
 ]
@@ -4383,9 +4302,18 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.61.1"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
@@ -4414,11 +4342,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -4434,6 +4379,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4444,6 +4395,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4458,10 +4415,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4476,6 +4445,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4486,6 +4461,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4500,6 +4481,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4510,6 +4497,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -4551,9 +4544,9 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "writeable"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "yansi"
@@ -4566,11 +4559,10 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
 dependencies = [
- "serde",
  "stable_deref_trait",
  "yoke-derive",
  "zerofrom",
@@ -4578,13 +4570,13 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.108",
  "synstructure",
 ]
 
@@ -4605,7 +4597,7 @@ checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -4625,7 +4617,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.108",
  "synstructure",
 ]
 
@@ -4637,9 +4629,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -4648,9 +4640,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -4659,13 +4651,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 2.0.108",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ resolver = "2"
 exclude = ["openapi"]
 
 [workspace.package]
-version = "1.0.0-alpha.4"
+version = "1.0.0-alpha.5"
 description = "API bindings for the Stripe HTTP API"
 rust-version = "1.88.0"
 authors = [

--- a/async-stripe-client-core/Cargo.toml
+++ b/async-stripe-client-core/Cargo.toml
@@ -17,8 +17,8 @@ edition.workspace = true
 name = "stripe_client_core"
 
 [dependencies]
-async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-alpha.4" }
-async-stripe-types = { path = "../async-stripe-types", version = "1.0.0-alpha.4" }
+async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-alpha.5" }
+async-stripe-types = { path = "../async-stripe-types", version = "1.0.0-alpha.5" }
 serde_json.workspace = true
 serde.workspace = true
 serde_qs.workspace = true

--- a/async-stripe-types/CHANGELOG.md
+++ b/async-stripe-types/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.5](https://github.com/arlyon/async-stripe/compare/async-stripe-types-v1.0.0-alpha.4...async-stripe-types-v1.0.0-alpha.5) - 2025-10-30
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [1.0.0-alpha.4](https://github.com/arlyon/async-stripe/compare/async-stripe-types-v1.0.0-alpha.3...async-stripe-types-v1.0.0-alpha.4) - 2025-10-02
 
 ### Other

--- a/async-stripe-webhook/CHANGELOG.md
+++ b/async-stripe-webhook/CHANGELOG.md
@@ -5,6 +5,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.5](https://github.com/arlyon/async-stripe/compare/async-stripe-webhook-v1.0.0-alpha.4...async-stripe-webhook-v1.0.0-alpha.5) - 2025-10-30
+
+### Fixed
+
+- large stack frames lint
+
+### Other
+
+- deny large stack frames
+
 ## [1.0.0-alpha.4](https://github.com/arlyon/async-stripe/compare/async-stripe-webhook-v1.0.0-alpha.3...async-stripe-webhook-v1.0.0-alpha.4) - 2025-10-02
 
 ### Other

--- a/async-stripe-webhook/Cargo.toml
+++ b/async-stripe-webhook/Cargo.toml
@@ -15,8 +15,8 @@ categories.workspace = true
 name = "stripe_webhook"
 
 [dependencies]
-async-stripe-types = { path = "../async-stripe-types", version = "1.0.0-alpha.4" }
-async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-alpha.4" }
+async-stripe-types = { path = "../async-stripe-types", version = "1.0.0-alpha.5" }
+async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-alpha.5" }
 hmac = "0.12"
 sha2 = "0.10"
 hex = "0.4"
@@ -26,14 +26,14 @@ miniserde.workspace = true
 serde.workspace = true
 serde_json = { workspace = true, optional = true }
 
-async-stripe-billing = { path = "../generated/async-stripe-billing", optional = true, version = "1.0.0-alpha.4" }
-async-stripe-checkout = { path = "../generated/async-stripe-checkout", optional = true, version = "1.0.0-alpha.4" }
-async-stripe-core = { path = "../generated/async-stripe-core", optional = true, version = "1.0.0-alpha.4" }
-async-stripe-fraud = { path = "../generated/async-stripe-fraud", optional = true, version = "1.0.0-alpha.4" }
-async-stripe-misc = { path = "../generated/async-stripe-misc", optional = true, version = "1.0.0-alpha.4" }
-async-stripe-payment = { path = "../generated/async-stripe-payment", optional = true, version = "1.0.0-alpha.4" }
-async-stripe-terminal = { path = "../generated/async-stripe-terminal", optional = true, version = "1.0.0-alpha.4" }
-async-stripe-treasury = { path = "../generated/async-stripe-treasury", optional = true, version = "1.0.0-alpha.4" }
+async-stripe-billing = { path = "../generated/async-stripe-billing", optional = true, version = "1.0.0-alpha.5" }
+async-stripe-checkout = { path = "../generated/async-stripe-checkout", optional = true, version = "1.0.0-alpha.5" }
+async-stripe-core = { path = "../generated/async-stripe-core", optional = true, version = "1.0.0-alpha.5" }
+async-stripe-fraud = { path = "../generated/async-stripe-fraud", optional = true, version = "1.0.0-alpha.5" }
+async-stripe-misc = { path = "../generated/async-stripe-misc", optional = true, version = "1.0.0-alpha.5" }
+async-stripe-payment = { path = "../generated/async-stripe-payment", optional = true, version = "1.0.0-alpha.5" }
+async-stripe-terminal = { path = "../generated/async-stripe-terminal", optional = true, version = "1.0.0-alpha.5" }
+async-stripe-treasury = { path = "../generated/async-stripe-treasury", optional = true, version = "1.0.0-alpha.5" }
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/async-stripe/Cargo.toml
+++ b/async-stripe/Cargo.toml
@@ -32,8 +32,8 @@ async-std = { version = "1.12.0", optional = true }
 surf = { version = "2.1", optional = true }
 http-types = { version = "2.12.0", default-features = false, optional = true }
 
-async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-alpha.4" }
-async-stripe-client-core = { path = "../async-stripe-client-core", version = "1.0.0-alpha.4" }
+async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-alpha.5" }
+async-stripe-client-core = { path = "../async-stripe-client-core", version = "1.0.0-alpha.5" }
 
 [features]
 default = ["default-tls"]

--- a/generated/async-stripe-billing/CHANGELOG.md
+++ b/generated/async-stripe-billing/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.5](https://github.com/arlyon/async-stripe/compare/async-stripe-billing-v1.0.0-alpha.4...async-stripe-billing-v1.0.0-alpha.5) - 2025-10-30
+
+### Other
+
+- deny large stack frames
+
 ## [1.0.0-alpha.4](https://github.com/arlyon/async-stripe/compare/async-stripe-billing-v1.0.0-alpha.3...async-stripe-billing-v1.0.0-alpha.4) - 2025-10-02
 
 ### Other

--- a/generated/async-stripe-billing/Cargo.toml
+++ b/generated/async-stripe-billing/Cargo.toml
@@ -20,10 +20,10 @@ serde.workspace = true
 serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.4" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.4" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.5" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.5" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.4" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.5" }
 
 
 [features]

--- a/generated/async-stripe-checkout/CHANGELOG.md
+++ b/generated/async-stripe-checkout/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.5](https://github.com/arlyon/async-stripe/compare/async-stripe-checkout-v1.0.0-alpha.4...async-stripe-checkout-v1.0.0-alpha.5) - 2025-10-30
+
+### Other
+
+- deny large stack frames
+
 ## [1.0.0-alpha.4](https://github.com/arlyon/async-stripe/compare/async-stripe-checkout-v1.0.0-alpha.3...async-stripe-checkout-v1.0.0-alpha.4) - 2025-10-02
 
 ### Other

--- a/generated/async-stripe-checkout/Cargo.toml
+++ b/generated/async-stripe-checkout/Cargo.toml
@@ -20,10 +20,10 @@ serde.workspace = true
 serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.4" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.4" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.5" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.5" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.4" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.5" }
 
 
 [features]

--- a/generated/async-stripe-connect/CHANGELOG.md
+++ b/generated/async-stripe-connect/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.5](https://github.com/arlyon/async-stripe/compare/async-stripe-connect-v1.0.0-alpha.4...async-stripe-connect-v1.0.0-alpha.5) - 2025-10-30
+
+### Other
+
+- deny large stack frames
+
 ## [1.0.0-alpha.4](https://github.com/arlyon/async-stripe/compare/async-stripe-connect-v1.0.0-alpha.3...async-stripe-connect-v1.0.0-alpha.4) - 2025-10-02
 
 ### Other

--- a/generated/async-stripe-connect/Cargo.toml
+++ b/generated/async-stripe-connect/Cargo.toml
@@ -20,10 +20,10 @@ serde.workspace = true
 serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.4" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.4" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.5" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.5" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.4" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.5" }
 
 
 [features]

--- a/generated/async-stripe-core/CHANGELOG.md
+++ b/generated/async-stripe-core/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.5](https://github.com/arlyon/async-stripe/compare/async-stripe-core-v1.0.0-alpha.4...async-stripe-core-v1.0.0-alpha.5) - 2025-10-30
+
+### Other
+
+- deny large stack frames
+
 ## [1.0.0-alpha.4](https://github.com/arlyon/async-stripe/compare/async-stripe-core-v1.0.0-alpha.3...async-stripe-core-v1.0.0-alpha.4) - 2025-10-02
 
 ### Other

--- a/generated/async-stripe-core/Cargo.toml
+++ b/generated/async-stripe-core/Cargo.toml
@@ -20,10 +20,10 @@ serde.workspace = true
 serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.4" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.4" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.5" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.5" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.4" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.5" }
 
 
 [features]

--- a/generated/async-stripe-fraud/CHANGELOG.md
+++ b/generated/async-stripe-fraud/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.5](https://github.com/arlyon/async-stripe/compare/async-stripe-fraud-v1.0.0-alpha.4...async-stripe-fraud-v1.0.0-alpha.5) - 2025-10-30
+
+### Other
+
+- deny large stack frames
+
 ## [1.0.0-alpha.4](https://github.com/arlyon/async-stripe/compare/async-stripe-fraud-v1.0.0-alpha.3...async-stripe-fraud-v1.0.0-alpha.4) - 2025-10-02
 
 ### Other

--- a/generated/async-stripe-fraud/Cargo.toml
+++ b/generated/async-stripe-fraud/Cargo.toml
@@ -20,10 +20,10 @@ serde.workspace = true
 serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.4" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.4" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.5" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.5" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.4" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.5" }
 
 
 [features]

--- a/generated/async-stripe-issuing/CHANGELOG.md
+++ b/generated/async-stripe-issuing/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.5](https://github.com/arlyon/async-stripe/compare/async-stripe-issuing-v1.0.0-alpha.4...async-stripe-issuing-v1.0.0-alpha.5) - 2025-10-30
+
+### Other
+
+- deny large stack frames
+
 ## [1.0.0-alpha.4](https://github.com/arlyon/async-stripe/compare/async-stripe-issuing-v1.0.0-alpha.3...async-stripe-issuing-v1.0.0-alpha.4) - 2025-10-02
 
 ### Other

--- a/generated/async-stripe-issuing/Cargo.toml
+++ b/generated/async-stripe-issuing/Cargo.toml
@@ -20,10 +20,10 @@ serde.workspace = true
 serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.4" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.4" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.5" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.5" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.4" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.5" }
 
 
 [features]

--- a/generated/async-stripe-misc/CHANGELOG.md
+++ b/generated/async-stripe-misc/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.5](https://github.com/arlyon/async-stripe/compare/async-stripe-misc-v1.0.0-alpha.4...async-stripe-misc-v1.0.0-alpha.5) - 2025-10-30
+
+### Other
+
+- deny large stack frames
+
 ## [1.0.0-alpha.4](https://github.com/arlyon/async-stripe/compare/async-stripe-misc-v1.0.0-alpha.3...async-stripe-misc-v1.0.0-alpha.4) - 2025-10-02
 
 ### Other

--- a/generated/async-stripe-misc/Cargo.toml
+++ b/generated/async-stripe-misc/Cargo.toml
@@ -20,10 +20,10 @@ serde.workspace = true
 serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.4" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.4" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.5" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.5" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.4" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.5" }
 
 
 [features]

--- a/generated/async-stripe-payment/CHANGELOG.md
+++ b/generated/async-stripe-payment/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.5](https://github.com/arlyon/async-stripe/compare/async-stripe-payment-v1.0.0-alpha.4...async-stripe-payment-v1.0.0-alpha.5) - 2025-10-30
+
+### Other
+
+- deny large stack frames
+
 ## [1.0.0-alpha.4](https://github.com/arlyon/async-stripe/compare/async-stripe-payment-v1.0.0-alpha.3...async-stripe-payment-v1.0.0-alpha.4) - 2025-10-02
 
 ### Other

--- a/generated/async-stripe-payment/Cargo.toml
+++ b/generated/async-stripe-payment/Cargo.toml
@@ -20,10 +20,10 @@ serde.workspace = true
 serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.4" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.4" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.5" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.5" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.4" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.5" }
 
 
 [features]

--- a/generated/async-stripe-product/CHANGELOG.md
+++ b/generated/async-stripe-product/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.5](https://github.com/arlyon/async-stripe/compare/async-stripe-product-v1.0.0-alpha.4...async-stripe-product-v1.0.0-alpha.5) - 2025-10-30
+
+### Other
+
+- deny large stack frames
+
 ## [1.0.0-alpha.4](https://github.com/arlyon/async-stripe/compare/async-stripe-product-v1.0.0-alpha.3...async-stripe-product-v1.0.0-alpha.4) - 2025-10-02
 
 ### Other

--- a/generated/async-stripe-product/Cargo.toml
+++ b/generated/async-stripe-product/Cargo.toml
@@ -20,10 +20,10 @@ serde.workspace = true
 serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.4" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.4" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.5" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.5" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.4" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.5" }
 
 
 [features]

--- a/generated/async-stripe-shared/CHANGELOG.md
+++ b/generated/async-stripe-shared/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.5](https://github.com/arlyon/async-stripe/compare/async-stripe-shared-v1.0.0-alpha.4...async-stripe-shared-v1.0.0-alpha.5) - 2025-10-30
+
+### Other
+
+- deny large stack frames
+
 ## [1.0.0-alpha.4](https://github.com/arlyon/async-stripe/compare/async-stripe-shared-v1.0.0-alpha.3...async-stripe-shared-v1.0.0-alpha.4) - 2025-10-02
 
 ### Other

--- a/generated/async-stripe-shared/Cargo.toml
+++ b/generated/async-stripe-shared/Cargo.toml
@@ -20,7 +20,7 @@ serde.workspace = true
 serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.4" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.5" }
 
 
 

--- a/generated/async-stripe-terminal/CHANGELOG.md
+++ b/generated/async-stripe-terminal/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.5](https://github.com/arlyon/async-stripe/compare/async-stripe-terminal-v1.0.0-alpha.4...async-stripe-terminal-v1.0.0-alpha.5) - 2025-10-30
+
+### Other
+
+- deny large stack frames
+
 ## [1.0.0-alpha.4](https://github.com/arlyon/async-stripe/compare/async-stripe-terminal-v1.0.0-alpha.3...async-stripe-terminal-v1.0.0-alpha.4) - 2025-10-02
 
 ### Other

--- a/generated/async-stripe-terminal/Cargo.toml
+++ b/generated/async-stripe-terminal/Cargo.toml
@@ -20,10 +20,10 @@ serde.workspace = true
 serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.4" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.4" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.5" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.5" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.4" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.5" }
 
 
 [features]

--- a/generated/async-stripe-treasury/CHANGELOG.md
+++ b/generated/async-stripe-treasury/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.5](https://github.com/arlyon/async-stripe/compare/async-stripe-treasury-v1.0.0-alpha.4...async-stripe-treasury-v1.0.0-alpha.5) - 2025-10-30
+
+### Other
+
+- deny large stack frames
+
 ## [1.0.0-alpha.4](https://github.com/arlyon/async-stripe/compare/async-stripe-treasury-v1.0.0-alpha.3...async-stripe-treasury-v1.0.0-alpha.4) - 2025-10-02
 
 ### Other

--- a/generated/async-stripe-treasury/Cargo.toml
+++ b/generated/async-stripe-treasury/Cargo.toml
@@ -20,10 +20,10 @@ serde.workspace = true
 serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.4" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.4" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.5" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.5" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.4" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.5" }
 
 
 [features]


### PR DESCRIPTION



## 🤖 New release

* `async-stripe-types`: 1.0.0-alpha.4 -> 1.0.0-alpha.5 (✓ API compatible changes)
* `async-stripe-shared`: 1.0.0-alpha.4 -> 1.0.0-alpha.5 (✓ API compatible changes)
* `async-stripe-client-core`: 1.0.0-alpha.4 -> 1.0.0-alpha.5
* `async-stripe-billing`: 1.0.0-alpha.4 -> 1.0.0-alpha.5 (✓ API compatible changes)
* `async-stripe-checkout`: 1.0.0-alpha.4 -> 1.0.0-alpha.5 (✓ API compatible changes)
* `async-stripe-core`: 1.0.0-alpha.4 -> 1.0.0-alpha.5 (✓ API compatible changes)
* `async-stripe-fraud`: 1.0.0-alpha.4 -> 1.0.0-alpha.5 (✓ API compatible changes)
* `async-stripe-misc`: 1.0.0-alpha.4 -> 1.0.0-alpha.5 (✓ API compatible changes)
* `async-stripe-payment`: 1.0.0-alpha.4 -> 1.0.0-alpha.5 (✓ API compatible changes)
* `async-stripe-terminal`: 1.0.0-alpha.4 -> 1.0.0-alpha.5 (✓ API compatible changes)
* `async-stripe-treasury`: 1.0.0-alpha.4 -> 1.0.0-alpha.5 (✓ API compatible changes)
* `async-stripe-webhook`: 1.0.0-alpha.4 -> 1.0.0-alpha.5 (✓ API compatible changes)
* `async-stripe`: 1.0.0-alpha.4 -> 1.0.0-alpha.5
* `async-stripe-connect`: 1.0.0-alpha.4 -> 1.0.0-alpha.5 (✓ API compatible changes)
* `async-stripe-issuing`: 1.0.0-alpha.4 -> 1.0.0-alpha.5 (✓ API compatible changes)
* `async-stripe-product`: 1.0.0-alpha.4 -> 1.0.0-alpha.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `async-stripe-types`

<blockquote>

## [1.0.0-alpha.5](https://github.com/arlyon/async-stripe/compare/async-stripe-types-v1.0.0-alpha.4...async-stripe-types-v1.0.0-alpha.5) - 2025-10-30

### Other

- update Cargo.toml dependencies
</blockquote>

## `async-stripe-shared`

<blockquote>

## [1.0.0-alpha.5](https://github.com/arlyon/async-stripe/compare/async-stripe-shared-v1.0.0-alpha.4...async-stripe-shared-v1.0.0-alpha.5) - 2025-10-30

### Other

- deny large stack frames
</blockquote>

## `async-stripe-client-core`

<blockquote>

## [1.0.0-alpha.4](https://github.com/arlyon/async-stripe/compare/async-stripe-client-core-v1.0.0-alpha.3...async-stripe-client-core-v1.0.0-alpha.4) - 2025-10-02

### Other

- update everything else to edition 2024
- add migration guide
</blockquote>

## `async-stripe-billing`

<blockquote>

## [1.0.0-alpha.5](https://github.com/arlyon/async-stripe/compare/async-stripe-billing-v1.0.0-alpha.4...async-stripe-billing-v1.0.0-alpha.5) - 2025-10-30

### Other

- deny large stack frames
</blockquote>

## `async-stripe-checkout`

<blockquote>

## [1.0.0-alpha.5](https://github.com/arlyon/async-stripe/compare/async-stripe-checkout-v1.0.0-alpha.4...async-stripe-checkout-v1.0.0-alpha.5) - 2025-10-30

### Other

- deny large stack frames
</blockquote>

## `async-stripe-core`

<blockquote>

## [1.0.0-alpha.5](https://github.com/arlyon/async-stripe/compare/async-stripe-core-v1.0.0-alpha.4...async-stripe-core-v1.0.0-alpha.5) - 2025-10-30

### Other

- deny large stack frames
</blockquote>

## `async-stripe-fraud`

<blockquote>

## [1.0.0-alpha.5](https://github.com/arlyon/async-stripe/compare/async-stripe-fraud-v1.0.0-alpha.4...async-stripe-fraud-v1.0.0-alpha.5) - 2025-10-30

### Other

- deny large stack frames
</blockquote>

## `async-stripe-misc`

<blockquote>

## [1.0.0-alpha.5](https://github.com/arlyon/async-stripe/compare/async-stripe-misc-v1.0.0-alpha.4...async-stripe-misc-v1.0.0-alpha.5) - 2025-10-30

### Other

- deny large stack frames
</blockquote>

## `async-stripe-payment`

<blockquote>

## [1.0.0-alpha.5](https://github.com/arlyon/async-stripe/compare/async-stripe-payment-v1.0.0-alpha.4...async-stripe-payment-v1.0.0-alpha.5) - 2025-10-30

### Other

- deny large stack frames
</blockquote>

## `async-stripe-terminal`

<blockquote>

## [1.0.0-alpha.5](https://github.com/arlyon/async-stripe/compare/async-stripe-terminal-v1.0.0-alpha.4...async-stripe-terminal-v1.0.0-alpha.5) - 2025-10-30

### Other

- deny large stack frames
</blockquote>

## `async-stripe-treasury`

<blockquote>

## [1.0.0-alpha.5](https://github.com/arlyon/async-stripe/compare/async-stripe-treasury-v1.0.0-alpha.4...async-stripe-treasury-v1.0.0-alpha.5) - 2025-10-30

### Other

- deny large stack frames
</blockquote>

## `async-stripe-webhook`

<blockquote>

## [1.0.0-alpha.5](https://github.com/arlyon/async-stripe/compare/async-stripe-webhook-v1.0.0-alpha.4...async-stripe-webhook-v1.0.0-alpha.5) - 2025-10-30

### Fixed

- large stack frames lint

### Other

- deny large stack frames
</blockquote>

## `async-stripe`

<blockquote>

## [1.0.0-alpha.4](https://github.com/arlyon/async-stripe/compare/async-stripe-v1.0.0-alpha.3...async-stripe-v1.0.0-alpha.4) - 2025-10-02

### Other

- update everything else to edition 2024
- add migration guide
</blockquote>

## `async-stripe-connect`

<blockquote>

## [1.0.0-alpha.5](https://github.com/arlyon/async-stripe/compare/async-stripe-connect-v1.0.0-alpha.4...async-stripe-connect-v1.0.0-alpha.5) - 2025-10-30

### Other

- deny large stack frames
</blockquote>

## `async-stripe-issuing`

<blockquote>

## [1.0.0-alpha.5](https://github.com/arlyon/async-stripe/compare/async-stripe-issuing-v1.0.0-alpha.4...async-stripe-issuing-v1.0.0-alpha.5) - 2025-10-30

### Other

- deny large stack frames
</blockquote>

## `async-stripe-product`

<blockquote>

## [1.0.0-alpha.5](https://github.com/arlyon/async-stripe/compare/async-stripe-product-v1.0.0-alpha.4...async-stripe-product-v1.0.0-alpha.5) - 2025-10-30

### Other

- deny large stack frames
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).