### PR TITLE
chore: release v1.0.0-alpha.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe"
-version = "1.0.0-alpha.5"
+version = "1.0.0-alpha.6"
 dependencies = [
  "async-std",
  "async-stripe-client-core",
@@ -505,7 +505,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-billing"
-version = "1.0.0-alpha.5"
+version = "1.0.0-alpha.6"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-checkout"
-version = "1.0.0-alpha.5"
+version = "1.0.0-alpha.6"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-client-core"
-version = "1.0.0-alpha.5"
+version = "1.0.0-alpha.6"
 dependencies = [
  "async-stripe-shared",
  "async-stripe-types",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-connect"
-version = "1.0.0-alpha.5"
+version = "1.0.0-alpha.6"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -561,7 +561,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-core"
-version = "1.0.0-alpha.5"
+version = "1.0.0-alpha.6"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-fraud"
-version = "1.0.0-alpha.5"
+version = "1.0.0-alpha.6"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -587,7 +587,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-issuing"
-version = "1.0.0-alpha.5"
+version = "1.0.0-alpha.6"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -600,7 +600,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-misc"
-version = "1.0.0-alpha.5"
+version = "1.0.0-alpha.6"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -613,7 +613,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-payment"
-version = "1.0.0-alpha.5"
+version = "1.0.0-alpha.6"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -626,7 +626,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-product"
-version = "1.0.0-alpha.5"
+version = "1.0.0-alpha.6"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -639,7 +639,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-shared"
-version = "1.0.0-alpha.5"
+version = "1.0.0-alpha.6"
 dependencies = [
  "async-stripe-types",
  "miniserde",
@@ -650,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-terminal"
-version = "1.0.0-alpha.5"
+version = "1.0.0-alpha.6"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -693,7 +693,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-treasury"
-version = "1.0.0-alpha.5"
+version = "1.0.0-alpha.6"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -706,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-types"
-version = "1.0.0-alpha.5"
+version = "1.0.0-alpha.6"
 dependencies = [
  "miniserde",
  "serde",
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-webhook"
-version = "1.0.0-alpha.5"
+version = "1.0.0-alpha.6"
 dependencies = [
  "async-stripe-billing",
  "async-stripe-checkout",
@@ -979,9 +979,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.43"
+version = "1.2.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "739eb0f94557554b3ca9a86d2d37bebd49c5e6d0c1d2bda35ba5bdac830befc2"
+checksum = "37521ac7aabe3d13122dc382493e20c9416f299d2ccd5b3a5340a2570cdeb0f3"
 dependencies = [
  "find-msvc-tools",
  "jobserver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ resolver = "2"
 exclude = ["openapi"]
 
 [workspace.package]
-version = "1.0.0-alpha.5"
+version = "1.0.0-alpha.6"
 description = "API bindings for the Stripe HTTP API"
 rust-version = "1.88.0"
 authors = [

--- a/async-stripe-client-core/Cargo.toml
+++ b/async-stripe-client-core/Cargo.toml
@@ -17,8 +17,8 @@ edition.workspace = true
 name = "stripe_client_core"
 
 [dependencies]
-async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-alpha.5" }
-async-stripe-types = { path = "../async-stripe-types", version = "1.0.0-alpha.5" }
+async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-alpha.6" }
+async-stripe-types = { path = "../async-stripe-types", version = "1.0.0-alpha.6" }
 serde_json.workspace = true
 serde.workspace = true
 serde_qs.workspace = true

--- a/async-stripe-webhook/CHANGELOG.md
+++ b/async-stripe-webhook/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.6](https://github.com/arlyon/async-stripe/compare/async-stripe-webhook-v1.0.0-alpha.5...async-stripe-webhook-v1.0.0-alpha.6) - 2025-10-31
+
+### Other
+
+- Generate latest changes from OpenApi spec
+
 ## [1.0.0-alpha.5](https://github.com/arlyon/async-stripe/compare/async-stripe-webhook-v1.0.0-alpha.4...async-stripe-webhook-v1.0.0-alpha.5) - 2025-10-30
 
 ### Fixed

--- a/async-stripe-webhook/Cargo.toml
+++ b/async-stripe-webhook/Cargo.toml
@@ -15,8 +15,8 @@ categories.workspace = true
 name = "stripe_webhook"
 
 [dependencies]
-async-stripe-types = { path = "../async-stripe-types", version = "1.0.0-alpha.5" }
-async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-alpha.5" }
+async-stripe-types = { path = "../async-stripe-types", version = "1.0.0-alpha.6" }
+async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-alpha.6" }
 hmac = "0.12"
 sha2 = "0.10"
 hex = "0.4"
@@ -26,14 +26,14 @@ miniserde.workspace = true
 serde.workspace = true
 serde_json = { workspace = true, optional = true }
 
-async-stripe-billing = { path = "../generated/async-stripe-billing", optional = true, version = "1.0.0-alpha.5" }
-async-stripe-checkout = { path = "../generated/async-stripe-checkout", optional = true, version = "1.0.0-alpha.5" }
-async-stripe-core = { path = "../generated/async-stripe-core", optional = true, version = "1.0.0-alpha.5" }
-async-stripe-fraud = { path = "../generated/async-stripe-fraud", optional = true, version = "1.0.0-alpha.5" }
-async-stripe-misc = { path = "../generated/async-stripe-misc", optional = true, version = "1.0.0-alpha.5" }
-async-stripe-payment = { path = "../generated/async-stripe-payment", optional = true, version = "1.0.0-alpha.5" }
-async-stripe-terminal = { path = "../generated/async-stripe-terminal", optional = true, version = "1.0.0-alpha.5" }
-async-stripe-treasury = { path = "../generated/async-stripe-treasury", optional = true, version = "1.0.0-alpha.5" }
+async-stripe-billing = { path = "../generated/async-stripe-billing", optional = true, version = "1.0.0-alpha.6" }
+async-stripe-checkout = { path = "../generated/async-stripe-checkout", optional = true, version = "1.0.0-alpha.6" }
+async-stripe-core = { path = "../generated/async-stripe-core", optional = true, version = "1.0.0-alpha.6" }
+async-stripe-fraud = { path = "../generated/async-stripe-fraud", optional = true, version = "1.0.0-alpha.6" }
+async-stripe-misc = { path = "../generated/async-stripe-misc", optional = true, version = "1.0.0-alpha.6" }
+async-stripe-payment = { path = "../generated/async-stripe-payment", optional = true, version = "1.0.0-alpha.6" }
+async-stripe-terminal = { path = "../generated/async-stripe-terminal", optional = true, version = "1.0.0-alpha.6" }
+async-stripe-treasury = { path = "../generated/async-stripe-treasury", optional = true, version = "1.0.0-alpha.6" }
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/async-stripe/Cargo.toml
+++ b/async-stripe/Cargo.toml
@@ -32,8 +32,8 @@ async-std = { version = "1.12.0", optional = true }
 surf = { version = "2.1", optional = true }
 http-types = { version = "2.12.0", default-features = false, optional = true }
 
-async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-alpha.5" }
-async-stripe-client-core = { path = "../async-stripe-client-core", version = "1.0.0-alpha.5" }
+async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-alpha.6" }
+async-stripe-client-core = { path = "../async-stripe-client-core", version = "1.0.0-alpha.6" }
 
 [features]
 default = ["default-tls"]

--- a/generated/async-stripe-billing/CHANGELOG.md
+++ b/generated/async-stripe-billing/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.6](https://github.com/arlyon/async-stripe/compare/async-stripe-billing-v1.0.0-alpha.5...async-stripe-billing-v1.0.0-alpha.6) - 2025-10-31
+
+### Other
+
+- Generate latest changes from OpenApi spec
+
 ## [1.0.0-alpha.5](https://github.com/arlyon/async-stripe/compare/async-stripe-billing-v1.0.0-alpha.4...async-stripe-billing-v1.0.0-alpha.5) - 2025-10-30
 
 ### Other

--- a/generated/async-stripe-billing/Cargo.toml
+++ b/generated/async-stripe-billing/Cargo.toml
@@ -20,10 +20,10 @@ serde.workspace = true
 serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.5" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.5" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.6" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.6" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.5" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.6" }
 
 
 [features]

--- a/generated/async-stripe-checkout/CHANGELOG.md
+++ b/generated/async-stripe-checkout/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.6](https://github.com/arlyon/async-stripe/compare/async-stripe-checkout-v1.0.0-alpha.5...async-stripe-checkout-v1.0.0-alpha.6) - 2025-10-31
+
+### Other
+
+- Generate latest changes from OpenApi spec
+
 ## [1.0.0-alpha.5](https://github.com/arlyon/async-stripe/compare/async-stripe-checkout-v1.0.0-alpha.4...async-stripe-checkout-v1.0.0-alpha.5) - 2025-10-30
 
 ### Other

--- a/generated/async-stripe-checkout/Cargo.toml
+++ b/generated/async-stripe-checkout/Cargo.toml
@@ -20,10 +20,10 @@ serde.workspace = true
 serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.5" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.5" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.6" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.6" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.5" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.6" }
 
 
 [features]

--- a/generated/async-stripe-connect/CHANGELOG.md
+++ b/generated/async-stripe-connect/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.6](https://github.com/arlyon/async-stripe/compare/async-stripe-connect-v1.0.0-alpha.5...async-stripe-connect-v1.0.0-alpha.6) - 2025-10-31
+
+### Other
+
+- Generate latest changes from OpenApi spec
+
 ## [1.0.0-alpha.5](https://github.com/arlyon/async-stripe/compare/async-stripe-connect-v1.0.0-alpha.4...async-stripe-connect-v1.0.0-alpha.5) - 2025-10-30
 
 ### Other

--- a/generated/async-stripe-connect/Cargo.toml
+++ b/generated/async-stripe-connect/Cargo.toml
@@ -20,10 +20,10 @@ serde.workspace = true
 serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.5" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.5" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.6" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.6" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.5" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.6" }
 
 
 [features]

--- a/generated/async-stripe-core/CHANGELOG.md
+++ b/generated/async-stripe-core/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.6](https://github.com/arlyon/async-stripe/compare/async-stripe-core-v1.0.0-alpha.5...async-stripe-core-v1.0.0-alpha.6) - 2025-10-31
+
+### Other
+
+- Generate latest changes from OpenApi spec
+
 ## [1.0.0-alpha.5](https://github.com/arlyon/async-stripe/compare/async-stripe-core-v1.0.0-alpha.4...async-stripe-core-v1.0.0-alpha.5) - 2025-10-30
 
 ### Other

--- a/generated/async-stripe-core/Cargo.toml
+++ b/generated/async-stripe-core/Cargo.toml
@@ -20,10 +20,10 @@ serde.workspace = true
 serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.5" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.5" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.6" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.6" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.5" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.6" }
 
 
 [features]

--- a/generated/async-stripe-fraud/CHANGELOG.md
+++ b/generated/async-stripe-fraud/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.6](https://github.com/arlyon/async-stripe/compare/async-stripe-fraud-v1.0.0-alpha.5...async-stripe-fraud-v1.0.0-alpha.6) - 2025-10-31
+
+### Other
+
+- Generate latest changes from OpenApi spec
+
 ## [1.0.0-alpha.5](https://github.com/arlyon/async-stripe/compare/async-stripe-fraud-v1.0.0-alpha.4...async-stripe-fraud-v1.0.0-alpha.5) - 2025-10-30
 
 ### Other

--- a/generated/async-stripe-fraud/Cargo.toml
+++ b/generated/async-stripe-fraud/Cargo.toml
@@ -20,10 +20,10 @@ serde.workspace = true
 serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.5" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.5" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.6" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.6" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.5" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.6" }
 
 
 [features]

--- a/generated/async-stripe-issuing/Cargo.toml
+++ b/generated/async-stripe-issuing/Cargo.toml
@@ -20,10 +20,10 @@ serde.workspace = true
 serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.5" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.5" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.6" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.6" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.5" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.6" }
 
 
 [features]

--- a/generated/async-stripe-misc/CHANGELOG.md
+++ b/generated/async-stripe-misc/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.6](https://github.com/arlyon/async-stripe/compare/async-stripe-misc-v1.0.0-alpha.5...async-stripe-misc-v1.0.0-alpha.6) - 2025-10-31
+
+### Other
+
+- Generate latest changes from OpenApi spec
+
 ## [1.0.0-alpha.5](https://github.com/arlyon/async-stripe/compare/async-stripe-misc-v1.0.0-alpha.4...async-stripe-misc-v1.0.0-alpha.5) - 2025-10-30
 
 ### Other

--- a/generated/async-stripe-misc/Cargo.toml
+++ b/generated/async-stripe-misc/Cargo.toml
@@ -20,10 +20,10 @@ serde.workspace = true
 serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.5" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.5" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.6" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.6" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.5" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.6" }
 
 
 [features]

--- a/generated/async-stripe-payment/CHANGELOG.md
+++ b/generated/async-stripe-payment/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.6](https://github.com/arlyon/async-stripe/compare/async-stripe-payment-v1.0.0-alpha.5...async-stripe-payment-v1.0.0-alpha.6) - 2025-10-31
+
+### Other
+
+- Generate latest changes from OpenApi spec
+
 ## [1.0.0-alpha.5](https://github.com/arlyon/async-stripe/compare/async-stripe-payment-v1.0.0-alpha.4...async-stripe-payment-v1.0.0-alpha.5) - 2025-10-30
 
 ### Other

--- a/generated/async-stripe-payment/Cargo.toml
+++ b/generated/async-stripe-payment/Cargo.toml
@@ -20,10 +20,10 @@ serde.workspace = true
 serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.5" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.5" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.6" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.6" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.5" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.6" }
 
 
 [features]

--- a/generated/async-stripe-product/CHANGELOG.md
+++ b/generated/async-stripe-product/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.6](https://github.com/arlyon/async-stripe/compare/async-stripe-product-v1.0.0-alpha.5...async-stripe-product-v1.0.0-alpha.6) - 2025-10-31
+
+### Other
+
+- Generate latest changes from OpenApi spec
+
 ## [1.0.0-alpha.5](https://github.com/arlyon/async-stripe/compare/async-stripe-product-v1.0.0-alpha.4...async-stripe-product-v1.0.0-alpha.5) - 2025-10-30
 
 ### Other

--- a/generated/async-stripe-product/Cargo.toml
+++ b/generated/async-stripe-product/Cargo.toml
@@ -20,10 +20,10 @@ serde.workspace = true
 serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.5" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.5" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.6" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.6" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.5" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.6" }
 
 
 [features]

--- a/generated/async-stripe-shared/CHANGELOG.md
+++ b/generated/async-stripe-shared/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.6](https://github.com/arlyon/async-stripe/compare/async-stripe-shared-v1.0.0-alpha.5...async-stripe-shared-v1.0.0-alpha.6) - 2025-10-31
+
+### Other
+
+- Generate latest changes from OpenApi spec
+
 ## [1.0.0-alpha.5](https://github.com/arlyon/async-stripe/compare/async-stripe-shared-v1.0.0-alpha.4...async-stripe-shared-v1.0.0-alpha.5) - 2025-10-30
 
 ### Other

--- a/generated/async-stripe-shared/Cargo.toml
+++ b/generated/async-stripe-shared/Cargo.toml
@@ -20,7 +20,7 @@ serde.workspace = true
 serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.5" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.6" }
 
 
 

--- a/generated/async-stripe-terminal/CHANGELOG.md
+++ b/generated/async-stripe-terminal/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.6](https://github.com/arlyon/async-stripe/compare/async-stripe-terminal-v1.0.0-alpha.5...async-stripe-terminal-v1.0.0-alpha.6) - 2025-10-31
+
+### Other
+
+- Generate latest changes from OpenApi spec
+
 ## [1.0.0-alpha.5](https://github.com/arlyon/async-stripe/compare/async-stripe-terminal-v1.0.0-alpha.4...async-stripe-terminal-v1.0.0-alpha.5) - 2025-10-30
 
 ### Other

--- a/generated/async-stripe-terminal/Cargo.toml
+++ b/generated/async-stripe-terminal/Cargo.toml
@@ -20,10 +20,10 @@ serde.workspace = true
 serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.5" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.5" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.6" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.6" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.5" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.6" }
 
 
 [features]

--- a/generated/async-stripe-treasury/CHANGELOG.md
+++ b/generated/async-stripe-treasury/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.6](https://github.com/arlyon/async-stripe/compare/async-stripe-treasury-v1.0.0-alpha.5...async-stripe-treasury-v1.0.0-alpha.6) - 2025-10-31
+
+### Other
+
+- Generate latest changes from OpenApi spec
+
 ## [1.0.0-alpha.5](https://github.com/arlyon/async-stripe/compare/async-stripe-treasury-v1.0.0-alpha.4...async-stripe-treasury-v1.0.0-alpha.5) - 2025-10-30
 
 ### Other

--- a/generated/async-stripe-treasury/Cargo.toml
+++ b/generated/async-stripe-treasury/Cargo.toml
@@ -20,10 +20,10 @@ serde.workspace = true
 serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.5" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.5" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.6" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.6" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.5" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.6" }
 
 
 [features]


### PR DESCRIPTION



## 🤖 New release

* `async-stripe-types`: 1.0.0-alpha.5 -> 1.0.0-alpha.6
* `async-stripe-shared`: 1.0.0-alpha.5 -> 1.0.0-alpha.6 (✓ API compatible changes)
* `async-stripe-client-core`: 1.0.0-alpha.5 -> 1.0.0-alpha.6
* `async-stripe-billing`: 1.0.0-alpha.5 -> 1.0.0-alpha.6 (✓ API compatible changes)
* `async-stripe-checkout`: 1.0.0-alpha.5 -> 1.0.0-alpha.6 (✓ API compatible changes)
* `async-stripe-core`: 1.0.0-alpha.5 -> 1.0.0-alpha.6 (✓ API compatible changes)
* `async-stripe-fraud`: 1.0.0-alpha.5 -> 1.0.0-alpha.6 (✓ API compatible changes)
* `async-stripe-misc`: 1.0.0-alpha.5 -> 1.0.0-alpha.6 (✓ API compatible changes)
* `async-stripe-payment`: 1.0.0-alpha.5 -> 1.0.0-alpha.6 (✓ API compatible changes)
* `async-stripe-terminal`: 1.0.0-alpha.5 -> 1.0.0-alpha.6 (✓ API compatible changes)
* `async-stripe-treasury`: 1.0.0-alpha.5 -> 1.0.0-alpha.6 (✓ API compatible changes)
* `async-stripe-webhook`: 1.0.0-alpha.5 -> 1.0.0-alpha.6 (✓ API compatible changes)
* `async-stripe`: 1.0.0-alpha.5 -> 1.0.0-alpha.6
* `async-stripe-connect`: 1.0.0-alpha.5 -> 1.0.0-alpha.6 (✓ API compatible changes)
* `async-stripe-issuing`: 1.0.0-alpha.5 -> 1.0.0-alpha.6
* `async-stripe-product`: 1.0.0-alpha.5 -> 1.0.0-alpha.6 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `async-stripe-types`

<blockquote>

## [1.0.0-alpha.5](https://github.com/arlyon/async-stripe/compare/async-stripe-types-v1.0.0-alpha.4...async-stripe-types-v1.0.0-alpha.5) - 2025-10-30

### Other

- update Cargo.toml dependencies
</blockquote>

## `async-stripe-shared`

<blockquote>

## [1.0.0-alpha.6](https://github.com/arlyon/async-stripe/compare/async-stripe-shared-v1.0.0-alpha.5...async-stripe-shared-v1.0.0-alpha.6) - 2025-10-31

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-client-core`

<blockquote>

## [1.0.0-alpha.4](https://github.com/arlyon/async-stripe/compare/async-stripe-client-core-v1.0.0-alpha.3...async-stripe-client-core-v1.0.0-alpha.4) - 2025-10-02

### Other

- update everything else to edition 2024
- add migration guide
</blockquote>

## `async-stripe-billing`

<blockquote>

## [1.0.0-alpha.6](https://github.com/arlyon/async-stripe/compare/async-stripe-billing-v1.0.0-alpha.5...async-stripe-billing-v1.0.0-alpha.6) - 2025-10-31

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-checkout`

<blockquote>

## [1.0.0-alpha.6](https://github.com/arlyon/async-stripe/compare/async-stripe-checkout-v1.0.0-alpha.5...async-stripe-checkout-v1.0.0-alpha.6) - 2025-10-31

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-core`

<blockquote>

## [1.0.0-alpha.6](https://github.com/arlyon/async-stripe/compare/async-stripe-core-v1.0.0-alpha.5...async-stripe-core-v1.0.0-alpha.6) - 2025-10-31

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-fraud`

<blockquote>

## [1.0.0-alpha.6](https://github.com/arlyon/async-stripe/compare/async-stripe-fraud-v1.0.0-alpha.5...async-stripe-fraud-v1.0.0-alpha.6) - 2025-10-31

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-misc`

<blockquote>

## [1.0.0-alpha.6](https://github.com/arlyon/async-stripe/compare/async-stripe-misc-v1.0.0-alpha.5...async-stripe-misc-v1.0.0-alpha.6) - 2025-10-31

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-payment`

<blockquote>

## [1.0.0-alpha.6](https://github.com/arlyon/async-stripe/compare/async-stripe-payment-v1.0.0-alpha.5...async-stripe-payment-v1.0.0-alpha.6) - 2025-10-31

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-terminal`

<blockquote>

## [1.0.0-alpha.6](https://github.com/arlyon/async-stripe/compare/async-stripe-terminal-v1.0.0-alpha.5...async-stripe-terminal-v1.0.0-alpha.6) - 2025-10-31

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-treasury`

<blockquote>

## [1.0.0-alpha.6](https://github.com/arlyon/async-stripe/compare/async-stripe-treasury-v1.0.0-alpha.5...async-stripe-treasury-v1.0.0-alpha.6) - 2025-10-31

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-webhook`

<blockquote>

## [1.0.0-alpha.6](https://github.com/arlyon/async-stripe/compare/async-stripe-webhook-v1.0.0-alpha.5...async-stripe-webhook-v1.0.0-alpha.6) - 2025-10-31

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe`

<blockquote>

## [1.0.0-alpha.4](https://github.com/arlyon/async-stripe/compare/async-stripe-v1.0.0-alpha.3...async-stripe-v1.0.0-alpha.4) - 2025-10-02

### Other

- update everything else to edition 2024
- add migration guide
</blockquote>

## `async-stripe-connect`

<blockquote>

## [1.0.0-alpha.6](https://github.com/arlyon/async-stripe/compare/async-stripe-connect-v1.0.0-alpha.5...async-stripe-connect-v1.0.0-alpha.6) - 2025-10-31

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-issuing`

<blockquote>

## [1.0.0-alpha.5](https://github.com/arlyon/async-stripe/compare/async-stripe-issuing-v1.0.0-alpha.4...async-stripe-issuing-v1.0.0-alpha.5) - 2025-10-30

### Other

- deny large stack frames
</blockquote>

## `async-stripe-product`

<blockquote>

## [1.0.0-alpha.6](https://github.com/arlyon/async-stripe/compare/async-stripe-product-v1.0.0-alpha.5...async-stripe-product-v1.0.0-alpha.6) - 2025-10-31

### Other

- Generate latest changes from OpenApi spec
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).