### PR TITLE
chore: release v1.0.0-alpha.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -182,7 +182,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -477,12 +477,12 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
 name = "async-stripe"
-version = "1.0.0-alpha.6"
+version = "1.0.0-alpha.7"
 dependencies = [
  "async-std",
  "async-stripe-client-core",
@@ -491,7 +491,7 @@ dependencies = [
  "http-body-util",
  "http-types",
  "httpmock",
- "hyper 1.7.0",
+ "hyper 1.8.0",
  "hyper-rustls",
  "hyper-tls",
  "hyper-util",
@@ -505,7 +505,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-billing"
-version = "1.0.0-alpha.6"
+version = "1.0.0-alpha.7"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-checkout"
-version = "1.0.0-alpha.6"
+version = "1.0.0-alpha.7"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -531,7 +531,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-client-core"
-version = "1.0.0-alpha.6"
+version = "1.0.0-alpha.7"
 dependencies = [
  "async-stripe-shared",
  "async-stripe-types",
@@ -548,7 +548,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-connect"
-version = "1.0.0-alpha.6"
+version = "1.0.0-alpha.7"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -561,7 +561,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-core"
-version = "1.0.0-alpha.6"
+version = "1.0.0-alpha.7"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-fraud"
-version = "1.0.0-alpha.6"
+version = "1.0.0-alpha.7"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -587,7 +587,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-issuing"
-version = "1.0.0-alpha.6"
+version = "1.0.0-alpha.7"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -600,7 +600,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-misc"
-version = "1.0.0-alpha.6"
+version = "1.0.0-alpha.7"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -613,7 +613,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-payment"
-version = "1.0.0-alpha.6"
+version = "1.0.0-alpha.7"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -626,7 +626,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-product"
-version = "1.0.0-alpha.6"
+version = "1.0.0-alpha.7"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -639,7 +639,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-shared"
-version = "1.0.0-alpha.6"
+version = "1.0.0-alpha.7"
 dependencies = [
  "async-stripe-types",
  "miniserde",
@@ -650,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-terminal"
-version = "1.0.0-alpha.6"
+version = "1.0.0-alpha.7"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -693,7 +693,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-treasury"
-version = "1.0.0-alpha.6"
+version = "1.0.0-alpha.7"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -706,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-types"
-version = "1.0.0-alpha.6"
+version = "1.0.0-alpha.7"
 dependencies = [
  "miniserde",
  "serde",
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-webhook"
-version = "1.0.0-alpha.6"
+version = "1.0.0-alpha.7"
 dependencies = [
  "async-stripe-billing",
  "async-stripe-checkout",
@@ -753,7 +753,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -797,7 +797,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.7.0",
+ "hyper 1.8.0",
  "hyper-util",
  "itoa",
  "matchit",
@@ -844,7 +844,7 @@ checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -979,9 +979,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.44"
+version = "1.2.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37521ac7aabe3d13122dc382493e20c9416f299d2ccd5b3a5340a2570cdeb0f3"
+checksum = "35900b6c8d709fb1d854671ae27aeaa9eec2f8b01b364e1619a40da3e6fe2afe"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1135,9 +1135,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
@@ -1179,9 +1179,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.83+curl-8.15.0"
+version = "0.4.84+curl-8.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5830daf304027db10c82632a464879d46a3f7c4ba17a31592657ad16c719b483"
+checksum = "abc4294dc41b882eaff37973c2ec3ae203d0091341ee68fbadd1d06e0c18a73b"
 dependencies = [
  "cc",
  "libc",
@@ -1237,7 +1237,7 @@ checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
  "unicode-xid",
 ]
 
@@ -1271,7 +1271,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1308,7 +1308,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1561,7 +1561,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1609,9 +1609,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.9"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -1921,9 +1921,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
+checksum = "1744436df46f0bde35af3eda22aeaba453aada65d8f1c171cd8a5f59030bd69f"
 dependencies = [
  "atomic-waker",
  "bytes 1.10.1",
@@ -1949,7 +1949,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http 1.3.1",
- "hyper 1.7.0",
+ "hyper 1.8.0",
  "hyper-util",
  "log",
  "rustls",
@@ -1969,7 +1969,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes 1.10.1",
  "http-body-util",
- "hyper 1.7.0",
+ "hyper 1.8.0",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -1979,9 +1979,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
+checksum = "52e9a2a24dc5c6821e71a7030e1e14b7b632acac55c40e9d2e082c621261bb56"
 dependencies = [
  "bytes 1.10.1",
  "futures-channel",
@@ -1989,7 +1989,7 @@ dependencies = [
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
- "hyper 1.7.0",
+ "hyper 1.8.0",
  "libc",
  "pin-project-lite",
  "socket2 0.6.1",
@@ -2268,9 +2268,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.22"
+version = "1.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
+checksum = "15d118bbf3771060e7311cc7bb0545b01d08a8b4a7de949198dec1fa0ca1c0f7"
 dependencies = [
  "cc",
  "libc",
@@ -2385,7 +2385,7 @@ checksum = "560f32b6891d8d9bade8942c45a27694f16d789d3b4b8e6b7135a5240de0a8af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -2505,9 +2505,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.74"
+version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ad14dd45412269e1a30f52ad8f0664f0f4f4a89ee8fe28c3b3527021ebb654"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -2526,7 +2526,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -2537,9 +2537,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.110"
+version = "0.9.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a9f0075ba3c21b09f8e8b2026584b1d18d49388648f2fbbf3c97ea8deced8e2"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
 dependencies = [
  "cc",
  "libc",
@@ -2606,7 +2606,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -2632,7 +2632,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -2736,16 +2736,16 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
  "version_check",
  "yansi",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.41"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
@@ -2882,7 +2882,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -2983,7 +2983,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rocket_http",
- "syn 2.0.108",
+ "syn 2.0.110",
  "unicode-xid",
  "version_check",
 ]
@@ -3039,9 +3039,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.34"
+version = "0.23.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9586e9ee2b4f8fab52a0048ca7334d7024eef48e2cb9407e3497bb7cab7fa7"
+checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
 dependencies = [
  "log",
  "once_cell",
@@ -3195,7 +3195,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -3553,9 +3553,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.108"
+version = "2.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da58917d35242480a05c2897064da0a80589a2a0476c9a3f2fdc83b53502e917"
+checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3576,7 +3576,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -3618,7 +3618,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -3629,7 +3629,7 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -3745,7 +3745,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -3781,9 +3781,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.16"
+version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
+checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
 dependencies = [
  "bytes 1.10.1",
  "futures-core",
@@ -3881,7 +3881,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -4132,7 +4132,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
  "wasm-bindgen-shared",
 ]
 
@@ -4185,9 +4185,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b130c0d2d49f8b6889abc456e795e82525204f27c42cf767cf0d7734e089b8"
+checksum = "b2878ef029c47c6e8cf779119f20fcf52bde7ad42a731b2a304bc221df17571e"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4244,7 +4244,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -4255,7 +4255,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -4525,7 +4525,7 @@ dependencies = [
  "futures",
  "http 1.3.1",
  "http-body-util",
- "hyper 1.7.0",
+ "hyper 1.8.0",
  "hyper-util",
  "log",
  "once_cell",
@@ -4576,7 +4576,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
  "synstructure",
 ]
 
@@ -4597,7 +4597,7 @@ checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -4617,7 +4617,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
  "synstructure",
 ]
 
@@ -4657,7 +4657,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.108",
+ "syn 2.0.110",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ resolver = "2"
 exclude = ["openapi"]
 
 [workspace.package]
-version = "1.0.0-alpha.6"
+version = "1.0.0-alpha.7"
 description = "API bindings for the Stripe HTTP API"
 rust-version = "1.88.0"
 authors = [

--- a/async-stripe-client-core/Cargo.toml
+++ b/async-stripe-client-core/Cargo.toml
@@ -17,8 +17,8 @@ edition.workspace = true
 name = "stripe_client_core"
 
 [dependencies]
-async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-alpha.6" }
-async-stripe-types = { path = "../async-stripe-types", version = "1.0.0-alpha.6" }
+async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-alpha.7" }
+async-stripe-types = { path = "../async-stripe-types", version = "1.0.0-alpha.7" }
 serde_json.workspace = true
 serde.workspace = true
 serde_qs.workspace = true

--- a/async-stripe-webhook/CHANGELOG.md
+++ b/async-stripe-webhook/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.7](https://github.com/arlyon/async-stripe/compare/async-stripe-webhook-v1.0.0-alpha.6...async-stripe-webhook-v1.0.0-alpha.7) - 2025-11-13
+
+### Other
+
+- Generate latest changes from OpenApi spec
+
 ## [1.0.0-alpha.6](https://github.com/arlyon/async-stripe/compare/async-stripe-webhook-v1.0.0-alpha.5...async-stripe-webhook-v1.0.0-alpha.6) - 2025-10-31
 
 ### Other

--- a/async-stripe-webhook/Cargo.toml
+++ b/async-stripe-webhook/Cargo.toml
@@ -15,8 +15,8 @@ categories.workspace = true
 name = "stripe_webhook"
 
 [dependencies]
-async-stripe-types = { path = "../async-stripe-types", version = "1.0.0-alpha.6" }
-async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-alpha.6" }
+async-stripe-types = { path = "../async-stripe-types", version = "1.0.0-alpha.7" }
+async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-alpha.7" }
 hmac = "0.12"
 sha2 = "0.10"
 hex = "0.4"
@@ -26,14 +26,14 @@ miniserde.workspace = true
 serde.workspace = true
 serde_json = { workspace = true, optional = true }
 
-async-stripe-billing = { path = "../generated/async-stripe-billing", optional = true, version = "1.0.0-alpha.6" }
-async-stripe-checkout = { path = "../generated/async-stripe-checkout", optional = true, version = "1.0.0-alpha.6" }
-async-stripe-core = { path = "../generated/async-stripe-core", optional = true, version = "1.0.0-alpha.6" }
-async-stripe-fraud = { path = "../generated/async-stripe-fraud", optional = true, version = "1.0.0-alpha.6" }
-async-stripe-misc = { path = "../generated/async-stripe-misc", optional = true, version = "1.0.0-alpha.6" }
-async-stripe-payment = { path = "../generated/async-stripe-payment", optional = true, version = "1.0.0-alpha.6" }
-async-stripe-terminal = { path = "../generated/async-stripe-terminal", optional = true, version = "1.0.0-alpha.6" }
-async-stripe-treasury = { path = "../generated/async-stripe-treasury", optional = true, version = "1.0.0-alpha.6" }
+async-stripe-billing = { path = "../generated/async-stripe-billing", optional = true, version = "1.0.0-alpha.7" }
+async-stripe-checkout = { path = "../generated/async-stripe-checkout", optional = true, version = "1.0.0-alpha.7" }
+async-stripe-core = { path = "../generated/async-stripe-core", optional = true, version = "1.0.0-alpha.7" }
+async-stripe-fraud = { path = "../generated/async-stripe-fraud", optional = true, version = "1.0.0-alpha.7" }
+async-stripe-misc = { path = "../generated/async-stripe-misc", optional = true, version = "1.0.0-alpha.7" }
+async-stripe-payment = { path = "../generated/async-stripe-payment", optional = true, version = "1.0.0-alpha.7" }
+async-stripe-terminal = { path = "../generated/async-stripe-terminal", optional = true, version = "1.0.0-alpha.7" }
+async-stripe-treasury = { path = "../generated/async-stripe-treasury", optional = true, version = "1.0.0-alpha.7" }
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/async-stripe/Cargo.toml
+++ b/async-stripe/Cargo.toml
@@ -32,8 +32,8 @@ async-std = { version = "1.12.0", optional = true }
 surf = { version = "2.1", optional = true }
 http-types = { version = "2.12.0", default-features = false, optional = true }
 
-async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-alpha.6" }
-async-stripe-client-core = { path = "../async-stripe-client-core", version = "1.0.0-alpha.6" }
+async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-alpha.7" }
+async-stripe-client-core = { path = "../async-stripe-client-core", version = "1.0.0-alpha.7" }
 
 [features]
 default = ["default-tls"]

--- a/generated/async-stripe-billing/CHANGELOG.md
+++ b/generated/async-stripe-billing/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.7](https://github.com/arlyon/async-stripe/compare/async-stripe-billing-v1.0.0-alpha.6...async-stripe-billing-v1.0.0-alpha.7) - 2025-11-13
+
+### Other
+
+- Generate latest changes from OpenApi spec
+
 ## [1.0.0-alpha.6](https://github.com/arlyon/async-stripe/compare/async-stripe-billing-v1.0.0-alpha.5...async-stripe-billing-v1.0.0-alpha.6) - 2025-10-31
 
 ### Other

--- a/generated/async-stripe-billing/Cargo.toml
+++ b/generated/async-stripe-billing/Cargo.toml
@@ -20,10 +20,10 @@ serde.workspace = true
 serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.6" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.6" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.7" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.7" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.6" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.7" }
 
 
 [features]

--- a/generated/async-stripe-checkout/Cargo.toml
+++ b/generated/async-stripe-checkout/Cargo.toml
@@ -20,10 +20,10 @@ serde.workspace = true
 serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.6" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.6" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.7" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.7" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.6" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.7" }
 
 
 [features]

--- a/generated/async-stripe-connect/CHANGELOG.md
+++ b/generated/async-stripe-connect/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.7](https://github.com/arlyon/async-stripe/compare/async-stripe-connect-v1.0.0-alpha.6...async-stripe-connect-v1.0.0-alpha.7) - 2025-11-13
+
+### Other
+
+- Generate latest changes from OpenApi spec
+
 ## [1.0.0-alpha.6](https://github.com/arlyon/async-stripe/compare/async-stripe-connect-v1.0.0-alpha.5...async-stripe-connect-v1.0.0-alpha.6) - 2025-10-31
 
 ### Other

--- a/generated/async-stripe-connect/Cargo.toml
+++ b/generated/async-stripe-connect/Cargo.toml
@@ -20,10 +20,10 @@ serde.workspace = true
 serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.6" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.6" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.7" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.7" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.6" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.7" }
 
 
 [features]

--- a/generated/async-stripe-core/CHANGELOG.md
+++ b/generated/async-stripe-core/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.7](https://github.com/arlyon/async-stripe/compare/async-stripe-core-v1.0.0-alpha.6...async-stripe-core-v1.0.0-alpha.7) - 2025-11-13
+
+### Other
+
+- Generate latest changes from OpenApi spec
+- Generate latest changes from OpenApi spec
+
 ## [1.0.0-alpha.6](https://github.com/arlyon/async-stripe/compare/async-stripe-core-v1.0.0-alpha.5...async-stripe-core-v1.0.0-alpha.6) - 2025-10-31
 
 ### Other

--- a/generated/async-stripe-core/Cargo.toml
+++ b/generated/async-stripe-core/Cargo.toml
@@ -20,10 +20,10 @@ serde.workspace = true
 serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.6" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.6" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.7" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.7" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.6" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.7" }
 
 
 [features]

--- a/generated/async-stripe-fraud/Cargo.toml
+++ b/generated/async-stripe-fraud/Cargo.toml
@@ -20,10 +20,10 @@ serde.workspace = true
 serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.6" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.6" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.7" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.7" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.6" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.7" }
 
 
 [features]

--- a/generated/async-stripe-issuing/CHANGELOG.md
+++ b/generated/async-stripe-issuing/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.7](https://github.com/arlyon/async-stripe/compare/async-stripe-issuing-v1.0.0-alpha.6...async-stripe-issuing-v1.0.0-alpha.7) - 2025-11-13
+
+### Other
+
+- Generate latest changes from OpenApi spec
+
 ## [1.0.0-alpha.5](https://github.com/arlyon/async-stripe/compare/async-stripe-issuing-v1.0.0-alpha.4...async-stripe-issuing-v1.0.0-alpha.5) - 2025-10-30
 
 ### Other

--- a/generated/async-stripe-issuing/Cargo.toml
+++ b/generated/async-stripe-issuing/Cargo.toml
@@ -20,10 +20,10 @@ serde.workspace = true
 serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.6" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.6" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.7" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.7" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.6" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.7" }
 
 
 [features]

--- a/generated/async-stripe-misc/CHANGELOG.md
+++ b/generated/async-stripe-misc/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.7](https://github.com/arlyon/async-stripe/compare/async-stripe-misc-v1.0.0-alpha.6...async-stripe-misc-v1.0.0-alpha.7) - 2025-11-13
+
+### Other
+
+- Generate latest changes from OpenApi spec
+
 ## [1.0.0-alpha.6](https://github.com/arlyon/async-stripe/compare/async-stripe-misc-v1.0.0-alpha.5...async-stripe-misc-v1.0.0-alpha.6) - 2025-10-31
 
 ### Other

--- a/generated/async-stripe-misc/Cargo.toml
+++ b/generated/async-stripe-misc/Cargo.toml
@@ -20,10 +20,10 @@ serde.workspace = true
 serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.6" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.6" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.7" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.7" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.6" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.7" }
 
 
 [features]

--- a/generated/async-stripe-payment/CHANGELOG.md
+++ b/generated/async-stripe-payment/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.7](https://github.com/arlyon/async-stripe/compare/async-stripe-payment-v1.0.0-alpha.6...async-stripe-payment-v1.0.0-alpha.7) - 2025-11-13
+
+### Other
+
+- Generate latest changes from OpenApi spec
+
 ## [1.0.0-alpha.6](https://github.com/arlyon/async-stripe/compare/async-stripe-payment-v1.0.0-alpha.5...async-stripe-payment-v1.0.0-alpha.6) - 2025-10-31
 
 ### Other

--- a/generated/async-stripe-payment/Cargo.toml
+++ b/generated/async-stripe-payment/Cargo.toml
@@ -20,10 +20,10 @@ serde.workspace = true
 serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.6" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.6" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.7" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.7" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.6" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.7" }
 
 
 [features]

--- a/generated/async-stripe-product/Cargo.toml
+++ b/generated/async-stripe-product/Cargo.toml
@@ -20,10 +20,10 @@ serde.workspace = true
 serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.6" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.6" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.7" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.7" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.6" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.7" }
 
 
 [features]

--- a/generated/async-stripe-shared/CHANGELOG.md
+++ b/generated/async-stripe-shared/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.7](https://github.com/arlyon/async-stripe/compare/async-stripe-shared-v1.0.0-alpha.6...async-stripe-shared-v1.0.0-alpha.7) - 2025-11-13
+
+### Other
+
+- Generate latest changes from OpenApi spec
+- Generate latest changes from OpenApi spec
+
 ## [1.0.0-alpha.6](https://github.com/arlyon/async-stripe/compare/async-stripe-shared-v1.0.0-alpha.5...async-stripe-shared-v1.0.0-alpha.6) - 2025-10-31
 
 ### Other

--- a/generated/async-stripe-shared/Cargo.toml
+++ b/generated/async-stripe-shared/Cargo.toml
@@ -20,7 +20,7 @@ serde.workspace = true
 serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.6" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.7" }
 
 
 

--- a/generated/async-stripe-terminal/CHANGELOG.md
+++ b/generated/async-stripe-terminal/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.7](https://github.com/arlyon/async-stripe/compare/async-stripe-terminal-v1.0.0-alpha.6...async-stripe-terminal-v1.0.0-alpha.7) - 2025-11-13
+
+### Other
+
+- Generate latest changes from OpenApi spec
+- Generate latest changes from OpenApi spec
+
 ## [1.0.0-alpha.6](https://github.com/arlyon/async-stripe/compare/async-stripe-terminal-v1.0.0-alpha.5...async-stripe-terminal-v1.0.0-alpha.6) - 2025-10-31
 
 ### Other

--- a/generated/async-stripe-terminal/Cargo.toml
+++ b/generated/async-stripe-terminal/Cargo.toml
@@ -20,10 +20,10 @@ serde.workspace = true
 serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.6" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.6" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.7" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.7" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.6" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.7" }
 
 
 [features]

--- a/generated/async-stripe-treasury/Cargo.toml
+++ b/generated/async-stripe-treasury/Cargo.toml
@@ -20,10 +20,10 @@ serde.workspace = true
 serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.6" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.6" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.7" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.7" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.6" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.7" }
 
 
 [features]


### PR DESCRIPTION
## 🤖 New release

- `async-stripe-types`: 1.0.0-alpha.6 -> 1.0.0-alpha.7
- `async-stripe-shared`: 1.0.0-alpha.6 -> 1.0.0-alpha.7 (✓ API compatible changes)
- `async-stripe-client-core`: 1.0.0-alpha.6 -> 1.0.0-alpha.7
- `async-stripe-billing`: 1.0.0-alpha.6 -> 1.0.0-alpha.7 (✓ API compatible changes)
- `async-stripe-checkout`: 1.0.0-alpha.6 -> 1.0.0-alpha.7
- `async-stripe-core`: 1.0.0-alpha.6 -> 1.0.0-alpha.7 (✓ API compatible changes)
- `async-stripe-fraud`: 1.0.0-alpha.6 -> 1.0.0-alpha.7
- `async-stripe-misc`: 1.0.0-alpha.6 -> 1.0.0-alpha.7 (✓ API compatible changes)
- `async-stripe-payment`: 1.0.0-alpha.6 -> 1.0.0-alpha.7 (✓ API compatible changes)
- `async-stripe-terminal`: 1.0.0-alpha.6 -> 1.0.0-alpha.7 (✓ API compatible changes)
- `async-stripe-treasury`: 1.0.0-alpha.6 -> 1.0.0-alpha.7
- `async-stripe-webhook`: 1.0.0-alpha.6 -> 1.0.0-alpha.7 (✓ API compatible changes)
- `async-stripe`: 1.0.0-alpha.6 -> 1.0.0-alpha.7
- `async-stripe-connect`: 1.0.0-alpha.6 -> 1.0.0-alpha.7 (✓ API compatible changes)
- `async-stripe-issuing`: 1.0.0-alpha.6 -> 1.0.0-alpha.7 (✓ API compatible changes)
- `async-stripe-product`: 1.0.0-alpha.6 -> 1.0.0-alpha.7

<details>
<summary>Changelog</summary><p>
`async-stripe-types`</p><blockquote>
[1.0.0-alpha.5](https://github.com/arlyon/async-stripe/compare/async-stripe-types-v1.0.0-alpha.4...async-stripe-types-v1.0.0-alpha.5) - 2025-10-30Otherupdate Cargo.toml dependencies</blockquote>
`async-stripe-shared`<blockquote>
[1.0.0-alpha.7](https://github.com/arlyon/async-stripe/compare/async-stripe-shared-v1.0.0-alpha.6...async-stripe-shared-v1.0.0-alpha.7) - 2025-11-13OtherGenerate latest changes from OpenApi specGenerate latest changes from OpenApi spec</blockquote>
`async-stripe-client-core`<blockquote>
[1.0.0-alpha.4](https://github.com/arlyon/async-stripe/compare/async-stripe-client-core-v1.0.0-alpha.3...async-stripe-client-core-v1.0.0-alpha.4) - 2025-10-02Otherupdate everything else to edition 2024add migration guide</blockquote>
`async-stripe-billing`<blockquote>
[1.0.0-alpha.7](https://github.com/arlyon/async-stripe/compare/async-stripe-billing-v1.0.0-alpha.6...async-stripe-billing-v1.0.0-alpha.7) - 2025-11-13OtherGenerate latest changes from OpenApi spec</blockquote>
`async-stripe-checkout`<blockquote>
[1.0.0-alpha.6](https://github.com/arlyon/async-stripe/compare/async-stripe-checkout-v1.0.0-alpha.5...async-stripe-checkout-v1.0.0-alpha.6) - 2025-10-31OtherGenerate latest changes from OpenApi spec</blockquote>
`async-stripe-core`<blockquote>
[1.0.0-alpha.7](https://github.com/arlyon/async-stripe/compare/async-stripe-core-v1.0.0-alpha.6...async-stripe-core-v1.0.0-alpha.7) - 2025-11-13OtherGenerate latest changes from OpenApi specGenerate latest changes from OpenApi spec</blockquote>
`async-stripe-fraud`<blockquote>
[1.0.0-alpha.6](https://github.com/arlyon/async-stripe/compare/async-stripe-fraud-v1.0.0-alpha.5...async-stripe-fraud-v1.0.0-alpha.6) - 2025-10-31OtherGenerate latest changes from OpenApi spec</blockquote>
`async-stripe-misc`<blockquote>
[1.0.0-alpha.7](https://github.com/arlyon/async-stripe/compare/async-stripe-misc-v1.0.0-alpha.6...async-stripe-misc-v1.0.0-alpha.7) - 2025-11-13OtherGenerate latest changes from OpenApi spec</blockquote>
`async-stripe-payment`<blockquote>
[1.0.0-alpha.7](https://github.com/arlyon/async-stripe/compare/async-stripe-payment-v1.0.0-alpha.6...async-stripe-payment-v1.0.0-alpha.7) - 2025-11-13OtherGenerate latest changes from OpenApi spec</blockquote>
`async-stripe-terminal`<blockquote>
[1.0.0-alpha.7](https://github.com/arlyon/async-stripe/compare/async-stripe-terminal-v1.0.0-alpha.6...async-stripe-terminal-v1.0.0-alpha.7) - 2025-11-13OtherGenerate latest changes from OpenApi specGenerate latest changes from OpenApi spec</blockquote>
`async-stripe-treasury`<blockquote>
[1.0.0-alpha.6](https://github.com/arlyon/async-stripe/compare/async-stripe-treasury-v1.0.0-alpha.5...async-stripe-treasury-v1.0.0-alpha.6) - 2025-10-31OtherGenerate latest changes from OpenApi spec</blockquote>
`async-stripe-webhook`<blockquote>
[1.0.0-alpha.7](https://github.com/arlyon/async-stripe/compare/async-stripe-webhook-v1.0.0-alpha.6...async-stripe-webhook-v1.0.0-alpha.7) - 2025-11-13OtherGenerate latest changes from OpenApi spec</blockquote>
`async-stripe`<blockquote>
[1.0.0-alpha.4](https://github.com/arlyon/async-stripe/compare/async-stripe-v1.0.0-alpha.3...async-stripe-v1.0.0-alpha.4) - 2025-10-02Otherupdate everything else to edition 2024add migration guide</blockquote>
`async-stripe-connect`<blockquote>
[1.0.0-alpha.7](https://github.com/arlyon/async-stripe/compare/async-stripe-connect-v1.0.0-alpha.6...async-stripe-connect-v1.0.0-alpha.7) - 2025-11-13OtherGenerate latest changes from OpenApi spec</blockquote>
`async-stripe-issuing`<blockquote>
[1.0.0-alpha.7](https://github.com/arlyon/async-stripe/compare/async-stripe-issuing-v1.0.0-alpha.6...async-stripe-issuing-v1.0.0-alpha.7) - 2025-11-13OtherGenerate latest changes from OpenApi spec</blockquote>
`async-stripe-product`<blockquote>
[1.0.0-alpha.6](https://github.com/arlyon/async-stripe/compare/async-stripe-product-v1.0.0-alpha.5...async-stripe-product-v1.0.0-alpha.6) - 2025-10-31OtherGenerate latest changes from OpenApi spec</blockquote>
<p></p>
</details>

---

This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).