### PR TITLE
chore: release v1.0.0-alpha.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
 dependencies = [
  "bitflags",
- "bytes 1.10.1",
+ "bytes 1.11.0",
  "futures-core",
  "futures-sink",
  "memchr",
@@ -32,7 +32,7 @@ dependencies = [
  "base64 0.22.1",
  "bitflags",
  "brotli",
- "bytes 1.10.1",
+ "bytes 1.11.0",
  "bytestring",
  "derive_more",
  "encoding_rs",
@@ -65,7 +65,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -132,9 +132,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "4.11.0"
+version = "4.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a597b77b5c6d6a1e1097fddde329a83665e25c5437c696a3a9a4aa514a614dea"
+checksum = "2233f53f6cb18ae038ce1f0713ca0c72ca0c4b71fe9aaeb59924ce2c89c6dd85"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -145,7 +145,7 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "actix-web-codegen",
- "bytes 1.10.1",
+ "bytes 1.11.0",
  "bytestring",
  "cfg-if",
  "cookie 0.16.2",
@@ -167,7 +167,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "smallvec",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "time 0.3.44",
  "tracing",
  "url",
@@ -182,7 +182,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -477,21 +477,21 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
 name = "async-stripe"
-version = "1.0.0-alpha.7"
+version = "1.0.0-alpha.8"
 dependencies = [
  "async-std",
  "async-stripe-client-core",
  "async-stripe-shared",
- "bytes 1.10.1",
+ "bytes 1.11.0",
  "http-body-util",
  "http-types",
  "httpmock",
- "hyper 1.8.0",
+ "hyper 1.8.1",
  "hyper-rustls",
  "hyper-tls",
  "hyper-util",
@@ -505,7 +505,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-billing"
-version = "1.0.0-alpha.7"
+version = "1.0.0-alpha.8"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -519,7 +519,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-checkout"
-version = "1.0.0-alpha.7"
+version = "1.0.0-alpha.8"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -533,11 +533,11 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-client-core"
-version = "1.0.0-alpha.7"
+version = "1.0.0-alpha.8"
 dependencies = [
  "async-stripe-shared",
  "async-stripe-types",
- "bytes 1.10.1",
+ "bytes 1.11.0",
  "futures-util",
  "miniserde",
  "serde",
@@ -550,7 +550,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-connect"
-version = "1.0.0-alpha.7"
+version = "1.0.0-alpha.8"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -564,7 +564,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-core"
-version = "1.0.0-alpha.7"
+version = "1.0.0-alpha.8"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-fraud"
-version = "1.0.0-alpha.7"
+version = "1.0.0-alpha.8"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-issuing"
-version = "1.0.0-alpha.7"
+version = "1.0.0-alpha.8"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -606,7 +606,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-misc"
-version = "1.0.0-alpha.7"
+version = "1.0.0-alpha.8"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -620,7 +620,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-payment"
-version = "1.0.0-alpha.7"
+version = "1.0.0-alpha.8"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -634,7 +634,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-product"
-version = "1.0.0-alpha.7"
+version = "1.0.0-alpha.8"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -648,7 +648,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-shared"
-version = "1.0.0-alpha.7"
+version = "1.0.0-alpha.8"
 dependencies = [
  "async-stripe-types",
  "miniserde",
@@ -660,7 +660,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-terminal"
-version = "1.0.0-alpha.7"
+version = "1.0.0-alpha.8"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -690,7 +690,7 @@ dependencies = [
  "async-stripe-terminal",
  "async-stripe-treasury",
  "async-stripe-types",
- "bytes 1.10.1",
+ "bytes 1.11.0",
  "chrono",
  "futures-util",
  "httpmock",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-treasury"
-version = "1.0.0-alpha.7"
+version = "1.0.0-alpha.8"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -718,7 +718,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-types"
-version = "1.0.0-alpha.7"
+version = "1.0.0-alpha.8"
 dependencies = [
  "miniserde",
  "serde",
@@ -729,7 +729,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-webhook"
-version = "1.0.0-alpha.7"
+version = "1.0.0-alpha.8"
 dependencies = [
  "async-stripe-billing",
  "async-stripe-checkout",
@@ -766,7 +766,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -820,19 +820,19 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18ed336352031311f4e0b4dd2ff392d4fbb370777c9d18d7fc9d7359f73871"
+checksum = "5b098575ebe77cb6d14fc7f32749631a6e44edbef6b796f89b020e99ba20d425"
 dependencies = [
  "axum-core",
  "axum-macros",
- "bytes 1.10.1",
+ "bytes 1.11.0",
  "form_urlencoded",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.0",
+ "hyper 1.8.1",
  "hyper-util",
  "itoa",
  "matchit",
@@ -858,9 +858,9 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59446ce19cd142f8833f856eb31f3eb097812d1479ab224f54d72428ca21ea22"
 dependencies = [
- "bytes 1.10.1",
+ "bytes 1.11.0",
  "futures-core",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
@@ -879,7 +879,7 @@ checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -951,9 +951,9 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad8646f98db542e39fc66e68a20b2144f6a732636df7c2354e74645faaa433ce"
+checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
 dependencies = [
  "cfg_aliases",
 ]
@@ -999,9 +999,9 @@ checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "bytestring"
@@ -1009,14 +1009,14 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "113b4343b5f6617e7ad401ced8de3cc8b012e73a594347c307b90db3e9271289"
 dependencies = [
- "bytes 1.10.1",
+ "bytes 1.11.0",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.45"
+version = "1.2.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35900b6c8d709fb1d854671ae27aeaa9eec2f8b01b364e1619a40da3e6fe2afe"
+checksum = "cd405d82c84ff7f35739f175f67d8b9fb7687a0e84ccdc78bd3568839827cf07"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1281,7 +1281,7 @@ checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
  "unicode-xid",
 ]
 
@@ -1315,7 +1315,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1352,7 +1352,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1466,9 +1466,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
+checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
 
 [[package]]
 name = "flate2"
@@ -1617,7 +1617,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -1741,7 +1741,7 @@ version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
 dependencies = [
- "bytes 1.10.1",
+ "bytes 1.11.0",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -1761,11 +1761,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
 dependencies = [
  "atomic-waker",
- "bytes 1.10.1",
+ "bytes 1.11.0",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.3.1",
+ "http 1.4.0",
  "indexmap",
  "slab",
  "tokio",
@@ -1775,9 +1775,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "hermit-abi"
@@ -1826,19 +1826,18 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
- "bytes 1.10.1",
+ "bytes 1.11.0",
  "fnv",
  "itoa",
 ]
 
 [[package]]
 name = "http"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
- "bytes 1.10.1",
- "fnv",
+ "bytes 1.11.0",
  "itoa",
 ]
 
@@ -1848,7 +1847,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
- "bytes 1.10.1",
+ "bytes 1.11.0",
  "http 0.2.12",
  "pin-project-lite",
 ]
@@ -1859,8 +1858,8 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
- "bytes 1.10.1",
- "http 1.3.1",
+ "bytes 1.11.0",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -1869,9 +1868,9 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
- "bytes 1.10.1",
+ "bytes 1.11.0",
  "futures-core",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -1957,7 +1956,7 @@ version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
 dependencies = [
- "bytes 1.10.1",
+ "bytes 1.11.0",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -1977,16 +1976,16 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744436df46f0bde35af3eda22aeaba453aada65d8f1c171cd8a5f59030bd69f"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
 dependencies = [
  "atomic-waker",
- "bytes 1.10.1",
+ "bytes 1.11.0",
  "futures-channel",
  "futures-core",
  "h2 0.4.12",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
@@ -2004,8 +2003,8 @@ version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http 1.3.1",
- "hyper 1.8.0",
+ "http 1.4.0",
+ "hyper 1.8.1",
  "hyper-util",
  "log",
  "rustls",
@@ -2023,9 +2022,9 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
- "bytes 1.10.1",
+ "bytes 1.11.0",
  "http-body-util",
- "hyper 1.8.0",
+ "hyper 1.8.1",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -2039,13 +2038,13 @@ version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52e9a2a24dc5c6821e71a7030e1e14b7b632acac55c40e9d2e082c621261bb56"
 dependencies = [
- "bytes 1.10.1",
+ "bytes 1.11.0",
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body 1.0.1",
- "hyper 1.8.0",
+ "hyper 1.8.1",
  "libc",
  "pin-project-lite",
  "socket2 0.6.1",
@@ -2188,9 +2187,9 @@ checksum = "e8a5a9a0ff0086c7a148acb942baaabeadf9504d10400b5a05645853729b9cd2"
 
 [[package]]
 name = "indexmap"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
+checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -2441,7 +2440,7 @@ checksum = "560f32b6891d8d9bade8942c45a27694f16d789d3b4b8e6b7135a5240de0a8af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2483,10 +2482,10 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
 dependencies = [
- "bytes 1.10.1",
+ "bytes 1.11.0",
  "encoding_rs",
  "futures-util",
- "http 1.3.1",
+ "http 1.4.0",
  "httparse",
  "memchr",
  "mime",
@@ -2582,7 +2581,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2662,7 +2661,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2688,7 +2687,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -2792,7 +2791,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
  "version_check",
  "yansi",
 ]
@@ -2938,7 +2937,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3000,7 +2999,7 @@ dependencies = [
  "async-trait",
  "atomic 0.5.3",
  "binascii",
- "bytes 1.10.1",
+ "bytes 1.11.0",
  "either",
  "figment",
  "futures",
@@ -3039,7 +3038,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rocket_http",
- "syn 2.0.110",
+ "syn 2.0.111",
  "unicode-xid",
  "version_check",
 ]
@@ -3253,7 +3252,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3400,9 +3399,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.6"
+version = "1.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
+checksum = "7664a098b8e616bdfcc2dc0e9ac44eb231eedf41db4e9fe95d8d32ec728dedad"
 dependencies = [
  "libc",
 ]
@@ -3611,9 +3610,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.110"
+version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
+checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3634,7 +3633,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3676,7 +3675,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3687,7 +3686,7 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3784,7 +3783,7 @@ version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
 dependencies = [
- "bytes 1.10.1",
+ "bytes 1.11.0",
  "libc",
  "mio",
  "parking_lot",
@@ -3803,7 +3802,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3843,7 +3842,7 @@ version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
 dependencies = [
- "bytes 1.10.1",
+ "bytes 1.11.0",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
@@ -3921,9 +3920,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "8eb41cbdb933e23b7929f47bb577710643157d7602ef3a2ebd3902b13ac5eda6"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -3933,20 +3932,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
 dependencies = [
  "once_cell",
  "valuable",
@@ -3975,9 +3974,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.20"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+checksum = "bee4bf13715d00789f2a099fd05d127c012bddc5c6628f2c8968374c1820c01d"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -4093,9 +4092,9 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "value-bag"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943ce29a8a743eb10d6082545d861b24f9d1b160b7d741e0f2cdf726bec909c5"
+checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
 
 [[package]]
 name = "vcpkg"
@@ -4190,7 +4189,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
  "wasm-bindgen-shared",
 ]
 
@@ -4302,7 +4301,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4313,7 +4312,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4581,9 +4580,9 @@ dependencies = [
  "base64 0.22.1",
  "deadpool",
  "futures",
- "http 1.3.1",
+ "http 1.4.0",
  "http-body-util",
- "hyper 1.8.0",
+ "hyper 1.8.1",
  "hyper-util",
  "log",
  "once_cell",
@@ -4634,28 +4633,28 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.27"
+version = "0.8.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+checksum = "4ea879c944afe8a2b25fef16bb4ba234f47c694565e97383b36f3a878219065c"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.27"
+version = "0.8.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+checksum = "cf955aa904d6040f70dc8e9384444cb1030aed272ba3cb09bbc4ab9e7c1f34f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -4675,7 +4674,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
  "synstructure",
 ]
 
@@ -4715,7 +4714,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.110",
+ "syn 2.0.111",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ resolver = "2"
 exclude = ["openapi"]
 
 [workspace.package]
-version = "1.0.0-alpha.7"
+version = "1.0.0-alpha.8"
 description = "API bindings for the Stripe HTTP API"
 rust-version = "1.88.0"
 authors = [

--- a/async-stripe-client-core/CHANGELOG.md
+++ b/async-stripe-client-core/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.8](https://github.com/arlyon/async-stripe/compare/async-stripe-client-core-v1.0.0-alpha.7...async-stripe-client-core-v1.0.0-alpha.8) - 2025-11-26
+
+### Fixed
+
+- allow restricted key (rk_) prefix in secret key validation
+- fix clippy lints in tests
+
 ## [1.0.0-alpha.4](https://github.com/arlyon/async-stripe/compare/async-stripe-client-core-v1.0.0-alpha.3...async-stripe-client-core-v1.0.0-alpha.4) - 2025-10-02
 
 ### Other

--- a/async-stripe-client-core/Cargo.toml
+++ b/async-stripe-client-core/Cargo.toml
@@ -17,8 +17,8 @@ edition.workspace = true
 name = "stripe_client_core"
 
 [dependencies]
-async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-alpha.7" }
-async-stripe-types = { path = "../async-stripe-types", version = "1.0.0-alpha.7" }
+async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-alpha.8" }
+async-stripe-types = { path = "../async-stripe-types", version = "1.0.0-alpha.8" }
 serde_json.workspace = true
 serde.workspace = true
 serde_qs.workspace = true

--- a/async-stripe-webhook/CHANGELOG.md
+++ b/async-stripe-webhook/CHANGELOG.md
@@ -5,6 +5,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.8](https://github.com/arlyon/async-stripe/compare/async-stripe-webhook-v1.0.0-alpha.7...async-stripe-webhook-v1.0.0-alpha.8) - 2025-11-26
+
+### Fixed
+
+- trace a warning when using a different SDK version than what stripe reports
+
+### Other
+
+- stronger compiler hints to improve stack space re-use
+- run api generate
+- BREAKING CHANGE: box all webhook variants to reduce clone stack usage
+
 ## [1.0.0-alpha.7](https://github.com/arlyon/async-stripe/compare/async-stripe-webhook-v1.0.0-alpha.6...async-stripe-webhook-v1.0.0-alpha.7) - 2025-11-13
 
 ### Other

--- a/async-stripe-webhook/Cargo.toml
+++ b/async-stripe-webhook/Cargo.toml
@@ -15,8 +15,8 @@ categories.workspace = true
 name = "stripe_webhook"
 
 [dependencies]
-async-stripe-types = { path = "../async-stripe-types", version = "1.0.0-alpha.7" }
-async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-alpha.7" }
+async-stripe-types = { path = "../async-stripe-types", version = "1.0.0-alpha.8" }
+async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-alpha.8" }
 hmac = "0.12"
 sha2 = "0.10"
 hex = "0.4"
@@ -27,14 +27,14 @@ miniserde.workspace = true
 serde.workspace = true
 serde_json = { workspace = true, optional = true }
 
-async-stripe-billing = { path = "../generated/async-stripe-billing", optional = true, version = "1.0.0-alpha.7" }
-async-stripe-checkout = { path = "../generated/async-stripe-checkout", optional = true, version = "1.0.0-alpha.7" }
-async-stripe-core = { path = "../generated/async-stripe-core", optional = true, version = "1.0.0-alpha.7" }
-async-stripe-fraud = { path = "../generated/async-stripe-fraud", optional = true, version = "1.0.0-alpha.7" }
-async-stripe-misc = { path = "../generated/async-stripe-misc", optional = true, version = "1.0.0-alpha.7" }
-async-stripe-payment = { path = "../generated/async-stripe-payment", optional = true, version = "1.0.0-alpha.7" }
-async-stripe-terminal = { path = "../generated/async-stripe-terminal", optional = true, version = "1.0.0-alpha.7" }
-async-stripe-treasury = { path = "../generated/async-stripe-treasury", optional = true, version = "1.0.0-alpha.7" }
+async-stripe-billing = { path = "../generated/async-stripe-billing", optional = true, version = "1.0.0-alpha.8" }
+async-stripe-checkout = { path = "../generated/async-stripe-checkout", optional = true, version = "1.0.0-alpha.8" }
+async-stripe-core = { path = "../generated/async-stripe-core", optional = true, version = "1.0.0-alpha.8" }
+async-stripe-fraud = { path = "../generated/async-stripe-fraud", optional = true, version = "1.0.0-alpha.8" }
+async-stripe-misc = { path = "../generated/async-stripe-misc", optional = true, version = "1.0.0-alpha.8" }
+async-stripe-payment = { path = "../generated/async-stripe-payment", optional = true, version = "1.0.0-alpha.8" }
+async-stripe-terminal = { path = "../generated/async-stripe-terminal", optional = true, version = "1.0.0-alpha.8" }
+async-stripe-treasury = { path = "../generated/async-stripe-treasury", optional = true, version = "1.0.0-alpha.8" }
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/async-stripe/CHANGELOG.md
+++ b/async-stripe/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.8](https://github.com/arlyon/async-stripe/compare/async-stripe-v1.0.0-alpha.7...async-stripe-v1.0.0-alpha.8) - 2025-11-26
+
+### Fixed
+
+- replace hard-coded ring with feature flags
+- fix clippy lints in tests
+
 ## [1.0.0-alpha.4](https://github.com/arlyon/async-stripe/compare/async-stripe-v1.0.0-alpha.3...async-stripe-v1.0.0-alpha.4) - 2025-10-02
 
 ### Other

--- a/async-stripe/Cargo.toml
+++ b/async-stripe/Cargo.toml
@@ -32,8 +32,8 @@ async-std = { version = "1.12.0", optional = true }
 surf = { version = "2.1", optional = true }
 http-types = { version = "2.12.0", default-features = false, optional = true }
 
-async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-alpha.7" }
-async-stripe-client-core = { path = "../async-stripe-client-core", version = "1.0.0-alpha.7" }
+async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-alpha.8" }
+async-stripe-client-core = { path = "../async-stripe-client-core", version = "1.0.0-alpha.8" }
 
 [features]
 default = ["default-tls"]

--- a/generated/async-stripe-billing/CHANGELOG.md
+++ b/generated/async-stripe-billing/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.8](https://github.com/arlyon/async-stripe/compare/async-stripe-billing-v1.0.0-alpha.7...async-stripe-billing-v1.0.0-alpha.8) - 2025-11-26
+
+### Other
+
+- Generate latest changes from OpenApi spec
+- run api generate
+
 ## [1.0.0-alpha.7](https://github.com/arlyon/async-stripe/compare/async-stripe-billing-v1.0.0-alpha.6...async-stripe-billing-v1.0.0-alpha.7) - 2025-11-13
 
 ### Other

--- a/generated/async-stripe-billing/Cargo.toml
+++ b/generated/async-stripe-billing/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.7" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.7" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.8" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.8" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.7" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.8" }
 
 
 [features]

--- a/generated/async-stripe-checkout/CHANGELOG.md
+++ b/generated/async-stripe-checkout/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.8](https://github.com/arlyon/async-stripe/compare/async-stripe-checkout-v1.0.0-alpha.7...async-stripe-checkout-v1.0.0-alpha.8) - 2025-11-26
+
+### Other
+
+- run api generate
+
 ## [1.0.0-alpha.6](https://github.com/arlyon/async-stripe/compare/async-stripe-checkout-v1.0.0-alpha.5...async-stripe-checkout-v1.0.0-alpha.6) - 2025-10-31
 
 ### Other

--- a/generated/async-stripe-checkout/Cargo.toml
+++ b/generated/async-stripe-checkout/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.7" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.7" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.8" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.8" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.7" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.8" }
 
 
 [features]

--- a/generated/async-stripe-connect/CHANGELOG.md
+++ b/generated/async-stripe-connect/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.8](https://github.com/arlyon/async-stripe/compare/async-stripe-connect-v1.0.0-alpha.7...async-stripe-connect-v1.0.0-alpha.8) - 2025-11-26
+
+### Other
+
+- run api generate
+
 ## [1.0.0-alpha.7](https://github.com/arlyon/async-stripe/compare/async-stripe-connect-v1.0.0-alpha.6...async-stripe-connect-v1.0.0-alpha.7) - 2025-11-13
 
 ### Other

--- a/generated/async-stripe-connect/Cargo.toml
+++ b/generated/async-stripe-connect/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.7" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.7" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.8" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.8" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.7" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.8" }
 
 
 [features]

--- a/generated/async-stripe-core/CHANGELOG.md
+++ b/generated/async-stripe-core/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.8](https://github.com/arlyon/async-stripe/compare/async-stripe-core-v1.0.0-alpha.7...async-stripe-core-v1.0.0-alpha.8) - 2025-11-26
+
+### Other
+
+- Generate latest changes from OpenApi spec
+- run api generate
+
 ## [1.0.0-alpha.7](https://github.com/arlyon/async-stripe/compare/async-stripe-core-v1.0.0-alpha.6...async-stripe-core-v1.0.0-alpha.7) - 2025-11-13
 
 ### Other

--- a/generated/async-stripe-core/Cargo.toml
+++ b/generated/async-stripe-core/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.7" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.7" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.8" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.8" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.7" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.8" }
 
 
 [features]

--- a/generated/async-stripe-fraud/CHANGELOG.md
+++ b/generated/async-stripe-fraud/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.8](https://github.com/arlyon/async-stripe/compare/async-stripe-fraud-v1.0.0-alpha.7...async-stripe-fraud-v1.0.0-alpha.8) - 2025-11-26
+
+### Other
+
+- run api generate
+
 ## [1.0.0-alpha.6](https://github.com/arlyon/async-stripe/compare/async-stripe-fraud-v1.0.0-alpha.5...async-stripe-fraud-v1.0.0-alpha.6) - 2025-10-31
 
 ### Other

--- a/generated/async-stripe-fraud/Cargo.toml
+++ b/generated/async-stripe-fraud/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.7" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.7" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.8" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.8" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.7" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.8" }
 
 
 [features]

--- a/generated/async-stripe-issuing/CHANGELOG.md
+++ b/generated/async-stripe-issuing/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.8](https://github.com/arlyon/async-stripe/compare/async-stripe-issuing-v1.0.0-alpha.7...async-stripe-issuing-v1.0.0-alpha.8) - 2025-11-26
+
+### Other
+
+- Generate latest changes from OpenApi spec
+- run api generate
+
 ## [1.0.0-alpha.7](https://github.com/arlyon/async-stripe/compare/async-stripe-issuing-v1.0.0-alpha.6...async-stripe-issuing-v1.0.0-alpha.7) - 2025-11-13
 
 ### Other

--- a/generated/async-stripe-issuing/Cargo.toml
+++ b/generated/async-stripe-issuing/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.7" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.7" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.8" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.8" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.7" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.8" }
 
 
 [features]

--- a/generated/async-stripe-misc/CHANGELOG.md
+++ b/generated/async-stripe-misc/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.8](https://github.com/arlyon/async-stripe/compare/async-stripe-misc-v1.0.0-alpha.7...async-stripe-misc-v1.0.0-alpha.8) - 2025-11-26
+
+### Other
+
+- Generate latest changes from OpenApi spec
+- run api generate
+
 ## [1.0.0-alpha.7](https://github.com/arlyon/async-stripe/compare/async-stripe-misc-v1.0.0-alpha.6...async-stripe-misc-v1.0.0-alpha.7) - 2025-11-13
 
 ### Other

--- a/generated/async-stripe-misc/Cargo.toml
+++ b/generated/async-stripe-misc/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.7" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.7" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.8" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.8" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.7" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.8" }
 
 
 [features]

--- a/generated/async-stripe-payment/CHANGELOG.md
+++ b/generated/async-stripe-payment/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.8](https://github.com/arlyon/async-stripe/compare/async-stripe-payment-v1.0.0-alpha.7...async-stripe-payment-v1.0.0-alpha.8) - 2025-11-26
+
+### Other
+
+- run api generate
+
 ## [1.0.0-alpha.7](https://github.com/arlyon/async-stripe/compare/async-stripe-payment-v1.0.0-alpha.6...async-stripe-payment-v1.0.0-alpha.7) - 2025-11-13
 
 ### Other

--- a/generated/async-stripe-payment/Cargo.toml
+++ b/generated/async-stripe-payment/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.7" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.7" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.8" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.8" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.7" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.8" }
 
 
 [features]

--- a/generated/async-stripe-product/CHANGELOG.md
+++ b/generated/async-stripe-product/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.8](https://github.com/arlyon/async-stripe/compare/async-stripe-product-v1.0.0-alpha.7...async-stripe-product-v1.0.0-alpha.8) - 2025-11-26
+
+### Other
+
+- run api generate
+
 ## [1.0.0-alpha.6](https://github.com/arlyon/async-stripe/compare/async-stripe-product-v1.0.0-alpha.5...async-stripe-product-v1.0.0-alpha.6) - 2025-10-31
 
 ### Other

--- a/generated/async-stripe-product/Cargo.toml
+++ b/generated/async-stripe-product/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.7" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.7" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.8" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.8" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.7" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.8" }
 
 
 [features]

--- a/generated/async-stripe-shared/CHANGELOG.md
+++ b/generated/async-stripe-shared/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.8](https://github.com/arlyon/async-stripe/compare/async-stripe-shared-v1.0.0-alpha.7...async-stripe-shared-v1.0.0-alpha.8) - 2025-11-26
+
+### Other
+
+- Generate latest changes from OpenApi spec
+- run api generate
+
 ## [1.0.0-alpha.7](https://github.com/arlyon/async-stripe/compare/async-stripe-shared-v1.0.0-alpha.6...async-stripe-shared-v1.0.0-alpha.7) - 2025-11-13
 
 ### Other

--- a/generated/async-stripe-shared/Cargo.toml
+++ b/generated/async-stripe-shared/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.7" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.8" }
 
 
 

--- a/generated/async-stripe-terminal/CHANGELOG.md
+++ b/generated/async-stripe-terminal/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.8](https://github.com/arlyon/async-stripe/compare/async-stripe-terminal-v1.0.0-alpha.7...async-stripe-terminal-v1.0.0-alpha.8) - 2025-11-26
+
+### Other
+
+- run api generate
+
 ## [1.0.0-alpha.7](https://github.com/arlyon/async-stripe/compare/async-stripe-terminal-v1.0.0-alpha.6...async-stripe-terminal-v1.0.0-alpha.7) - 2025-11-13
 
 ### Other

--- a/generated/async-stripe-terminal/Cargo.toml
+++ b/generated/async-stripe-terminal/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.7" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.7" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.8" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.8" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.7" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.8" }
 
 
 [features]

--- a/generated/async-stripe-treasury/CHANGELOG.md
+++ b/generated/async-stripe-treasury/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.8](https://github.com/arlyon/async-stripe/compare/async-stripe-treasury-v1.0.0-alpha.7...async-stripe-treasury-v1.0.0-alpha.8) - 2025-11-26
+
+### Other
+
+- run api generate
+
 ## [1.0.0-alpha.6](https://github.com/arlyon/async-stripe/compare/async-stripe-treasury-v1.0.0-alpha.5...async-stripe-treasury-v1.0.0-alpha.6) - 2025-10-31
 
 ### Other

--- a/generated/async-stripe-treasury/Cargo.toml
+++ b/generated/async-stripe-treasury/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.7" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.7" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.8" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.8" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.7" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.8" }
 
 
 [features]


### PR DESCRIPTION



## 🤖 New release

* `async-stripe-types`: 1.0.0-alpha.7 -> 1.0.0-alpha.8
* `async-stripe-shared`: 1.0.0-alpha.7 -> 1.0.0-alpha.8 (✓ API compatible changes)
* `async-stripe-client-core`: 1.0.0-alpha.7 -> 1.0.0-alpha.8 (✓ API compatible changes)
* `async-stripe-billing`: 1.0.0-alpha.7 -> 1.0.0-alpha.8 (✓ API compatible changes)
* `async-stripe-checkout`: 1.0.0-alpha.7 -> 1.0.0-alpha.8 (✓ API compatible changes)
* `async-stripe-core`: 1.0.0-alpha.7 -> 1.0.0-alpha.8 (✓ API compatible changes)
* `async-stripe-fraud`: 1.0.0-alpha.7 -> 1.0.0-alpha.8 (✓ API compatible changes)
* `async-stripe-misc`: 1.0.0-alpha.7 -> 1.0.0-alpha.8 (✓ API compatible changes)
* `async-stripe-payment`: 1.0.0-alpha.7 -> 1.0.0-alpha.8 (✓ API compatible changes)
* `async-stripe-terminal`: 1.0.0-alpha.7 -> 1.0.0-alpha.8 (✓ API compatible changes)
* `async-stripe-treasury`: 1.0.0-alpha.7 -> 1.0.0-alpha.8 (✓ API compatible changes)
* `async-stripe-webhook`: 1.0.0-alpha.7 -> 1.0.0-alpha.8 (✓ API compatible changes)
* `async-stripe`: 1.0.0-alpha.7 -> 1.0.0-alpha.8 (✓ API compatible changes)
* `async-stripe-connect`: 1.0.0-alpha.7 -> 1.0.0-alpha.8 (✓ API compatible changes)
* `async-stripe-issuing`: 1.0.0-alpha.7 -> 1.0.0-alpha.8 (✓ API compatible changes)
* `async-stripe-product`: 1.0.0-alpha.7 -> 1.0.0-alpha.8 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `async-stripe-types`

<blockquote>

## [1.0.0-alpha.5](https://github.com/arlyon/async-stripe/compare/async-stripe-types-v1.0.0-alpha.4...async-stripe-types-v1.0.0-alpha.5) - 2025-10-30

### Other

- update Cargo.toml dependencies
</blockquote>

## `async-stripe-shared`

<blockquote>

## [1.0.0-alpha.8](https://github.com/arlyon/async-stripe/compare/async-stripe-shared-v1.0.0-alpha.7...async-stripe-shared-v1.0.0-alpha.8) - 2025-11-26

### Other

- Generate latest changes from OpenApi spec
- run api generate
</blockquote>

## `async-stripe-client-core`

<blockquote>

## [1.0.0-alpha.8](https://github.com/arlyon/async-stripe/compare/async-stripe-client-core-v1.0.0-alpha.7...async-stripe-client-core-v1.0.0-alpha.8) - 2025-11-26

### Fixed

- allow restricted key (rk_) prefix in secret key validation
- fix clippy lints in tests
</blockquote>

## `async-stripe-billing`

<blockquote>

## [1.0.0-alpha.8](https://github.com/arlyon/async-stripe/compare/async-stripe-billing-v1.0.0-alpha.7...async-stripe-billing-v1.0.0-alpha.8) - 2025-11-26

### Other

- Generate latest changes from OpenApi spec
- run api generate
</blockquote>

## `async-stripe-checkout`

<blockquote>

## [1.0.0-alpha.8](https://github.com/arlyon/async-stripe/compare/async-stripe-checkout-v1.0.0-alpha.7...async-stripe-checkout-v1.0.0-alpha.8) - 2025-11-26

### Other

- run api generate
</blockquote>

## `async-stripe-core`

<blockquote>

## [1.0.0-alpha.8](https://github.com/arlyon/async-stripe/compare/async-stripe-core-v1.0.0-alpha.7...async-stripe-core-v1.0.0-alpha.8) - 2025-11-26

### Other

- Generate latest changes from OpenApi spec
- run api generate
</blockquote>

## `async-stripe-fraud`

<blockquote>

## [1.0.0-alpha.8](https://github.com/arlyon/async-stripe/compare/async-stripe-fraud-v1.0.0-alpha.7...async-stripe-fraud-v1.0.0-alpha.8) - 2025-11-26

### Other

- run api generate
</blockquote>

## `async-stripe-misc`

<blockquote>

## [1.0.0-alpha.8](https://github.com/arlyon/async-stripe/compare/async-stripe-misc-v1.0.0-alpha.7...async-stripe-misc-v1.0.0-alpha.8) - 2025-11-26

### Other

- Generate latest changes from OpenApi spec
- run api generate
</blockquote>

## `async-stripe-payment`

<blockquote>

## [1.0.0-alpha.8](https://github.com/arlyon/async-stripe/compare/async-stripe-payment-v1.0.0-alpha.7...async-stripe-payment-v1.0.0-alpha.8) - 2025-11-26

### Other

- run api generate
</blockquote>

## `async-stripe-terminal`

<blockquote>

## [1.0.0-alpha.8](https://github.com/arlyon/async-stripe/compare/async-stripe-terminal-v1.0.0-alpha.7...async-stripe-terminal-v1.0.0-alpha.8) - 2025-11-26

### Other

- run api generate
</blockquote>

## `async-stripe-treasury`

<blockquote>

## [1.0.0-alpha.8](https://github.com/arlyon/async-stripe/compare/async-stripe-treasury-v1.0.0-alpha.7...async-stripe-treasury-v1.0.0-alpha.8) - 2025-11-26

### Other

- run api generate
</blockquote>

## `async-stripe-webhook`

<blockquote>

## [1.0.0-alpha.8](https://github.com/arlyon/async-stripe/compare/async-stripe-webhook-v1.0.0-alpha.7...async-stripe-webhook-v1.0.0-alpha.8) - 2025-11-26

### Fixed

- trace a warning when using a different SDK version than what stripe reports

### Other

- stronger compiler hints to improve stack space re-use
- run api generate
- BREAKING CHANGE: box all webhook variants to reduce clone stack usage
</blockquote>

## `async-stripe`

<blockquote>

## [1.0.0-alpha.8](https://github.com/arlyon/async-stripe/compare/async-stripe-v1.0.0-alpha.7...async-stripe-v1.0.0-alpha.8) - 2025-11-26

### Fixed

- replace hard-coded ring with feature flags
- fix clippy lints in tests
</blockquote>

## `async-stripe-connect`

<blockquote>

## [1.0.0-alpha.8](https://github.com/arlyon/async-stripe/compare/async-stripe-connect-v1.0.0-alpha.7...async-stripe-connect-v1.0.0-alpha.8) - 2025-11-26

### Other

- run api generate
</blockquote>

## `async-stripe-issuing`

<blockquote>

## [1.0.0-alpha.8](https://github.com/arlyon/async-stripe/compare/async-stripe-issuing-v1.0.0-alpha.7...async-stripe-issuing-v1.0.0-alpha.8) - 2025-11-26

### Other

- Generate latest changes from OpenApi spec
- run api generate
</blockquote>

## `async-stripe-product`

<blockquote>

## [1.0.0-alpha.8](https://github.com/arlyon/async-stripe/compare/async-stripe-product-v1.0.0-alpha.7...async-stripe-product-v1.0.0-alpha.8) - 2025-11-26

### Other

- run api generate
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).