### PR TITLE
fix: allow restricted key (rk_) prefix in secret key validation

### DIFF
--- a/async-stripe-client-core/src/config.rs
+++ b/async-stripe-client-core/src/config.rs
@@ -39,7 +39,7 @@ impl SharedConfigBuilder {
 
         // some basic sanity checks
         // TODO: maybe a full-blown type here rather than a warning?
-        if secret.trim() != secret || !secret.starts_with("sk_") {
+        if secret.trim() != secret || !(secret.starts_with("sk_") || secret.starts_with("rk_")) {
             tracing::warn!("suspiciously formatted secret key")
         }
 


### PR DESCRIPTION
Stripe restricted keys use the 'rk_' prefix instead of the standard 'sk_' prefix. Updated the sanity check to accept both prefixes to prevent spurious warnings when using restricted keys.

Fixes #796

Generated with [Claude Code](https://claude.ai/code)