### PR TITLE
chore: release v1.0.0-alpha.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,9 +132,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "4.12.0"
+version = "4.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2233f53f6cb18ae038ce1f0713ca0c72ca0c4b71fe9aaeb59924ce2c89c6dd85"
+checksum = "1654a77ba142e37f049637a3e5685f864514af11fcbc51cb51eb6596afe5b8d6"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe"
-version = "1.0.0-alpha.8"
+version = "1.0.0-alpha.9"
 dependencies = [
  "async-std",
  "async-stripe-client-core",
@@ -506,7 +506,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-billing"
-version = "1.0.0-alpha.8"
+version = "1.0.0-alpha.9"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-checkout"
-version = "1.0.0-alpha.8"
+version = "1.0.0-alpha.9"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-client-core"
-version = "1.0.0-alpha.8"
+version = "1.0.0-alpha.9"
 dependencies = [
  "async-stripe-shared",
  "async-stripe-types",
@@ -551,7 +551,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-connect"
-version = "1.0.0-alpha.8"
+version = "1.0.0-alpha.9"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-core"
-version = "1.0.0-alpha.8"
+version = "1.0.0-alpha.9"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-fraud"
-version = "1.0.0-alpha.8"
+version = "1.0.0-alpha.9"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -593,7 +593,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-issuing"
-version = "1.0.0-alpha.8"
+version = "1.0.0-alpha.9"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-misc"
-version = "1.0.0-alpha.8"
+version = "1.0.0-alpha.9"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -621,7 +621,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-parser"
-version = "1.0.0-alpha.8"
+version = "1.0.0-alpha.9"
 dependencies = [
  "async-stripe-billing",
  "async-stripe-checkout",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-payment"
-version = "1.0.0-alpha.8"
+version = "1.0.0-alpha.9"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -659,7 +659,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-product"
-version = "1.0.0-alpha.8"
+version = "1.0.0-alpha.9"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -673,7 +673,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-shared"
-version = "1.0.0-alpha.8"
+version = "1.0.0-alpha.9"
 dependencies = [
  "async-stripe-types",
  "miniserde",
@@ -685,7 +685,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-terminal"
-version = "1.0.0-alpha.8"
+version = "1.0.0-alpha.9"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -729,7 +729,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-treasury"
-version = "1.0.0-alpha.8"
+version = "1.0.0-alpha.9"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-types"
-version = "1.0.0-alpha.8"
+version = "1.0.0-alpha.9"
 dependencies = [
  "miniserde",
  "serde",
@@ -754,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-webhook"
-version = "1.0.0-alpha.8"
+version = "1.0.0-alpha.9"
 dependencies = [
  "async-stripe-billing",
  "async-stripe-checkout",
@@ -1040,9 +1040,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.47"
+version = "1.2.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd405d82c84ff7f35739f175f67d8b9fb7687a0e84ccdc78bd3568839827cf07"
+checksum = "c481bdbf0ed3b892f6f806287d72acd515b352a4ec27a208489b8c1bc839633a"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1119,6 +1119,15 @@ name = "const_fn"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f8a2ca5ac02d09563609681103aada9e1777d54fc57a5acd7a41404f9c93b6e"
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "cookie"
@@ -1304,21 +1313,23 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+checksum = "10b768e943bed7bf2cab53df09f4bc34bfd217cdb57d971e769874c9a6710618"
 dependencies = [
  "derive_more-impl",
 ]
 
 [[package]]
 name = "derive_more-impl"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+checksum = "6d286bfdaf75e988b4a78e013ecd79c581e06399ab53fbacd2d916c2f904f30b"
 dependencies = [
+ "convert_case",
  "proc-macro2",
  "quote",
+ "rustc_version 0.4.1",
  "syn 2.0.111",
  "unicode-xid",
 ]
@@ -2078,9 +2089,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52e9a2a24dc5c6821e71a7030e1e14b7b632acac55c40e9d2e082c621261bb56"
+checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
  "bytes 1.11.0",
  "futures-channel",
@@ -2363,9 +2374,9 @@ checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
 name = "libnghttp2-sys"
@@ -2429,9 +2440,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 dependencies = [
  "value-bag",
 ]
@@ -2522,9 +2533,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "log",
@@ -3132,7 +3143,16 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
- "semver",
+ "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver 1.0.27",
 ]
 
 [[package]]
@@ -3178,9 +3198,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94182ad936a0c91c324cd46c6511b9510ed16af436d7b5bab34beab0afd55f7a"
+checksum = "708c0f9d5f54ba0272468c1d306a52c495b31fa155e91bc25371e6df7996908c"
 dependencies = [
  "zeroize",
 ]
@@ -3274,6 +3294,12 @@ checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
  "semver-parser",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "semver-parser"
@@ -3582,7 +3608,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
 dependencies = [
  "discard",
- "rustc_version",
+ "rustc_version 0.2.3",
  "stdweb-derive",
  "stdweb-internal-macros",
  "stdweb-internal-runtime",
@@ -3976,9 +4002,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.42"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eb41cbdb933e23b7929f47bb577710643157d7602ef3a2ebd3902b13ac5eda6"
+checksum = "2d15d90a0b5c19378952d479dc858407149d7bb45a14de0142f6c534b16fc647"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -4030,9 +4056,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.21"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee4bf13715d00789f2a099fd05d127c012bddc5c6628f2c8968374c1820c01d"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -4090,6 +4116,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4131,9 +4163,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.18.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
 dependencies = [
  "getrandom 0.3.4",
  "js-sys",
@@ -4619,9 +4651,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
@@ -4695,18 +4727,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.30"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea879c944afe8a2b25fef16bb4ba234f47c694565e97383b36f3a878219065c"
+checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.30"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf955aa904d6040f70dc8e9384444cb1030aed272ba3cb09bbc4ab9e7c1f34f5"
+checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ resolver = "2"
 exclude = ["openapi"]
 
 [workspace.package]
-version = "1.0.0-alpha.8"
+version = "1.0.0-alpha.9"
 description = "API bindings for the Stripe HTTP API"
 rust-version = "1.88.0"
 authors = [

--- a/async-stripe-client-core/CHANGELOG.md
+++ b/async-stripe-client-core/CHANGELOG.md
@@ -5,6 +5,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.9](https://github.com/arlyon/async-stripe/compare/async-stripe-client-core-v1.0.0-alpha.8...async-stripe-client-core-v1.0.0-alpha.9) - 2025-12-04
+
+### Fixed
+
+- fix tests
+
+### Other
+
+- Merge pull request #804 from arlyon/claude/issue-722-20251126-2114
+- Fix retry mechanism to follow Stripe documentation
+- update readme
+- make site public and add docs
+
 ## [1.0.0-alpha.8](https://github.com/arlyon/async-stripe/compare/async-stripe-client-core-v1.0.0-alpha.7...async-stripe-client-core-v1.0.0-alpha.8) - 2025-11-26
 
 ### Fixed

--- a/async-stripe-client-core/Cargo.toml
+++ b/async-stripe-client-core/Cargo.toml
@@ -17,8 +17,8 @@ edition.workspace = true
 name = "stripe_client_core"
 
 [dependencies]
-async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-alpha.8" }
-async-stripe-types = { path = "../async-stripe-types", version = "1.0.0-alpha.8" }
+async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-alpha.9" }
+async-stripe-types = { path = "../async-stripe-types", version = "1.0.0-alpha.9" }
 serde_json.workspace = true
 serde.workspace = true
 serde_qs.workspace = true

--- a/async-stripe-parser/Cargo.toml
+++ b/async-stripe-parser/Cargo.toml
@@ -18,19 +18,19 @@ edition.workspace = true
 crate-type = ["cdylib"]
 
 [dependencies]
-async-stripe-billing = { features = ["full", "deserialize"], version = "1.0.0-alpha.8", path = "../generated/async-stripe-billing" }
-async-stripe-checkout = { features = ["full", "deserialize"], version = "1.0.0-alpha.8", path = "../generated/async-stripe-checkout" }
-async-stripe-connect = { features = ["full", "deserialize"],version = "1.0.0-alpha.8", path = "../generated/async-stripe-connect" }
-async-stripe-core = { features = ["full", "deserialize"],version = "1.0.0-alpha.8", path = "../generated/async-stripe-core" }
-async-stripe-fraud = { features = ["full", "deserialize"],version = "1.0.0-alpha.8", path = "../generated/async-stripe-fraud" }
-async-stripe-issuing = {features = ["full", "deserialize"], version = "1.0.0-alpha.8", path = "../generated/async-stripe-issuing" }
-async-stripe-misc = { features = ["full", "deserialize"],version = "1.0.0-alpha.8", path = "../generated/async-stripe-misc" }
-async-stripe-payment = { features = ["full", "deserialize"],version = "1.0.0-alpha.8", path = "../generated/async-stripe-payment" }
-async-stripe-product = { features = ["full", "deserialize"],version = "1.0.0-alpha.8", path = "../generated/async-stripe-product" }
-async-stripe-shared = { features = ["deserialize"],version = "1.0.0-alpha.8", path = "../generated/async-stripe-shared" }
-async-stripe-terminal = {features = ["full", "deserialize"], version = "1.0.0-alpha.8", path = "../generated/async-stripe-terminal" }
-async-stripe-treasury = {features = ["full", "deserialize"], version = "1.0.0-alpha.8", path = "../generated/async-stripe-treasury" }
-async-stripe-webhook = { version = "1.0.0-alpha.8", path = "../async-stripe-webhook", features = ["deserialize", "serialize", "full", "detailed-errors"] }
+async-stripe-billing = { features = ["full", "deserialize"], version = "1.0.0-alpha.9", path = "../generated/async-stripe-billing" }
+async-stripe-checkout = { features = ["full", "deserialize"], version = "1.0.0-alpha.9", path = "../generated/async-stripe-checkout" }
+async-stripe-connect = { features = ["full", "deserialize"], version = "1.0.0-alpha.9", path = "../generated/async-stripe-connect" }
+async-stripe-core = { features = ["full", "deserialize"], version = "1.0.0-alpha.9", path = "../generated/async-stripe-core" }
+async-stripe-fraud = { features = ["full", "deserialize"], version = "1.0.0-alpha.9", path = "../generated/async-stripe-fraud" }
+async-stripe-issuing = {features = ["full", "deserialize"], version = "1.0.0-alpha.9", path = "../generated/async-stripe-issuing" }
+async-stripe-misc = { features = ["full", "deserialize"], version = "1.0.0-alpha.9", path = "../generated/async-stripe-misc" }
+async-stripe-payment = { features = ["full", "deserialize"], version = "1.0.0-alpha.9", path = "../generated/async-stripe-payment" }
+async-stripe-product = { features = ["full", "deserialize"], version = "1.0.0-alpha.9", path = "../generated/async-stripe-product" }
+async-stripe-shared = { features = ["deserialize"], version = "1.0.0-alpha.9", path = "../generated/async-stripe-shared" }
+async-stripe-terminal = {features = ["full", "deserialize"], version = "1.0.0-alpha.9", path = "../generated/async-stripe-terminal" }
+async-stripe-treasury = {features = ["full", "deserialize"], version = "1.0.0-alpha.9", path = "../generated/async-stripe-treasury" }
+async-stripe-webhook = { version = "1.0.0-alpha.9", path = "../async-stripe-webhook", features = ["deserialize", "serialize", "full", "detailed-errors"] }
 serde.workspace = true
 serde_json.workspace = true
 serde_path_to_error = "0.1.20"

--- a/async-stripe-webhook/CHANGELOG.md
+++ b/async-stripe-webhook/CHANGELOG.md
@@ -5,6 +5,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.9](https://github.com/arlyon/async-stripe/compare/async-stripe-webhook-v1.0.0-alpha.8...async-stripe-webhook-v1.0.0-alpha.9) - 2025-12-04
+
+### Added
+
+- add generate_test_header for webhook signature testing
+
+### Other
+
+- round trip webhook
+- Merge pull request #815 from arlyon/claude/issue-808-20251127-2210
+- add wasm webhook parser
+
 ## [1.0.0-alpha.8](https://github.com/arlyon/async-stripe/compare/async-stripe-webhook-v1.0.0-alpha.7...async-stripe-webhook-v1.0.0-alpha.8) - 2025-11-26
 
 ### Fixed

--- a/async-stripe-webhook/Cargo.toml
+++ b/async-stripe-webhook/Cargo.toml
@@ -15,8 +15,8 @@ categories.workspace = true
 name = "stripe_webhook"
 
 [dependencies]
-async-stripe-types = { path = "../async-stripe-types", version = "1.0.0-alpha.8" }
-async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-alpha.8" }
+async-stripe-types = { path = "../async-stripe-types", version = "1.0.0-alpha.9" }
+async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-alpha.9" }
 hmac = "0.12"
 sha2 = "0.10"
 hex = "0.4"
@@ -27,14 +27,14 @@ miniserde.workspace = true
 serde.workspace = true
 serde_json = { workspace = true, optional = true }
 
-async-stripe-billing = { path = "../generated/async-stripe-billing", optional = true, version = "1.0.0-alpha.8" }
-async-stripe-checkout = { path = "../generated/async-stripe-checkout", optional = true, version = "1.0.0-alpha.8" }
-async-stripe-core = { path = "../generated/async-stripe-core", optional = true, version = "1.0.0-alpha.8" }
-async-stripe-fraud = { path = "../generated/async-stripe-fraud", optional = true, version = "1.0.0-alpha.8" }
-async-stripe-misc = { path = "../generated/async-stripe-misc", optional = true, version = "1.0.0-alpha.8" }
-async-stripe-payment = { path = "../generated/async-stripe-payment", optional = true, version = "1.0.0-alpha.8" }
-async-stripe-terminal = { path = "../generated/async-stripe-terminal", optional = true, version = "1.0.0-alpha.8" }
-async-stripe-treasury = { path = "../generated/async-stripe-treasury", optional = true, version = "1.0.0-alpha.8" }
+async-stripe-billing = { path = "../generated/async-stripe-billing", optional = true, version = "1.0.0-alpha.9" }
+async-stripe-checkout = { path = "../generated/async-stripe-checkout", optional = true, version = "1.0.0-alpha.9" }
+async-stripe-core = { path = "../generated/async-stripe-core", optional = true, version = "1.0.0-alpha.9" }
+async-stripe-fraud = { path = "../generated/async-stripe-fraud", optional = true, version = "1.0.0-alpha.9" }
+async-stripe-misc = { path = "../generated/async-stripe-misc", optional = true, version = "1.0.0-alpha.9" }
+async-stripe-payment = { path = "../generated/async-stripe-payment", optional = true, version = "1.0.0-alpha.9" }
+async-stripe-terminal = { path = "../generated/async-stripe-terminal", optional = true, version = "1.0.0-alpha.9" }
+async-stripe-treasury = { path = "../generated/async-stripe-treasury", optional = true, version = "1.0.0-alpha.9" }
 serde_path_to_error = { version = "0.1.20", optional = true }
 
 [dev-dependencies]

--- a/async-stripe/CHANGELOG.md
+++ b/async-stripe/CHANGELOG.md
@@ -5,6 +5,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.9](https://github.com/arlyon/async-stripe/compare/async-stripe-v1.0.0-alpha.8...async-stripe-v1.0.0-alpha.9) - 2025-12-04
+
+### Fixed
+
+- fix tests
+
+### Other
+
+- update readme
+- make site public and add docs
+- Add tracing instrumentation to core API calls
+
 ## [1.0.0-alpha.8](https://github.com/arlyon/async-stripe/compare/async-stripe-v1.0.0-alpha.7...async-stripe-v1.0.0-alpha.8) - 2025-11-26
 
 ### Fixed

--- a/async-stripe/Cargo.toml
+++ b/async-stripe/Cargo.toml
@@ -33,8 +33,8 @@ async-std = { version = "1.12.0", optional = true }
 surf = { version = "2.1", optional = true }
 http-types = { version = "2.12.0", default-features = false, optional = true }
 
-async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-alpha.8" }
-async-stripe-client-core = { path = "../async-stripe-client-core", version = "1.0.0-alpha.8" }
+async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-alpha.9" }
+async-stripe-client-core = { path = "../async-stripe-client-core", version = "1.0.0-alpha.9" }
 
 [features]
 default = ["default-tls"]

--- a/generated/async-stripe-billing/Cargo.toml
+++ b/generated/async-stripe-billing/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.8" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.8" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.9" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.9" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.8" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.9" }
 
 
 [features]

--- a/generated/async-stripe-checkout/Cargo.toml
+++ b/generated/async-stripe-checkout/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.8" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.8" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.9" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.9" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.8" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.9" }
 
 
 [features]

--- a/generated/async-stripe-connect/Cargo.toml
+++ b/generated/async-stripe-connect/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.8" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.8" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.9" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.9" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.8" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.9" }
 
 
 [features]

--- a/generated/async-stripe-core/Cargo.toml
+++ b/generated/async-stripe-core/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.8" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.8" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.9" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.9" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.8" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.9" }
 
 
 [features]

--- a/generated/async-stripe-fraud/Cargo.toml
+++ b/generated/async-stripe-fraud/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.8" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.8" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.9" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.9" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.8" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.9" }
 
 
 [features]

--- a/generated/async-stripe-issuing/Cargo.toml
+++ b/generated/async-stripe-issuing/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.8" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.8" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.9" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.9" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.8" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.9" }
 
 
 [features]

--- a/generated/async-stripe-misc/Cargo.toml
+++ b/generated/async-stripe-misc/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.8" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.8" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.9" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.9" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.8" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.9" }
 
 
 [features]

--- a/generated/async-stripe-payment/Cargo.toml
+++ b/generated/async-stripe-payment/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.8" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.8" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.9" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.9" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.8" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.9" }
 
 
 [features]

--- a/generated/async-stripe-product/Cargo.toml
+++ b/generated/async-stripe-product/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.8" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.8" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.9" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.9" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.8" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.9" }
 
 
 [features]

--- a/generated/async-stripe-shared/Cargo.toml
+++ b/generated/async-stripe-shared/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.8" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.9" }
 
 
 

--- a/generated/async-stripe-terminal/Cargo.toml
+++ b/generated/async-stripe-terminal/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.8" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.8" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.9" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.9" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.8" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.9" }
 
 
 [features]

--- a/generated/async-stripe-treasury/Cargo.toml
+++ b/generated/async-stripe-treasury/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.8" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.8" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.9" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.9" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.8" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.9" }
 
 
 [features]


### PR DESCRIPTION



## 🤖 New release

* `async-stripe-types`: 1.0.0-alpha.8 -> 1.0.0-alpha.9
* `async-stripe-shared`: 1.0.0-alpha.8 -> 1.0.0-alpha.9
* `async-stripe-client-core`: 1.0.0-alpha.8 -> 1.0.0-alpha.9 (✓ API compatible changes)
* `async-stripe-billing`: 1.0.0-alpha.8 -> 1.0.0-alpha.9
* `async-stripe-checkout`: 1.0.0-alpha.8 -> 1.0.0-alpha.9
* `async-stripe-core`: 1.0.0-alpha.8 -> 1.0.0-alpha.9
* `async-stripe-fraud`: 1.0.0-alpha.8 -> 1.0.0-alpha.9
* `async-stripe-misc`: 1.0.0-alpha.8 -> 1.0.0-alpha.9
* `async-stripe-payment`: 1.0.0-alpha.8 -> 1.0.0-alpha.9
* `async-stripe-terminal`: 1.0.0-alpha.8 -> 1.0.0-alpha.9
* `async-stripe-treasury`: 1.0.0-alpha.8 -> 1.0.0-alpha.9
* `async-stripe-webhook`: 1.0.0-alpha.8 -> 1.0.0-alpha.9 (✓ API compatible changes)
* `async-stripe-connect`: 1.0.0-alpha.8 -> 1.0.0-alpha.9
* `async-stripe-issuing`: 1.0.0-alpha.8 -> 1.0.0-alpha.9
* `async-stripe-product`: 1.0.0-alpha.8 -> 1.0.0-alpha.9
* `async-stripe`: 1.0.0-alpha.8 -> 1.0.0-alpha.9 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `async-stripe-types`

<blockquote>

## [1.0.0-alpha.5](https://github.com/arlyon/async-stripe/compare/async-stripe-types-v1.0.0-alpha.4...async-stripe-types-v1.0.0-alpha.5) - 2025-10-30

### Other

- update Cargo.toml dependencies
</blockquote>

## `async-stripe-shared`

<blockquote>

## [1.0.0-alpha.8](https://github.com/arlyon/async-stripe/compare/async-stripe-shared-v1.0.0-alpha.7...async-stripe-shared-v1.0.0-alpha.8) - 2025-11-26

### Other

- Generate latest changes from OpenApi spec
- run api generate
</blockquote>

## `async-stripe-client-core`

<blockquote>

## [1.0.0-alpha.9](https://github.com/arlyon/async-stripe/compare/async-stripe-client-core-v1.0.0-alpha.8...async-stripe-client-core-v1.0.0-alpha.9) - 2025-12-04

### Fixed

- fix tests

### Other

- Merge pull request #804 from arlyon/claude/issue-722-20251126-2114
- Fix retry mechanism to follow Stripe documentation
- update readme
- make site public and add docs
</blockquote>

## `async-stripe-billing`

<blockquote>

## [1.0.0-alpha.8](https://github.com/arlyon/async-stripe/compare/async-stripe-billing-v1.0.0-alpha.7...async-stripe-billing-v1.0.0-alpha.8) - 2025-11-26

### Other

- Generate latest changes from OpenApi spec
- run api generate
</blockquote>

## `async-stripe-checkout`

<blockquote>

## [1.0.0-alpha.8](https://github.com/arlyon/async-stripe/compare/async-stripe-checkout-v1.0.0-alpha.7...async-stripe-checkout-v1.0.0-alpha.8) - 2025-11-26

### Other

- run api generate
</blockquote>

## `async-stripe-core`

<blockquote>

## [1.0.0-alpha.8](https://github.com/arlyon/async-stripe/compare/async-stripe-core-v1.0.0-alpha.7...async-stripe-core-v1.0.0-alpha.8) - 2025-11-26

### Other

- Generate latest changes from OpenApi spec
- run api generate
</blockquote>

## `async-stripe-fraud`

<blockquote>

## [1.0.0-alpha.8](https://github.com/arlyon/async-stripe/compare/async-stripe-fraud-v1.0.0-alpha.7...async-stripe-fraud-v1.0.0-alpha.8) - 2025-11-26

### Other

- run api generate
</blockquote>

## `async-stripe-misc`

<blockquote>

## [1.0.0-alpha.8](https://github.com/arlyon/async-stripe/compare/async-stripe-misc-v1.0.0-alpha.7...async-stripe-misc-v1.0.0-alpha.8) - 2025-11-26

### Other

- Generate latest changes from OpenApi spec
- run api generate
</blockquote>

## `async-stripe-payment`

<blockquote>

## [1.0.0-alpha.8](https://github.com/arlyon/async-stripe/compare/async-stripe-payment-v1.0.0-alpha.7...async-stripe-payment-v1.0.0-alpha.8) - 2025-11-26

### Other

- run api generate
</blockquote>

## `async-stripe-terminal`

<blockquote>

## [1.0.0-alpha.8](https://github.com/arlyon/async-stripe/compare/async-stripe-terminal-v1.0.0-alpha.7...async-stripe-terminal-v1.0.0-alpha.8) - 2025-11-26

### Other

- run api generate
</blockquote>

## `async-stripe-treasury`

<blockquote>

## [1.0.0-alpha.8](https://github.com/arlyon/async-stripe/compare/async-stripe-treasury-v1.0.0-alpha.7...async-stripe-treasury-v1.0.0-alpha.8) - 2025-11-26

### Other

- run api generate
</blockquote>

## `async-stripe-webhook`

<blockquote>

## [1.0.0-alpha.9](https://github.com/arlyon/async-stripe/compare/async-stripe-webhook-v1.0.0-alpha.8...async-stripe-webhook-v1.0.0-alpha.9) - 2025-12-04

### Added

- add generate_test_header for webhook signature testing

### Other

- round trip webhook
- Merge pull request #815 from arlyon/claude/issue-808-20251127-2210
- add wasm webhook parser
</blockquote>

## `async-stripe-connect`

<blockquote>

## [1.0.0-alpha.8](https://github.com/arlyon/async-stripe/compare/async-stripe-connect-v1.0.0-alpha.7...async-stripe-connect-v1.0.0-alpha.8) - 2025-11-26

### Other

- run api generate
</blockquote>

## `async-stripe-issuing`

<blockquote>

## [1.0.0-alpha.8](https://github.com/arlyon/async-stripe/compare/async-stripe-issuing-v1.0.0-alpha.7...async-stripe-issuing-v1.0.0-alpha.8) - 2025-11-26

### Other

- Generate latest changes from OpenApi spec
- run api generate
</blockquote>

## `async-stripe-product`

<blockquote>

## [1.0.0-alpha.8](https://github.com/arlyon/async-stripe/compare/async-stripe-product-v1.0.0-alpha.7...async-stripe-product-v1.0.0-alpha.8) - 2025-11-26

### Other

- run api generate
</blockquote>

## `async-stripe`

<blockquote>

## [1.0.0-alpha.9](https://github.com/arlyon/async-stripe/compare/async-stripe-v1.0.0-alpha.8...async-stripe-v1.0.0-alpha.9) - 2025-12-04

### Fixed

- fix tests

### Other

- update readme
- make site public and add docs
- Add tracing instrumentation to core API calls
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).