### PR TITLE
round trip webhook

### DIFF
--- a/async-stripe-parser/Cargo.toml
+++ b/async-stripe-parser/Cargo.toml
@@ -30,7 +30,7 @@ async-stripe-product = { features = ["full", "deserialize"],version = "1.0.0-alp
 async-stripe-shared = { features = ["deserialize"],version = "1.0.0-alpha.8", path = "../generated/async-stripe-shared" }
 async-stripe-terminal = {features = ["full", "deserialize"], version = "1.0.0-alpha.8", path = "../generated/async-stripe-terminal" }
 async-stripe-treasury = {features = ["full", "deserialize"], version = "1.0.0-alpha.8", path = "../generated/async-stripe-treasury" }
-async-stripe-webhook = { version = "1.0.0-alpha.8", path = "../async-stripe-webhook", features = ["deserialize", "full", "detailed-errors"] }
+async-stripe-webhook = { version = "1.0.0-alpha.8", path = "../async-stripe-webhook", features = ["deserialize", "serialize", "full", "detailed-errors"] }
 serde.workspace = true
 serde_json.workspace = true
 serde_path_to_error = "0.1.20"

--- a/async-stripe-parser/src/lib.rs
+++ b/async-stripe-parser/src/lib.rs
@@ -207,4 +207,60 @@ mod tests {
         let result = parse("Event", payload);
         insta::assert_snapshot!(result.unwrap_err());
     }
+    #[test]
+    fn test_roundtrip() {
+        let payload = r#"{
+          "id": "evt_1SYARgFuzxtsmcCa56A419qD",
+          "object": "event",
+          "api_version": "2024-06-20",
+          "created": 1764270096,
+          "data": {
+            "object": {
+              "object": "entitlements.active_entitlement_summary",
+              "customer": "cus_TVAmqNlyaYgEBn",
+              "entitlements": {
+                "object": "list",
+                "data": [
+                  {
+                    "id": "ent_61ThYP2iCNV4w0FC341FuzxtsmcCaIqu",
+                    "object": "entitlements.active_entitlement",
+                    "feature": "feat_61RwMxrXpU9nzwARs41FuzxtsmcCa6hs",
+                    "livemode": true,
+                    "lookup_key": "ai-insights"
+                  }
+                ],
+                "has_more": false,
+                "url": "/v1/customer/cus_TVAmqNlyaYgEBn/entitlements"
+              },
+              "livemode": true
+            },
+            "previous_attributes": {
+              "entitlements": {
+                "data": []
+              }
+            }
+          },
+          "livemode": true,
+          "pending_webhooks": 2,
+          "request": {
+            "id": null,
+            "idempotency_key": null
+          },
+          "type": "entitlements.active_entitlement_summary.updated"
+        }"#;
+
+        let event: stripe_webhook::Event =
+            serde_json::from_str(payload).expect("Failed to deserialize");
+        let serialized = serde_json::to_string(&event).expect("Failed to serialize");
+        println!("{}", serialized);
+        let event_2: stripe_webhook::Event =
+            serde_json::from_str(&serialized).expect("Failed to deserialize");
+
+        let original_value: serde_json::Value = serde_json::from_str(payload).unwrap();
+        let serialized_value: serde_json::Value = serde_json::from_str(&serialized).unwrap();
+
+        println!("{:#?}\n\n{:#?}", event, event_2);
+
+        assert_eq!(original_value, serialized_value);
+    }
 }

--- a/async-stripe-webhook/src/generated/mod.rs
+++ b/async-stripe-webhook/src/generated/mod.rs
@@ -719,6 +719,7 @@ const _: () = {
 #[derive(Clone, Debug)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
 #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+#[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(untagged))]
 #[non_exhaustive]
 /// The event data for a webhook event.
 pub enum EventObject {

--- a/openapi/src/webhook.rs
+++ b/openapi/src/webhook.rs
@@ -95,6 +95,7 @@ fn write_event_object(components: &Components, out_path: &Path) -> anyhow::Resul
     let _ = writedoc! {out, r#"
     #[cfg_attr(feature = "serialize", derive(serde::Serialize))]
     #[cfg_attr(feature = "deserialize", derive(serde::Deserialize))]
+    #[cfg_attr(any(feature = "serialize", feature = "deserialize"), serde(untagged))]
     #[non_exhaustive]
     /// The event data for a webhook event.
     pub enum EventObject {{


### PR DESCRIPTION
Closes #814

# Summary
Ensure that webhooks serialize and deserialize in a round trip

### Checklist

- [x] ran `cargo make fmt`
- [x] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features
 
