### PR TITLE
chore: release v1.0.0-alpha.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe"
-version = "1.0.0-alpha.10"
+version = "1.0.0-alpha.11"
 dependencies = [
  "async-std",
  "async-stripe-client-core",
@@ -506,7 +506,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-billing"
-version = "1.0.0-alpha.10"
+version = "1.0.0-alpha.11"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-checkout"
-version = "1.0.0-alpha.10"
+version = "1.0.0-alpha.11"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-client-core"
-version = "1.0.0-alpha.10"
+version = "1.0.0-alpha.11"
 dependencies = [
  "async-stripe-shared",
  "async-stripe-types",
@@ -551,7 +551,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-connect"
-version = "1.0.0-alpha.10"
+version = "1.0.0-alpha.11"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-core"
-version = "1.0.0-alpha.10"
+version = "1.0.0-alpha.11"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-fraud"
-version = "1.0.0-alpha.10"
+version = "1.0.0-alpha.11"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -593,7 +593,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-issuing"
-version = "1.0.0-alpha.10"
+version = "1.0.0-alpha.11"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-misc"
-version = "1.0.0-alpha.10"
+version = "1.0.0-alpha.11"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -621,7 +621,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-parser"
-version = "1.0.0-alpha.10"
+version = "1.0.0-alpha.11"
 dependencies = [
  "async-stripe-billing",
  "async-stripe-checkout",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-payment"
-version = "1.0.0-alpha.10"
+version = "1.0.0-alpha.11"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -659,7 +659,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-product"
-version = "1.0.0-alpha.10"
+version = "1.0.0-alpha.11"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -673,7 +673,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-shared"
-version = "1.0.0-alpha.10"
+version = "1.0.0-alpha.11"
 dependencies = [
  "async-stripe-types",
  "miniserde",
@@ -685,7 +685,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-terminal"
-version = "1.0.0-alpha.10"
+version = "1.0.0-alpha.11"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -729,7 +729,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-treasury"
-version = "1.0.0-alpha.10"
+version = "1.0.0-alpha.11"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-types"
-version = "1.0.0-alpha.10"
+version = "1.0.0-alpha.11"
 dependencies = [
  "miniserde",
  "serde",
@@ -754,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-webhook"
-version = "1.0.0-alpha.10"
+version = "1.0.0-alpha.11"
 dependencies = [
  "async-stripe-billing",
  "async-stripe-checkout",
@@ -1086,9 +1086,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.55"
+version = "0.1.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d49d74c227b6cc9f3c51a2c7c667a05b6453f7f0f952a5f8e4493bb9e731d68e"
+checksum = "b042e5d8a74ae91bb0961acd039822472ec99f8ab0948cbf6d1369588f8be586"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ resolver = "2"
 exclude = ["openapi"]
 
 [workspace.package]
-version = "1.0.0-alpha.10"
+version = "1.0.0-alpha.11"
 description = "API bindings for the Stripe HTTP API"
 rust-version = "1.88.0"
 authors = [

--- a/async-stripe-client-core/CHANGELOG.md
+++ b/async-stripe-client-core/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.11](https://github.com/arlyon/async-stripe/compare/async-stripe-client-core-v1.0.0-alpha.10...async-stripe-client-core-v1.0.0-alpha.11) - 2025-12-15
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [1.0.0-alpha.9](https://github.com/arlyon/async-stripe/compare/async-stripe-client-core-v1.0.0-alpha.8...async-stripe-client-core-v1.0.0-alpha.9) - 2025-12-04
 
 ### Fixed

--- a/async-stripe-client-core/Cargo.toml
+++ b/async-stripe-client-core/Cargo.toml
@@ -17,8 +17,8 @@ edition.workspace = true
 name = "stripe_client_core"
 
 [dependencies]
-async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-alpha.10" }
-async-stripe-types = { path = "../async-stripe-types", version = "1.0.0-alpha.10" }
+async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-alpha.11" }
+async-stripe-types = { path = "../async-stripe-types", version = "1.0.0-alpha.11" }
 serde_json.workspace = true
 serde.workspace = true
 serde_qs.workspace = true

--- a/async-stripe-parser/Cargo.toml
+++ b/async-stripe-parser/Cargo.toml
@@ -18,19 +18,19 @@ edition.workspace = true
 crate-type = ["cdylib"]
 
 [dependencies]
-async-stripe-billing = { features = ["full", "deserialize"], version = "1.0.0-alpha.10", path = "../generated/async-stripe-billing" }
-async-stripe-checkout = { features = ["full", "deserialize"], version = "1.0.0-alpha.10", path = "../generated/async-stripe-checkout" }
-async-stripe-connect = { features = ["full", "deserialize"], version = "1.0.0-alpha.10", path = "../generated/async-stripe-connect" }
-async-stripe-core = { features = ["full", "deserialize"], version = "1.0.0-alpha.10", path = "../generated/async-stripe-core" }
-async-stripe-fraud = { features = ["full", "deserialize"], version = "1.0.0-alpha.10", path = "../generated/async-stripe-fraud" }
-async-stripe-issuing = {features = ["full", "deserialize"], version = "1.0.0-alpha.10", path = "../generated/async-stripe-issuing" }
-async-stripe-misc = { features = ["full", "deserialize"], version = "1.0.0-alpha.10", path = "../generated/async-stripe-misc" }
-async-stripe-payment = { features = ["full", "deserialize"], version = "1.0.0-alpha.10", path = "../generated/async-stripe-payment" }
-async-stripe-product = { features = ["full", "deserialize"], version = "1.0.0-alpha.10", path = "../generated/async-stripe-product" }
-async-stripe-shared = { features = ["deserialize"], version = "1.0.0-alpha.10", path = "../generated/async-stripe-shared" }
-async-stripe-terminal = {features = ["full", "deserialize"], version = "1.0.0-alpha.10", path = "../generated/async-stripe-terminal" }
-async-stripe-treasury = {features = ["full", "deserialize"], version = "1.0.0-alpha.10", path = "../generated/async-stripe-treasury" }
-async-stripe-webhook = { version = "1.0.0-alpha.10", path = "../async-stripe-webhook", features = ["deserialize", "serialize", "full", "detailed-errors"] }
+async-stripe-billing = { features = ["full", "deserialize"], version = "1.0.0-alpha.11", path = "../generated/async-stripe-billing" }
+async-stripe-checkout = { features = ["full", "deserialize"], version = "1.0.0-alpha.11", path = "../generated/async-stripe-checkout" }
+async-stripe-connect = { features = ["full", "deserialize"], version = "1.0.0-alpha.11", path = "../generated/async-stripe-connect" }
+async-stripe-core = { features = ["full", "deserialize"], version = "1.0.0-alpha.11", path = "../generated/async-stripe-core" }
+async-stripe-fraud = { features = ["full", "deserialize"], version = "1.0.0-alpha.11", path = "../generated/async-stripe-fraud" }
+async-stripe-issuing = {features = ["full", "deserialize"], version = "1.0.0-alpha.11", path = "../generated/async-stripe-issuing" }
+async-stripe-misc = { features = ["full", "deserialize"], version = "1.0.0-alpha.11", path = "../generated/async-stripe-misc" }
+async-stripe-payment = { features = ["full", "deserialize"], version = "1.0.0-alpha.11", path = "../generated/async-stripe-payment" }
+async-stripe-product = { features = ["full", "deserialize"], version = "1.0.0-alpha.11", path = "../generated/async-stripe-product" }
+async-stripe-shared = { features = ["deserialize"], version = "1.0.0-alpha.11", path = "../generated/async-stripe-shared" }
+async-stripe-terminal = {features = ["full", "deserialize"], version = "1.0.0-alpha.11", path = "../generated/async-stripe-terminal" }
+async-stripe-treasury = {features = ["full", "deserialize"], version = "1.0.0-alpha.11", path = "../generated/async-stripe-treasury" }
+async-stripe-webhook = { version = "1.0.0-alpha.11", path = "../async-stripe-webhook", features = ["deserialize", "serialize", "full", "detailed-errors"] }
 serde.workspace = true
 serde_json.workspace = true
 serde_path_to_error = "0.1.20"

--- a/async-stripe-types/CHANGELOG.md
+++ b/async-stripe-types/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-alpha.11](https://github.com/arlyon/async-stripe/compare/async-stripe-types-v1.0.0-alpha.10...async-stripe-types-v1.0.0-alpha.11) - 2025-12-15
+
+### Other
+
+- Bump to serde_qs v1
+
 ## [1.0.0-alpha.5](https://github.com/arlyon/async-stripe/compare/async-stripe-types-v1.0.0-alpha.4...async-stripe-types-v1.0.0-alpha.5) - 2025-10-30
 
 ### Other

--- a/async-stripe-webhook/Cargo.toml
+++ b/async-stripe-webhook/Cargo.toml
@@ -15,8 +15,8 @@ categories.workspace = true
 name = "stripe_webhook"
 
 [dependencies]
-async-stripe-types = { path = "../async-stripe-types", version = "1.0.0-alpha.10" }
-async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-alpha.10" }
+async-stripe-types = { path = "../async-stripe-types", version = "1.0.0-alpha.11" }
+async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-alpha.11" }
 hmac = "0.12"
 sha2 = "0.10"
 hex = "0.4"
@@ -27,14 +27,14 @@ miniserde.workspace = true
 serde.workspace = true
 serde_json = { workspace = true, optional = true }
 
-async-stripe-billing = { path = "../generated/async-stripe-billing", optional = true, version = "1.0.0-alpha.10" }
-async-stripe-checkout = { path = "../generated/async-stripe-checkout", optional = true, version = "1.0.0-alpha.10" }
-async-stripe-core = { path = "../generated/async-stripe-core", optional = true, version = "1.0.0-alpha.10" }
-async-stripe-fraud = { path = "../generated/async-stripe-fraud", optional = true, version = "1.0.0-alpha.10" }
-async-stripe-misc = { path = "../generated/async-stripe-misc", optional = true, version = "1.0.0-alpha.10" }
-async-stripe-payment = { path = "../generated/async-stripe-payment", optional = true, version = "1.0.0-alpha.10" }
-async-stripe-terminal = { path = "../generated/async-stripe-terminal", optional = true, version = "1.0.0-alpha.10" }
-async-stripe-treasury = { path = "../generated/async-stripe-treasury", optional = true, version = "1.0.0-alpha.10" }
+async-stripe-billing = { path = "../generated/async-stripe-billing", optional = true, version = "1.0.0-alpha.11" }
+async-stripe-checkout = { path = "../generated/async-stripe-checkout", optional = true, version = "1.0.0-alpha.11" }
+async-stripe-core = { path = "../generated/async-stripe-core", optional = true, version = "1.0.0-alpha.11" }
+async-stripe-fraud = { path = "../generated/async-stripe-fraud", optional = true, version = "1.0.0-alpha.11" }
+async-stripe-misc = { path = "../generated/async-stripe-misc", optional = true, version = "1.0.0-alpha.11" }
+async-stripe-payment = { path = "../generated/async-stripe-payment", optional = true, version = "1.0.0-alpha.11" }
+async-stripe-terminal = { path = "../generated/async-stripe-terminal", optional = true, version = "1.0.0-alpha.11" }
+async-stripe-treasury = { path = "../generated/async-stripe-treasury", optional = true, version = "1.0.0-alpha.11" }
 serde_path_to_error = { version = "0.1.20", optional = true }
 
 [dev-dependencies]

--- a/async-stripe/Cargo.toml
+++ b/async-stripe/Cargo.toml
@@ -33,8 +33,8 @@ async-std = { version = "1.12.0", optional = true }
 surf = { version = "2.1", optional = true }
 http-types = { version = "2.12.0", default-features = false, optional = true }
 
-async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-alpha.10" }
-async-stripe-client-core = { path = "../async-stripe-client-core", version = "1.0.0-alpha.10" }
+async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-alpha.11" }
+async-stripe-client-core = { path = "../async-stripe-client-core", version = "1.0.0-alpha.11" }
 
 [features]
 default = ["default-tls"]

--- a/generated/async-stripe-billing/Cargo.toml
+++ b/generated/async-stripe-billing/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.10" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.10" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.11" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.11" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.10" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.11" }
 
 
 [features]

--- a/generated/async-stripe-checkout/Cargo.toml
+++ b/generated/async-stripe-checkout/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.10" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.10" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.11" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.11" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.10" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.11" }
 
 
 [features]

--- a/generated/async-stripe-connect/Cargo.toml
+++ b/generated/async-stripe-connect/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.10" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.10" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.11" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.11" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.10" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.11" }
 
 
 [features]

--- a/generated/async-stripe-core/Cargo.toml
+++ b/generated/async-stripe-core/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.10" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.10" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.11" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.11" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.10" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.11" }
 
 
 [features]

--- a/generated/async-stripe-fraud/Cargo.toml
+++ b/generated/async-stripe-fraud/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.10" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.10" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.11" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.11" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.10" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.11" }
 
 
 [features]

--- a/generated/async-stripe-issuing/Cargo.toml
+++ b/generated/async-stripe-issuing/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.10" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.10" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.11" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.11" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.10" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.11" }
 
 
 [features]

--- a/generated/async-stripe-misc/Cargo.toml
+++ b/generated/async-stripe-misc/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.10" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.10" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.11" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.11" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.10" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.11" }
 
 
 [features]

--- a/generated/async-stripe-payment/Cargo.toml
+++ b/generated/async-stripe-payment/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.10" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.10" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.11" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.11" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.10" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.11" }
 
 
 [features]

--- a/generated/async-stripe-product/Cargo.toml
+++ b/generated/async-stripe-product/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.10" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.10" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.11" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.11" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.10" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.11" }
 
 
 [features]

--- a/generated/async-stripe-shared/Cargo.toml
+++ b/generated/async-stripe-shared/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.10" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.11" }
 
 
 

--- a/generated/async-stripe-terminal/Cargo.toml
+++ b/generated/async-stripe-terminal/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.10" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.10" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.11" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.11" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.10" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.11" }
 
 
 [features]

--- a/generated/async-stripe-treasury/Cargo.toml
+++ b/generated/async-stripe-treasury/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.10" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.10" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-alpha.11" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-alpha.11" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.10" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-alpha.11" }
 
 
 [features]


### PR DESCRIPTION



## 🤖 New release

* `async-stripe-types`: 1.0.0-alpha.10 -> 1.0.0-alpha.11 (✓ API compatible changes)
* `async-stripe-shared`: 1.0.0-alpha.10 -> 1.0.0-alpha.11
* `async-stripe-client-core`: 1.0.0-alpha.10 -> 1.0.0-alpha.11 (✓ API compatible changes)
* `async-stripe-billing`: 1.0.0-alpha.10 -> 1.0.0-alpha.11
* `async-stripe-checkout`: 1.0.0-alpha.10 -> 1.0.0-alpha.11
* `async-stripe-core`: 1.0.0-alpha.10 -> 1.0.0-alpha.11
* `async-stripe-fraud`: 1.0.0-alpha.10 -> 1.0.0-alpha.11
* `async-stripe-misc`: 1.0.0-alpha.10 -> 1.0.0-alpha.11
* `async-stripe-payment`: 1.0.0-alpha.10 -> 1.0.0-alpha.11
* `async-stripe-terminal`: 1.0.0-alpha.10 -> 1.0.0-alpha.11
* `async-stripe-treasury`: 1.0.0-alpha.10 -> 1.0.0-alpha.11
* `async-stripe-webhook`: 1.0.0-alpha.10 -> 1.0.0-alpha.11
* `async-stripe-connect`: 1.0.0-alpha.10 -> 1.0.0-alpha.11
* `async-stripe-issuing`: 1.0.0-alpha.10 -> 1.0.0-alpha.11
* `async-stripe-product`: 1.0.0-alpha.10 -> 1.0.0-alpha.11
* `async-stripe`: 1.0.0-alpha.10 -> 1.0.0-alpha.11

<details><summary><i><b>Changelog</b></i></summary><p>

## `async-stripe-types`

<blockquote>

## [1.0.0-alpha.11](https://github.com/arlyon/async-stripe/compare/async-stripe-types-v1.0.0-alpha.10...async-stripe-types-v1.0.0-alpha.11) - 2025-12-15

### Other

- Bump to serde_qs v1
</blockquote>

## `async-stripe-shared`

<blockquote>

## [1.0.0-alpha.10](https://github.com/arlyon/async-stripe/compare/async-stripe-shared-v1.0.0-alpha.9...async-stripe-shared-v1.0.0-alpha.10) - 2025-12-12

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-client-core`

<blockquote>

## [1.0.0-alpha.11](https://github.com/arlyon/async-stripe/compare/async-stripe-client-core-v1.0.0-alpha.10...async-stripe-client-core-v1.0.0-alpha.11) - 2025-12-15

### Other

- update Cargo.toml dependencies
</blockquote>

## `async-stripe-billing`

<blockquote>

## [1.0.0-alpha.10](https://github.com/arlyon/async-stripe/compare/async-stripe-billing-v1.0.0-alpha.9...async-stripe-billing-v1.0.0-alpha.10) - 2025-12-12

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-checkout`

<blockquote>

## [1.0.0-alpha.10](https://github.com/arlyon/async-stripe/compare/async-stripe-checkout-v1.0.0-alpha.9...async-stripe-checkout-v1.0.0-alpha.10) - 2025-12-12

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-core`

<blockquote>

## [1.0.0-alpha.10](https://github.com/arlyon/async-stripe/compare/async-stripe-core-v1.0.0-alpha.9...async-stripe-core-v1.0.0-alpha.10) - 2025-12-12

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-fraud`

<blockquote>

## [1.0.0-alpha.10](https://github.com/arlyon/async-stripe/compare/async-stripe-fraud-v1.0.0-alpha.9...async-stripe-fraud-v1.0.0-alpha.10) - 2025-12-12

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-misc`

<blockquote>

## [1.0.0-alpha.10](https://github.com/arlyon/async-stripe/compare/async-stripe-misc-v1.0.0-alpha.9...async-stripe-misc-v1.0.0-alpha.10) - 2025-12-12

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-payment`

<blockquote>

## [1.0.0-alpha.10](https://github.com/arlyon/async-stripe/compare/async-stripe-payment-v1.0.0-alpha.9...async-stripe-payment-v1.0.0-alpha.10) - 2025-12-12

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-terminal`

<blockquote>

## [1.0.0-alpha.10](https://github.com/arlyon/async-stripe/compare/async-stripe-terminal-v1.0.0-alpha.9...async-stripe-terminal-v1.0.0-alpha.10) - 2025-12-12

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-treasury`

<blockquote>

## [1.0.0-alpha.10](https://github.com/arlyon/async-stripe/compare/async-stripe-treasury-v1.0.0-alpha.9...async-stripe-treasury-v1.0.0-alpha.10) - 2025-12-12

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-webhook`

<blockquote>

## [1.0.0-alpha.9](https://github.com/arlyon/async-stripe/compare/async-stripe-webhook-v1.0.0-alpha.8...async-stripe-webhook-v1.0.0-alpha.9) - 2025-12-04

### Added

- add generate_test_header for webhook signature testing

### Other

- round trip webhook
- Merge pull request #815 from arlyon/claude/issue-808-20251127-2210
- add wasm webhook parser
</blockquote>

## `async-stripe-connect`

<blockquote>

## [1.0.0-alpha.10](https://github.com/arlyon/async-stripe/compare/async-stripe-connect-v1.0.0-alpha.9...async-stripe-connect-v1.0.0-alpha.10) - 2025-12-12

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-issuing`

<blockquote>

## [1.0.0-alpha.10](https://github.com/arlyon/async-stripe/compare/async-stripe-issuing-v1.0.0-alpha.9...async-stripe-issuing-v1.0.0-alpha.10) - 2025-12-12

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-product`

<blockquote>

## [1.0.0-alpha.10](https://github.com/arlyon/async-stripe/compare/async-stripe-product-v1.0.0-alpha.9...async-stripe-product-v1.0.0-alpha.10) - 2025-12-12

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe`

<blockquote>

## [1.0.0-alpha.9](https://github.com/arlyon/async-stripe/compare/async-stripe-v1.0.0-alpha.8...async-stripe-v1.0.0-alpha.9) - 2025-12-04

### Fixed

- fix tests

### Other

- update readme
- make site public and add docs
- Add tracing instrumentation to core API calls
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).