### PR TITLE
chore: release v1.0.0-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.111",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -167,8 +167,8 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "smallvec",
- "socket2 0.6.1",
- "time 0.3.44",
+ "socket2 0.6.2",
+ "time 0.3.46",
  "tracing",
  "url",
 ]
@@ -182,7 +182,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -376,9 +376,9 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "3.4.1"
+version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
 dependencies = [
  "event-listener 5.4.1",
  "event-listener-strategy",
@@ -477,12 +477,12 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "async-stripe"
-version = "1.0.0-rc.0"
+version = "1.0.0-rc.1"
 dependencies = [
  "async-std",
  "async-stripe-client-core",
@@ -499,14 +499,14 @@ dependencies = [
  "serde",
  "serde_json",
  "surf",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "async-stripe-billing"
-version = "1.0.0-rc.0"
+version = "1.0.0-rc.1"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-checkout"
-version = "1.0.0-rc.0"
+version = "1.0.0-rc.1"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-client-core"
-version = "1.0.0-rc.0"
+version = "1.0.0-rc.1"
 dependencies = [
  "async-stripe-shared",
  "async-stripe-types",
@@ -543,15 +543,15 @@ dependencies = [
  "miniserde",
  "serde",
  "serde_json",
- "serde_qs 1.0.0-rc.4",
- "thiserror 2.0.17",
+ "serde_qs 1.0.0",
+ "thiserror 2.0.18",
  "tracing",
  "uuid",
 ]
 
 [[package]]
 name = "async-stripe-connect"
-version = "1.0.0-rc.0"
+version = "1.0.0-rc.1"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-core"
-version = "1.0.0-rc.0"
+version = "1.0.0-rc.1"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-fraud"
-version = "1.0.0-rc.0"
+version = "1.0.0-rc.1"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -593,7 +593,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-issuing"
-version = "1.0.0-rc.0"
+version = "1.0.0-rc.1"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-misc"
-version = "1.0.0-rc.0"
+version = "1.0.0-rc.1"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -621,7 +621,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-parser"
-version = "1.0.0-rc.0"
+version = "1.0.0-rc.1"
 dependencies = [
  "async-stripe-billing",
  "async-stripe-checkout",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-payment"
-version = "1.0.0-rc.0"
+version = "1.0.0-rc.1"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -659,7 +659,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-product"
-version = "1.0.0-rc.0"
+version = "1.0.0-rc.1"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -673,7 +673,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-shared"
-version = "1.0.0-rc.0"
+version = "1.0.0-rc.1"
 dependencies = [
  "async-stripe-types",
  "miniserde",
@@ -685,7 +685,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-terminal"
-version = "1.0.0-rc.0"
+version = "1.0.0-rc.1"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -722,14 +722,14 @@ dependencies = [
  "miniserde",
  "serde",
  "serde_json",
- "serde_qs 1.0.0-rc.4",
+ "serde_qs 1.0.0",
  "tokio",
  "wiremock",
 ]
 
 [[package]]
 name = "async-stripe-treasury"
-version = "1.0.0-rc.0"
+version = "1.0.0-rc.1"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -743,18 +743,18 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-types"
-version = "1.0.0-rc.0"
+version = "1.0.0-rc.1"
 dependencies = [
  "miniserde",
  "serde",
  "serde_json",
- "serde_qs 1.0.0-rc.4",
+ "serde_qs 1.0.0",
  "smol_str",
 ]
 
 [[package]]
 name = "async-stripe-webhook"
-version = "1.0.0-rc.0"
+version = "1.0.0-rc.1"
 dependencies = [
  "async-stripe-billing",
  "async-stripe-checkout",
@@ -774,7 +774,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "sha2 0.10.9",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -792,7 +792,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -824,9 +824,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.15.1"
+version = "1.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b5ce75405893cd713f9ab8e297d8e438f624dde7d706108285f7e17a25a180f"
+checksum = "7b7b6141e96a8c160799cc2d5adecd5cbbe5054cb8c7c4af53da0f83bb7ad256"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -834,9 +834,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.34.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "179c3777a8b5e70e90ea426114ffc565b2c1a9f82f6c4a0c5a34aa6ef5e781b6"
+checksum = "5c34dda4df7017c8db52132f0f8a2e0f8161649d15723ed63fc00c82d0f2081a"
 dependencies = [
  "cc",
  "cmake",
@@ -846,9 +846,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b098575ebe77cb6d14fc7f32749631a6e44edbef6b796f89b020e99ba20d425"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core",
  "axum-macros",
@@ -880,9 +880,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59446ce19cd142f8833f856eb31f3eb097812d1479ab224f54d72428ca21ea22"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes 1.11.0",
  "futures-core",
@@ -905,7 +905,7 @@ checksum = "604fde5e028fea851ce1d8570bbdc034bec850d157f7569d10f347d06808c05c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1007,15 +1007,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "bytemuck"
-version = "1.24.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "bytes"
@@ -1040,9 +1040,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.49"
+version = "1.2.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90583009037521a116abf44494efecd645ba48b6622457080f080b85544e2215"
+checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1064,9 +1064,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.42"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -1086,9 +1086,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.55"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d49d74c227b6cc9f3c51a2c7c667a05b6453f7f0f952a5f8e4493bb9e731d68e"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
 ]
@@ -1153,7 +1153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
 dependencies = [
  "percent-encoding",
- "time 0.3.44",
+ "time 0.3.46",
  "version_check",
 ]
 
@@ -1164,7 +1164,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
  "percent-encoding",
- "time 0.3.44",
+ "time 0.3.46",
  "version_check",
 ]
 
@@ -1261,18 +1261,18 @@ checksum = "79fc3b6dd0b87ba36e565715bf9a2ced221311db47bd18011676f24a6066edbc"
 dependencies = [
  "curl-sys",
  "libc",
- "openssl-probe",
+ "openssl-probe 0.1.6",
  "openssl-sys",
  "schannel",
- "socket2 0.6.1",
+ "socket2 0.6.2",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "curl-sys"
-version = "0.4.84+curl-8.17.0"
+version = "0.4.85+curl-8.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abc4294dc41b882eaff37973c2ec3ae203d0091341ee68fbadd1d06e0c18a73b"
+checksum = "c0efa6142b5ecc05f6d3eaa39e6af4888b9d3939273fb592c92b7088a8cf3fdb"
 dependencies = [
  "cc",
  "libc",
@@ -1313,24 +1313,24 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10b768e943bed7bf2cab53df09f4bc34bfd217cdb57d971e769874c9a6710618"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
 dependencies = [
  "derive_more-impl",
 ]
 
 [[package]]
 name = "derive_more-impl"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d286bfdaf75e988b4a78e013ecd79c581e06399ab53fbacd2d916c2f904f30b"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.111",
+ "syn 2.0.114",
  "unicode-xid",
 ]
 
@@ -1364,7 +1364,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1401,7 +1401,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1539,15 +1539,15 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.5"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
-version = "1.1.5"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
+checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1690,7 +1690,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1759,9 +1759,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1829,9 +1829,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
 dependencies = [
  "atomic-waker",
  "bytes 1.11.0",
@@ -2057,7 +2057,7 @@ dependencies = [
  "bytes 1.11.0",
  "futures-channel",
  "futures-core",
- "h2 0.4.12",
+ "h2 0.4.13",
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
@@ -2120,7 +2120,7 @@ dependencies = [
  "hyper 1.8.1",
  "libc",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.6.2",
  "tokio",
  "tower-service",
  "tracing",
@@ -2128,9 +2128,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.64"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -2260,9 +2260,9 @@ checksum = "e8a5a9a0ff0086c7a148acb942baaabeadf9504d10400b5a05645853729b9cd2"
 
 [[package]]
 name = "indexmap"
-version = "2.12.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -2284,14 +2284,15 @@ checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
 name = "insta"
-version = "1.44.3"
+version = "1.46.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5c943d4415edd8153251b6f197de5eb1640e56d84e8d9159bea190421c73698"
+checksum = "38c91d64f9ad425e80200a50a0e8b8a641680b44e33ce832efe5b8bc65161b07"
 dependencies = [
  "console",
  "once_cell",
  "serde",
  "similar",
+ "tempfile",
 ]
 
 [[package]]
@@ -2339,9 +2340,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jobserver"
@@ -2355,9 +2356,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.83"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
+checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2392,9 +2393,9 @@ checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
-version = "0.2.178"
+version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "libnghttp2-sys"
@@ -2519,24 +2520,24 @@ dependencies = [
 
 [[package]]
 name = "mini-internal"
-version = "0.1.43"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "560f32b6891d8d9bade8942c45a27694f16d789d3b4b8e6b7135a5240de0a8af"
+checksum = "2a8df435db5df1dd82a74f77e3c3addf6ab7665079c31e222a64f34f7475d87e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "miniserde"
-version = "0.1.43"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac79f4123c070de643a7a93b9339abf18c30005c622bf4b1c29c2c0960f52d39"
+checksum = "8c48e83ec09ab8a51d4e6be46608bf2a1293a79e2f7ea60246a2ce50eaef44ba"
 dependencies = [
  "itoa",
  "mini-internal",
- "ryu",
+ "zmij",
 ]
 
 [[package]]
@@ -2589,7 +2590,7 @@ dependencies = [
  "libc",
  "log",
  "openssl",
- "openssl-probe",
+ "openssl-probe 0.1.6",
  "openssl-sys",
  "schannel",
  "security-framework 2.11.1",
@@ -2608,9 +2609,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-traits"
@@ -2666,7 +2667,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2674,6 +2675,12 @@ name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
@@ -2746,7 +2753,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2772,7 +2779,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -2861,9 +2868,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -2876,16 +2883,16 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.114",
  "version_check",
  "yansi",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
@@ -2927,7 +2934,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2957,7 +2964,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2975,14 +2982,14 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
@@ -3022,7 +3029,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3068,7 +3075,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -3102,7 +3109,7 @@ dependencies = [
  "serde",
  "state",
  "tempfile",
- "time 0.3.44",
+ "time 0.3.46",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -3123,7 +3130,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rocket_http",
- "syn 2.0.111",
+ "syn 2.0.114",
  "unicode-xid",
  "version_check",
 ]
@@ -3150,7 +3157,7 @@ dependencies = [
  "smallvec",
  "stable-pattern",
  "state",
- "time 0.3.44",
+ "time 0.3.46",
  "tokio",
  "uncased",
 ]
@@ -3175,9 +3182,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
  "bitflags",
  "errno",
@@ -3188,9 +3195,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.35"
+version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
+checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -3204,11 +3211,11 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9980d917ebb0c0536119ba501e90834767bffc3d60641457fd84a1f3fd337923"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe",
+ "openssl-probe 0.2.1",
  "rustls-pki-types",
  "schannel",
  "security-framework 3.5.1",
@@ -3216,18 +3223,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "708c0f9d5f54ba0272468c1d306a52c495b31fa155e91bc25371e6df7996908c"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.8"
+version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3243,9 +3250,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
 name = "schannel"
@@ -3352,20 +3359,20 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -3392,15 +3399,14 @@ dependencies = [
 
 [[package]]
 name = "serde_qs"
-version = "1.0.0-rc.4"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18c21dc864770a74dc4d61d6454bf3b5eb7bc7014d0cead189aa909472a70c9c"
+checksum = "ac22439301a0b6f45a037681518e3169e8db1db76080e2e9600a08d1027df037"
 dependencies = [
  "itoa",
  "percent-encoding",
  "ryu",
  "serde",
- "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -3501,10 +3507,11 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.7"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7664a098b8e616bdfcc2dc0e9ac44eb231eedf41db4e9fe95d8d32ec728dedad"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
 ]
 
@@ -3522,9 +3529,9 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "sluice"
@@ -3565,9 +3572,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
@@ -3687,7 +3694,7 @@ dependencies = [
  "cfg-if",
  "encoding_rs",
  "futures-util",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "http-client",
  "http-types",
  "log",
@@ -3712,9 +3719,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.111"
+version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
+checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3735,14 +3742,14 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "tempfile"
-version = "3.23.0"
+version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand 2.3.0",
  "getrandom 0.3.4",
@@ -3762,11 +3769,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -3777,18 +3784,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3817,24 +3824,24 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.44"
+version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+checksum = "9da98b7d9b7dad93488a84b8248efc35352b0b2657397d4167e7ad67e5d535e5"
 dependencies = [
  "deranged",
  "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
- "time-macros 0.2.24",
+ "time-macros 0.2.26",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
@@ -3848,9 +3855,9 @@ dependencies = [
 
 [[package]]
 name = "time-macros"
-version = "0.2.24"
+version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+checksum = "78cc610bac2dcee56805c99642447d4c5dbde4d01f752ffea0199aee1f601dc4"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3881,9 +3888,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.48.0"
+version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
  "bytes 1.11.0",
  "libc",
@@ -3891,7 +3898,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.1",
+ "socket2 0.6.2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -3904,7 +3911,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -3929,9 +3936,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -3940,9 +3947,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes 1.11.0",
  "futures-core",
@@ -3994,9 +4001,9 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -4022,9 +4029,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d15d90a0b5c19378952d479dc858407149d7bb45a14de0142f6c534b16fc647"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -4040,14 +4047,14 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.35"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -4125,9 +4132,9 @@ dependencies = [
 
 [[package]]
 name = "unicase"
-version = "2.8.1"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
@@ -4165,14 +4172,15 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.7"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -4183,9 +4191,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
+checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
 dependencies = [
  "getrandom 0.3.4",
  "js-sys",
@@ -4245,18 +4253,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.106"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
+checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4267,11 +4275,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.56"
+version = "0.4.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
+checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
 dependencies = [
  "cfg-if",
+ "futures-util",
  "js-sys",
  "once_cell",
  "wasm-bindgen",
@@ -4280,9 +4289,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.106"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
+checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4290,31 +4299,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.106"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
+checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.114",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.106"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
+checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.83"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
+checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4350,9 +4359,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2878ef029c47c6e8cf779119f20fcf52bde7ad42a731b2a304bc221df17571e"
+checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4409,7 +4418,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4420,7 +4429,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4703,9 +4712,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "writeable"
@@ -4741,28 +4750,28 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.114",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.31"
+version = "0.8.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
+checksum = "7456cf00f0685ad319c5b1693f291a650eaf345e941d082fc4e03df8a03996ac"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.31"
+version = "0.8.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
+checksum = "1328722bbf2115db7e19d69ebcc15e795719e2d66b60827c6a69a117365e37a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -4782,7 +4791,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.114",
  "synstructure",
 ]
 
@@ -4822,8 +4831,14 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.114",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ resolver = "2"
 exclude = ["openapi"]
 
 [workspace.package]
-version = "1.0.0-rc.0"
+version = "1.0.0-rc.1"
 description = "API bindings for the Stripe HTTP API"
 rust-version = "1.88.0"
 authors = [

--- a/async-stripe-client-core/Cargo.toml
+++ b/async-stripe-client-core/Cargo.toml
@@ -17,8 +17,8 @@ edition.workspace = true
 name = "stripe_client_core"
 
 [dependencies]
-async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-rc.0" }
-async-stripe-types = { path = "../async-stripe-types", version = "1.0.0-rc.0" }
+async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-rc.1" }
+async-stripe-types = { path = "../async-stripe-types", version = "1.0.0-rc.1" }
 serde_json.workspace = true
 serde.workspace = true
 serde_qs.workspace = true

--- a/async-stripe-parser/Cargo.toml
+++ b/async-stripe-parser/Cargo.toml
@@ -18,19 +18,19 @@ edition.workspace = true
 crate-type = ["cdylib"]
 
 [dependencies]
-async-stripe-billing = { features = ["full", "deserialize"], version = "1.0.0-rc.0", path = "../generated/async-stripe-billing" }
-async-stripe-checkout = { features = ["full", "deserialize"], version = "1.0.0-rc.0", path = "../generated/async-stripe-checkout" }
-async-stripe-connect = { features = ["full", "deserialize"], version = "1.0.0-rc.0", path = "../generated/async-stripe-connect" }
-async-stripe-core = { features = ["full", "deserialize"], version = "1.0.0-rc.0", path = "../generated/async-stripe-core" }
-async-stripe-fraud = { features = ["full", "deserialize"], version = "1.0.0-rc.0", path = "../generated/async-stripe-fraud" }
-async-stripe-issuing = {features = ["full", "deserialize"], version = "1.0.0-rc.0", path = "../generated/async-stripe-issuing" }
-async-stripe-misc = { features = ["full", "deserialize"], version = "1.0.0-rc.0", path = "../generated/async-stripe-misc" }
-async-stripe-payment = { features = ["full", "deserialize"], version = "1.0.0-rc.0", path = "../generated/async-stripe-payment" }
-async-stripe-product = { features = ["full", "deserialize"], version = "1.0.0-rc.0", path = "../generated/async-stripe-product" }
-async-stripe-shared = { features = ["deserialize"], version = "1.0.0-rc.0", path = "../generated/async-stripe-shared" }
-async-stripe-terminal = {features = ["full", "deserialize"], version = "1.0.0-rc.0", path = "../generated/async-stripe-terminal" }
-async-stripe-treasury = {features = ["full", "deserialize"], version = "1.0.0-rc.0", path = "../generated/async-stripe-treasury" }
-async-stripe-webhook = { version = "1.0.0-rc.0", path = "../async-stripe-webhook", features = ["deserialize", "serialize", "full", "detailed-errors"] }
+async-stripe-billing = { features = ["full", "deserialize"], version = "1.0.0-rc.1", path = "../generated/async-stripe-billing" }
+async-stripe-checkout = { features = ["full", "deserialize"], version = "1.0.0-rc.1", path = "../generated/async-stripe-checkout" }
+async-stripe-connect = { features = ["full", "deserialize"], version = "1.0.0-rc.1", path = "../generated/async-stripe-connect" }
+async-stripe-core = { features = ["full", "deserialize"], version = "1.0.0-rc.1", path = "../generated/async-stripe-core" }
+async-stripe-fraud = { features = ["full", "deserialize"], version = "1.0.0-rc.1", path = "../generated/async-stripe-fraud" }
+async-stripe-issuing = {features = ["full", "deserialize"], version = "1.0.0-rc.1", path = "../generated/async-stripe-issuing" }
+async-stripe-misc = { features = ["full", "deserialize"], version = "1.0.0-rc.1", path = "../generated/async-stripe-misc" }
+async-stripe-payment = { features = ["full", "deserialize"], version = "1.0.0-rc.1", path = "../generated/async-stripe-payment" }
+async-stripe-product = { features = ["full", "deserialize"], version = "1.0.0-rc.1", path = "../generated/async-stripe-product" }
+async-stripe-shared = { features = ["deserialize"], version = "1.0.0-rc.1", path = "../generated/async-stripe-shared" }
+async-stripe-terminal = {features = ["full", "deserialize"], version = "1.0.0-rc.1", path = "../generated/async-stripe-terminal" }
+async-stripe-treasury = {features = ["full", "deserialize"], version = "1.0.0-rc.1", path = "../generated/async-stripe-treasury" }
+async-stripe-webhook = { version = "1.0.0-rc.1", path = "../async-stripe-webhook", features = ["deserialize", "serialize", "full", "detailed-errors"] }
 serde.workspace = true
 serde_json.workspace = true
 serde_path_to_error = "0.1.20"

--- a/async-stripe-webhook/Cargo.toml
+++ b/async-stripe-webhook/Cargo.toml
@@ -15,8 +15,8 @@ categories.workspace = true
 name = "stripe_webhook"
 
 [dependencies]
-async-stripe-types = { path = "../async-stripe-types", version = "1.0.0-rc.0" }
-async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-rc.0" }
+async-stripe-types = { path = "../async-stripe-types", version = "1.0.0-rc.1" }
+async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-rc.1" }
 hmac = "0.12"
 sha2 = "0.10"
 hex = "0.4"
@@ -27,14 +27,14 @@ miniserde.workspace = true
 serde.workspace = true
 serde_json = { workspace = true, optional = true }
 
-async-stripe-billing = { path = "../generated/async-stripe-billing", optional = true, version = "1.0.0-rc.0" }
-async-stripe-checkout = { path = "../generated/async-stripe-checkout", optional = true, version = "1.0.0-rc.0" }
-async-stripe-core = { path = "../generated/async-stripe-core", optional = true, version = "1.0.0-rc.0" }
-async-stripe-fraud = { path = "../generated/async-stripe-fraud", optional = true, version = "1.0.0-rc.0" }
-async-stripe-misc = { path = "../generated/async-stripe-misc", optional = true, version = "1.0.0-rc.0" }
-async-stripe-payment = { path = "../generated/async-stripe-payment", optional = true, version = "1.0.0-rc.0" }
-async-stripe-terminal = { path = "../generated/async-stripe-terminal", optional = true, version = "1.0.0-rc.0" }
-async-stripe-treasury = { path = "../generated/async-stripe-treasury", optional = true, version = "1.0.0-rc.0" }
+async-stripe-billing = { path = "../generated/async-stripe-billing", optional = true, version = "1.0.0-rc.1" }
+async-stripe-checkout = { path = "../generated/async-stripe-checkout", optional = true, version = "1.0.0-rc.1" }
+async-stripe-core = { path = "../generated/async-stripe-core", optional = true, version = "1.0.0-rc.1" }
+async-stripe-fraud = { path = "../generated/async-stripe-fraud", optional = true, version = "1.0.0-rc.1" }
+async-stripe-misc = { path = "../generated/async-stripe-misc", optional = true, version = "1.0.0-rc.1" }
+async-stripe-payment = { path = "../generated/async-stripe-payment", optional = true, version = "1.0.0-rc.1" }
+async-stripe-terminal = { path = "../generated/async-stripe-terminal", optional = true, version = "1.0.0-rc.1" }
+async-stripe-treasury = { path = "../generated/async-stripe-treasury", optional = true, version = "1.0.0-rc.1" }
 serde_path_to_error = { version = "0.1.20", optional = true }
 
 [dev-dependencies]

--- a/async-stripe/Cargo.toml
+++ b/async-stripe/Cargo.toml
@@ -33,8 +33,8 @@ async-std = { version = "1.12.0", optional = true }
 surf = { version = "2.1", optional = true }
 http-types = { version = "2.12.0", default-features = false, optional = true }
 
-async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-rc.0" }
-async-stripe-client-core = { path = "../async-stripe-client-core", version = "1.0.0-rc.0" }
+async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-rc.1" }
+async-stripe-client-core = { path = "../async-stripe-client-core", version = "1.0.0-rc.1" }
 
 [features]
 default = ["default-tls"]

--- a/generated/async-stripe-billing/CHANGELOG.md
+++ b/generated/async-stripe-billing/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-rc.1](https://github.com/arlyon/async-stripe/compare/async-stripe-billing-v1.0.0-rc.0...async-stripe-billing-v1.0.0-rc.1) - 2026-02-02
+
+### Other
+
+- Generate latest changes from OpenApi spec
+
 ## [1.0.0-alpha.10](https://github.com/arlyon/async-stripe/compare/async-stripe-billing-v1.0.0-alpha.9...async-stripe-billing-v1.0.0-alpha.10) - 2025-12-12
 
 ### Other

--- a/generated/async-stripe-billing/Cargo.toml
+++ b/generated/async-stripe-billing/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.0" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.0" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.1" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.1" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.0" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.1" }
 
 
 [features]

--- a/generated/async-stripe-checkout/CHANGELOG.md
+++ b/generated/async-stripe-checkout/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-rc.1](https://github.com/arlyon/async-stripe/compare/async-stripe-checkout-v1.0.0-rc.0...async-stripe-checkout-v1.0.0-rc.1) - 2026-02-02
+
+### Other
+
+- Generate latest changes from OpenApi spec
+
 ## [1.0.0-alpha.10](https://github.com/arlyon/async-stripe/compare/async-stripe-checkout-v1.0.0-alpha.9...async-stripe-checkout-v1.0.0-alpha.10) - 2025-12-12
 
 ### Other

--- a/generated/async-stripe-checkout/Cargo.toml
+++ b/generated/async-stripe-checkout/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.0" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.0" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.1" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.1" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.0" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.1" }
 
 
 [features]

--- a/generated/async-stripe-connect/CHANGELOG.md
+++ b/generated/async-stripe-connect/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-rc.1](https://github.com/arlyon/async-stripe/compare/async-stripe-connect-v1.0.0-rc.0...async-stripe-connect-v1.0.0-rc.1) - 2026-02-02
+
+### Other
+
+- Generate latest changes from OpenApi spec
+
 ## [1.0.0-alpha.10](https://github.com/arlyon/async-stripe/compare/async-stripe-connect-v1.0.0-alpha.9...async-stripe-connect-v1.0.0-alpha.10) - 2025-12-12
 
 ### Other

--- a/generated/async-stripe-connect/Cargo.toml
+++ b/generated/async-stripe-connect/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.0" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.0" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.1" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.1" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.0" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.1" }
 
 
 [features]

--- a/generated/async-stripe-core/CHANGELOG.md
+++ b/generated/async-stripe-core/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-rc.1](https://github.com/arlyon/async-stripe/compare/async-stripe-core-v1.0.0-rc.0...async-stripe-core-v1.0.0-rc.1) - 2026-02-02
+
+### Other
+
+- Generate latest changes from OpenApi spec
+
 ## [1.0.0-alpha.10](https://github.com/arlyon/async-stripe/compare/async-stripe-core-v1.0.0-alpha.9...async-stripe-core-v1.0.0-alpha.10) - 2025-12-12
 
 ### Other

--- a/generated/async-stripe-core/Cargo.toml
+++ b/generated/async-stripe-core/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.0" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.0" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.1" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.1" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.0" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.1" }
 
 
 [features]

--- a/generated/async-stripe-fraud/CHANGELOG.md
+++ b/generated/async-stripe-fraud/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-rc.1](https://github.com/arlyon/async-stripe/compare/async-stripe-fraud-v1.0.0-rc.0...async-stripe-fraud-v1.0.0-rc.1) - 2026-02-02
+
+### Other
+
+- Generate latest changes from OpenApi spec
+
 ## [1.0.0-alpha.10](https://github.com/arlyon/async-stripe/compare/async-stripe-fraud-v1.0.0-alpha.9...async-stripe-fraud-v1.0.0-alpha.10) - 2025-12-12
 
 ### Other

--- a/generated/async-stripe-fraud/Cargo.toml
+++ b/generated/async-stripe-fraud/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.0" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.0" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.1" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.1" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.0" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.1" }
 
 
 [features]

--- a/generated/async-stripe-issuing/Cargo.toml
+++ b/generated/async-stripe-issuing/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.0" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.0" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.1" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.1" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.0" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.1" }
 
 
 [features]

--- a/generated/async-stripe-misc/CHANGELOG.md
+++ b/generated/async-stripe-misc/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-rc.1](https://github.com/arlyon/async-stripe/compare/async-stripe-misc-v1.0.0-rc.0...async-stripe-misc-v1.0.0-rc.1) - 2026-02-02
+
+### Other
+
+- Generate latest changes from OpenApi spec
+
 ## [1.0.0-alpha.10](https://github.com/arlyon/async-stripe/compare/async-stripe-misc-v1.0.0-alpha.9...async-stripe-misc-v1.0.0-alpha.10) - 2025-12-12
 
 ### Other

--- a/generated/async-stripe-misc/Cargo.toml
+++ b/generated/async-stripe-misc/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.0" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.0" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.1" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.1" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.0" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.1" }
 
 
 [features]

--- a/generated/async-stripe-payment/CHANGELOG.md
+++ b/generated/async-stripe-payment/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-rc.1](https://github.com/arlyon/async-stripe/compare/async-stripe-payment-v1.0.0-rc.0...async-stripe-payment-v1.0.0-rc.1) - 2026-02-02
+
+### Other
+
+- Generate latest changes from OpenApi spec
+
 ## [1.0.0-alpha.10](https://github.com/arlyon/async-stripe/compare/async-stripe-payment-v1.0.0-alpha.9...async-stripe-payment-v1.0.0-alpha.10) - 2025-12-12
 
 ### Other

--- a/generated/async-stripe-payment/Cargo.toml
+++ b/generated/async-stripe-payment/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.0" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.0" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.1" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.1" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.0" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.1" }
 
 
 [features]

--- a/generated/async-stripe-product/CHANGELOG.md
+++ b/generated/async-stripe-product/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-rc.1](https://github.com/arlyon/async-stripe/compare/async-stripe-product-v1.0.0-rc.0...async-stripe-product-v1.0.0-rc.1) - 2026-02-02
+
+### Other
+
+- Generate latest changes from OpenApi spec
+
 ## [1.0.0-alpha.10](https://github.com/arlyon/async-stripe/compare/async-stripe-product-v1.0.0-alpha.9...async-stripe-product-v1.0.0-alpha.10) - 2025-12-12
 
 ### Other

--- a/generated/async-stripe-product/Cargo.toml
+++ b/generated/async-stripe-product/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.0" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.0" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.1" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.1" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.0" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.1" }
 
 
 [features]

--- a/generated/async-stripe-shared/CHANGELOG.md
+++ b/generated/async-stripe-shared/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-rc.1](https://github.com/arlyon/async-stripe/compare/async-stripe-shared-v1.0.0-rc.0...async-stripe-shared-v1.0.0-rc.1) - 2026-02-02
+
+### Other
+
+- Generate latest changes from OpenApi spec
+
 ## [1.0.0-alpha.10](https://github.com/arlyon/async-stripe/compare/async-stripe-shared-v1.0.0-alpha.9...async-stripe-shared-v1.0.0-alpha.10) - 2025-12-12
 
 ### Other

--- a/generated/async-stripe-shared/Cargo.toml
+++ b/generated/async-stripe-shared/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.0" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.1" }
 
 
 

--- a/generated/async-stripe-terminal/CHANGELOG.md
+++ b/generated/async-stripe-terminal/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-rc.1](https://github.com/arlyon/async-stripe/compare/async-stripe-terminal-v1.0.0-rc.0...async-stripe-terminal-v1.0.0-rc.1) - 2026-02-02
+
+### Other
+
+- Generate latest changes from OpenApi spec
+
 ## [1.0.0-alpha.10](https://github.com/arlyon/async-stripe/compare/async-stripe-terminal-v1.0.0-alpha.9...async-stripe-terminal-v1.0.0-alpha.10) - 2025-12-12
 
 ### Other

--- a/generated/async-stripe-terminal/Cargo.toml
+++ b/generated/async-stripe-terminal/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.0" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.0" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.1" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.1" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.0" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.1" }
 
 
 [features]

--- a/generated/async-stripe-treasury/CHANGELOG.md
+++ b/generated/async-stripe-treasury/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-rc.1](https://github.com/arlyon/async-stripe/compare/async-stripe-treasury-v1.0.0-rc.0...async-stripe-treasury-v1.0.0-rc.1) - 2026-02-02
+
+### Other
+
+- Generate latest changes from OpenApi spec
+
 ## [1.0.0-alpha.10](https://github.com/arlyon/async-stripe/compare/async-stripe-treasury-v1.0.0-alpha.9...async-stripe-treasury-v1.0.0-alpha.10) - 2025-12-12
 
 ### Other

--- a/generated/async-stripe-treasury/Cargo.toml
+++ b/generated/async-stripe-treasury/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.0" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.0" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.1" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.1" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.0" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.1" }
 
 
 [features]


### PR DESCRIPTION



## 🤖 New release

* `async-stripe-types`: 1.0.0-rc.0 -> 1.0.0-rc.1
* `async-stripe-shared`: 1.0.0-rc.0 -> 1.0.0-rc.1 (✓ API compatible changes)
* `async-stripe-client-core`: 1.0.0-rc.0 -> 1.0.0-rc.1
* `async-stripe-billing`: 1.0.0-rc.0 -> 1.0.0-rc.1 (✓ API compatible changes)
* `async-stripe-checkout`: 1.0.0-rc.0 -> 1.0.0-rc.1 (✓ API compatible changes)
* `async-stripe-core`: 1.0.0-rc.0 -> 1.0.0-rc.1 (✓ API compatible changes)
* `async-stripe-fraud`: 1.0.0-rc.0 -> 1.0.0-rc.1 (✓ API compatible changes)
* `async-stripe-misc`: 1.0.0-rc.0 -> 1.0.0-rc.1 (✓ API compatible changes)
* `async-stripe-payment`: 1.0.0-rc.0 -> 1.0.0-rc.1 (✓ API compatible changes)
* `async-stripe-terminal`: 1.0.0-rc.0 -> 1.0.0-rc.1 (✓ API compatible changes)
* `async-stripe-treasury`: 1.0.0-rc.0 -> 1.0.0-rc.1 (✓ API compatible changes)
* `async-stripe-webhook`: 1.0.0-rc.0 -> 1.0.0-rc.1
* `async-stripe-connect`: 1.0.0-rc.0 -> 1.0.0-rc.1 (✓ API compatible changes)
* `async-stripe-issuing`: 1.0.0-rc.0 -> 1.0.0-rc.1
* `async-stripe-product`: 1.0.0-rc.0 -> 1.0.0-rc.1 (✓ API compatible changes)
* `async-stripe`: 1.0.0-rc.0 -> 1.0.0-rc.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `async-stripe-types`

<blockquote>

## [1.0.0-alpha.5](https://github.com/arlyon/async-stripe/compare/async-stripe-types-v1.0.0-alpha.4...async-stripe-types-v1.0.0-alpha.5) - 2025-10-30

### Other

- update Cargo.toml dependencies
</blockquote>

## `async-stripe-shared`

<blockquote>

## [1.0.0-rc.1](https://github.com/arlyon/async-stripe/compare/async-stripe-shared-v1.0.0-rc.0...async-stripe-shared-v1.0.0-rc.1) - 2026-02-02

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-client-core`

<blockquote>

## [1.0.0-rc.0](https://github.com/arlyon/async-stripe/compare/async-stripe-client-core-v1.0.0-alpha.8...async-stripe-client-core-v1.0.0-rc.0) - 2025-12-04

### Fixed

- fix tests

### Other

- Merge pull request #804 from arlyon/claude/issue-722-20251126-2114
- Fix retry mechanism to follow Stripe documentation
- update readme
- make site public and add docs
</blockquote>

## `async-stripe-billing`

<blockquote>

## [1.0.0-rc.1](https://github.com/arlyon/async-stripe/compare/async-stripe-billing-v1.0.0-rc.0...async-stripe-billing-v1.0.0-rc.1) - 2026-02-02

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-checkout`

<blockquote>

## [1.0.0-rc.1](https://github.com/arlyon/async-stripe/compare/async-stripe-checkout-v1.0.0-rc.0...async-stripe-checkout-v1.0.0-rc.1) - 2026-02-02

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-core`

<blockquote>

## [1.0.0-rc.1](https://github.com/arlyon/async-stripe/compare/async-stripe-core-v1.0.0-rc.0...async-stripe-core-v1.0.0-rc.1) - 2026-02-02

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-fraud`

<blockquote>

## [1.0.0-rc.1](https://github.com/arlyon/async-stripe/compare/async-stripe-fraud-v1.0.0-rc.0...async-stripe-fraud-v1.0.0-rc.1) - 2026-02-02

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-misc`

<blockquote>

## [1.0.0-rc.1](https://github.com/arlyon/async-stripe/compare/async-stripe-misc-v1.0.0-rc.0...async-stripe-misc-v1.0.0-rc.1) - 2026-02-02

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-payment`

<blockquote>

## [1.0.0-rc.1](https://github.com/arlyon/async-stripe/compare/async-stripe-payment-v1.0.0-rc.0...async-stripe-payment-v1.0.0-rc.1) - 2026-02-02

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-terminal`

<blockquote>

## [1.0.0-rc.1](https://github.com/arlyon/async-stripe/compare/async-stripe-terminal-v1.0.0-rc.0...async-stripe-terminal-v1.0.0-rc.1) - 2026-02-02

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-treasury`

<blockquote>

## [1.0.0-rc.1](https://github.com/arlyon/async-stripe/compare/async-stripe-treasury-v1.0.0-rc.0...async-stripe-treasury-v1.0.0-rc.1) - 2026-02-02

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-webhook`

<blockquote>

## [1.0.0-rc.0](https://github.com/arlyon/async-stripe/compare/async-stripe-webhook-v1.0.0-alpha.8...async-stripe-webhook-v1.0.0-rc.0) - 2025-12-04

### Added

- add generate_test_header for webhook signature testing

### Other

- round trip webhook
- Merge pull request #815 from arlyon/claude/issue-808-20251127-2210
- add wasm webhook parser
</blockquote>

## `async-stripe-connect`

<blockquote>

## [1.0.0-rc.1](https://github.com/arlyon/async-stripe/compare/async-stripe-connect-v1.0.0-rc.0...async-stripe-connect-v1.0.0-rc.1) - 2026-02-02

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-issuing`

<blockquote>

## [1.0.0-alpha.10](https://github.com/arlyon/async-stripe/compare/async-stripe-issuing-v1.0.0-alpha.9...async-stripe-issuing-v1.0.0-alpha.10) - 2025-12-12

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-product`

<blockquote>

## [1.0.0-rc.1](https://github.com/arlyon/async-stripe/compare/async-stripe-product-v1.0.0-rc.0...async-stripe-product-v1.0.0-rc.1) - 2026-02-02

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe`

<blockquote>

## [1.0.0-rc.0](https://github.com/arlyon/async-stripe/compare/async-stripe-v1.0.0-alpha.8...async-stripe-v1.0.0-rc.0) - 2025-12-04

### Fixed

- fix tests

### Other

- update readme
- make site public and add docs
- Add tracing instrumentation to core API calls
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).