### PR TITLE
chore: release v1.0.0-rc.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,7 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
 dependencies = [
  "bitflags",
- "bytes 1.11.0",
+ "bytes 1.11.1",
  "futures-core",
  "futures-sink",
  "memchr",
@@ -32,7 +32,7 @@ dependencies = [
  "base64 0.22.1",
  "bitflags",
  "brotli",
- "bytes 1.11.0",
+ "bytes 1.11.1",
  "bytestring",
  "derive_more",
  "encoding_rs",
@@ -145,7 +145,7 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "actix-web-codegen",
- "bytes 1.11.0",
+ "bytes 1.11.1",
  "bytestring",
  "cfg-if",
  "cookie 0.16.2",
@@ -168,7 +168,7 @@ dependencies = [
  "serde_urlencoded",
  "smallvec",
  "socket2 0.6.2",
- "time 0.3.46",
+ "time 0.3.47",
  "tracing",
  "url",
 ]
@@ -280,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "assert-json-diff"
@@ -482,12 +482,12 @@ dependencies = [
 
 [[package]]
 name = "async-stripe"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "async-std",
  "async-stripe-client-core",
  "async-stripe-shared",
- "bytes 1.11.0",
+ "bytes 1.11.1",
  "http-body-util",
  "http-types",
  "httpmock",
@@ -506,7 +506,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-billing"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-checkout"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -534,11 +534,11 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-client-core"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "async-stripe-shared",
  "async-stripe-types",
- "bytes 1.11.0",
+ "bytes 1.11.1",
  "futures-util",
  "miniserde",
  "serde",
@@ -551,7 +551,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-connect"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-core"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-fraud"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -593,7 +593,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-issuing"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-misc"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -621,7 +621,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-parser"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "async-stripe-billing",
  "async-stripe-checkout",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-payment"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -659,7 +659,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-product"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -673,7 +673,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-shared"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "async-stripe-types",
  "miniserde",
@@ -685,7 +685,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-terminal"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -715,7 +715,7 @@ dependencies = [
  "async-stripe-terminal",
  "async-stripe-treasury",
  "async-stripe-types",
- "bytes 1.11.0",
+ "bytes 1.11.1",
  "chrono",
  "futures-util",
  "httpmock",
@@ -729,7 +729,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-treasury"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-types"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "miniserde",
  "serde",
@@ -754,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-webhook"
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 dependencies = [
  "async-stripe-billing",
  "async-stripe-checkout",
@@ -834,9 +834,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.37.0"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c34dda4df7017c8db52132f0f8a2e0f8161649d15723ed63fc00c82d0f2081a"
+checksum = "b092fe214090261288111db7a2b2c2118e5a7f30dc2569f1732c4069a6840549"
 dependencies = [
  "cc",
  "cmake",
@@ -852,7 +852,7 @@ checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core",
  "axum-macros",
- "bytes 1.11.0",
+ "bytes 1.11.1",
  "form_urlencoded",
  "futures-util",
  "http 1.4.0",
@@ -884,7 +884,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
- "bytes 1.11.0",
+ "bytes 1.11.1",
  "futures-core",
  "http 1.4.0",
  "http-body 1.0.1",
@@ -1025,9 +1025,9 @@ checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "bytestring"
@@ -1035,7 +1035,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "113b4343b5f6617e7ad401ced8de3cc8b012e73a594347c307b90db3e9271289"
 dependencies = [
- "bytes 1.11.0",
+ "bytes 1.11.1",
 ]
 
 [[package]]
@@ -1153,7 +1153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
 dependencies = [
  "percent-encoding",
- "time 0.3.46",
+ "time 0.3.47",
  "version_check",
 ]
 
@@ -1164,7 +1164,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
  "percent-encoding",
- "time 0.3.46",
+ "time 0.3.47",
  "version_check",
 ]
 
@@ -1304,9 +1304,9 @@ checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
 dependencies = [
  "powerfmt",
 ]
@@ -1545,9 +1545,9 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1781,6 +1781,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
 name = "ghash"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1814,7 +1827,7 @@ version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
 dependencies = [
- "bytes 1.11.0",
+ "bytes 1.11.1",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -1834,7 +1847,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
 dependencies = [
  "atomic-waker",
- "bytes 1.11.0",
+ "bytes 1.11.1",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -1848,9 +1861,24 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -1899,7 +1927,7 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
- "bytes 1.11.0",
+ "bytes 1.11.1",
  "fnv",
  "itoa",
 ]
@@ -1910,7 +1938,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
- "bytes 1.11.0",
+ "bytes 1.11.1",
  "itoa",
 ]
 
@@ -1920,7 +1948,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
- "bytes 1.11.0",
+ "bytes 1.11.1",
  "http 0.2.12",
  "pin-project-lite",
 ]
@@ -1931,7 +1959,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
- "bytes 1.11.0",
+ "bytes 1.11.1",
  "http 1.4.0",
 ]
 
@@ -1941,7 +1969,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
- "bytes 1.11.0",
+ "bytes 1.11.1",
  "futures-core",
  "http 1.4.0",
  "http-body 1.0.1",
@@ -2029,7 +2057,7 @@ version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
 dependencies = [
- "bytes 1.11.0",
+ "bytes 1.11.1",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -2054,7 +2082,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
 dependencies = [
  "atomic-waker",
- "bytes 1.11.0",
+ "bytes 1.11.1",
  "futures-channel",
  "futures-core",
  "h2 0.4.13",
@@ -2095,7 +2123,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
- "bytes 1.11.0",
+ "bytes 1.11.1",
  "http-body-util",
  "hyper 1.8.1",
  "hyper-util",
@@ -2107,13 +2135,12 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "bytes 1.11.0",
+ "bytes 1.11.1",
  "futures-channel",
- "futures-core",
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
@@ -2232,6 +2259,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2265,7 +2298,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
  "serde",
  "serde_core",
 ]
@@ -2284,9 +2317,9 @@ checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
 name = "insta"
-version = "1.46.2"
+version = "1.46.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c91d64f9ad425e80200a50a0e8b8a641680b44e33ce832efe5b8bc65161b07"
+checksum = "e82db8c87c7f1ccecb34ce0c24399b8a73081427f3c7c50a5d597925356115e4"
 dependencies = [
  "console",
  "once_cell",
@@ -2386,6 +2419,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "levenshtein"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2393,9 +2432,9 @@ checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.181"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "459427e2af2b9c839b132acb702a1c654d95e10f8c326bfc2ad11310e458b1c5"
 
 [[package]]
 name = "libnghttp2-sys"
@@ -2498,9 +2537,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mime"
@@ -2568,7 +2607,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
 dependencies = [
- "bytes 1.11.0",
+ "bytes 1.11.1",
  "encoding_rs",
  "futures-util",
  "http 1.4.0",
@@ -2861,6 +2900,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.114",
+]
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.20+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3034,9 +3083,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3046,9 +3095,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3057,15 +3106,15 @@ dependencies = [
 
 [[package]]
 name = "regex-lite"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d942b98df5e658f56f20d592c7f868833fe38115e65c33003d8cd224b0155da"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "ring"
@@ -3091,7 +3140,7 @@ dependencies = [
  "async-trait",
  "atomic 0.5.3",
  "binascii",
- "bytes 1.11.0",
+ "bytes 1.11.1",
  "either",
  "figment",
  "futures",
@@ -3109,7 +3158,7 @@ dependencies = [
  "serde",
  "state",
  "tempfile",
- "time 0.3.46",
+ "time 0.3.47",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -3157,7 +3206,7 @@ dependencies = [
  "smallvec",
  "stable-pattern",
  "state",
- "time 0.3.46",
+ "time 0.3.47",
  "tokio",
  "uncased",
 ]
@@ -3250,9 +3299,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "schannel"
@@ -3747,12 +3796,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.24.0"
+version = "3.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand 2.3.0",
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -3824,9 +3873,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.46"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9da98b7d9b7dad93488a84b8248efc35352b0b2657397d4167e7ad67e5d535e5"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -3834,7 +3883,7 @@ dependencies = [
  "powerfmt",
  "serde_core",
  "time-core",
- "time-macros 0.2.26",
+ "time-macros 0.2.27",
 ]
 
 [[package]]
@@ -3855,9 +3904,9 @@ dependencies = [
 
 [[package]]
 name = "time-macros"
-version = "0.2.26"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc610bac2dcee56805c99642447d4c5dbde4d01f752ffea0199aee1f601dc4"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3892,7 +3941,7 @@ version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
- "bytes 1.11.0",
+ "bytes 1.11.1",
  "libc",
  "mio",
  "parking_lot",
@@ -3951,7 +4000,7 @@ version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
- "bytes 1.11.0",
+ "bytes 1.11.1",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
@@ -4138,9 +4187,9 @@ checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
 
 [[package]]
 name = "unicode-segmentation"
@@ -4261,6 +4310,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4320,6 +4378,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver 1.0.27",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4359,9 +4451,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4715,6 +4807,88 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.114",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver 1.0.27",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
@@ -4756,18 +4930,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.37"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7456cf00f0685ad319c5b1693f291a650eaf345e941d082fc4e03df8a03996ac"
+checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.37"
+version = "0.8.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1328722bbf2115db7e19d69ebcc15e795719e2d66b60827c6a69a117365e37a0"
+checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4836,9 +5010,9 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
+checksum = "4de98dfa5d5b7fef4ee834d0073d560c9ca7b6c46a71d058c48db7960f8cfaf7"
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ resolver = "2"
 exclude = ["openapi"]
 
 [workspace.package]
-version = "1.0.0-rc.1"
+version = "1.0.0-rc.2"
 description = "API bindings for the Stripe HTTP API"
 rust-version = "1.88.0"
 authors = [

--- a/async-stripe-client-core/CHANGELOG.md
+++ b/async-stripe-client-core/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-rc.2](https://github.com/arlyon/async-stripe/compare/async-stripe-client-core-v1.0.0-rc.1...async-stripe-client-core-v1.0.0-rc.2) - 2026-02-12
+
+### Other
+
+- Make StripeClient.execute method return a `Send` future
+- Fix typo in dependencies section of README.md
+
 ## [1.0.0-rc.0](https://github.com/arlyon/async-stripe/compare/async-stripe-client-core-v1.0.0-alpha.8...async-stripe-client-core-v1.0.0-rc.0) - 2025-12-04
 
 ### Fixed

--- a/async-stripe-client-core/Cargo.toml
+++ b/async-stripe-client-core/Cargo.toml
@@ -17,8 +17,8 @@ edition.workspace = true
 name = "stripe_client_core"
 
 [dependencies]
-async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-rc.1" }
-async-stripe-types = { path = "../async-stripe-types", version = "1.0.0-rc.1" }
+async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-rc.2" }
+async-stripe-types = { path = "../async-stripe-types", version = "1.0.0-rc.2" }
 serde_json.workspace = true
 serde.workspace = true
 serde_qs.workspace = true

--- a/async-stripe-parser/Cargo.toml
+++ b/async-stripe-parser/Cargo.toml
@@ -18,19 +18,19 @@ edition.workspace = true
 crate-type = ["cdylib"]
 
 [dependencies]
-async-stripe-billing = { features = ["full", "deserialize"], version = "1.0.0-rc.1", path = "../generated/async-stripe-billing" }
-async-stripe-checkout = { features = ["full", "deserialize"], version = "1.0.0-rc.1", path = "../generated/async-stripe-checkout" }
-async-stripe-connect = { features = ["full", "deserialize"], version = "1.0.0-rc.1", path = "../generated/async-stripe-connect" }
-async-stripe-core = { features = ["full", "deserialize"], version = "1.0.0-rc.1", path = "../generated/async-stripe-core" }
-async-stripe-fraud = { features = ["full", "deserialize"], version = "1.0.0-rc.1", path = "../generated/async-stripe-fraud" }
-async-stripe-issuing = {features = ["full", "deserialize"], version = "1.0.0-rc.1", path = "../generated/async-stripe-issuing" }
-async-stripe-misc = { features = ["full", "deserialize"], version = "1.0.0-rc.1", path = "../generated/async-stripe-misc" }
-async-stripe-payment = { features = ["full", "deserialize"], version = "1.0.0-rc.1", path = "../generated/async-stripe-payment" }
-async-stripe-product = { features = ["full", "deserialize"], version = "1.0.0-rc.1", path = "../generated/async-stripe-product" }
-async-stripe-shared = { features = ["deserialize"], version = "1.0.0-rc.1", path = "../generated/async-stripe-shared" }
-async-stripe-terminal = {features = ["full", "deserialize"], version = "1.0.0-rc.1", path = "../generated/async-stripe-terminal" }
-async-stripe-treasury = {features = ["full", "deserialize"], version = "1.0.0-rc.1", path = "../generated/async-stripe-treasury" }
-async-stripe-webhook = { version = "1.0.0-rc.1", path = "../async-stripe-webhook", features = ["deserialize", "serialize", "full", "detailed-errors"] }
+async-stripe-billing = { features = ["full", "deserialize"], version = "1.0.0-rc.2", path = "../generated/async-stripe-billing" }
+async-stripe-checkout = { features = ["full", "deserialize"], version = "1.0.0-rc.2", path = "../generated/async-stripe-checkout" }
+async-stripe-connect = { features = ["full", "deserialize"], version = "1.0.0-rc.2", path = "../generated/async-stripe-connect" }
+async-stripe-core = { features = ["full", "deserialize"], version = "1.0.0-rc.2", path = "../generated/async-stripe-core" }
+async-stripe-fraud = { features = ["full", "deserialize"], version = "1.0.0-rc.2", path = "../generated/async-stripe-fraud" }
+async-stripe-issuing = {features = ["full", "deserialize"], version = "1.0.0-rc.2", path = "../generated/async-stripe-issuing" }
+async-stripe-misc = { features = ["full", "deserialize"], version = "1.0.0-rc.2", path = "../generated/async-stripe-misc" }
+async-stripe-payment = { features = ["full", "deserialize"], version = "1.0.0-rc.2", path = "../generated/async-stripe-payment" }
+async-stripe-product = { features = ["full", "deserialize"], version = "1.0.0-rc.2", path = "../generated/async-stripe-product" }
+async-stripe-shared = { features = ["deserialize"], version = "1.0.0-rc.2", path = "../generated/async-stripe-shared" }
+async-stripe-terminal = {features = ["full", "deserialize"], version = "1.0.0-rc.2", path = "../generated/async-stripe-terminal" }
+async-stripe-treasury = {features = ["full", "deserialize"], version = "1.0.0-rc.2", path = "../generated/async-stripe-treasury" }
+async-stripe-webhook = { version = "1.0.0-rc.2", path = "../async-stripe-webhook", features = ["deserialize", "serialize", "full", "detailed-errors"] }
 serde.workspace = true
 serde_json.workspace = true
 serde_path_to_error = "0.1.20"

--- a/async-stripe-webhook/Cargo.toml
+++ b/async-stripe-webhook/Cargo.toml
@@ -15,8 +15,8 @@ categories.workspace = true
 name = "stripe_webhook"
 
 [dependencies]
-async-stripe-types = { path = "../async-stripe-types", version = "1.0.0-rc.1" }
-async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-rc.1" }
+async-stripe-types = { path = "../async-stripe-types", version = "1.0.0-rc.2" }
+async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-rc.2" }
 hmac = "0.12"
 sha2 = "0.10"
 hex = "0.4"
@@ -27,14 +27,14 @@ miniserde.workspace = true
 serde.workspace = true
 serde_json = { workspace = true, optional = true }
 
-async-stripe-billing = { path = "../generated/async-stripe-billing", optional = true, version = "1.0.0-rc.1" }
-async-stripe-checkout = { path = "../generated/async-stripe-checkout", optional = true, version = "1.0.0-rc.1" }
-async-stripe-core = { path = "../generated/async-stripe-core", optional = true, version = "1.0.0-rc.1" }
-async-stripe-fraud = { path = "../generated/async-stripe-fraud", optional = true, version = "1.0.0-rc.1" }
-async-stripe-misc = { path = "../generated/async-stripe-misc", optional = true, version = "1.0.0-rc.1" }
-async-stripe-payment = { path = "../generated/async-stripe-payment", optional = true, version = "1.0.0-rc.1" }
-async-stripe-terminal = { path = "../generated/async-stripe-terminal", optional = true, version = "1.0.0-rc.1" }
-async-stripe-treasury = { path = "../generated/async-stripe-treasury", optional = true, version = "1.0.0-rc.1" }
+async-stripe-billing = { path = "../generated/async-stripe-billing", optional = true, version = "1.0.0-rc.2" }
+async-stripe-checkout = { path = "../generated/async-stripe-checkout", optional = true, version = "1.0.0-rc.2" }
+async-stripe-core = { path = "../generated/async-stripe-core", optional = true, version = "1.0.0-rc.2" }
+async-stripe-fraud = { path = "../generated/async-stripe-fraud", optional = true, version = "1.0.0-rc.2" }
+async-stripe-misc = { path = "../generated/async-stripe-misc", optional = true, version = "1.0.0-rc.2" }
+async-stripe-payment = { path = "../generated/async-stripe-payment", optional = true, version = "1.0.0-rc.2" }
+async-stripe-terminal = { path = "../generated/async-stripe-terminal", optional = true, version = "1.0.0-rc.2" }
+async-stripe-treasury = { path = "../generated/async-stripe-treasury", optional = true, version = "1.0.0-rc.2" }
 serde_path_to_error = { version = "0.1.20", optional = true }
 
 [dev-dependencies]

--- a/async-stripe/Cargo.toml
+++ b/async-stripe/Cargo.toml
@@ -33,8 +33,8 @@ async-std = { version = "1.12.0", optional = true }
 surf = { version = "2.1", optional = true }
 http-types = { version = "2.12.0", default-features = false, optional = true }
 
-async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-rc.1" }
-async-stripe-client-core = { path = "../async-stripe-client-core", version = "1.0.0-rc.1" }
+async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-rc.2" }
+async-stripe-client-core = { path = "../async-stripe-client-core", version = "1.0.0-rc.2" }
 
 [features]
 default = ["default-tls"]

--- a/generated/async-stripe-billing/Cargo.toml
+++ b/generated/async-stripe-billing/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.1" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.1" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.2" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.2" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.1" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.2" }
 
 
 [features]

--- a/generated/async-stripe-checkout/Cargo.toml
+++ b/generated/async-stripe-checkout/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.1" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.1" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.2" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.2" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.1" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.2" }
 
 
 [features]

--- a/generated/async-stripe-connect/Cargo.toml
+++ b/generated/async-stripe-connect/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.1" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.1" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.2" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.2" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.1" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.2" }
 
 
 [features]

--- a/generated/async-stripe-core/Cargo.toml
+++ b/generated/async-stripe-core/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.1" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.1" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.2" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.2" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.1" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.2" }
 
 
 [features]

--- a/generated/async-stripe-fraud/Cargo.toml
+++ b/generated/async-stripe-fraud/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.1" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.1" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.2" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.2" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.1" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.2" }
 
 
 [features]

--- a/generated/async-stripe-issuing/Cargo.toml
+++ b/generated/async-stripe-issuing/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.1" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.1" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.2" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.2" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.1" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.2" }
 
 
 [features]

--- a/generated/async-stripe-misc/Cargo.toml
+++ b/generated/async-stripe-misc/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.1" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.1" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.2" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.2" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.1" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.2" }
 
 
 [features]

--- a/generated/async-stripe-payment/Cargo.toml
+++ b/generated/async-stripe-payment/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.1" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.1" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.2" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.2" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.1" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.2" }
 
 
 [features]

--- a/generated/async-stripe-product/Cargo.toml
+++ b/generated/async-stripe-product/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.1" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.1" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.2" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.2" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.1" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.2" }
 
 
 [features]

--- a/generated/async-stripe-shared/Cargo.toml
+++ b/generated/async-stripe-shared/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.1" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.2" }
 
 
 

--- a/generated/async-stripe-terminal/Cargo.toml
+++ b/generated/async-stripe-terminal/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.1" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.1" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.2" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.2" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.1" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.2" }
 
 
 [features]

--- a/generated/async-stripe-treasury/Cargo.toml
+++ b/generated/async-stripe-treasury/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.1" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.1" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.2" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.2" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.1" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.2" }
 
 
 [features]


### PR DESCRIPTION



## 🤖 New release

* `async-stripe-types`: 1.0.0-rc.1 -> 1.0.0-rc.2
* `async-stripe-shared`: 1.0.0-rc.1 -> 1.0.0-rc.2
* `async-stripe-client-core`: 1.0.0-rc.1 -> 1.0.0-rc.2 (✓ API compatible changes)
* `async-stripe-billing`: 1.0.0-rc.1 -> 1.0.0-rc.2
* `async-stripe-checkout`: 1.0.0-rc.1 -> 1.0.0-rc.2
* `async-stripe-core`: 1.0.0-rc.1 -> 1.0.0-rc.2
* `async-stripe-fraud`: 1.0.0-rc.1 -> 1.0.0-rc.2
* `async-stripe-misc`: 1.0.0-rc.1 -> 1.0.0-rc.2
* `async-stripe-payment`: 1.0.0-rc.1 -> 1.0.0-rc.2
* `async-stripe-terminal`: 1.0.0-rc.1 -> 1.0.0-rc.2
* `async-stripe-treasury`: 1.0.0-rc.1 -> 1.0.0-rc.2
* `async-stripe-webhook`: 1.0.0-rc.1 -> 1.0.0-rc.2
* `async-stripe-connect`: 1.0.0-rc.1 -> 1.0.0-rc.2
* `async-stripe-issuing`: 1.0.0-rc.1 -> 1.0.0-rc.2
* `async-stripe-product`: 1.0.0-rc.1 -> 1.0.0-rc.2
* `async-stripe`: 1.0.0-rc.1 -> 1.0.0-rc.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `async-stripe-types`

<blockquote>

## [1.0.0-alpha.5](https://github.com/arlyon/async-stripe/compare/async-stripe-types-v1.0.0-alpha.4...async-stripe-types-v1.0.0-alpha.5) - 2025-10-30

### Other

- update Cargo.toml dependencies
</blockquote>

## `async-stripe-shared`

<blockquote>

## [1.0.0-rc.1](https://github.com/arlyon/async-stripe/compare/async-stripe-shared-v1.0.0-rc.0...async-stripe-shared-v1.0.0-rc.1) - 2026-02-02

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-client-core`

<blockquote>

## [1.0.0-rc.2](https://github.com/arlyon/async-stripe/compare/async-stripe-client-core-v1.0.0-rc.1...async-stripe-client-core-v1.0.0-rc.2) - 2026-02-12

### Other

- Make StripeClient.execute method return a `Send` future
- Fix typo in dependencies section of README.md
</blockquote>

## `async-stripe-billing`

<blockquote>

## [1.0.0-rc.1](https://github.com/arlyon/async-stripe/compare/async-stripe-billing-v1.0.0-rc.0...async-stripe-billing-v1.0.0-rc.1) - 2026-02-02

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-checkout`

<blockquote>

## [1.0.0-rc.1](https://github.com/arlyon/async-stripe/compare/async-stripe-checkout-v1.0.0-rc.0...async-stripe-checkout-v1.0.0-rc.1) - 2026-02-02

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-core`

<blockquote>

## [1.0.0-rc.1](https://github.com/arlyon/async-stripe/compare/async-stripe-core-v1.0.0-rc.0...async-stripe-core-v1.0.0-rc.1) - 2026-02-02

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-fraud`

<blockquote>

## [1.0.0-rc.1](https://github.com/arlyon/async-stripe/compare/async-stripe-fraud-v1.0.0-rc.0...async-stripe-fraud-v1.0.0-rc.1) - 2026-02-02

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-misc`

<blockquote>

## [1.0.0-rc.1](https://github.com/arlyon/async-stripe/compare/async-stripe-misc-v1.0.0-rc.0...async-stripe-misc-v1.0.0-rc.1) - 2026-02-02

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-payment`

<blockquote>

## [1.0.0-rc.1](https://github.com/arlyon/async-stripe/compare/async-stripe-payment-v1.0.0-rc.0...async-stripe-payment-v1.0.0-rc.1) - 2026-02-02

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-terminal`

<blockquote>

## [1.0.0-rc.1](https://github.com/arlyon/async-stripe/compare/async-stripe-terminal-v1.0.0-rc.0...async-stripe-terminal-v1.0.0-rc.1) - 2026-02-02

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-treasury`

<blockquote>

## [1.0.0-rc.1](https://github.com/arlyon/async-stripe/compare/async-stripe-treasury-v1.0.0-rc.0...async-stripe-treasury-v1.0.0-rc.1) - 2026-02-02

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-webhook`

<blockquote>

## [1.0.0-rc.0](https://github.com/arlyon/async-stripe/compare/async-stripe-webhook-v1.0.0-alpha.8...async-stripe-webhook-v1.0.0-rc.0) - 2025-12-04

### Added

- add generate_test_header for webhook signature testing

### Other

- round trip webhook
- Merge pull request #815 from arlyon/claude/issue-808-20251127-2210
- add wasm webhook parser
</blockquote>

## `async-stripe-connect`

<blockquote>

## [1.0.0-rc.1](https://github.com/arlyon/async-stripe/compare/async-stripe-connect-v1.0.0-rc.0...async-stripe-connect-v1.0.0-rc.1) - 2026-02-02

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-issuing`

<blockquote>

## [1.0.0-alpha.10](https://github.com/arlyon/async-stripe/compare/async-stripe-issuing-v1.0.0-alpha.9...async-stripe-issuing-v1.0.0-alpha.10) - 2025-12-12

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-product`

<blockquote>

## [1.0.0-rc.1](https://github.com/arlyon/async-stripe/compare/async-stripe-product-v1.0.0-rc.0...async-stripe-product-v1.0.0-rc.1) - 2026-02-02

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe`

<blockquote>

## [1.0.0-rc.0](https://github.com/arlyon/async-stripe/compare/async-stripe-v1.0.0-alpha.8...async-stripe-v1.0.0-rc.0) - 2025-12-04

### Fixed

- fix tests

### Other

- update readme
- make site public and add docs
- Add tracing instrumentation to core API calls
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).