### PR TITLE
Fix typo in dependencies section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ crate for the APIs you want to use (e.g., `stripe-core` for customers).
 
     [dependencies]
     async-stripe = "=1.0.0-alpha.8"
-    stripe-core = { version = "=1.0.0-alpha.8", features = ["customer"] }
+    async-stripe-core = { version = "=1.0.0-alpha.8", features = ["customer"] }
     tokio = { version = "1", features = ["full"] }
 
 **2. Create a Customer:**


### PR DESCRIPTION
# Summary

The current dependencies list `stripe-core` which doesn't exist in `crates.io`. Instead, it should be `async-stripe-core` which exists.

### Checklist

- [ ] ran `cargo make fmt`
- [ ] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features
  <!--
  EXAMPLES:
  feat: you can now add and remove principals from a project
  fix: fixes an issue where the combobox was displaying incorrect values
  -->
