### PR TITLE
Make StripeClient.execute method return a `Send` future

### DIFF
--- a/async-stripe-client-core/src/stripe_request.rs
+++ b/async-stripe-client-core/src/stripe_request.rs
@@ -43,7 +43,7 @@ pub trait StripeClient {
     fn execute(
         &self,
         req: CustomizedStripeRequest,
-    ) -> impl std::future::Future<Output = Result<Bytes, Self::Err>>;
+    ) -> impl std::future::Future<Output = Result<Bytes, Self::Err>> + Send;
 }
 
 /// An abstraction for defining HTTP clients capable of making blocking Stripe API requests compatible

--- a/tests/tests/it/async_tests/mod.rs
+++ b/tests/tests/it/async_tests/mod.rs
@@ -37,7 +37,7 @@ impl stripe_client_core::StripeClient for StripeClient {
     fn execute(
         &self,
         req: CustomizedStripeRequest,
-    ) -> Pin<Box<dyn Future<Output = Result<Bytes, SimpleStripeClientError>> + '_>> {
+    ) -> Pin<Box<dyn Future<Output = Result<Bytes, SimpleStripeClientError>> + '_ + Send>> {
         match self {
             StripeClient::Hyper(c) => {
                 Box::pin(c.execute(req).map_err(|err| SimpleStripeClientError(err.to_string())))


### PR DESCRIPTION

# Summary

This commit adds the `Send` trait to the returned future for the `execute` method of `StripeRequest`. This is handy for code wanting to send requests from sections that should be thread-safe (requiring `Send`).

### Checklist

- [ ] ran `cargo make fmt`
- [ ] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features
  <!--
  EXAMPLES:
  feat: you can now add and remove principals from a project
  fix: fixes an issue where the combobox was displaying incorrect values
  -->
