### PR TITLE
chore: release v1.0.0-rc.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand 0.9.2",
+ "rand 0.9.3",
  "sha1 0.10.6",
  "smallvec",
  "tokio",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "async-std",
  "async-stripe-client-core",
@@ -506,7 +506,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-billing"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-checkout"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-client-core"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "async-stripe-shared",
  "async-stripe-types",
@@ -551,7 +551,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-connect"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-core"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-fraud"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -593,7 +593,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-issuing"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-misc"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -621,7 +621,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-parser"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "async-stripe-billing",
  "async-stripe-checkout",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-payment"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -659,7 +659,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-product"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -673,7 +673,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-reserve"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -687,7 +687,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-shared"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "async-stripe-types",
  "miniserde",
@@ -699,7 +699,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-terminal"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-treasury"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-types"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "miniserde",
  "serde",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-webhook"
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 dependencies = [
  "async-stripe-billing",
  "async-stripe-checkout",
@@ -1057,9 +1057,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1875,9 +1875,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -2104,9 +2104,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "c2b52f86d1d4bc0d6b4e6826d960b1b333217e07d36b882dca570a5e1c48895b"
 dependencies = [
  "http 1.4.0",
  "hyper 1.9.0",
@@ -2114,7 +2114,6 @@ dependencies = [
  "log",
  "rustls",
  "rustls-native-certs",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -2298,12 +2297,12 @@ checksum = "e8a5a9a0ff0086c7a148acb942baaabeadf9504d10400b5a05645853729b9cd2"
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -2394,9 +2393,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2692,9 +2691,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -2730,9 +2729,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
 dependencies = [
  "cc",
  "libc",
@@ -2853,9 +2852,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "polling"
@@ -2991,9 +2990,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3257,9 +3256,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -3294,9 +3293,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3937,9 +3936,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.51.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes 1.11.1",
  "libc",
@@ -4320,9 +4319,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4333,9 +4332,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.67"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4343,9 +4342,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4353,9 +4352,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4366,9 +4365,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -4409,9 +4408,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ resolver = "2"
 exclude = ["openapi"]
 
 [workspace.package]
-version = "1.0.0-rc.4"
+version = "1.0.0-rc.5"
 description = "API bindings for the Stripe HTTP API"
 rust-version = "1.88.0"
 authors = [

--- a/async-stripe-client-core/CHANGELOG.md
+++ b/async-stripe-client-core/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-rc.5](https://github.com/arlyon/async-stripe/compare/async-stripe-client-core-v1.0.0-rc.4...async-stripe-client-core-v1.0.0-rc.5) - 2026-04-13
+
+### Added
+
+- redact-generated-debug feature
+
 ## [1.0.0-rc.4](https://github.com/arlyon/async-stripe/compare/async-stripe-client-core-v1.0.0-rc.3...async-stripe-client-core-v1.0.0-rc.4) - 2026-04-07
 
 ### Other

--- a/async-stripe-client-core/Cargo.toml
+++ b/async-stripe-client-core/Cargo.toml
@@ -17,8 +17,8 @@ edition.workspace = true
 name = "stripe_client_core"
 
 [dependencies]
-async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-rc.4" }
-async-stripe-types = { path = "../async-stripe-types", version = "1.0.0-rc.4" }
+async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-rc.5" }
+async-stripe-types = { path = "../async-stripe-types", version = "1.0.0-rc.5" }
 serde_json.workspace = true
 serde.workspace = true
 serde_qs.workspace = true

--- a/async-stripe-parser/Cargo.toml
+++ b/async-stripe-parser/Cargo.toml
@@ -18,19 +18,19 @@ edition.workspace = true
 crate-type = ["cdylib"]
 
 [dependencies]
-async-stripe-billing = { features = ["full", "deserialize"], version = "1.0.0-rc.4", path = "../generated/async-stripe-billing" }
-async-stripe-checkout = { features = ["full", "deserialize"], version = "1.0.0-rc.4", path = "../generated/async-stripe-checkout" }
-async-stripe-connect = { features = ["full", "deserialize"], version = "1.0.0-rc.4", path = "../generated/async-stripe-connect" }
-async-stripe-core = { features = ["full", "deserialize"], version = "1.0.0-rc.4", path = "../generated/async-stripe-core" }
-async-stripe-fraud = { features = ["full", "deserialize"], version = "1.0.0-rc.4", path = "../generated/async-stripe-fraud" }
-async-stripe-issuing = {features = ["full", "deserialize"], version = "1.0.0-rc.4", path = "../generated/async-stripe-issuing" }
-async-stripe-misc = { features = ["full", "deserialize"], version = "1.0.0-rc.4", path = "../generated/async-stripe-misc" }
-async-stripe-payment = { features = ["full", "deserialize"], version = "1.0.0-rc.4", path = "../generated/async-stripe-payment" }
-async-stripe-product = { features = ["full", "deserialize"], version = "1.0.0-rc.4", path = "../generated/async-stripe-product" }
-async-stripe-shared = { features = ["deserialize"], version = "1.0.0-rc.4", path = "../generated/async-stripe-shared" }
-async-stripe-terminal = {features = ["full", "deserialize"], version = "1.0.0-rc.4", path = "../generated/async-stripe-terminal" }
-async-stripe-treasury = {features = ["full", "deserialize"], version = "1.0.0-rc.4", path = "../generated/async-stripe-treasury" }
-async-stripe-webhook = { version = "1.0.0-rc.4", path = "../async-stripe-webhook", features = ["deserialize", "serialize", "full", "detailed-errors"] }
+async-stripe-billing = { features = ["full", "deserialize"], version = "1.0.0-rc.5", path = "../generated/async-stripe-billing" }
+async-stripe-checkout = { features = ["full", "deserialize"], version = "1.0.0-rc.5", path = "../generated/async-stripe-checkout" }
+async-stripe-connect = { features = ["full", "deserialize"], version = "1.0.0-rc.5", path = "../generated/async-stripe-connect" }
+async-stripe-core = { features = ["full", "deserialize"], version = "1.0.0-rc.5", path = "../generated/async-stripe-core" }
+async-stripe-fraud = { features = ["full", "deserialize"], version = "1.0.0-rc.5", path = "../generated/async-stripe-fraud" }
+async-stripe-issuing = {features = ["full", "deserialize"], version = "1.0.0-rc.5", path = "../generated/async-stripe-issuing" }
+async-stripe-misc = { features = ["full", "deserialize"], version = "1.0.0-rc.5", path = "../generated/async-stripe-misc" }
+async-stripe-payment = { features = ["full", "deserialize"], version = "1.0.0-rc.5", path = "../generated/async-stripe-payment" }
+async-stripe-product = { features = ["full", "deserialize"], version = "1.0.0-rc.5", path = "../generated/async-stripe-product" }
+async-stripe-shared = { features = ["deserialize"], version = "1.0.0-rc.5", path = "../generated/async-stripe-shared" }
+async-stripe-terminal = {features = ["full", "deserialize"], version = "1.0.0-rc.5", path = "../generated/async-stripe-terminal" }
+async-stripe-treasury = {features = ["full", "deserialize"], version = "1.0.0-rc.5", path = "../generated/async-stripe-treasury" }
+async-stripe-webhook = { version = "1.0.0-rc.5", path = "../async-stripe-webhook", features = ["deserialize", "serialize", "full", "detailed-errors"] }
 serde.workspace = true
 serde_json.workspace = true
 serde_path_to_error = "0.1.20"

--- a/async-stripe-types/CHANGELOG.md
+++ b/async-stripe-types/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-rc.5](https://github.com/arlyon/async-stripe/compare/async-stripe-types-v1.0.0-rc.4...async-stripe-types-v1.0.0-rc.5) - 2026-04-13
+
+### Added
+
+- redact-generated-debug feature
+
 ## [1.0.0-rc.3](https://github.com/arlyon/async-stripe/compare/async-stripe-types-v1.0.0-rc.2...async-stripe-types-v1.0.0-rc.3) - 2026-03-10
 
 ### Added

--- a/async-stripe-webhook/CHANGELOG.md
+++ b/async-stripe-webhook/CHANGELOG.md
@@ -5,6 +5,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-rc.5](https://github.com/arlyon/async-stripe/compare/async-stripe-webhook-v1.0.0-rc.4...async-stripe-webhook-v1.0.0-rc.5) - 2026-04-13
+
+### Added
+
+- redact-generated-debug feature
+
+### Other
+
+- regenerate codegen
+
 ## [1.0.0-rc.4](https://github.com/arlyon/async-stripe/compare/async-stripe-webhook-v1.0.0-rc.3...async-stripe-webhook-v1.0.0-rc.4) - 2026-04-07
 
 ### Fixed

--- a/async-stripe-webhook/Cargo.toml
+++ b/async-stripe-webhook/Cargo.toml
@@ -15,8 +15,8 @@ categories.workspace = true
 name = "stripe_webhook"
 
 [dependencies]
-async-stripe-types = { path = "../async-stripe-types", version = "1.0.0-rc.4" }
-async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-rc.4" }
+async-stripe-types = { path = "../async-stripe-types", version = "1.0.0-rc.5" }
+async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-rc.5" }
 hmac = "0.12"
 sha2 = "0.10"
 hex = "0.4"
@@ -27,15 +27,15 @@ miniserde.workspace = true
 serde.workspace = true
 serde_json = { workspace = true, optional = true }
 
-async-stripe-billing = { path = "../generated/async-stripe-billing", optional = true, version = "1.0.0-rc.4" }
-async-stripe-checkout = { path = "../generated/async-stripe-checkout", optional = true, version = "1.0.0-rc.4" }
-async-stripe-core = { path = "../generated/async-stripe-core", optional = true, version = "1.0.0-rc.4" }
-async-stripe-fraud = { path = "../generated/async-stripe-fraud", optional = true, version = "1.0.0-rc.4" }
-async-stripe-misc = { path = "../generated/async-stripe-misc", optional = true, version = "1.0.0-rc.4" }
-async-stripe-payment = { path = "../generated/async-stripe-payment", optional = true, version = "1.0.0-rc.4" }
-async-stripe-terminal = { path = "../generated/async-stripe-terminal", optional = true, version = "1.0.0-rc.4" }
-async-stripe-treasury = { path = "../generated/async-stripe-treasury", optional = true, version = "1.0.0-rc.4" }
-async-stripe-reserve = { path = "../generated/async-stripe-reserve", optional = true, version = "1.0.0-rc.4" }
+async-stripe-billing = { path = "../generated/async-stripe-billing", optional = true, version = "1.0.0-rc.5" }
+async-stripe-checkout = { path = "../generated/async-stripe-checkout", optional = true, version = "1.0.0-rc.5" }
+async-stripe-core = { path = "../generated/async-stripe-core", optional = true, version = "1.0.0-rc.5" }
+async-stripe-fraud = { path = "../generated/async-stripe-fraud", optional = true, version = "1.0.0-rc.5" }
+async-stripe-misc = { path = "../generated/async-stripe-misc", optional = true, version = "1.0.0-rc.5" }
+async-stripe-payment = { path = "../generated/async-stripe-payment", optional = true, version = "1.0.0-rc.5" }
+async-stripe-terminal = { path = "../generated/async-stripe-terminal", optional = true, version = "1.0.0-rc.5" }
+async-stripe-treasury = { path = "../generated/async-stripe-treasury", optional = true, version = "1.0.0-rc.5" }
+async-stripe-reserve = { path = "../generated/async-stripe-reserve", optional = true, version = "1.0.0-rc.5" }
 serde_path_to_error = { version = "0.1.20", optional = true }
 
 [dev-dependencies]

--- a/async-stripe/CHANGELOG.md
+++ b/async-stripe/CHANGELOG.md
@@ -5,6 +5,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-rc.5](https://github.com/arlyon/async-stripe/compare/async-stripe-v1.0.0-rc.4...async-stripe-v1.0.0-rc.5) - 2026-04-13
+
+### Added
+
+- redact-generated-debug feature
+
+### Other
+
+- add cargo features component
+
 ## [1.0.0-rc.4](https://github.com/arlyon/async-stripe/compare/async-stripe-v1.0.0-rc.3...async-stripe-v1.0.0-rc.4) - 2026-04-07
 
 ### Other

--- a/async-stripe/Cargo.toml
+++ b/async-stripe/Cargo.toml
@@ -33,8 +33,8 @@ async-std = { version = "1.12.0", optional = true }
 surf = { version = "2.1", optional = true }
 http-types = { version = "2.12.0", default-features = false, optional = true }
 
-async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-rc.4" }
-async-stripe-client-core = { path = "../async-stripe-client-core", version = "1.0.0-rc.4" }
+async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-rc.5" }
+async-stripe-client-core = { path = "../async-stripe-client-core", version = "1.0.0-rc.5" }
 
 [features]
 default = ["default-tls"]

--- a/generated/async-stripe-billing/CHANGELOG.md
+++ b/generated/async-stripe-billing/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-rc.5](https://github.com/arlyon/async-stripe/compare/async-stripe-billing-v1.0.0-rc.4...async-stripe-billing-v1.0.0-rc.5) - 2026-04-13
+
+### Other
+
+- regenerate codegen
+
 ## [1.0.0-rc.4](https://github.com/arlyon/async-stripe/compare/async-stripe-billing-v1.0.0-rc.3...async-stripe-billing-v1.0.0-rc.4) - 2026-04-07
 
 ### Other

--- a/generated/async-stripe-billing/Cargo.toml
+++ b/generated/async-stripe-billing/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.4" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.4" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.5" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.5" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.4" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.5" }
 
 
 [features]

--- a/generated/async-stripe-checkout/CHANGELOG.md
+++ b/generated/async-stripe-checkout/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-rc.5](https://github.com/arlyon/async-stripe/compare/async-stripe-checkout-v1.0.0-rc.4...async-stripe-checkout-v1.0.0-rc.5) - 2026-04-13
+
+### Other
+
+- regenerate codegen
+
 ## [1.0.0-rc.4](https://github.com/arlyon/async-stripe/compare/async-stripe-checkout-v1.0.0-rc.3...async-stripe-checkout-v1.0.0-rc.4) - 2026-04-07
 
 ### Other

--- a/generated/async-stripe-checkout/Cargo.toml
+++ b/generated/async-stripe-checkout/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.4" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.4" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.5" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.5" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.4" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.5" }
 
 
 [features]

--- a/generated/async-stripe-connect/CHANGELOG.md
+++ b/generated/async-stripe-connect/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-rc.5](https://github.com/arlyon/async-stripe/compare/async-stripe-connect-v1.0.0-rc.4...async-stripe-connect-v1.0.0-rc.5) - 2026-04-13
+
+### Other
+
+- regenerate codegen
+
 ## [1.0.0-rc.4](https://github.com/arlyon/async-stripe/compare/async-stripe-connect-v1.0.0-rc.3...async-stripe-connect-v1.0.0-rc.4) - 2026-04-07
 
 ### Other

--- a/generated/async-stripe-connect/Cargo.toml
+++ b/generated/async-stripe-connect/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.4" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.4" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.5" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.5" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.4" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.5" }
 
 
 [features]

--- a/generated/async-stripe-core/CHANGELOG.md
+++ b/generated/async-stripe-core/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-rc.5](https://github.com/arlyon/async-stripe/compare/async-stripe-core-v1.0.0-rc.4...async-stripe-core-v1.0.0-rc.5) - 2026-04-13
+
+### Other
+
+- regenerate codegen
+
 ## [1.0.0-rc.4](https://github.com/arlyon/async-stripe/compare/async-stripe-core-v1.0.0-rc.3...async-stripe-core-v1.0.0-rc.4) - 2026-04-07
 
 ### Other

--- a/generated/async-stripe-core/Cargo.toml
+++ b/generated/async-stripe-core/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.4" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.4" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.5" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.5" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.4" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.5" }
 
 
 [features]

--- a/generated/async-stripe-fraud/CHANGELOG.md
+++ b/generated/async-stripe-fraud/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-rc.5](https://github.com/arlyon/async-stripe/compare/async-stripe-fraud-v1.0.0-rc.4...async-stripe-fraud-v1.0.0-rc.5) - 2026-04-13
+
+### Other
+
+- regenerate codegen
+
 ## [1.0.0-rc.4](https://github.com/arlyon/async-stripe/compare/async-stripe-fraud-v1.0.0-rc.3...async-stripe-fraud-v1.0.0-rc.4) - 2026-04-07
 
 ### Other

--- a/generated/async-stripe-fraud/Cargo.toml
+++ b/generated/async-stripe-fraud/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.4" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.4" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.5" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.5" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.4" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.5" }
 
 
 [features]

--- a/generated/async-stripe-issuing/CHANGELOG.md
+++ b/generated/async-stripe-issuing/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-rc.5](https://github.com/arlyon/async-stripe/compare/async-stripe-issuing-v1.0.0-rc.4...async-stripe-issuing-v1.0.0-rc.5) - 2026-04-13
+
+### Other
+
+- regenerate codegen
+
 ## [1.0.0-rc.4](https://github.com/arlyon/async-stripe/compare/async-stripe-issuing-v1.0.0-rc.3...async-stripe-issuing-v1.0.0-rc.4) - 2026-04-07
 
 ### Other

--- a/generated/async-stripe-issuing/Cargo.toml
+++ b/generated/async-stripe-issuing/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.4" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.4" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.5" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.5" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.4" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.5" }
 
 
 [features]

--- a/generated/async-stripe-misc/CHANGELOG.md
+++ b/generated/async-stripe-misc/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-rc.5](https://github.com/arlyon/async-stripe/compare/async-stripe-misc-v1.0.0-rc.4...async-stripe-misc-v1.0.0-rc.5) - 2026-04-13
+
+### Other
+
+- regenerate codegen
+
 ## [1.0.0-rc.4](https://github.com/arlyon/async-stripe/compare/async-stripe-misc-v1.0.0-rc.3...async-stripe-misc-v1.0.0-rc.4) - 2026-04-07
 
 ### Other

--- a/generated/async-stripe-misc/Cargo.toml
+++ b/generated/async-stripe-misc/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.4" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.4" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.5" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.5" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.4" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.5" }
 
 
 [features]

--- a/generated/async-stripe-payment/CHANGELOG.md
+++ b/generated/async-stripe-payment/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-rc.5](https://github.com/arlyon/async-stripe/compare/async-stripe-payment-v1.0.0-rc.4...async-stripe-payment-v1.0.0-rc.5) - 2026-04-13
+
+### Other
+
+- regenerate codegen
+
 ## [1.0.0-rc.4](https://github.com/arlyon/async-stripe/compare/async-stripe-payment-v1.0.0-rc.3...async-stripe-payment-v1.0.0-rc.4) - 2026-04-07
 
 ### Other

--- a/generated/async-stripe-payment/Cargo.toml
+++ b/generated/async-stripe-payment/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.4" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.4" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.5" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.5" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.4" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.5" }
 
 
 [features]

--- a/generated/async-stripe-product/CHANGELOG.md
+++ b/generated/async-stripe-product/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-rc.5](https://github.com/arlyon/async-stripe/compare/async-stripe-product-v1.0.0-rc.4...async-stripe-product-v1.0.0-rc.5) - 2026-04-13
+
+### Other
+
+- regenerate codegen
+
 ## [1.0.0-rc.4](https://github.com/arlyon/async-stripe/compare/async-stripe-product-v1.0.0-rc.3...async-stripe-product-v1.0.0-rc.4) - 2026-04-07
 
 ### Other

--- a/generated/async-stripe-product/Cargo.toml
+++ b/generated/async-stripe-product/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.4" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.4" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.5" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.5" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.4" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.5" }
 
 
 [features]

--- a/generated/async-stripe-reserve/CHANGELOG.md
+++ b/generated/async-stripe-reserve/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-rc.5](https://github.com/arlyon/async-stripe/compare/async-stripe-reserve-v1.0.0-rc.4...async-stripe-reserve-v1.0.0-rc.5) - 2026-04-13
+
+### Other
+
+- regenerate codegen
+
 ## [1.0.0-rc.4](https://github.com/arlyon/async-stripe/compare/async-stripe-reserve-v1.0.0-rc.3...async-stripe-reserve-v1.0.0-rc.4) - 2026-04-07
 
 ### Other

--- a/generated/async-stripe-reserve/Cargo.toml
+++ b/generated/async-stripe-reserve/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.4" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.4" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.5" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.5" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.4" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.5" }
 
 
 [features]

--- a/generated/async-stripe-shared/CHANGELOG.md
+++ b/generated/async-stripe-shared/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-rc.5](https://github.com/arlyon/async-stripe/compare/async-stripe-shared-v1.0.0-rc.4...async-stripe-shared-v1.0.0-rc.5) - 2026-04-13
+
+### Other
+
+- regenerate codegen
+
 ## [1.0.0-rc.4](https://github.com/arlyon/async-stripe/compare/async-stripe-shared-v1.0.0-rc.3...async-stripe-shared-v1.0.0-rc.4) - 2026-04-07
 
 ### Other

--- a/generated/async-stripe-shared/Cargo.toml
+++ b/generated/async-stripe-shared/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.4" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.5" }
 
 
 

--- a/generated/async-stripe-terminal/CHANGELOG.md
+++ b/generated/async-stripe-terminal/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-rc.5](https://github.com/arlyon/async-stripe/compare/async-stripe-terminal-v1.0.0-rc.4...async-stripe-terminal-v1.0.0-rc.5) - 2026-04-13
+
+### Other
+
+- regenerate codegen
+
 ## [1.0.0-rc.4](https://github.com/arlyon/async-stripe/compare/async-stripe-terminal-v1.0.0-rc.3...async-stripe-terminal-v1.0.0-rc.4) - 2026-04-07
 
 ### Other

--- a/generated/async-stripe-terminal/Cargo.toml
+++ b/generated/async-stripe-terminal/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.4" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.4" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.5" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.5" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.4" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.5" }
 
 
 [features]

--- a/generated/async-stripe-treasury/CHANGELOG.md
+++ b/generated/async-stripe-treasury/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-rc.5](https://github.com/arlyon/async-stripe/compare/async-stripe-treasury-v1.0.0-rc.4...async-stripe-treasury-v1.0.0-rc.5) - 2026-04-13
+
+### Other
+
+- regenerate codegen
+
 ## [1.0.0-rc.4](https://github.com/arlyon/async-stripe/compare/async-stripe-treasury-v1.0.0-rc.3...async-stripe-treasury-v1.0.0-rc.4) - 2026-04-07
 
 ### Other

--- a/generated/async-stripe-treasury/Cargo.toml
+++ b/generated/async-stripe-treasury/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.4" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.4" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.5" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.5" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.4" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.5" }
 
 
 [features]


### PR DESCRIPTION



## 🤖 New release

* `async-stripe-types`: 1.0.0-rc.4 -> 1.0.0-rc.5 (✓ API compatible changes)
* `async-stripe-shared`: 1.0.0-rc.4 -> 1.0.0-rc.5 (✓ API compatible changes)
* `async-stripe-client-core`: 1.0.0-rc.4 -> 1.0.0-rc.5 (✓ API compatible changes)
* `async-stripe-billing`: 1.0.0-rc.4 -> 1.0.0-rc.5 (✓ API compatible changes)
* `async-stripe-checkout`: 1.0.0-rc.4 -> 1.0.0-rc.5 (✓ API compatible changes)
* `async-stripe-core`: 1.0.0-rc.4 -> 1.0.0-rc.5 (✓ API compatible changes)
* `async-stripe-fraud`: 1.0.0-rc.4 -> 1.0.0-rc.5 (✓ API compatible changes)
* `async-stripe-misc`: 1.0.0-rc.4 -> 1.0.0-rc.5 (✓ API compatible changes)
* `async-stripe-payment`: 1.0.0-rc.4 -> 1.0.0-rc.5 (✓ API compatible changes)
* `async-stripe-reserve`: 1.0.0-rc.4 -> 1.0.0-rc.5 (✓ API compatible changes)
* `async-stripe-terminal`: 1.0.0-rc.4 -> 1.0.0-rc.5 (✓ API compatible changes)
* `async-stripe-treasury`: 1.0.0-rc.4 -> 1.0.0-rc.5 (✓ API compatible changes)
* `async-stripe-webhook`: 1.0.0-rc.4 -> 1.0.0-rc.5 (✓ API compatible changes)
* `async-stripe-connect`: 1.0.0-rc.4 -> 1.0.0-rc.5 (✓ API compatible changes)
* `async-stripe-issuing`: 1.0.0-rc.4 -> 1.0.0-rc.5 (✓ API compatible changes)
* `async-stripe-product`: 1.0.0-rc.4 -> 1.0.0-rc.5 (✓ API compatible changes)
* `async-stripe`: 1.0.0-rc.4 -> 1.0.0-rc.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `async-stripe-types`

<blockquote>

## [1.0.0-rc.5](https://github.com/arlyon/async-stripe/compare/async-stripe-types-v1.0.0-rc.4...async-stripe-types-v1.0.0-rc.5) - 2026-04-13

### Added

- redact-generated-debug feature
</blockquote>

## `async-stripe-shared`

<blockquote>

## [1.0.0-rc.5](https://github.com/arlyon/async-stripe/compare/async-stripe-shared-v1.0.0-rc.4...async-stripe-shared-v1.0.0-rc.5) - 2026-04-13

### Other

- regenerate codegen
</blockquote>

## `async-stripe-client-core`

<blockquote>

## [1.0.0-rc.5](https://github.com/arlyon/async-stripe/compare/async-stripe-client-core-v1.0.0-rc.4...async-stripe-client-core-v1.0.0-rc.5) - 2026-04-13

### Added

- redact-generated-debug feature
</blockquote>

## `async-stripe-billing`

<blockquote>

## [1.0.0-rc.5](https://github.com/arlyon/async-stripe/compare/async-stripe-billing-v1.0.0-rc.4...async-stripe-billing-v1.0.0-rc.5) - 2026-04-13

### Other

- regenerate codegen
</blockquote>

## `async-stripe-checkout`

<blockquote>

## [1.0.0-rc.5](https://github.com/arlyon/async-stripe/compare/async-stripe-checkout-v1.0.0-rc.4...async-stripe-checkout-v1.0.0-rc.5) - 2026-04-13

### Other

- regenerate codegen
</blockquote>

## `async-stripe-core`

<blockquote>

## [1.0.0-rc.5](https://github.com/arlyon/async-stripe/compare/async-stripe-core-v1.0.0-rc.4...async-stripe-core-v1.0.0-rc.5) - 2026-04-13

### Other

- regenerate codegen
</blockquote>

## `async-stripe-fraud`

<blockquote>

## [1.0.0-rc.5](https://github.com/arlyon/async-stripe/compare/async-stripe-fraud-v1.0.0-rc.4...async-stripe-fraud-v1.0.0-rc.5) - 2026-04-13

### Other

- regenerate codegen
</blockquote>

## `async-stripe-misc`

<blockquote>

## [1.0.0-rc.5](https://github.com/arlyon/async-stripe/compare/async-stripe-misc-v1.0.0-rc.4...async-stripe-misc-v1.0.0-rc.5) - 2026-04-13

### Other

- regenerate codegen
</blockquote>

## `async-stripe-payment`

<blockquote>

## [1.0.0-rc.5](https://github.com/arlyon/async-stripe/compare/async-stripe-payment-v1.0.0-rc.4...async-stripe-payment-v1.0.0-rc.5) - 2026-04-13

### Other

- regenerate codegen
</blockquote>

## `async-stripe-reserve`

<blockquote>

## [1.0.0-rc.5](https://github.com/arlyon/async-stripe/compare/async-stripe-reserve-v1.0.0-rc.4...async-stripe-reserve-v1.0.0-rc.5) - 2026-04-13

### Other

- regenerate codegen
</blockquote>

## `async-stripe-terminal`

<blockquote>

## [1.0.0-rc.5](https://github.com/arlyon/async-stripe/compare/async-stripe-terminal-v1.0.0-rc.4...async-stripe-terminal-v1.0.0-rc.5) - 2026-04-13

### Other

- regenerate codegen
</blockquote>

## `async-stripe-treasury`

<blockquote>

## [1.0.0-rc.5](https://github.com/arlyon/async-stripe/compare/async-stripe-treasury-v1.0.0-rc.4...async-stripe-treasury-v1.0.0-rc.5) - 2026-04-13

### Other

- regenerate codegen
</blockquote>

## `async-stripe-webhook`

<blockquote>

## [1.0.0-rc.5](https://github.com/arlyon/async-stripe/compare/async-stripe-webhook-v1.0.0-rc.4...async-stripe-webhook-v1.0.0-rc.5) - 2026-04-13

### Added

- redact-generated-debug feature

### Other

- regenerate codegen
</blockquote>

## `async-stripe-connect`

<blockquote>

## [1.0.0-rc.5](https://github.com/arlyon/async-stripe/compare/async-stripe-connect-v1.0.0-rc.4...async-stripe-connect-v1.0.0-rc.5) - 2026-04-13

### Other

- regenerate codegen
</blockquote>

## `async-stripe-issuing`

<blockquote>

## [1.0.0-rc.5](https://github.com/arlyon/async-stripe/compare/async-stripe-issuing-v1.0.0-rc.4...async-stripe-issuing-v1.0.0-rc.5) - 2026-04-13

### Other

- regenerate codegen
</blockquote>

## `async-stripe-product`

<blockquote>

## [1.0.0-rc.5](https://github.com/arlyon/async-stripe/compare/async-stripe-product-v1.0.0-rc.4...async-stripe-product-v1.0.0-rc.5) - 2026-04-13

### Other

- regenerate codegen
</blockquote>

## `async-stripe`

<blockquote>

## [1.0.0-rc.5](https://github.com/arlyon/async-stripe/compare/async-stripe-v1.0.0-rc.4...async-stripe-v1.0.0-rc.5) - 2026-04-13

### Added

- redact-generated-debug feature

### Other

- add cargo features component
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).