### PR TITLE
Add per-request timeouts

### DIFF
--- a/async-stripe-client-core/src/config.rs
+++ b/async-stripe-client-core/src/config.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 use std::fmt::{Display, Formatter};
+use std::time::Duration;
 
 use stripe_shared::version::VERSION;
 use stripe_shared::{AccountId, ApiVersion, ApplicationId};
@@ -30,6 +31,10 @@ pub struct SharedConfigBuilder {
     pub secret: String,
     /// The base URL to send requests to.
     pub api_base: Option<String>,
+    /// The default per-attempt timeout to apply to each HTTP request.
+    /// Backoff sleeps between retries are not counted.
+    /// `None` means no timeout.
+    pub timeout: Option<Duration>,
 }
 
 impl SharedConfigBuilder {
@@ -51,6 +56,7 @@ impl SharedConfigBuilder {
             request_strategy: None,
             secret,
             api_base: None,
+            timeout: None,
         }
     }
 
@@ -78,6 +84,18 @@ impl SharedConfigBuilder {
     /// Create a new client pointed at a specific URL. This is useful for testing.
     pub fn url(mut self, url: impl Into<String>) -> Self {
         self.api_base = Some(url.into());
+        self
+    }
+
+    /// Set the default per-attempt timeout used when making requests.
+    ///
+    /// The timeout applies to each individual HTTP attempt; backoff sleeps
+    /// between retries are not counted. A timed-out attempt is treated like
+    /// any other network error and will be retried by strategies that
+    /// permit it. Per-request `ConfigOverride` values take precedence over
+    /// this default.
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = Some(timeout);
         self
     }
 
@@ -126,6 +144,7 @@ impl fmt::Debug for SharedConfigBuilder {
             builder.field("api_base", api_base);
         }
         builder.field("stripe_version", &self.stripe_version);
+        builder.field("timeout", &self.timeout);
         builder.finish()
     }
 }
@@ -138,10 +157,12 @@ pub struct ConfigOverride {
     pub account_id: Option<AccountId>,
     /// Use a particular `RequestStrategy`, instead of the client default.
     pub request_strategy: Option<RequestStrategy>,
+    /// Use a particular timeout, instead of the client default.
+    pub timeout: Option<Duration>,
 }
 
 impl ConfigOverride {
     pub(crate) fn new() -> Self {
-        Self { account_id: None, request_strategy: None }
+        Self { account_id: None, request_strategy: None, timeout: None }
     }
 }

--- a/async-stripe-client-core/src/stripe_request.rs
+++ b/async-stripe-client-core/src/stripe_request.rs
@@ -1,5 +1,6 @@
 use std::fmt::Display;
 use std::marker::PhantomData;
+use std::time::Duration;
 
 use bytes::Bytes;
 use miniserde::json::from_str;
@@ -120,6 +121,15 @@ impl<T> CustomizableStripeRequest<T> {
     /// during configuration.
     pub fn account_id(mut self, account_id: AccountId) -> Self {
         self.inner.config_override.account_id = Some(account_id);
+        self
+    }
+
+    /// Set a per-attempt timeout to use for this request, overriding the
+    /// default set during configuration. The timeout applies to each
+    /// individual HTTP attempt; the request strategy may still retry a
+    /// timed-out attempt.
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.inner.config_override.timeout = Some(timeout);
         self
     }
 }

--- a/async-stripe/src/async_std/client.rs
+++ b/async-stripe/src/async_std/client.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use async_std::task::sleep;
 use http_types::{Body, Request, StatusCode};
 use miniserde::json::from_str;
@@ -68,6 +70,7 @@ impl Client {
         &self,
         mut request: Request,
         strategy: RequestStrategy,
+        timeout: Option<Duration>,
     ) -> Result<Vec<u8>, StripeError> {
         let mut tries = 0;
         let mut last_status: Option<StatusCode> = None;
@@ -103,23 +106,30 @@ impl Client {
                     request.set_body(body.clone());
 
                     tracing::debug!("sending request (attempt {})", tries + 1);
-                    let mut response = match self.client.send(request).await {
-                        Ok(response) => response,
+                    let attempt = async {
+                        let mut response = self.client.send(request).await?;
+                        let status = response.status();
+                        let retry = response
+                            .header("Stripe-Should-Retry")
+                            .and_then(|s| s.last().as_str().parse().ok());
+                        let bytes = response.body_bytes().await?;
+                        Ok::<_, StripeError>((status, retry, bytes))
+                    };
+                    let attempt_result = match timeout {
+                        Some(t) => async_std::future::timeout(t, attempt)
+                            .await
+                            .unwrap_or_else(|_| Err(StripeError::Timeout)),
+                        None => attempt.await,
+                    };
+                    let (status, retry, bytes) = match attempt_result {
+                        Ok(parts) => parts,
                         Err(err) => {
                             tracing::warn!("request failed: {}", err);
-                            last_error = StripeError::from(err);
+                            last_error = err;
                             tries += 1;
                             continue;
                         }
                     };
-
-                    let status = response.status();
-                    let retry = response
-                        .header("Stripe-Should-Retry")
-                        .and_then(|s| s.last().as_str().parse().ok());
-
-                    // if this fails parsing, we can probably just exit
-                    let bytes = response.body_bytes().await?;
 
                     if !status.is_success() {
                         tries += 1;
@@ -170,8 +180,9 @@ impl stripe_client_core::StripeClient for Client {
 
         let request_strategy =
             config.request_strategy.unwrap_or_else(|| self.config.request_strategy.clone());
+        let timeout = config.timeout.or(self.config.timeout);
         let req = self.create_request(req, config.account_id);
-        let bytes = self.send_inner(req, request_strategy).await?;
+        let bytes = self.send_inner(req, request_strategy, timeout).await?;
         Ok(bytes::Bytes::from(bytes))
     }
 }

--- a/async-stripe/src/async_std/config.rs
+++ b/async-stripe/src/async_std/config.rs
@@ -1,5 +1,6 @@
 use std::fmt::{Debug, Formatter};
 use std::str::FromStr;
+use std::time::Duration;
 
 use http_types::Url;
 use stripe_client_core::{RequestStrategy, SharedConfigBuilder};
@@ -53,6 +54,23 @@ impl ClientBuilder {
         self
     }
 
+    /// Set the default per-attempt timeout used when making requests.
+    ///
+    /// The timeout applies to each individual HTTP attempt (including
+    /// response body collection). When the request strategy retries, each
+    /// attempt gets its own fresh budget; backoff sleeps between attempts
+    /// are not counted. A timed-out attempt is treated like any other
+    /// network error — if the strategy permits, it will be retried;
+    /// otherwise [`StripeError::Timeout`] is returned.
+    ///
+    /// Per-request timeouts set via
+    /// [`stripe_client_core::CustomizableStripeRequest::timeout`] take
+    /// precedence.
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.inner = self.inner.timeout(timeout);
+        self
+    }
+
     /// Set the application info for the client.
     ///
     /// It is recommended that applications set this so that
@@ -91,6 +109,7 @@ impl ClientBuilder {
             request_strategy: self.inner.request_strategy.unwrap_or(RequestStrategy::Once),
             secret: self.inner.secret,
             api_base,
+            timeout: self.inner.timeout,
         })
     }
 
@@ -113,6 +132,7 @@ pub struct ClientConfig {
     pub request_strategy: RequestStrategy,
     pub secret: String,
     pub api_base: Url,
+    pub timeout: Option<Duration>,
 }
 
 impl ClientConfig {
@@ -136,6 +156,7 @@ impl Debug for ClientConfig {
         s.field("api_base", &self.api_base);
         s.field("user_agent", &self.user_agent);
         s.field("stripe_version", &self.stripe_version);
+        s.field("timeout", &self.timeout);
         s.finish()
     }
 }

--- a/async-stripe/src/hyper/blocking.rs
+++ b/async-stripe/src/hyper/blocking.rs
@@ -14,8 +14,10 @@ use stripe_client_core::{CustomizedStripeRequest, StripeBlockingClient, StripeCl
 
 use crate::error::StripeError;
 
-/// The delay after which the blocking `Client` will assume the request has failed.
-const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+/// The default per-attempt request timeout applied to a blocking client
+/// built via [`crate::ClientBuilder::build_sync`] when no explicit timeout
+/// has been set.
+pub(crate) const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// A blocking client for making Stripe API requests.
 #[derive(Clone, Debug)]
@@ -30,7 +32,7 @@ impl Client {
     /// # Panics
     /// This method panics if called from within an async runtime.
     pub fn new(secret_key: impl Into<String>) -> Client {
-        Client::from_async(crate::Client::new(secret_key))
+        crate::ClientBuilder::new(secret_key).build_sync().expect("invalid secret provided")
     }
 
     pub(crate) fn from_async(inner: crate::Client) -> Client {
@@ -47,14 +49,10 @@ impl StripeBlockingClient for Client {
     type Err = StripeError;
 
     fn execute(&self, req: CustomizedStripeRequest) -> Result<Bytes, Self::Err> {
-        let future = self.inner.execute(req);
-        match self.runtime.block_on(async {
-            // N.B. The `tokio::time::timeout` must be called from within a running async
-            //      context or else it will panic (it registers with the thread-local timer).
-            tokio::time::timeout(DEFAULT_TIMEOUT, future).await
-        }) {
-            Ok(finished) => finished,
-            Err(_) => Err(StripeError::Timeout),
-        }
+        // The inner async client applies the per-attempt timeout configured
+        // on its `ClientConfig` (defaulted to `DEFAULT_TIMEOUT` by
+        // `build_sync`), so the blocking wrapper just drives the future to
+        // completion.
+        self.runtime.block_on(self.inner.execute(req))
     }
 }

--- a/async-stripe/src/hyper/client.rs
+++ b/async-stripe/src/hyper/client.rs
@@ -1,4 +1,5 @@
 use std::fmt::Write as _;
+use std::time::Duration;
 
 use http_body_util::{BodyExt, Full};
 use hyper::body::Bytes;
@@ -95,6 +96,7 @@ impl Client {
         body: Option<Bytes>,
         mut req_builder: Builder,
         strategy: RequestStrategy,
+        timeout: Option<Duration>,
     ) -> Result<Bytes, StripeError> {
         let mut tries = 0;
         let mut last_status: Option<StatusCode> = None;
@@ -124,23 +126,33 @@ impl Client {
                     }
 
                     tracing::debug!("sending request (attempt {})", tries + 1);
-                    let response = match self.client.request(req.clone()).await {
-                        Ok(resp) => resp,
+                    let attempt = async {
+                        let response = self.client.request(req.clone()).await?;
+                        let status = response.status();
+                        let retry = response
+                            .headers()
+                            .get("Stripe-Should-Retry")
+                            .and_then(|s| s.to_str().ok())
+                            .and_then(|s| s.parse().ok());
+                        let bytes = response.into_body().collect().await?.to_bytes();
+                        Ok::<_, StripeError>((status, retry, bytes))
+                    };
+                    let attempt_result = match timeout {
+                        Some(t) => tokio::time::timeout(t, attempt)
+                            .await
+                            .unwrap_or_else(|_| Err(StripeError::Timeout)),
+                        None => attempt.await,
+                    };
+                    let (status, retry, bytes) = match attempt_result {
+                        Ok(parts) => parts,
                         Err(err) => {
                             tracing::warn!("request failed: {}", err);
-                            last_error = StripeError::from(err);
+                            last_error = err;
                             tries += 1;
                             continue;
                         }
                     };
-                    let status = response.status();
-                    let retry = response
-                        .headers()
-                        .get("Stripe-Should-Retry")
-                        .and_then(|s| s.to_str().ok())
-                        .and_then(|s| s.parse().ok());
 
-                    let bytes = response.into_body().collect().await?.to_bytes();
                     if !status.is_success() {
                         tries += 1;
                         tracing::warn!("request returned error status: {}", status);
@@ -191,6 +203,7 @@ impl stripe_client_core::StripeClient for Client {
 
         let request_strategy =
             config.request_strategy.unwrap_or_else(|| self.config.request_strategy.clone());
-        self.send_inner(body, builder, request_strategy).await
+        let timeout = config.timeout.or(self.config.timeout);
+        self.send_inner(body, builder, request_strategy, timeout).await
     }
 }

--- a/async-stripe/src/hyper/client_builder.rs
+++ b/async-stripe/src/hyper/client_builder.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use hyper::http::{HeaderValue, Uri};
 use stripe_client_core::{RequestStrategy, SharedConfigBuilder};
 use stripe_shared::{AccountId, ApplicationId};
@@ -47,6 +49,28 @@ impl ClientBuilder {
     /// Create a new client pointed at a specific URL. This is useful for testing.
     pub fn url(mut self, url: impl Into<String>) -> Self {
         self.inner = self.inner.url(url);
+        self
+    }
+
+    /// Set the default per-attempt timeout used when making requests.
+    ///
+    /// The timeout applies to each individual HTTP attempt (including
+    /// response body collection). When the request strategy retries, each
+    /// attempt gets its own fresh budget; backoff sleeps between attempts
+    /// are not counted. A timed-out attempt is treated like any other
+    /// network error — if the strategy permits, it will be retried;
+    /// otherwise [`StripeError::Timeout`] is returned.
+    ///
+    /// Per-request timeouts set via
+    /// [`CustomizableStripeRequest::timeout`] take precedence.
+    ///
+    /// By default the async client has no timeout. The blocking client built
+    /// via [`ClientBuilder::build_sync`] defaults to 30 seconds per attempt
+    /// when no timeout has been set.
+    ///
+    /// [`CustomizableStripeRequest::timeout`]: stripe_client_core::CustomizableStripeRequest::timeout
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.inner = self.inner.timeout(timeout);
         self
     }
 
@@ -103,6 +127,7 @@ impl ClientBuilder {
             request_strategy: self.inner.request_strategy.unwrap_or(RequestStrategy::Once),
             secret,
             api_base,
+            timeout: self.inner.timeout,
         })
     }
 
@@ -116,13 +141,20 @@ impl ClientBuilder {
 
     /// Builds a Stripe `client` for making blocking API calls.
     ///
+    /// If no timeout has been configured via [`Self::timeout`], a default of
+    /// 30 seconds per attempt is applied so blocking calls are never
+    /// unbounded.
+    ///
     /// # Errors
     /// This method errors if any of the specified configuration is invalid.
     ///
     /// # Panics
     /// This method panics if called from within an async runtime.
     #[cfg(feature = "blocking")]
-    pub fn build_sync(self) -> Result<crate::hyper::blocking::Client, StripeError> {
+    pub fn build_sync(mut self) -> Result<crate::hyper::blocking::Client, StripeError> {
+        if self.inner.timeout.is_none() {
+            self.inner = self.inner.timeout(crate::hyper::blocking::DEFAULT_TIMEOUT);
+        }
         Ok(crate::hyper::blocking::Client::from_async(self.build()?))
     }
 }
@@ -143,4 +175,5 @@ pub struct ClientConfig {
     // NB: This `HeaderValue` is marked as sensitive, so it won't be debug printed.
     pub secret: HeaderValue,
     pub api_base: Uri,
+    pub timeout: Option<Duration>,
 }

--- a/async-stripe/tests/it/async_std.rs
+++ b/async-stripe/tests/it/async_std.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use http_types::convert::{Deserialize, Serialize};
 use httpmock::prelude::*;
 use stripe::StripeError;
@@ -129,4 +131,28 @@ async fn retry_body() {
 
     hello_mock.assert_hits_async(5).await;
     assert!(res.is_err());
+}
+
+#[async_std::test]
+async fn timeout_per_attempt() {
+    // The mock server delays 500ms before responding. With a 100ms per-attempt
+    // timeout and Retry(3), each attempt should time out and we should see
+    // exactly 3 attempts before giving up with StripeError::Timeout.
+    let server = MockServer::start_async().await;
+    let mock = server.mock(|when, then| {
+        when.method(GET).path("/v1/slow");
+        then.status(200).delay(Duration::from_millis(500)).body("{\"id\":\"test-id\"}");
+    });
+
+    let client = client_builder()
+        .url(server.base_url())
+        .timeout(Duration::from_millis(100))
+        .request_strategy(RequestStrategy::Retry(3))
+        .build()
+        .unwrap();
+
+    let res = RequestBuilder::new(StripeMethod::Get, "/slow").customize::<()>().send(&client).await;
+
+    mock.assert_hits_async(3).await;
+    assert!(matches!(res, Err(StripeError::Timeout)));
 }

--- a/async-stripe/tests/it/hyper.rs
+++ b/async-stripe/tests/it/hyper.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use httpmock::Method::{GET, POST};
 use httpmock::MockServer;
 use serde::{Deserialize, Serialize};
@@ -306,6 +308,52 @@ async fn assert_header_ids(
         headers.push(("stripe-account", acct_id.as_str()));
     }
     assert_headers_sent(builder, req, headers).await;
+}
+
+#[tokio::test]
+async fn timeout_per_attempt() {
+    // The mock server delays 500ms before responding. With a 100ms per-attempt
+    // timeout and Retry(3), each attempt should time out and we should see
+    // exactly 3 attempts before giving up with StripeError::Timeout.
+    let server = MockServer::start_async().await;
+    let mock = server.mock(|when, then| {
+        when.method(GET).path("/v1/slow");
+        then.status(200).delay(Duration::from_millis(500)).body("{\"id\":\"test-id\"}");
+    });
+
+    let client = client_builder()
+        .url(server.base_url())
+        .timeout(Duration::from_millis(100))
+        .request_strategy(RequestStrategy::Retry(3))
+        .build()
+        .unwrap();
+
+    let res =
+        RequestBuilder::new(StripeMethod::Get, "/slow").customize::<TestData>().send(&client).await;
+
+    // Retry(n) makes n+1 attempts (initial + n retries) when last_status is
+    // None — the strategy keeps continuing until tries == n.
+    mock.assert_hits_async(3).await;
+    assert!(matches!(res, Err(StripeError::Timeout)));
+}
+
+#[tokio::test]
+async fn timeout_per_request_override() {
+    // Per-request timeout should override the client default, including
+    // raising it above a tight client default.
+    let server = MockServer::start_async().await;
+    let mock = server.mock(|when, then| {
+        when.method(GET).path("/v1/test");
+        then.status(200).delay(Duration::from_millis(150)).json_body_obj(&TestData::new());
+    });
+
+    let client =
+        client_builder().url(server.base_url()).timeout(Duration::from_millis(50)).build().unwrap();
+
+    let res = test_req().timeout(Duration::from_secs(5)).send(&client).await;
+
+    mock.assert_hits_async(1).await;
+    assert!(res.is_ok());
 }
 
 #[tokio::test]


### PR DESCRIPTION
# Summary

Add configurable per-request timeouts to all three clients via the `SharedConfigBuilder` and allow overriding per-request via `CustomizableStripeRequest`.

I've made sure to respect the hyper blocking client's default 30s timeout, while the async clients were previously unbounded. This PR shouldn't cause any breaking changes.

I was previously wrapping all of my stripe requests in timeout wrappers and thought it would be cleaner to be centralised in the async-stripe config, and couldn't find any previous issues/PRs regarding timeouts. Thank you!

### Checklist

- [x] ran `cargo make fmt`
- [x] using [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) to hightlight user-facing fixes and features
  <!--
  EXAMPLES:
  feat: you can now add and remove principals from a project
  fix: fixes an issue where the combobox was displaying incorrect values
  -->
