### PR TITLE
chore: release v1.0.0-rc.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,7 +167,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "smallvec",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "time 0.3.47",
  "tracing",
  "url",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe"
-version = "1.0.0-rc.6"
+version = "1.0.0-rc.7"
 dependencies = [
  "async-std",
  "async-stripe-client-core",
@@ -491,7 +491,7 @@ dependencies = [
  "http-body-util",
  "http-types",
  "httpmock",
- "hyper 1.10.0",
+ "hyper 1.10.1",
  "hyper-rustls",
  "hyper-tls",
  "hyper-util",
@@ -506,7 +506,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-billing"
-version = "1.0.0-rc.6"
+version = "1.0.0-rc.7"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-checkout"
-version = "1.0.0-rc.6"
+version = "1.0.0-rc.7"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-client-core"
-version = "1.0.0-rc.6"
+version = "1.0.0-rc.7"
 dependencies = [
  "async-stripe-shared",
  "async-stripe-types",
@@ -551,7 +551,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-connect"
-version = "1.0.0-rc.6"
+version = "1.0.0-rc.7"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-core"
-version = "1.0.0-rc.6"
+version = "1.0.0-rc.7"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-fraud"
-version = "1.0.0-rc.6"
+version = "1.0.0-rc.7"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -593,7 +593,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-issuing"
-version = "1.0.0-rc.6"
+version = "1.0.0-rc.7"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-misc"
-version = "1.0.0-rc.6"
+version = "1.0.0-rc.7"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -621,7 +621,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-parser"
-version = "1.0.0-rc.6"
+version = "1.0.0-rc.7"
 dependencies = [
  "async-stripe-billing",
  "async-stripe-checkout",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-payment"
-version = "1.0.0-rc.6"
+version = "1.0.0-rc.7"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -659,7 +659,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-product"
-version = "1.0.0-rc.6"
+version = "1.0.0-rc.7"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -673,7 +673,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-reserve"
-version = "1.0.0-rc.6"
+version = "1.0.0-rc.7"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -687,7 +687,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-shared"
-version = "1.0.0-rc.6"
+version = "1.0.0-rc.7"
 dependencies = [
  "async-stripe-types",
  "miniserde",
@@ -699,7 +699,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-terminal"
-version = "1.0.0-rc.6"
+version = "1.0.0-rc.7"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-treasury"
-version = "1.0.0-rc.6"
+version = "1.0.0-rc.7"
 dependencies = [
  "async-stripe-client-core",
  "async-stripe-shared",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-types"
-version = "1.0.0-rc.6"
+version = "1.0.0-rc.7"
 dependencies = [
  "miniserde",
  "serde",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "async-stripe-webhook"
-version = "1.0.0-rc.6"
+version = "1.0.0-rc.7"
 dependencies = [
  "async-stripe-billing",
  "async-stripe-checkout",
@@ -874,7 +874,7 @@ dependencies = [
  "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.10.0",
+ "hyper 1.10.1",
  "hyper-util",
  "itoa",
  "matchit",
@@ -956,9 +956,9 @@ checksum = "383d29d513d8764dcdc42ea295d979eb99c3c9f00607b3692cf68a431f7dca72"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "block-buffer"
@@ -1012,9 +1012,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "8.0.2"
+version = "8.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+checksum = "8119e4516436f5708bbc474a9d395bf12f1b5395e93a92a56e647ac3388c8610"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -1023,9 +1023,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "5.0.0"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+checksum = "5962523e1b92ce1b5e793d9169b9943eece10d39f62550bc04bb605d75b94924"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -1066,9 +1066,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1101,9 +1101,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -1314,7 +1314,7 @@ dependencies = [
  "openssl-probe 0.1.6",
  "openssl-sys",
  "schannel",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "windows-sys 0.59.0",
 ]
 
@@ -2147,9 +2147,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb92f162bf56536459fc83c79b974bb12837acfed43d6bc370a7916d0ae15ecc"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes 1.11.1",
@@ -2174,7 +2174,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http 1.4.1",
- "hyper 1.10.0",
+ "hyper 1.10.1",
  "hyper-util",
  "log",
  "rustls",
@@ -2193,7 +2193,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes 1.11.1",
  "http-body-util",
- "hyper 1.10.0",
+ "hyper 1.10.1",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -2212,10 +2212,10 @@ dependencies = [
  "futures-util",
  "http 1.4.1",
  "http-body 1.0.1",
- "hyper 1.10.0",
+ "hyper 1.10.1",
  "libc",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -2519,9 +2519,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.28"
+version = "1.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
 dependencies = [
  "cc",
  "libc",
@@ -2569,9 +2569,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.30"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 dependencies = [
  "value-bag",
 ]
@@ -2662,9 +2662,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "log",
@@ -3324,9 +3324,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe 0.2.1",
  "rustls-pki-types",
@@ -3511,9 +3511,9 @@ dependencies = [
 
 [[package]]
 name = "serde_regex"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
+checksum = "bafc8d0c5330cecff10f16b459b479fd9acaa5b4acd7167301414e21b0057012"
 dependencies = [
  "regex",
  "serde",
@@ -3601,9 +3601,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -3672,9 +3672,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -3998,7 +3998,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -4207,9 +4207,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ubyte"
@@ -4244,9 +4244,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-xid"
@@ -4291,9 +4291,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -4764,7 +4764,7 @@ dependencies = [
  "futures",
  "http 1.4.1",
  "http-body-util",
- "hyper 1.10.0",
+ "hyper 1.10.1",
  "hyper-util",
  "log",
  "once_cell",
@@ -4886,9 +4886,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -4909,18 +4909,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.49"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.49"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ resolver = "2"
 exclude = ["openapi"]
 
 [workspace.package]
-version = "1.0.0-rc.6"
+version = "1.0.0-rc.7"
 description = "API bindings for the Stripe HTTP API"
 rust-version = "1.88.0"
 authors = [

--- a/async-stripe-client-core/Cargo.toml
+++ b/async-stripe-client-core/Cargo.toml
@@ -17,8 +17,8 @@ edition.workspace = true
 name = "stripe_client_core"
 
 [dependencies]
-async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-rc.6" }
-async-stripe-types = { path = "../async-stripe-types", version = "1.0.0-rc.6" }
+async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-rc.7" }
+async-stripe-types = { path = "../async-stripe-types", version = "1.0.0-rc.7" }
 serde_json.workspace = true
 serde.workspace = true
 serde_qs.workspace = true

--- a/async-stripe-parser/Cargo.toml
+++ b/async-stripe-parser/Cargo.toml
@@ -18,19 +18,19 @@ edition.workspace = true
 crate-type = ["cdylib"]
 
 [dependencies]
-async-stripe-billing = { features = ["full", "deserialize"], version = "1.0.0-rc.6", path = "../generated/async-stripe-billing" }
-async-stripe-checkout = { features = ["full", "deserialize"], version = "1.0.0-rc.6", path = "../generated/async-stripe-checkout" }
-async-stripe-connect = { features = ["full", "deserialize"], version = "1.0.0-rc.6", path = "../generated/async-stripe-connect" }
-async-stripe-core = { features = ["full", "deserialize"], version = "1.0.0-rc.6", path = "../generated/async-stripe-core" }
-async-stripe-fraud = { features = ["full", "deserialize"], version = "1.0.0-rc.6", path = "../generated/async-stripe-fraud" }
-async-stripe-issuing = {features = ["full", "deserialize"], version = "1.0.0-rc.6", path = "../generated/async-stripe-issuing" }
-async-stripe-misc = { features = ["full", "deserialize"], version = "1.0.0-rc.6", path = "../generated/async-stripe-misc" }
-async-stripe-payment = { features = ["full", "deserialize"], version = "1.0.0-rc.6", path = "../generated/async-stripe-payment" }
-async-stripe-product = { features = ["full", "deserialize"], version = "1.0.0-rc.6", path = "../generated/async-stripe-product" }
-async-stripe-shared = { features = ["deserialize"], version = "1.0.0-rc.6", path = "../generated/async-stripe-shared" }
-async-stripe-terminal = {features = ["full", "deserialize"], version = "1.0.0-rc.6", path = "../generated/async-stripe-terminal" }
-async-stripe-treasury = {features = ["full", "deserialize"], version = "1.0.0-rc.6", path = "../generated/async-stripe-treasury" }
-async-stripe-webhook = { version = "1.0.0-rc.6", path = "../async-stripe-webhook", features = ["deserialize", "serialize", "full", "detailed-errors"] }
+async-stripe-billing = { features = ["full", "deserialize"], version = "1.0.0-rc.7", path = "../generated/async-stripe-billing" }
+async-stripe-checkout = { features = ["full", "deserialize"], version = "1.0.0-rc.7", path = "../generated/async-stripe-checkout" }
+async-stripe-connect = { features = ["full", "deserialize"], version = "1.0.0-rc.7", path = "../generated/async-stripe-connect" }
+async-stripe-core = { features = ["full", "deserialize"], version = "1.0.0-rc.7", path = "../generated/async-stripe-core" }
+async-stripe-fraud = { features = ["full", "deserialize"], version = "1.0.0-rc.7", path = "../generated/async-stripe-fraud" }
+async-stripe-issuing = {features = ["full", "deserialize"], version = "1.0.0-rc.7", path = "../generated/async-stripe-issuing" }
+async-stripe-misc = { features = ["full", "deserialize"], version = "1.0.0-rc.7", path = "../generated/async-stripe-misc" }
+async-stripe-payment = { features = ["full", "deserialize"], version = "1.0.0-rc.7", path = "../generated/async-stripe-payment" }
+async-stripe-product = { features = ["full", "deserialize"], version = "1.0.0-rc.7", path = "../generated/async-stripe-product" }
+async-stripe-shared = { features = ["deserialize"], version = "1.0.0-rc.7", path = "../generated/async-stripe-shared" }
+async-stripe-terminal = {features = ["full", "deserialize"], version = "1.0.0-rc.7", path = "../generated/async-stripe-terminal" }
+async-stripe-treasury = {features = ["full", "deserialize"], version = "1.0.0-rc.7", path = "../generated/async-stripe-treasury" }
+async-stripe-webhook = { version = "1.0.0-rc.7", path = "../async-stripe-webhook", features = ["deserialize", "serialize", "full", "detailed-errors"] }
 serde.workspace = true
 serde_json.workspace = true
 serde_path_to_error = "0.1.20"

--- a/async-stripe-webhook/Cargo.toml
+++ b/async-stripe-webhook/Cargo.toml
@@ -15,8 +15,8 @@ categories.workspace = true
 name = "stripe_webhook"
 
 [dependencies]
-async-stripe-types = { path = "../async-stripe-types", version = "1.0.0-rc.6" }
-async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-rc.6" }
+async-stripe-types = { path = "../async-stripe-types", version = "1.0.0-rc.7" }
+async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-rc.7" }
 hmac = "0.12"
 sha2 = "0.10"
 hex = "0.4"
@@ -27,15 +27,15 @@ miniserde.workspace = true
 serde.workspace = true
 serde_json = { workspace = true, optional = true }
 
-async-stripe-billing = { path = "../generated/async-stripe-billing", optional = true, version = "1.0.0-rc.6" }
-async-stripe-checkout = { path = "../generated/async-stripe-checkout", optional = true, version = "1.0.0-rc.6" }
-async-stripe-core = { path = "../generated/async-stripe-core", optional = true, version = "1.0.0-rc.6" }
-async-stripe-fraud = { path = "../generated/async-stripe-fraud", optional = true, version = "1.0.0-rc.6" }
-async-stripe-misc = { path = "../generated/async-stripe-misc", optional = true, version = "1.0.0-rc.6" }
-async-stripe-payment = { path = "../generated/async-stripe-payment", optional = true, version = "1.0.0-rc.6" }
-async-stripe-terminal = { path = "../generated/async-stripe-terminal", optional = true, version = "1.0.0-rc.6" }
-async-stripe-treasury = { path = "../generated/async-stripe-treasury", optional = true, version = "1.0.0-rc.6" }
-async-stripe-reserve = { path = "../generated/async-stripe-reserve", optional = true, version = "1.0.0-rc.6" }
+async-stripe-billing = { path = "../generated/async-stripe-billing", optional = true, version = "1.0.0-rc.7" }
+async-stripe-checkout = { path = "../generated/async-stripe-checkout", optional = true, version = "1.0.0-rc.7" }
+async-stripe-core = { path = "../generated/async-stripe-core", optional = true, version = "1.0.0-rc.7" }
+async-stripe-fraud = { path = "../generated/async-stripe-fraud", optional = true, version = "1.0.0-rc.7" }
+async-stripe-misc = { path = "../generated/async-stripe-misc", optional = true, version = "1.0.0-rc.7" }
+async-stripe-payment = { path = "../generated/async-stripe-payment", optional = true, version = "1.0.0-rc.7" }
+async-stripe-terminal = { path = "../generated/async-stripe-terminal", optional = true, version = "1.0.0-rc.7" }
+async-stripe-treasury = { path = "../generated/async-stripe-treasury", optional = true, version = "1.0.0-rc.7" }
+async-stripe-reserve = { path = "../generated/async-stripe-reserve", optional = true, version = "1.0.0-rc.7" }
 serde_path_to_error = { version = "0.1.20", optional = true }
 
 [dev-dependencies]

--- a/async-stripe/Cargo.toml
+++ b/async-stripe/Cargo.toml
@@ -33,8 +33,8 @@ async-std = { version = "1.12.0", optional = true }
 surf = { version = "2.1", optional = true }
 http-types = { version = "2.12.0", default-features = false, optional = true }
 
-async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-rc.6" }
-async-stripe-client-core = { path = "../async-stripe-client-core", version = "1.0.0-rc.6" }
+async-stripe-shared = { path = "../generated/async-stripe-shared", version = "1.0.0-rc.7" }
+async-stripe-client-core = { path = "../async-stripe-client-core", version = "1.0.0-rc.7" }
 
 [features]
 default = ["default-tls"]

--- a/generated/async-stripe-billing/CHANGELOG.md
+++ b/generated/async-stripe-billing/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-rc.7](https://github.com/arlyon/async-stripe/compare/async-stripe-billing-v1.0.0-rc.6...async-stripe-billing-v1.0.0-rc.7) - 2026-06-08
+
+### Other
+
+- Generate latest changes from OpenApi spec
+
 ## [1.0.0-rc.6](https://github.com/arlyon/async-stripe/compare/async-stripe-billing-v1.0.0-rc.5...async-stripe-billing-v1.0.0-rc.6) - 2026-05-27
 
 ### Other

--- a/generated/async-stripe-billing/Cargo.toml
+++ b/generated/async-stripe-billing/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.6" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.6" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.7" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.7" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.6" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.7" }
 
 
 [features]

--- a/generated/async-stripe-checkout/CHANGELOG.md
+++ b/generated/async-stripe-checkout/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-rc.7](https://github.com/arlyon/async-stripe/compare/async-stripe-checkout-v1.0.0-rc.6...async-stripe-checkout-v1.0.0-rc.7) - 2026-06-08
+
+### Other
+
+- Generate latest changes from OpenApi spec
+
 ## [1.0.0-rc.6](https://github.com/arlyon/async-stripe/compare/async-stripe-checkout-v1.0.0-rc.5...async-stripe-checkout-v1.0.0-rc.6) - 2026-05-27
 
 ### Other

--- a/generated/async-stripe-checkout/Cargo.toml
+++ b/generated/async-stripe-checkout/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.6" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.6" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.7" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.7" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.6" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.7" }
 
 
 [features]

--- a/generated/async-stripe-connect/CHANGELOG.md
+++ b/generated/async-stripe-connect/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-rc.7](https://github.com/arlyon/async-stripe/compare/async-stripe-connect-v1.0.0-rc.6...async-stripe-connect-v1.0.0-rc.7) - 2026-06-08
+
+### Other
+
+- Generate latest changes from OpenApi spec
+
 ## [1.0.0-rc.6](https://github.com/arlyon/async-stripe/compare/async-stripe-connect-v1.0.0-rc.5...async-stripe-connect-v1.0.0-rc.6) - 2026-05-27
 
 ### Other

--- a/generated/async-stripe-connect/Cargo.toml
+++ b/generated/async-stripe-connect/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.6" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.6" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.7" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.7" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.6" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.7" }
 
 
 [features]

--- a/generated/async-stripe-core/CHANGELOG.md
+++ b/generated/async-stripe-core/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-rc.7](https://github.com/arlyon/async-stripe/compare/async-stripe-core-v1.0.0-rc.6...async-stripe-core-v1.0.0-rc.7) - 2026-06-08
+
+### Other
+
+- Generate latest changes from OpenApi spec
+
 ## [1.0.0-rc.6](https://github.com/arlyon/async-stripe/compare/async-stripe-core-v1.0.0-rc.5...async-stripe-core-v1.0.0-rc.6) - 2026-05-27
 
 ### Other

--- a/generated/async-stripe-core/Cargo.toml
+++ b/generated/async-stripe-core/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.6" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.6" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.7" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.7" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.6" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.7" }
 
 
 [features]

--- a/generated/async-stripe-fraud/CHANGELOG.md
+++ b/generated/async-stripe-fraud/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-rc.7](https://github.com/arlyon/async-stripe/compare/async-stripe-fraud-v1.0.0-rc.6...async-stripe-fraud-v1.0.0-rc.7) - 2026-06-08
+
+### Other
+
+- Generate latest changes from OpenApi spec
+
 ## [1.0.0-rc.6](https://github.com/arlyon/async-stripe/compare/async-stripe-fraud-v1.0.0-rc.5...async-stripe-fraud-v1.0.0-rc.6) - 2026-05-27
 
 ### Other

--- a/generated/async-stripe-fraud/Cargo.toml
+++ b/generated/async-stripe-fraud/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.6" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.6" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.7" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.7" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.6" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.7" }
 
 
 [features]

--- a/generated/async-stripe-issuing/Cargo.toml
+++ b/generated/async-stripe-issuing/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.6" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.6" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.7" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.7" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.6" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.7" }
 
 
 [features]

--- a/generated/async-stripe-misc/Cargo.toml
+++ b/generated/async-stripe-misc/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.6" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.6" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.7" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.7" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.6" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.7" }
 
 
 [features]

--- a/generated/async-stripe-payment/CHANGELOG.md
+++ b/generated/async-stripe-payment/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-rc.7](https://github.com/arlyon/async-stripe/compare/async-stripe-payment-v1.0.0-rc.6...async-stripe-payment-v1.0.0-rc.7) - 2026-06-08
+
+### Other
+
+- Generate latest changes from OpenApi spec
+
 ## [1.0.0-rc.6](https://github.com/arlyon/async-stripe/compare/async-stripe-payment-v1.0.0-rc.5...async-stripe-payment-v1.0.0-rc.6) - 2026-05-27
 
 ### Other

--- a/generated/async-stripe-payment/Cargo.toml
+++ b/generated/async-stripe-payment/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.6" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.6" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.7" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.7" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.6" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.7" }
 
 
 [features]

--- a/generated/async-stripe-product/Cargo.toml
+++ b/generated/async-stripe-product/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.6" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.6" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.7" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.7" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.6" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.7" }
 
 
 [features]

--- a/generated/async-stripe-reserve/Cargo.toml
+++ b/generated/async-stripe-reserve/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.6" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.6" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.7" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.7" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.6" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.7" }
 
 
 [features]

--- a/generated/async-stripe-shared/CHANGELOG.md
+++ b/generated/async-stripe-shared/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-rc.7](https://github.com/arlyon/async-stripe/compare/async-stripe-shared-v1.0.0-rc.6...async-stripe-shared-v1.0.0-rc.7) - 2026-06-08
+
+### Other
+
+- Generate latest changes from OpenApi spec
+
 ## [1.0.0-rc.6](https://github.com/arlyon/async-stripe/compare/async-stripe-shared-v1.0.0-rc.5...async-stripe-shared-v1.0.0-rc.6) - 2026-05-27
 
 ### Other

--- a/generated/async-stripe-shared/Cargo.toml
+++ b/generated/async-stripe-shared/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.6" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.7" }
 
 
 

--- a/generated/async-stripe-terminal/CHANGELOG.md
+++ b/generated/async-stripe-terminal/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.0.0-rc.7](https://github.com/arlyon/async-stripe/compare/async-stripe-terminal-v1.0.0-rc.6...async-stripe-terminal-v1.0.0-rc.7) - 2026-06-08
+
+### Other
+
+- Generate latest changes from OpenApi spec
+
 ## [1.0.0-rc.6](https://github.com/arlyon/async-stripe/compare/async-stripe-terminal-v1.0.0-rc.5...async-stripe-terminal-v1.0.0-rc.6) - 2026-05-27
 
 ### Other

--- a/generated/async-stripe-terminal/Cargo.toml
+++ b/generated/async-stripe-terminal/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.6" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.6" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.7" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.7" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.6" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.7" }
 
 
 [features]

--- a/generated/async-stripe-treasury/Cargo.toml
+++ b/generated/async-stripe-treasury/Cargo.toml
@@ -21,10 +21,10 @@ serde_json = { workspace = true, optional = true }
 smol_str.workspace = true
 miniserde.workspace = true
 tracing = { version = "0.1", default-features = false }
-async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.6" }
-async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.6" }
+async-stripe-types = {path = "../../async-stripe-types", version = "1.0.0-rc.7" }
+async-stripe-client-core = {path = "../../async-stripe-client-core", version = "1.0.0-rc.7" }
 
-async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.6" }
+async-stripe-shared = {path = "../../generated/async-stripe-shared", version = "1.0.0-rc.7" }
 
 
 [features]


### PR DESCRIPTION



## 🤖 New release

* `async-stripe-types`: 1.0.0-rc.6 -> 1.0.0-rc.7
* `async-stripe-shared`: 1.0.0-rc.6 -> 1.0.0-rc.7 (✓ API compatible changes)
* `async-stripe-client-core`: 1.0.0-rc.6 -> 1.0.0-rc.7
* `async-stripe-billing`: 1.0.0-rc.6 -> 1.0.0-rc.7 (✓ API compatible changes)
* `async-stripe-checkout`: 1.0.0-rc.6 -> 1.0.0-rc.7 (✓ API compatible changes)
* `async-stripe-core`: 1.0.0-rc.6 -> 1.0.0-rc.7 (✓ API compatible changes)
* `async-stripe-fraud`: 1.0.0-rc.6 -> 1.0.0-rc.7 (✓ API compatible changes)
* `async-stripe-misc`: 1.0.0-rc.6 -> 1.0.0-rc.7
* `async-stripe-payment`: 1.0.0-rc.6 -> 1.0.0-rc.7 (✓ API compatible changes)
* `async-stripe-reserve`: 1.0.0-rc.6 -> 1.0.0-rc.7
* `async-stripe-terminal`: 1.0.0-rc.6 -> 1.0.0-rc.7 (✓ API compatible changes)
* `async-stripe-treasury`: 1.0.0-rc.6 -> 1.0.0-rc.7
* `async-stripe-webhook`: 1.0.0-rc.6 -> 1.0.0-rc.7
* `async-stripe-connect`: 1.0.0-rc.6 -> 1.0.0-rc.7 (✓ API compatible changes)
* `async-stripe-issuing`: 1.0.0-rc.6 -> 1.0.0-rc.7
* `async-stripe-product`: 1.0.0-rc.6 -> 1.0.0-rc.7
* `async-stripe`: 1.0.0-rc.6 -> 1.0.0-rc.7

<details><summary><i><b>Changelog</b></i></summary><p>

## `async-stripe-types`

<blockquote>

## [1.0.0-rc.5](https://github.com/arlyon/async-stripe/compare/async-stripe-types-v1.0.0-rc.4...async-stripe-types-v1.0.0-rc.5) - 2026-04-13

### Added

- redact-generated-debug feature
</blockquote>

## `async-stripe-shared`

<blockquote>

## [1.0.0-rc.7](https://github.com/arlyon/async-stripe/compare/async-stripe-shared-v1.0.0-rc.6...async-stripe-shared-v1.0.0-rc.7) - 2026-06-08

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-client-core`

<blockquote>

## [1.0.0-rc.6](https://github.com/arlyon/async-stripe/compare/async-stripe-client-core-v1.0.0-rc.5...async-stripe-client-core-v1.0.0-rc.6) - 2026-05-27

### Added

- *(client)* add per-attempt request timeouts

### Other

- Fall back to retryable status codes
- Treat HTTP 424 as retryable status
- Fallback to Stripe transient status codes for retries
- update readme
</blockquote>

## `async-stripe-billing`

<blockquote>

## [1.0.0-rc.7](https://github.com/arlyon/async-stripe/compare/async-stripe-billing-v1.0.0-rc.6...async-stripe-billing-v1.0.0-rc.7) - 2026-06-08

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-checkout`

<blockquote>

## [1.0.0-rc.7](https://github.com/arlyon/async-stripe/compare/async-stripe-checkout-v1.0.0-rc.6...async-stripe-checkout-v1.0.0-rc.7) - 2026-06-08

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-core`

<blockquote>

## [1.0.0-rc.7](https://github.com/arlyon/async-stripe/compare/async-stripe-core-v1.0.0-rc.6...async-stripe-core-v1.0.0-rc.7) - 2026-06-08

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-fraud`

<blockquote>

## [1.0.0-rc.7](https://github.com/arlyon/async-stripe/compare/async-stripe-fraud-v1.0.0-rc.6...async-stripe-fraud-v1.0.0-rc.7) - 2026-06-08

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-misc`

<blockquote>

## [1.0.0-rc.6](https://github.com/arlyon/async-stripe/compare/async-stripe-misc-v1.0.0-rc.5...async-stripe-misc-v1.0.0-rc.6) - 2026-05-27

### Other

- Generate latest changes from OpenApi spec
- Inline Deserialize::default
</blockquote>

## `async-stripe-payment`

<blockquote>

## [1.0.0-rc.7](https://github.com/arlyon/async-stripe/compare/async-stripe-payment-v1.0.0-rc.6...async-stripe-payment-v1.0.0-rc.7) - 2026-06-08

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-reserve`

<blockquote>

## [1.0.0-rc.6](https://github.com/arlyon/async-stripe/compare/async-stripe-reserve-v1.0.0-rc.5...async-stripe-reserve-v1.0.0-rc.6) - 2026-05-27

### Other

- Inline Deserialize::default
</blockquote>

## `async-stripe-terminal`

<blockquote>

## [1.0.0-rc.7](https://github.com/arlyon/async-stripe/compare/async-stripe-terminal-v1.0.0-rc.6...async-stripe-terminal-v1.0.0-rc.7) - 2026-06-08

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-treasury`

<blockquote>

## [1.0.0-rc.6](https://github.com/arlyon/async-stripe/compare/async-stripe-treasury-v1.0.0-rc.5...async-stripe-treasury-v1.0.0-rc.6) - 2026-05-27

### Other

- Inline Deserialize::default
</blockquote>

## `async-stripe-webhook`

<blockquote>

## [1.0.0-rc.6](https://github.com/arlyon/async-stripe/compare/async-stripe-webhook-v1.0.0-rc.5...async-stripe-webhook-v1.0.0-rc.6) - 2026-05-27

### Fixed

- fix collapsible_if clippy warnings
</blockquote>

## `async-stripe-connect`

<blockquote>

## [1.0.0-rc.7](https://github.com/arlyon/async-stripe/compare/async-stripe-connect-v1.0.0-rc.6...async-stripe-connect-v1.0.0-rc.7) - 2026-06-08

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-issuing`

<blockquote>

## [1.0.0-rc.6](https://github.com/arlyon/async-stripe/compare/async-stripe-issuing-v1.0.0-rc.5...async-stripe-issuing-v1.0.0-rc.6) - 2026-05-27

### Other

- Generate latest changes from OpenApi spec
</blockquote>

## `async-stripe-product`

<blockquote>

## [1.0.0-rc.6](https://github.com/arlyon/async-stripe/compare/async-stripe-product-v1.0.0-rc.5...async-stripe-product-v1.0.0-rc.6) - 2026-05-27

### Other

- Inline Deserialize::default
</blockquote>

## `async-stripe`

<blockquote>

## [1.0.0-rc.6](https://github.com/arlyon/async-stripe/compare/async-stripe-v1.0.0-rc.5...async-stripe-v1.0.0-rc.6) - 2026-05-27

### Added

- *(client)* add per-attempt request timeouts

### Other

- Fallback to Stripe transient status codes for retries
- update readme
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).